### PR TITLE
[Updater] Spike out a possible implementation for grouping by SemVer

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -4,9 +4,11 @@ module Dependabot
   module Config
     # Filters versions that should not be considered for dependency updates
     class IgnoreCondition
-      PATCH_VERSION_TYPE = "version-update:semver-patch"
-      MINOR_VERSION_TYPE = "version-update:semver-minor"
-      MAJOR_VERSION_TYPE = "version-update:semver-major"
+      VERSION_UPDATE_TYPES = [
+        PATCH_VERSION_TYPE = "version-update:semver-patch",
+        MINOR_VERSION_TYPE = "version-update:semver-minor",
+        MAJOR_VERSION_TYPE = "version-update:semver-major",
+      ]
 
       ALL_VERSIONS = ">= 0"
 

--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -7,7 +7,7 @@ module Dependabot
       VERSION_UPDATE_TYPES = [
         PATCH_VERSION_TYPE = "version-update:semver-patch",
         MINOR_VERSION_TYPE = "version-update:semver-minor",
-        MAJOR_VERSION_TYPE = "version-update:semver-major",
+        MAJOR_VERSION_TYPE = "version-update:semver-major"
       ]
 
       ALL_VERSIONS = ">= 0"

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -38,6 +38,14 @@ module Dependabot
       @ignore_condition.ignored_versions(dependency, SECURITY_UPDATES_ONLY)
     end
 
+    def targets_highest_versions_possible?
+      return true unless update_type_rules?
+
+      # If we are grouping by update-type but excluding Major versions then we are leaving
+      # some potential updates behind on purpose.
+      !rules["update-types"].include?(Dependabot::Config::IgnoreCondition::MAJOR_VERSION_TYPE)
+    end
+
     def to_h
       { "name" => name }
     end
@@ -72,6 +80,13 @@ module Dependabot
       rules.key?("patterns") && rules["patterns"]&.any?
     end
 
+    # TODO: update-types should probably just be the higest value, not an array
+    #
+    # Having a group which is major and patch versions is non-sensical, it makes
+    # the logic hard to reason about, it should just be a sliding rule where you
+    # pick the higest version you want included.
+    #
+    # We should consider setting it to `minor` by default.
     def generate_ignore_condition!
       return NullIgnoreCondition.new unless update_type_rules?
 

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -89,6 +89,76 @@ RSpec.describe Dependabot::DependencyGroup do
     end
   end
 
+  describe "#ignored_versions_for" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "business",
+        package_manager: "bundler",
+        version: "1.8.0",
+        requirements: [
+          { file: "Gemfile", requirement: "~> 1.8.0", groups: [], source: nil }
+        ]
+      )
+    end
+
+    context "the group has not defined any update-type rules" do
+      it "returns an empty array" do
+        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
+      end
+    end
+
+    context "when group only permits patch versions" do
+      let(:rules) do
+        {
+          "update-types" => [
+            "version-update:semver-major"
+          ]
+        }
+      end
+
+      it "returns ranges which ignore minor and patch updates" do
+        expect(dependency_group.ignored_versions_for(dependency)).to eql([
+          "> 1.8.0, < 1.9",
+          ">= 1.9.a, < 2"
+        ])
+      end
+    end
+
+    context "when group only permits minor versions" do
+      let(:rules) do
+        {
+          "update-types" => [
+            "version-update:semver-minor"
+          ]
+        }
+      end
+
+      it "returns ranges which ignore major and patch updates" do
+        expect(dependency_group.ignored_versions_for(dependency)).to eql([
+          "> 1.8.0, < 1.9",
+          ">= 2.a"
+        ])
+      end
+    end
+
+    context "when the group only permits patch versions" do
+      let(:rules) do
+        {
+          "update-types" => [
+            "version-update:semver-patch"
+          ]
+        }
+      end
+
+      it "returns ranges which ignore major and minor updates" do
+        expect(dependency_group.ignored_versions_for(dependency)).to eql([
+          ">= 1.9.a, < 2",
+          ">= 2.a"
+        ])
+      end
+    end
+  end
+
   describe "#contains?" do
     context "when the rules include patterns" do
       let(:rules) do

--- a/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
   end
 
   let(:dependency_group) do
-    Dependabot::DependencyGroup.new(name: "my-dependency-group", rules: anything)
+    Dependabot::DependencyGroup.new(name: "my-dependency-group", rules: { patterns: ["*"] })
   end
   let(:max_length) { nil }
 
@@ -145,7 +145,10 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
 
       context "with a maximum length shorter than branch name" do
         let(:dependency_group) do
-          Dependabot::DependencyGroup.new(name: "business-and-work-and-desks-and-tables-and-chairs", rules: anything)
+          Dependabot::DependencyGroup.new(
+            name: "business-and-work-and-desks-and-tables-and-chairs",
+            rules: { patterns: ["*"] }
+          )
         end
 
         let(:sha1_digest) { Digest::SHA1.hexdigest("dependabot/bundler/#{dependency_group.name}-b8d660191d") }

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
     context "for a dependency group" do
       let(:dependency_group) do
-        Dependabot::DependencyGroup.new(name: "all-the-things", rules: anything)
+        Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })
       end
 
       before do
@@ -1877,7 +1877,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "for a dependency group", :vcr do
         let(:dependency_group) do
-          Dependabot::DependencyGroup.new(name: "all-the-things", rules: anything)
+          Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })
         end
 
         it "has the correct message" do

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Dependabot::PullRequestCreator do
     end
 
     context "with a dependency group" do
-      let(:dependency_group) { Dependabot::DependencyGroup.new(name: "all-the-things", rules: anything) }
+      let(:dependency_group) { Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] }) }
       let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bp") }
       let(:dummy_creator) { instance_double(described_class::Github) }
 

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -56,6 +56,11 @@ module Dependabot
       @groups_calculated = true
     end
 
+    def dependencies_with_ungrouped_semvar_levels
+      # TODO: This is a hack, we need to implement this for real
+      dependency_groups.map(&:dependencies).flatten
+    end
+
     private
 
     def initialize(dependency_groups:)

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -57,8 +57,14 @@ module Dependabot
     end
 
     def dependencies_with_ungrouped_semvar_levels
-      # TODO: This is a hack, we need to implement this for real
-      dependency_groups.map(&:dependencies).flatten
+      # TODO: Limit the dependency set to those we know have passed-over updates
+      #
+      # This will make a second update attempt on every dependency in any groups
+      # which do not permit highest version avaliable upgrades.
+      #
+      # We can be smarter about this since the versions available will need
+      # to be checked at least once prior to this set being evaluated.
+      dependency_groups.select(&:targets_highest_versions_possible?).map(&:dependencies).flatten
     end
 
     private

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -70,7 +70,8 @@ module Dependabot
       # If no groups are defined, all dependencies are ungrouped by default.
       return allowed_dependencies unless groups.any?
 
-      @dependency_group_engine.ungrouped_dependencies
+      @dependency_group_engine.ungrouped_dependencies +
+        @dependency_group_engine.dependencies_with_ungrouped_semvar_levels
     end
 
     private

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -190,7 +190,9 @@ module Dependabot
         # It returns verion ranges which implement IgnoreCondition objects' rules
         # not the objects themselves so this is a little misleading.
         versions_ignored_from_configuration = job.ignore_conditions_for(dependency)
-        # group.inject_ignores(configured_ignores)
+        versions_ignored_from_group = group.ignored_versions_for(dependency)
+
+        (versions_ignored_from_configuration + versions_ignored_from_group).uniq
       end
 
       def log_checking_for_update(dependency)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -114,7 +114,7 @@ module Dependabot
       # This method **must** must return an Array when it errors
       #
       def compile_updates_for(dependency, dependency_files, group) # rubocop:disable Metrics/MethodLength
-        checker = update_checker_for(dependency, dependency_files, raise_on_ignored: raise_on_ignored?(dependency))
+        checker = update_checker_for(dependency, dependency_files, group, raise_on_ignored: raise_on_ignored?(dependency))
 
         log_checking_for_update(dependency)
 
@@ -170,18 +170,27 @@ module Dependabot
         job.ignore_conditions_for(dependency).any?
       end
 
-      def update_checker_for(dependency, dependency_files, raise_on_ignored:)
+      def update_checker_for(dependency, dependency_files, group, raise_on_ignored:)
         Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
           dependency: dependency,
           dependency_files: dependency_files,
           repo_contents_path: job.repo_contents_path,
           credentials: job.credentials,
-          ignored_versions: job.ignore_conditions_for(dependency),
+          ignored_versions: ignored_versions_for(dependency, group),
           security_advisories: [], # FIXME: Version updates do not use advisory data for now
           raise_on_ignored: raise_on_ignored,
           requirements_update_strategy: job.requirements_update_strategy,
           options: job.experiments
         )
+      end
+
+      def ignored_versions_for(dependency, group)
+        # TODO: Rename job.ignore_conditions_for
+        #
+        # It returns verion ranges which implement IgnoreCondition objects' rules
+        # not the objects themselves so this is a little misleading.
+        versions_ignored_from_configuration = job.ignore_conditions_for(dependency)
+        # group.inject_ignores(configured_ignores)
       end
 
       def log_checking_for_update(dependency)

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Dependabot::ApiClient do
       end
 
       it "flags the PR as having dependency-groups if the dependency change has a dependency group assigned" do
-        group = Dependabot::DependencyGroup.new(name: "dummy-group-name", rules: ["*"])
+        group = Dependabot::DependencyGroup.new(name: "dummy-group-name", rules: { patterns: ["*"] })
 
         grouped_dependency_change = Dependabot::DependencyChange.new(
           job: job,

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -107,10 +107,7 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
 
     context "when the source is a dependency group" do
       let(:change_source) do
-        # FIXME: rules are actually a hash but for the purposes of this pass we can leave it as a list
-        # Once this is refactored we should create a DependencyGroup like so
-        # Dependabot::DependencyGroup.new(name: "dummy-pkg-*", rules: { "patterns" => ["dummy-pkg-*"] })
-        Dependabot::DependencyGroup.new(name: "dummy-pkg-*", rules: ["dummy-pkg-*"])
+        Dependabot::DependencyGroup.new(name: "dummy-pkg-*", rules: { patterns: ["dummy-pkg-*"] })
       end
 
       it "creates a new DependencyChange flagged as a grouped update" do

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Dependabot::DependencyChange do
 
     context "when a dependency group is assigned" do
       it "delegates to the Dependabot::PullRequestCreator::MessageBuilder with the group included" do
-        group = Dependabot::DependencyGroup.new(name: "foo", rules: anything)
+        group = Dependabot::DependencyGroup.new(name: "foo", rules: { patterns: ["*"] })
 
         dependency_change = described_class.new(
           job: job,
@@ -143,7 +143,7 @@ RSpec.describe Dependabot::DependencyChange do
           job: job,
           updated_dependencies: updated_dependencies,
           updated_dependency_files: updated_dependency_files,
-          dependency_group: Dependabot::DependencyGroup.new(name: "foo", rules: anything)
+          dependency_group: Dependabot::DependencyGroup.new(name: "foo", rules: { patterns: ["*"] })
         )
 
         expect(dependency_change.grouped_update?).to be true

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -241,21 +241,21 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         expect(gemfile_lock.content).to eql(fixture("bundler_grouped_by_types/updated_minor_and_patch/Gemfile.lock"))
       end
 
-      # # We should also create isolated PRs for their major versions
-      # expect(mock_service).to receive(:create_pull_request) do |dependency_change|
-      #   expect(dependency_change.dependency_group).to be_nil
+      # We should also create isolated PRs for their major versions
+      expect(mock_service).to receive(:create_pull_request) do |dependency_change|
+        expect(dependency_change.dependency_group).to be_nil
 
-      #   # We updated the right dependencies
-      #   expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rack))
-      # end
+        # We updated the right dependencies
+        expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rack))
+      end
 
-      # # We should also create isolated PRs for their major versions
-      # expect(mock_service).to receive(:create_pull_request) do |dependency_change|
-      #   expect(dependency_change.dependency_group).to be_nil
+      # We should also create isolated PRs for their major versions
+      expect(mock_service).to receive(:create_pull_request) do |dependency_change|
+        expect(dependency_change.dependency_group).to be_nil
 
-      #   # We updated the right dependencies
-      #   expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rubocop))
-      # end
+        # We updated the right dependencies
+        expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rubocop))
+      end
 
       group_update_all.perform
     end

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -245,17 +245,19 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group).to be_nil
 
-        # We updated the right dependencies
-        expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rack))
-      end
+        puts dependency_change.updated_dependencies.map(&:name)
+
+        # # We updated the right dependencies
+        # expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rack))
+      end.twice
 
       # We should also create isolated PRs for their major versions
-      expect(mock_service).to receive(:create_pull_request) do |dependency_change|
-        expect(dependency_change.dependency_group).to be_nil
+      # expect(mock_service).to receive(:create_pull_request) do |dependency_change|
+      #   expect(dependency_change.dependency_group).to be_nil
 
-        # We updated the right dependencies
-        expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rubocop))
-      end
+      #   # # We updated the right dependencies
+      #   # expect(dependency_change.updated_dependencies.map(&:name)).to eql(%w(rubocop))
+      # end
 
       group_update_all.perform
     end

--- a/updater/spec/fixtures/bundler_grouped_by_types/original/Gemfile
+++ b/updater/spec/fixtures/bundler_grouped_by_types/original/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rack", "~> 2.1.4"
+gem "toml-rb", "~> 2.2.0"
+
+group :development do
+  gem "rubocop", "~> 0.76.0"
+end

--- a/updater/spec/fixtures/bundler_grouped_by_types/original/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_grouped_by_types/original/Gemfile.lock
@@ -1,0 +1,35 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    citrus (3.0.2)
+    jaro_winkler (1.5.6)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rack (2.1.4.3)
+    rainbow (3.1.1)
+    rubocop (0.76.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.13.0)
+    toml-rb (2.2.0)
+      citrus (~> 3.0, > 3.0)
+    unicode-display_width (1.6.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack (~> 2.1.4)
+  rubocop (~> 0.76.0)
+  toml-rb (~> 2.2.0)
+
+BUNDLED WITH
+   1.14.6

--- a/updater/spec/fixtures/bundler_grouped_by_types/updated_minor_and_patch/Gemfile
+++ b/updater/spec/fixtures/bundler_grouped_by_types/updated_minor_and_patch/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rack", "~> 2.2.7"
+gem "toml-rb", "~> 2.2.0"
+
+group :development do
+  gem "rubocop", "~> 0.93.1"
+end

--- a/updater/spec/fixtures/bundler_grouped_by_types/updated_minor_and_patch/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_grouped_by_types/updated_minor_and_patch/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    citrus (3.0.2)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rack (2.2.7)
+    rainbow (3.1.1)
+    regexp_parser (2.8.1)
+    rexml (3.2.5)
+    rubocop (0.93.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    toml-rb (2.2.0)
+      citrus (~> 3.0, > 3.0)
+    unicode-display_width (1.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack (~> 2.2.7)
+  rubocop (~> 0.93.1)
+  toml-rb (~> 2.2.0)
+
+BUNDLED WITH
+   1.14.6

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semvar_grouping.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semvar_grouping.yaml
@@ -1,0 +1,39 @@
+job:
+  package-manager: bundler
+  source:
+    provider: github
+    repo: dependabot/smoke-tests
+    directory: "/bundler"
+    branch:
+    api-endpoint: https://api.github.com/
+    hostname: github.com
+  dependencies:
+  existing-pull-requests: []
+  updating-a-pull-request: false
+  lockfile-only: false
+  update-subdependencies: false
+  ignore-conditions: []
+  requirements-update-strategy:
+  allowed-updates:
+  - dependency-type: direct
+    update-type: all
+  credentials-metadata:
+  - type: git_source
+    host: github.com
+  security-advisories: []
+  max-updater-run-time: 2700
+  vendor-dependencies: false
+  experiments:
+    grouped-updates-prototype: true
+  reject-external-code: false
+  commit-message-options:
+    prefix:
+    prefix-development:
+    include-scope:
+  security-updates-only: false
+  dependency-groups:
+  - name: small-bumps
+    rules:
+      update-types:
+        - "version-update:semver-patch"
+        - "version-update:semver-minor"

--- a/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_is_only_grouping_minor-_and_patch-level_changes/creates_a_group_PR_for_minor-_and_patch-level_changes_and_individual_PRs_for_major-level_changes.yml
+++ b/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_is_only_grouping_minor-_and_patch-level_changes/creates_a_group_PR_for_minor-_and_patch-level_changes_and_individual_PRs_for_major-level_changes.yml
@@ -1,0 +1,2536 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rack.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '9130'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Wed, 14 Jun 2023 02:01:53 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A1269705373217865435
+      X-Request-Id:
+      - c1f7207f-9e41-4a95-9d7d-7652fcd2f9e6
+      X-Runtime:
+      - '0.046143'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 34.223.193.61:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:19:43 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2614'
+      X-Served-By:
+      - cache-lhr7365-LHR
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689344383.346174,VS0,VE8
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"d036bd62fd9be73c96e87b117101398b"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Leah Neukirchen","built_at":"2023-06-14T00:00:00.000Z","created_at":"2023-06-14T02:01:53.401Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1107716,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.8","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c2c912fb7bb367ddeea98193fc51f2aa526733066d0846911aaddb13a457248"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-16T00:00:00.000Z","created_at":"2023-03-16T02:22:59.785Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":3728313,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.7","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4383a019926cfd250c3027f8cc7064f6859e478871b4e09b9cf967800947e7ce"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:10:08.055Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":266189,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.6.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a3f89e07502bda2f4c866a2fe37f416458c9e1defadc05cd6d8e3991ca63f960"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T06:00:02.662Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":37083,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.6","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"431f49518ddcd70913767aef2327830388eff1de94b3c5be40044af297784d20"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-12T00:00:00.000Z","created_at":"2023-03-12T06:28:17.816Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":25603,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.5","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fb590ecd5ba8a047b18fc991c5235d1501e2dc1be2976e6dac14a63599847adc"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:31.330Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":446505,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5e3f987030d83c8e9477e2002410531943f441df6b8224113039eb3f91fdbb4"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:39.596Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1816901,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6fe0042b786617e966ebc082f76dba624f5167f70acb741209805b216e0d07d7"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-16T00:00:00.000Z","created_at":"2023-01-16T22:41:09.758Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":42127,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"93008e4e29af4ac220ec19ed814f288f0cc27e14b1a4b27216e6e4b7e1e73cf6"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-26T00:00:00.000Z","created_at":"2022-12-26T20:20:10.238Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":685041,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3a3b430e04eb9c5eb1e93502ce80e1c534eb20586eca8d2fbfb1b99960aad300"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-05T00:00:00.000Z","created_at":"2022-12-05T05:13:22.496Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":799314,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7313e1a28e8301e08f86de3ee0c82d9e3e1602586683007fdd018abe5e818420"},{"authors":"Leah
+        Neukirchen","built_at":"2022-11-18T00:00:00.000Z","created_at":"2022-11-18T20:59:51.381Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":587886,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0fe3e8d68b2a4684bcdff0b1fecb0a5e201b7ea3f6fac868fa18d596035eff3c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-09-06T00:00:00.000Z","created_at":"2022-09-06T16:28:59.486Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":2909954,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"197adbbe5d585dca1909fe6c544f369919d795d54fc76f86b6ce458008f6e29c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-09-04T00:00:00.000Z","created_at":"2022-09-04T23:52:01.005Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":846,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0.rc1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.4.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"9ded32f01d520c16076c72649873229fcd83a18e79d9ebd696fc22d34e484088"},{"authors":"Leah
+        Neukirchen","built_at":"2022-08-08T00:00:00.000Z","created_at":"2022-08-08T20:34:51.637Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1901,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0.beta1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.4.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"293cd882966e417d38329ff96b62f3ce1be14cc534cdec22a9150e93ec803cc9"},{"authors":"Leah
+        Neukirchen","built_at":"2023-04-24T00:00:00.000Z","created_at":"2023-04-24T23:22:24.296Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":9520526,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.7","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b3377e8b2227b8ffa6b617ef8649ffb5e265e46ca8fa1f31244c809fe609829b"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:10:14.661Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":11441236,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d3d92be402b5881058caccc0975e6d67a1e0ba929d1d144a43daf689169bfce1"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:25.059Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":3138312,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"421648340bfe81e20fc766304129e08c92d7a661a856466ec2f1c224784a8f9f"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T21:22:23.931Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":11182440,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4be320c0fdea6651f0247dbd4182c1bd8acc06606a6b8935a19ad6a504347763"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:33.530Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":16786,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"252ebd625fa53bbc5aa5aa43cb658d3d92342850898b5f0592dc170d20b8ba88"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-16T00:00:00.000Z","created_at":"2023-01-16T21:05:52.483Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":248891,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d903a6529095f624bb7bd3b6b0e29a1aa0fdcd85d476033648d93e7a68760308"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-26T00:00:00.000Z","created_at":"2022-12-26T20:19:38.461Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":2677954,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.5","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"724426d0d1dd60f35247024413af93f8e1071c7cfe2c012e59503e5bd7f4b293"},{"authors":"Leah
+        Neukirchen","built_at":"2022-06-30T00:00:00.000Z","created_at":"2022-06-30T22:22:23.466Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":40347739,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ea2232b638cbd919129c8c8ad8012ecaccc09f848152a7e705d2139d0137ac2b"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:55.752Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":28458619,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.3.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c728da28f6d800c3839d226fdbce702c94eeb68e25e752b6c2f2be7c1d338ac"},{"authors":"Leah
+        Neukirchen","built_at":"2020-06-15T00:00:00.000Z","created_at":"2020-06-15T22:25:14.574Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":169337514,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2638e7eb6689a5725c7e16f30cc4aa4e31694dc3ca30d790952526781bd0bb44"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-10T00:00:00.000Z","created_at":"2020-02-10T22:25:17.510Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":17003097,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"77f51f9a1409e388a7c002612311fc8cef06f70309eba90800dc6a8d884eb782"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-09T00:00:00.000Z","created_at":"2020-02-09T06:20:24.822Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":194726,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"da7f8ccc5dcdc4a25a6fc7086e6969f32ded6d70ae3d79bb8fe6c30c4bd67fbc"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:26:43.205Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":46342,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.0","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"740433e3a52f9862f508db646e7d324eb209db02572a633de01e406483c29cf3"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:19.576Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":41953,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9b421416c3dd3ea788bcfe642ce9da7622cd5a7fd684fdc7262f5f6028f50f85"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:28.897Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":86357,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42eff000e8df7e9ac284deb30b9140570592be565582d84768825e2354a9b77c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:49.864Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":431390,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af609439fca4ac98fb3d9a5f82800d37c2758ebe50c2bbeb4d4d1db568ebe47d"},{"authors":"Leah
+        Neukirchen","built_at":"2020-06-15T00:00:00.000Z","created_at":"2020-06-15T22:24:45.579Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":3088713,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bfae1fd43aab62bb60b268329c860f214d2ffb15c4bca48931135a2dea52e2f4"},{"authors":"Leah
+        Neukirchen","built_at":"2020-05-12T00:00:00.000Z","created_at":"2020-05-12T21:44:50.346Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":137080,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f8088454a5ad6974e5710cb7441c233773bb2871610aa802009c6e86c0f2f916"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-27T00:00:00.000Z","created_at":"2020-01-27T22:42:41.077Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":3340150,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c45c0dac286ae71afe8d74265ccfb39a2ba36950e44b8ebe4ae43237c060a13"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-11T00:00:00.000Z","created_at":"2020-01-11T22:18:36.652Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":1685043,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dc6653775cc44febfc82132783e0a7d7284cf248d42c0c13bd77ecc327b79375"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-10T00:00:00.000Z","created_at":"2020-01-10T17:49:19.823Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":93277,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d0a52989ce13125be491dd30e6b6c23c539ecf0cc404b2cb5d862dddbcb3e68"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:12.585Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":73881,"metadata":{},"number":"2.0.9.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c38013104cf9f83d645bd7ad9c036e96d0e8ee4dfc6891cde4480274bfbbd79"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:23.635Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":49750,"metadata":{},"number":"2.0.9.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b1cfbe2f35832ce9d06e9bf52d5d5b2ef75f0960ce90f3d8c8890ed71bdd93e"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:43.757Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":643061,"metadata":{},"number":"2.0.9.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3cc510b7943eb9d963ad028438501f06c6f909377ffe58206339fa2b73cd61d3"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:21:51.799Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":6450875,"metadata":{},"number":"2.0.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"733a9e53a7470c472d58b94532d70d6e31edb49245ca6449333f53df4598bfd7"},{"authors":"Leah
+        Neukirchen","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T18:08:51.732Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":10774791,"metadata":{},"number":"2.0.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f98171fb30e104950abe1e9fb97c177d8bb5643dd649bc2ed837864eb596a0c5"},{"authors":"Leah
+        Neukirchen","built_at":"2019-04-02T00:00:00.000Z","created_at":"2019-04-02T16:54:37.554Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":36329344,"metadata":{},"number":"2.0.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5158fb64313c17fb2535c8e5def3de7e8b38baf2ab9e4c90155ebed5a9db207d"},{"authors":"Leah
+        Neukirchen","built_at":"2018-11-05T00:00:00.000Z","created_at":"2018-11-05T20:00:33.151Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":25266876,"metadata":{},"number":"2.0.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5874ac9c2223ecc65fcad3120c884fc2a868c1c18f548ff676a6eb21bda8fdd"},{"authors":"Leah
+        Neukirchen","built_at":"2018-04-23T00:00:00.000Z","created_at":"2018-04-23T17:47:56.538Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":20603428,"metadata":{},"number":"2.0.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"81e3ece3d36e7507ff6a05666cc2ff759bdd08a96aefb8c5fd6c309a8f5d1095"},{"authors":"Christian
+        Neukirchen","built_at":"2018-01-31T00:00:00.000Z","created_at":"2018-01-31T18:17:19.593Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":7674794,"metadata":{},"number":"2.0.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2700d52bdc681b103e161d1da2b3767850e58f3de80e87d16e232491058fd9d5"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-15T00:00:00.000Z","created_at":"2017-05-15T16:50:19.287Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":16195009,"metadata":{},"number":"2.0.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c1c9bbafd74f11c78a29bd87c72a70e7b5b872712d1768ab83b33fec57d9fcd"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-08T00:00:00.000Z","created_at":"2017-05-08T17:08:46.316Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":24832790,"metadata":{},"number":"2.0.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b9009b9acbefd85bea220ca13011e6f0f76630169289d9e433a0558dc73542d2"},{"authors":"Christian
+        Neukirchen","built_at":"2016-06-30T00:00:00.000Z","created_at":"2016-06-30T17:34:18.298Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":9677816,"metadata":{},"number":"2.0.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"61f78033bf5b1cd0221549ecce7c7b73205d4634b0e63c66e1f295dcf3c26b14"},{"authors":"Christian
+        Neukirchen","built_at":"2016-05-06T00:00:00.000Z","created_at":"2016-05-06T20:52:56.316Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":162356,"metadata":{},"number":"2.0.0.rc1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f5b00b0977166f79073c79b2b1d11fc7fe335697e05eafde380379ddf253ba77"},{"authors":"Christian
+        Neukirchen","built_at":"2015-12-17T00:00:00.000Z","created_at":"2015-12-17T21:34:53.915Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":249233,"metadata":{},"number":"2.0.0.alpha","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f6d4e7b7673f1d3d09e52c9b0d7fbfd7702f23f6d14f82e8283e19460bb223f9"},{"authors":"Christian
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:19:58.581Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":18427637,"metadata":{},"number":"1.6.13","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"207e60f917a7b47cb858a6e813500bc6042a958c2ca9eeb64631b19cde702173"},{"authors":"Christian
+        Neukirchen","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T18:08:57.819Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2228070,"metadata":{},"number":"1.6.12","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"928527a0897796d2575e8cacdfa526341dc4c55d05e09b31c39b3704c80738e6"},{"authors":"Christian
+        Neukirchen","built_at":"2018-11-05T00:00:00.000Z","created_at":"2018-11-05T20:00:22.853Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":19109195,"metadata":{},"number":"1.6.11","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"},{"authors":"Christian
+        Neukirchen","built_at":"2018-04-23T00:00:00.000Z","created_at":"2018-04-23T17:52:31.754Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":9663889,"metadata":{},"number":"1.6.10","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"58e8ae09c502f219a6ad2e7f932072faf2d2b38ce6fd0251ac7ff3096c55c046"},{"authors":"Christian
+        Neukirchen","built_at":"2018-02-27T00:00:00.000Z","created_at":"2018-02-27T17:19:24.605Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2484253,"metadata":{},"number":"1.6.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0764d8edafbd52a1055966045a27d1c73fb572a18db5151c000887444bcc810f"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-16T00:00:00.000Z","created_at":"2017-05-16T21:29:10.758Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":23132492,"metadata":{},"number":"1.6.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eae37ccb7686b2c672f64bc6be366cfda4d828ea58e1086cb82766b17a54a7a6"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-15T00:00:00.000Z","created_at":"2017-05-15T16:47:41.052Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":49528,"metadata":{},"number":"1.6.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"485c1bf52521ff354be7dd2a9f529423ee976a51ddec5aace4cf2eebc2ce9c59"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-08T00:00:00.000Z","created_at":"2017-05-08T17:07:35.278Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":1610843,"metadata":{},"number":"1.6.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5d098ff67ab8c44a9a9007a445fac67db7f53075d943bda0ec6439fc64366d1c"},{"authors":"Christian
+        Neukirchen","built_at":"2016-11-10T00:00:00.000Z","created_at":"2016-11-10T21:55:00.409Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":10723972,"metadata":{},"number":"1.6.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ff9d8fc9e89af3f59ba1708d5dec642e3ec421dbeca567bc460b5b8ba0efe48c"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T21:51:38.677Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":38305888,"metadata":{},"number":"1.6.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"455ec4545a54b40dae9937bc5f61ee0e32134191cc1ef9a7959a19ec4b127a25"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T18:45:14.478Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":15970,"metadata":{},"number":"1.6.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4da0c396487e0914cd380c9ec43d4511992756d2c0fa079f70de0a03651cd783"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T17:59:02.851Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":499503,"metadata":{},"number":"1.6.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"89278d4842d0ecdd1e79cbf7a894dc86f976e6d25debc6814343298fd19ed017"},{"authors":"Christian
+        Neukirchen","built_at":"2015-05-06T00:00:00.000Z","created_at":"2015-05-06T18:37:48.080Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2791350,"metadata":{},"number":"1.6.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4017a0a84dd36f1a6b38baa081731e3696a356f8f83ed74a09ff109afd9e338"},{"authors":"Christian
+        Neukirchen","built_at":"2014-12-18T00:00:00.000Z","created_at":"2014-12-18T22:45:11.060Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":25591746,"metadata":{},"number":"1.6.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b6941d48013bc605538fc453006a9df18114ddf0757a3cd69cfbd5c3b72a7b8"},{"authors":"Christian
+        Neukirchen","built_at":"2014-11-27T00:00:00.000Z","created_at":"2014-11-27T18:52:53.658Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":101987,"metadata":{},"number":"1.6.0.beta2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"078f2babefc7c659f1833f08e03ca79cb1a8ab80f2a6cb6fec057b9f60e7a494"},{"authors":"Christian
+        Neukirchen","built_at":"2014-08-18T00:00:00.000Z","created_at":"2014-08-18T19:02:15.332Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":350114,"metadata":{},"number":"1.6.0.beta","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"fbfe6d3f321a863809ade0c8fb5db95721ddd95831d01342623123789c596125"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T18:46:19.771Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":9136217,"metadata":{},"number":"1.5.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ae4a74f555008ecc541060515c37baa9e16f131538447a668c0bf52117c43b7"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T17:58:54.690Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":258310,"metadata":{},"number":"1.5.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"401f8725be81ca60a4c8366fca674a9f18e9bc577b6ad4f42c9f66d763107e6e"},{"authors":"Christian
+        Neukirchen","built_at":"2015-05-06T00:00:00.000Z","created_at":"2015-05-06T18:43:23.519Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":498785,"metadata":{},"number":"1.5.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b4cbe46b77cd1887c8175bd5f08b1644ab4397122edc1bb1551c9e14390100f"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:14:13.517Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":45811781,"metadata":{},"number":"1.5.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"e64af00234e8faaa69ea81ef4e3800f40743c69560f0dda8fc9969660e775fa7"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-28T00:00:00.000Z","created_at":"2013-01-28T22:52:21.850Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":477888,"metadata":{},"number":"1.5.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"398896c8a109b402d4f62b7fc3b93f65249b3ffd8024ca8127a763a1a0fa6f84"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-22T00:00:00.000Z","created_at":"2013-01-22T07:40:50.789Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":209690,"metadata":{},"number":"1.5.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"d0ac19e607aae98dc2ebe9e45b0d07405efae90a43874cfa5b7a47e4f76af624"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:10:44.503Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":5133,"metadata":{},"number":"1.5.0.beta.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":[],"requirements":null,"sha":"9e6b45061429c21a9c50fe5252efb83f3faf1f54e2bfcf629d1a9d5a2340c2ed"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-11T00:00:00.000Z","created_at":"2013-01-11T22:58:13.295Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":4940,"metadata":{},"number":"1.5.0.beta.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":[],"requirements":null,"sha":"92a8748082af00c11b47df71f66ce04e96b724d8a67c51dc301b56a955312468"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T21:12:18.862Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":11906984,"metadata":{},"number":"1.4.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":[],"requirements":[],"sha":"fa06e970605808834fc7e5a8b9babd4871d7d4c23a4d9d61cb94cbd4c15de5e6"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T20:47:05.112Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":99389,"metadata":{},"number":"1.4.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":[],"requirements":[],"sha":"f65ad9022e83e6517d6e3e37cecb781cd172061e769068334bab142d3435f13d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:13:08.844Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":17810070,"metadata":{},"number":"1.4.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"f7bf3faa8e09a2ff26475372de36a724e7470d6bdc33d189a0ec34b49605f308"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:07:50.276Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":872297,"metadata":{},"number":"1.4.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"7f8b61b0d1f65279474f09e0a92d121dfd0d0651843755a0f152e8f02c281dc0"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T18:49:46.932Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":582717,"metadata":{},"number":"1.4.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"e16392baa87833c0eb51afcec13f96a521339af183032fa211b6d31e57f320df"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:43:24.200Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":34391,"metadata":{},"number":"1.4.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"cf09934534722129318d8049fdc98bf319a3e9254565e0edc31529fed889b840"},{"authors":"Christian
+        Neukirchen","built_at":"2012-01-23T00:00:00.000Z","created_at":"2012-01-23T06:51:48.577Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":9621708,"metadata":{},"number":"1.4.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2005d0cee536e76b5d0dc853778e3f7840e98c38380265d6d2c45e44dee7a3b3"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:56:39.698Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":225508,"metadata":{},"number":"1.4.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"09b3fbc957e182b00db573b0693014065745432f4bc53920e8d019e4a7cfb896"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:11:09.654Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":817312,"metadata":{},"number":"1.3.10","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"7a7e3e07181d05dc39bdfa566c4025c126a1eb9ac0f434848a9ea0a9c127d9b6"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:07:05.217Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":53129,"metadata":{},"number":"1.3.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"c75023e17509f4fdee8f62f86140175c8dd279e0e0b489fd9e2662226640243f"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T18:49:00.051Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":46998,"metadata":{},"number":"1.3.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"977aef187206d8706b074a3f900b1ac1dcdf86eccbfc7fc4b234d821ee1b8015"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:42:07.617Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":6140,"metadata":{},"number":"1.3.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"258d673aedab569c5f9ed6f6bd5c19907b6d948aa92a25aac83afc8a35cc46b9"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:52:24.315Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1064011,"metadata":{},"number":"1.3.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d4090f47205a8af4e602be73cf6e5f94f0c91951cfb4e4682e93fc17b2e670e2"},{"authors":"Christian
+        Neukirchen","built_at":"2011-10-18T00:00:00.000Z","created_at":"2011-10-18T05:33:18.912Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1279976,"metadata":{},"number":"1.3.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"1722c36ea1200116560f7e8973a7675a27e6fc2e08a5cc1c146523351ab6e5e1"},{"authors":"Christian
+        Neukirchen","built_at":"2011-10-01T00:00:00.000Z","created_at":"2011-10-01T20:50:43.592Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":238407,"metadata":{},"number":"1.3.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"347f9bc51d2ecba71caa31e0fe2a0cddf88c0877ba0047ffaa365ee474a0919f"},{"authors":"Christian
+        Neukirchen","built_at":"2011-09-16T00:00:00.000Z","created_at":"2011-09-16T23:32:21.895Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":233256,"metadata":{},"number":"1.3.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"8a32cf05128c1d89f6899ef67826ead71ec44a9c9ff4b7cafcb82eae50cc7e47"},{"authors":"Christian
+        Neukirchen","built_at":"2011-07-26T00:00:00.000Z","created_at":"2011-07-26T01:40:42.197Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1880598,"metadata":{},"number":"1.3.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"f3fc568ecab28b26473c97e5e3a3ff36368128db157d95931b8c28247d263ae3"},{"authors":"Christian
+        Neukirchen","built_at":"2011-07-13T00:00:00.000Z","created_at":"2011-07-13T23:20:57.656Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":79756,"metadata":{},"number":"1.3.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d64b700e33f156fb6e7ddfbafcd6a962b441394f04c31f559e2078c45ceb6b68"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-22T07:00:00.000Z","created_at":"2011-05-23T06:08:16.127Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":384326,"metadata":{},"number":"1.3.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"98c4aa69ea449c54bcb6f5a7417e2bdad1b34a0de20608c0fe8c621b01914aa4"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-19T04:00:00.000Z","created_at":"2011-05-19T17:16:00.870Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":70977,"metadata":{},"number":"1.3.0.beta2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"2ba51abc21a6543d117f1a31318bc3acf41ed90cc5397090857746c01f187555"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-03T07:00:00.000Z","created_at":"2011-05-03T10:39:20.440Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":14791,"metadata":{},"number":"1.3.0.beta","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"a5f8a8a2233e43636c4164c35fe837364a1fb673e52a578c5a73485e5acd2057"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:09:59.888Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1098617,"metadata":{},"number":"1.2.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4b0414a7267d6426d61a105f0ccd75ed0c94cf3ceebb25a0740d3894dbca5cc6"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:05:30.848Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":106722,"metadata":{},"number":"1.2.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"107cee2cda7b9cd4231c849dc9dcf06867beb7c67b64a4066502452908847ac0"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:39:13.764Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":68222,"metadata":{},"number":"1.2.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"673af82991bd3f51f7f063b701abe910c4eca7711b34821a31cee743e48357d7"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:48:19.240Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":849029,"metadata":{},"number":"1.2.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2722169809a6fcd73b395a405e43985af24d0cc005a3f9ec389967ecfc6f2c6c"},{"authors":"Christian
+        Neukirchen","built_at":"2011-09-16T00:00:00.000Z","created_at":"2011-09-17T00:00:17.782Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":516000,"metadata":{},"number":"1.2.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2f0d158a077e40f2150922d0049e33fb21854b1b2d4a795c0bed0a2872fda002"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-23T07:00:00.000Z","created_at":"2011-05-23T07:42:19.332Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1056323,"metadata":{},"number":"1.2.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d1c6f65e54facecd0cd3f06ea60c63a81c8f36497e6ebb575d48cf015b13847f"},{"authors":"Christian
+        Neukirchen","built_at":"2011-03-12T23:00:00.000Z","created_at":"2011-03-13T14:03:14.786Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":4952006,"metadata":{},"number":"1.2.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"6463a86f1d86fa9850f24d32bb398889103c4bca0a1ad34c3f1e6a1cd77e51b3"},{"authors":"Christian
+        Neukirchen","built_at":"2010-06-14T22:00:00.000Z","created_at":"2010-06-15T09:57:28.836Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":3175102,"metadata":{},"number":"1.2.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"72014a9f5b565bd088735f54e6d601a715c5d4d89c89bc387f9ddb9d6f749a2f"},{"authors":"Christian
+        Neukirchen","built_at":"2010-06-12T22:00:00.000Z","created_at":"2010-06-13T17:53:23.974Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":24262,"metadata":{},"number":"1.2.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"dede6fbef9c9f00435d68c90e404e18988dd9e22d4bf3317e7d29b0fa4562f2d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:08:42.626Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1636355,"metadata":{},"number":"1.1.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"fd0aaca346d52758e4b152783418c5b6e04861862001c54a0d3715ed08e0ecb8"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:03:48.342Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":68410,"metadata":{},"number":"1.1.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"49cf6108fb5aa606cd121d63a16ba40bd56af83b8e12d9ea06edafdd58a4926d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:21:38.382Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":43612,"metadata":{},"number":"1.1.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4d8a7504ac93a872712275e4d5a2b6274ea6e17b7e30dd92d49ec73f329b1909"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:37:38.280Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":506516,"metadata":{},"number":"1.1.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"e774004d0229a82835d21fcfed2feda1b0df1fe7e609d3d4324660890a57ac3e"},{"authors":"Christian
+        Neukirchen","built_at":"2011-03-12T23:00:00.000Z","created_at":"2011-03-13T14:02:46.405Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":506170,"metadata":{},"number":"1.1.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"0caaa479982622042c4af7411a3f9b9748c9b3a5a03b60a0991c7e44a22f15f5"},{"authors":"Christian
+        Neukirchen","built_at":"2011-02-28T08:00:00.000Z","created_at":"2011-03-01T06:04:51.617Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":86803,"metadata":{},"number":"1.1.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"89c18ffce62358c17ba8a4674b500635f6a9debb0bd612d816c998ae16be7148"},{"authors":"Christian
+        Neukirchen","built_at":"2011-02-09T08:00:00.000Z","created_at":"2011-02-10T03:12:48.548Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":5420,"metadata":{},"number":"1.1.1.pre","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"ea26b77b9b55d364ec38d649a98901abbd5ab2317906a947532fd96facfc568c"},{"authors":"Christian
+        Neukirchen","built_at":"2010-01-03T23:00:00.000Z","created_at":"2010-01-03T23:15:29.326Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1849970,"metadata":{},"number":"1.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"96c618247e5f53c20ad51de0b7682ca589abe7070ce5325502054f80ed29011f"},{"authors":"Christian
+        Neukirchen","built_at":"2009-10-18T01:00:00.000Z","created_at":"2009-10-18T22:45:05.531Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":1793679,"metadata":{},"number":"1.0.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"78b9d7d82d40a3c2e361fdc93db8652c527d397b4a4eda99e6873e14190ec612"},{"authors":"Christian
+        Neukirchen","built_at":"2009-04-24T22:00:00.000Z","created_at":"2009-07-25T18:02:12.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":88784,"metadata":{},"number":"1.0.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"b1147fd2991884dfbac9b101b0c88a0f0fc71abbd1bd24fb29cde3fdfc8ebd77"},{"authors":"Christian
+        Neukirchen","built_at":"2009-01-08T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":23605,"metadata":{},"number":"0.9.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"0b10d9a9ae7dec712abb18a4e684a660e80c095ee03062dfa48a15f7a643720b"},{"authors":"Christian
+        Neukirchen","built_at":"2009-01-05T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":5197,"metadata":{},"number":"0.9.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"412426b5b2c95d60f014469baabf5ed50fc6cca2ec098b5ad32c24eddfab63de"},{"authors":"Christian
+        Neukirchen","built_at":"2008-08-20T22:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":8555,"metadata":{},"number":"0.4.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"720ce53dfe04ab32724871f135d9fe6b9af79070ab4c2b2b22aaf93aa7fa52dd"},{"authors":"Christian
+        Neukirchen","built_at":"2008-02-25T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":6296,"metadata":{},"number":"0.3.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"344a154a0aeaeff1b7114a62263cd42e902521ff6869e6d7159d76e3df066d82"},{"authors":"Christian
+        Neukirchen","built_at":"2007-05-15T22:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":4830,"metadata":{},"number":"0.2.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"865666f11c3016e89e689078358edb895691170b11482ec252e42ae9c08b0772"},{"authors":"Christian
+        Neukirchen","built_at":"2007-03-02T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":6878,"metadata":{},"number":"0.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"ae2a16ef7744acf003a2f1adc0d8c5cbb3dfa614f6f70f7b99165ba5fad3c0ac"}]'
+  recorded_at: Fri, 14 Jul 2023 14:19:43 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/toml-rb.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2640'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Fri, 15 Jul 2022 09:00:06 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A2776833695039155608
+      X-Request-Id:
+      - 50c450d3-fa97-4f75-8cfe-93bc36e4d2b0
+      X-Runtime:
+      - '0.020500'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 34.223.193.61:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:19:45 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-lcy-eglc8600059-LCY
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1689344386.703924,VS0,VE166
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"7b4f06968d50f51f6a290ce7dacf9e78"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Emiliano Mancuso, Lucas Tolchinsky","built_at":"2022-07-15T00:00:00.000Z","created_at":"2022-07-15T09:00:06.684Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":5839435,"metadata":{},"number":"2.2.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1e2c54ac3cc9d49861004f75f0648b3622ac03a76abe105358c31553227d9a6"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2022-01-27T00:00:00.000Z","created_at":"2022-01-27T10:12:59.502Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":801009,"metadata":{},"number":"2.1.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ced902c8de778cf3556b0c335a383ce24af7b214b57140a2bace51cd2c5f30a2"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2022-01-19T00:00:00.000Z","created_at":"2022-01-19T17:59:09.198Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":27894,"metadata":{},"number":"2.1.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"915ef9d397a0b58413bcffc1a2303e5be1223a34d5debe2330ee4a4b30faca0c"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2021-11-01T00:00:00.000Z","created_at":"2021-11-01T10:37:10.046Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":412300,"metadata":{},"number":"2.1.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"595bc99fda33682dd7e9d18f632444a00bc33ed6960ea35fa2c9d5a7124339d7"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2021-11-01T00:00:00.000Z","created_at":"2021-11-01T10:28:17.330Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":36498,"metadata":{},"number":"2.0.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5715daa5d05ca424829fb54d9e049bf9b2f3687ab1c0261540c027e9945596e"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2019-11-18T00:00:00.000Z","created_at":"2019-11-18T09:46:24.255Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":10358682,"metadata":{},"number":"2.0.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5016c6c77ac72bca5fe67c372722bdfdd4479a6fe1a1c4ff2a486e247849b274"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2019-10-25T00:00:00.000Z","created_at":"2019-10-25T15:21:19.133Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":17614,"metadata":{},"number":"2.0.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"967f44df7882d6494ec773f7126b26803704bc04a20c0cfb78d654220620aa43"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2018-08-16T00:00:00.000Z","created_at":"2018-08-16T10:38:02.132Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":727368,"metadata":{},"number":"1.1.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        1.9","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e70993afeddfee6fc5f01cd168870603a2878011baa0d2c0fcb997724a96047d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-11-25T00:00:00.000Z","created_at":"2017-11-25T12:26:27.634Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":463604,"metadata":{},"number":"1.1.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c43f188f68a8cefa790950e8eb02100164710479c6f6d189cb30098e6b212665"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-10-01T00:00:00.000Z","created_at":"2017-10-02T02:15:21.004Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":248655,"metadata":{},"number":"1.1.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4a674f4d815aabf20f2ed97f7271261f77aabe3b2380b1174fabb5875954c727"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-06-14T00:00:00.000Z","created_at":"2017-06-14T14:54:10.984Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":10768752,"metadata":{},"number":"1.0.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d440e2c075ba681d73c0537938a04f7d280896d75f4352123dbe6c36af8e65f"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-10-22T00:00:00.000Z","created_at":"2016-10-22T21:03:58.526Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":1474462,"metadata":{},"number":"0.3.15","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2e937e6a2ffbe094e166cd662079bd8a4e99703cec9397e02a39c491c21c590f"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-04-18T00:00:00.000Z","created_at":"2016-04-18T12:36:25.934Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":32316,"metadata":{},"number":"0.3.14","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ea2824e01479b653e4648c4a66e1cf5620af8f87e67614b75346b269c23bd5dd"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-04-02T00:00:00.000Z","created_at":"2016-04-02T21:31:13.069Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4018,"metadata":{},"number":"0.3.13","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a5442186b21abb3c9b20e08f1aef4ba469c302c13f0f9c3c3f7d39334d1b6c2b"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-03-10T00:00:00.000Z","created_at":"2016-03-10T13:52:13.108Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":18847,"metadata":{},"number":"0.3.12","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5c605fded9badfd6ee84ef25cda294084235b47312e3b0e5d38560a871ab84f2"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-03-08T00:00:00.000Z","created_at":"2016-03-09T00:00:11.277Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2304,"metadata":{},"number":"0.3.11","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"caf6b55302f4de162fa6a3aeb806792cf3017672ffafae7c7139e0a2632ab48d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-02-23T00:00:00.000Z","created_at":"2016-02-23T15:47:50.855Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":3475,"metadata":{},"number":"0.3.10","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3db4a604458446d2372a0923f38e40eae7d158991c4bf59948a1dc162ec808cf"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-12-28T00:00:00.000Z","created_at":"2015-12-28T15:06:15.159Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":6341,"metadata":{},"number":"0.3.9","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"799894ebffe778b4e7ee121a9aec890548581bb546bd10e7812c3a58886b8c8d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-06-12T00:00:00.000Z","created_at":"2015-06-12T12:34:31.349Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":8230,"metadata":{},"number":"0.3.8","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5c2bf7d0b6545dacef67832aa6008abfb1f8d1faf15f2a93879bcab2dfac7cf3"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-06-08T00:00:00.000Z","created_at":"2015-06-09T01:20:16.618Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2039,"metadata":{},"number":"0.3.7","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"aa66498e2e5ddf60be95ddcdf93e847738d1b430f0d5efac4fde5154c6ae6624"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-22T00:00:00.000Z","created_at":"2015-05-22T20:49:50.980Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2364,"metadata":{},"number":"0.3.6","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d1accad4caa1f0ae44475a04cdad11240b66a38df974898c0db0a7e222bd929"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-14T00:00:00.000Z","created_at":"2015-05-15T00:22:52.510Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2161,"metadata":{},"number":"0.3.5","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b8b137b7e741ce53865cf19898342584ef79e6dbc7d37e3ec40c77eebc52da72"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-13T00:00:00.000Z","created_at":"2015-05-13T23:11:35.823Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2041,"metadata":{},"number":"0.3.4","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af8e3e5894ad875fb3a46cacef4ddece4eba24b6f03e97cb9af7efe4d5414834"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-04-17T00:00:00.000Z","created_at":"2015-04-18T01:08:02.325Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2919,"metadata":{},"number":"0.3.3","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3652aaa990a837ddbe1cd0269ba9d9f1a57e03e7e929eb48877f41ab7f9df103"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-02-19T00:00:00.000Z","created_at":"2015-02-19T14:04:46.429Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4655,"metadata":{},"number":"0.3.0","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"39ab52eb9575a8d7c6e07250cf3fb2194a0dfab72a93233f4dea42e6012d76e8"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-02-05T00:00:00.000Z","created_at":"2015-02-05T12:02:24.579Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2344,"metadata":{},"number":"0.2.1","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"542f9a144200c00fad32ed6d9bd81bf2c4f0a42091b3b159c54ed514a33b5499"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-01-31T00:00:00.000Z","created_at":"2015-01-31T13:21:32.125Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2063,"metadata":{},"number":"0.2.0","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ce285781f13c04dcfff200925c893cdf59f421bb959882683c58482062c4d8b"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2014-03-26T00:00:00.000Z","created_at":"2014-03-26T15:10:52.601Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4838,"metadata":{},"number":"0.1.6","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0541beef8203204a243603f42964958810d33629a6c38a3231936dc28afe6e2d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2014-03-16T00:00:00.000Z","created_at":"2014-03-16T16:57:58.913Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2447,"metadata":{},"number":"0.1.5","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f8df352a62984084c26764adfb0a4a048e8bfa4617ed90edf57063ac65ae05a1"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-10-15T00:00:00.000Z","created_at":"2013-10-15T14:08:12.587Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":5757,"metadata":{},"number":"0.1.4","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4812e0672c7beacb291d4a13b08f0d6ce8c5f392453145896a92b626356f737"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-05-07T00:00:00.000Z","created_at":"2013-05-07T03:49:35.472Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":3224,"metadata":{},"number":"0.1.3","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"04f0a7a1c46ecde6c89bf4bb1f9556bf4336d0fc850333836837b513fa2cae29"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-04-12T00:00:00.000Z","created_at":"2013-04-12T20:23:35.014Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":2538,"metadata":{},"number":"0.1.2","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"509881e2e820c77145f1258669f93b8eea9e5d0dfd4cd1ce3d806077732c386a"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-04-03T00:00:00.000Z","created_at":"2013-04-03T14:37:25.812Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":2475,"metadata":{},"number":"0.1.0","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2bbf858d9f55251df8522671c54972d7b6a3a43e407cd6baa3f7d0a5a5862b2a"}]'
+  recorded_at: Fri, 14 Jul 2023 14:19:45 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rubocop.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18097'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Thu, 13 Jul 2023 11:02:41 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A3925452854273042507
+      X-Request-Id:
+      - a3eb1599-a4a2-4b12-83ef-6507585a3765
+      X-Runtime:
+      - '0.083410'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 44.229.71.21:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:19:46 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2864'
+      X-Served-By:
+      - cache-lhr7380-LHR
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689344386.234549,VS0,VE5
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"d1f4378033d6966704eb6a8baacf9507"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Bozhidar Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-13T00:00:00.000Z","created_at":"2023-07-13T11:02:41.121Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":44963,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f9884d2335026b22c6341355da508cecd3762ea4180e2cf65edcdd07553284c1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-04T00:00:00.000Z","created_at":"2023-07-04T07:34:06.364Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":654568,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e4bc497a45928beb95cf5d2688a4bfe8258b4b778bf41921d6118402da5274ee"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-01T00:00:00.000Z","created_at":"2023-07-01T08:14:24.868Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":145144,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1fe1fd463dfe1cae2c57b9ea60c29c780bbdc7ff8b36173a9197cd17e292da0b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-26T00:00:00.000Z","created_at":"2023-06-26T10:56:26.570Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":324824,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.53/","rubygems_mfa_required":"true"},"number":"1.53.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cf1844ecc1e610dc72116dbfeb39ca1d74c609913203c91f539db313e625bed4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-23T00:00:00.000Z","created_at":"2023-06-23T09:44:11.779Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":101617,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.53/","rubygems_mfa_required":"true"},"number":"1.53.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"01e56decdd30c12163c3ec5784ee6f579e61c939c04edb64d2f74c131272f72c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-12T00:00:00.000Z","created_at":"2023-06-12T08:02:12.517Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":881821,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.52/","rubygems_mfa_required":"true"},"number":"1.52.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"908718035c4771f414280412be0d9168a7abd310da1ab859a50d41bece0dac2f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-02T00:00:00.000Z","created_at":"2023-06-02T09:27:27.204Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":548416,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.52/","rubygems_mfa_required":"true"},"number":"1.52.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a9860af191f6d51696de9ece6ca8c072643ee6c04af4310242b13e642b11ef91"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-05-13T00:00:00.000Z","created_at":"2023-05-13T07:54:17.418Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1311715,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.51/","rubygems_mfa_required":"true"},"number":"1.51.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"beba4c57242d3dfd9561d67f6588e2568a818445d51d172dda836223bfad2300"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-17T00:00:00.000Z","created_at":"2023-04-17T08:12:58.522Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2846277,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7cfeb0616f686ac61d049beae89f31446792d7e9f5728152657548f70aa78650"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-12T00:00:00.000Z","created_at":"2023-04-12T12:52:35.268Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":315171,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"acfcbf5a410f7afe00d42fa696e752646057731396411d5066078ec26b909242"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-11T00:00:00.000Z","created_at":"2023-04-11T07:14:22.682Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":191289,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad8ce5c13982a66c4e9c0d54040e96d210f9f88405e903b0e31081bd53e11dbd"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-03T00:00:00.000Z","created_at":"2023-04-03T07:00:18.540Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":638712,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.49/","rubygems_mfa_required":"true"},"number":"1.49.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d4c09409555ae24bca5b80cce20954544b057c1e7ec89c361f676aaba4b705b6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T06:59:23.990Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2294972,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.48/","rubygems_mfa_required":"true"},"number":"1.48.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"18cf7216ba8febb2f8a2a5978f36c54cfdf0de4427cb190a20fd0ee38ccdbee8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-06T00:00:00.000Z","created_at":"2023-03-06T09:50:13.745Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":724284,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.48/","rubygems_mfa_required":"true"},"number":"1.48.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2a90d242c2155c6d72cfaaf86d68bbbe58a6816cc8b192ac8c6702466c40c231"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-01T00:00:00.000Z","created_at":"2023-03-01T11:21:14.919Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":348336,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.47/","rubygems_mfa_required":"true"},"number":"1.47.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"90c159d8584eca251e90c45112301c4519dea61ecdda11a1ff6e65e4d1f49241"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-22T00:00:00.000Z","created_at":"2023-02-22T18:46:08.467Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":671326,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.46/","rubygems_mfa_required":"true"},"number":"1.46.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad46816d898ceec42babb5564f73d48d95cda7c3950cb4dba61b8252f0404c98"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-08T00:00:00.000Z","created_at":"2023-02-08T17:34:23.239Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1275104,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.45/","rubygems_mfa_required":"true"},"number":"1.45.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5863c6aa3954e62d583f13a51d100bc45040454adca92b5e85ab0e247f251cb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-08T00:00:00.000Z","created_at":"2023-02-08T12:27:53.350Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":36869,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.45/","rubygems_mfa_required":"true"},"number":"1.45.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"283f2aaa2bc2a2e9a14f290ac735c284473c47ec0451d539bf55b0cc7f444d5f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T12:34:55.402Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2229654,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.44/","rubygems_mfa_required":"true"},"number":"1.44.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d734ba640caea1b6de27ed49e9ef7c6206f230aa8aa5e35a5b598aec09419638"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-23T00:00:00.000Z","created_at":"2023-01-23T10:46:02.014Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1486768,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.44/","rubygems_mfa_required":"true"},"number":"1.44.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6152012525035a7cdd62c7a6acede84ac7a25f1880f33a3fc5cfee6bf2295228"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-10T00:00:00.000Z","created_at":"2023-01-10T10:32:39.737Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3864489,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.43/","rubygems_mfa_required":"true"},"number":"1.43.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d08127ff6d99b7217b9ac27b51be872270bc7f19151706d799e18a5e4777adc6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-01T00:00:00.000Z","created_at":"2023-01-01T14:16:25.547Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1444501,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.42/","rubygems_mfa_required":"true"},"number":"1.42.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a8eaa22c3e5c2741229d65804211a9867699fc03e17d3a150fe654b986aa0b6a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-22T00:00:00.000Z","created_at":"2022-12-22T08:40:32.261Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":918293,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.41/","rubygems_mfa_required":"true"},"number":"1.41.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"23fdc9ed8f1f78acda597a4c6d54ace2feafdffc4871fba207ea0afbcc566d57"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-20T00:00:00.000Z","created_at":"2022-12-20T08:41:26.726Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":170222,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.41/","rubygems_mfa_required":"true"},"number":"1.41.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f53c9bbee7ad00e3294379e0f3e702bf4b9a8733bb95c5ff82de6bdd27c77184"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-08T00:00:00.000Z","created_at":"2022-12-08T07:50:52.498Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1057393,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.40/","rubygems_mfa_required":"true"},"number":"1.40.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"031881f824594fdb08713d5187c7bf07a11ff83fda869a7dd2d7765f92846a35"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-11-14T00:00:00.000Z","created_at":"2022-11-14T06:09:18.582Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2415171,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.39/","rubygems_mfa_required":"true"},"number":"1.39.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7ce41a7778f3b65d3b8ca9d39ea360bbe58551fe3b7b2ab2f5b5b7860c9efd3d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-11-01T00:00:00.000Z","created_at":"2022-11-01T07:26:18.895Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3091479,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.38/","rubygems_mfa_required":"true"},"number":"1.38.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"64a64a66d746bd417224c0292d08d8bf5affcfe8fbfc3d50a36810ee8c8a1eba"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-10-24T00:00:00.000Z","created_at":"2022-10-24T06:34:17.041Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1034798,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.37/","rubygems_mfa_required":"true"},"number":"1.37.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c1a5dc9b54913531ae03b6856216487734fba881d5673b77249fe8ff054215f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-10-20T00:00:00.000Z","created_at":"2022-10-20T07:55:22.076Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":267503,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.37/","rubygems_mfa_required":"true"},"number":"1.37.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"285b6e8ac2ba7d7651122974669839cfd64b8a960d3ce29270bd1cb598be250f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-09-01T00:00:00.000Z","created_at":"2022-09-01T07:59:06.750Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":6700612,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.36/","rubygems_mfa_required":"true"},"number":"1.36.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"368e47dcab8417419949bbadb11ec41fd94e6b785f8bff4f9cc56a1ddf60ffac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-22T00:00:00.000Z","created_at":"2022-08-22T05:48:01.573Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1735122,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.35/","rubygems_mfa_required":"true"},"number":"1.35.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d5cf370e27d5e44ed4cd6eeabd5224b21faafa677e6ec0cc0836c847ae3db8d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-12T00:00:00.000Z","created_at":"2022-08-12T12:50:07.105Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":726371,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.35/","rubygems_mfa_required":"true"},"number":"1.35.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7fdcffa6eff2272e0e31993743caec05d1d48e9e6de8d0f6c1a57b4e849183f1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-09T00:00:00.000Z","created_at":"2022-08-09T12:00:48.363Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":375847,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.34/","rubygems_mfa_required":"true"},"number":"1.34.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eed2747f54da1414f6a163442ad9c02d07b93c8b3d5a571e52b22b7cb4e508d8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-09T00:00:00.000Z","created_at":"2022-08-09T05:25:37.049Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":44423,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.34/","rubygems_mfa_required":"true"},"number":"1.34.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c794b2713af8017c3e17941ae42c99000d4188fdfc164fb033c67f8dec1e3f0a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-04T00:00:00.000Z","created_at":"2022-08-04T09:25:43.239Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":643807,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.33/","rubygems_mfa_required":"true"},"number":"1.33.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7613b5d7bced82209ec8d8455f9f0910732dc623e6717a6c21aec45e6f3a389a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-07-21T00:00:00.000Z","created_at":"2022-07-21T10:33:44.211Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2211805,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.32/","rubygems_mfa_required":"true"},"number":"1.32.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"82d2a9c2995324ee0d27b75f4396d30a021e965c0e82c39162e7041a6a386326"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-07-07T00:00:00.000Z","created_at":"2022-07-07T08:04:49.754Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1564030,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"641f15809e4850d86fc9337f8b783b1accd23c16f19e347608ff35fa270dd2f2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-29T00:00:00.000Z","created_at":"2022-06-29T06:55:06.791Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":767564,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bc8cbc2ca284d31785e3379bad610447e4cb43688a6db38c0c4f50c0c3afca19"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-27T00:00:00.000Z","created_at":"2022-06-27T06:28:07.483Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":517874,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a20b666d1702649efff1d27f95cf6fbb412a8d162441afce2def2276b7a104f4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-06T00:00:00.000Z","created_at":"2022-06-06T07:58:39.398Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1912339,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.30/","rubygems_mfa_required":"true"},"number":"1.30.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e1fcbed368d823ff8bbda00819f0abf0d522a914dfe62499884fcb6df0ff1d21"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-26T00:00:00.000Z","created_at":"2022-05-26T06:05:15.705Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1051607,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.30/","rubygems_mfa_required":"true"},"number":"1.30.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"665a7539677efb17bd644106a463047bd4c6a38963fca98fe50189de504109a2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-12T00:00:00.000Z","created_at":"2022-05-12T11:19:28.982Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1944141,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.29/","rubygems_mfa_required":"true"},"number":"1.29.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2880817bba3d1f7f3418a8f50f12de84580f34750aa33b4560be5ddc75ba5c4c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-06T00:00:00.000Z","created_at":"2022-05-06T15:51:42.728Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":575609,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.29/","rubygems_mfa_required":"true"},"number":"1.29.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eb47f76dbc87b5b6eb449ace51a6f2819df2f1ee49734a866554ef80b8f478cc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-25T00:00:00.000Z","created_at":"2022-04-25T06:44:26.428Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4251691,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-21T00:00:00.000Z","created_at":"2022-04-21T12:36:57.304Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":338739,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d608991e7f0038b0bd3012ba5c6e59aba587dc0451a36ee3f970330c380b59c4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-21T00:00:00.000Z","created_at":"2022-04-21T08:07:06.255Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":50800,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"40934c4b94f39b9cd1108b4ace5e39584971bd47ab2fe8a806da08d5078f553d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-08T00:00:00.000Z","created_at":"2022-04-08T06:05:25.410Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1262983,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.27/","rubygems_mfa_required":"true"},"number":"1.27.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"936a444b2915697e8f1f0e97d92e1682260d15cb6209e5279623f765e9b7a901"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-03-22T00:00:00.000Z","created_at":"2022-03-22T11:02:36.495Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2611535,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.26/","rubygems_mfa_required":"true"},"number":"1.26.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4c91b087a10596529fb82146f214824f952e6b2e15977002df54a85b32f2018"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-03-09T00:00:00.000Z","created_at":"2022-03-09T16:40:38.227Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1495983,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.26/","rubygems_mfa_required":"true"},"number":"1.26.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9939f5ded335c505b4f34d856dbbc11138a74ed7c045a09add8837ec96d9860d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-02-03T00:00:00.000Z","created_at":"2022-02-03T06:44:47.250Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4318596,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.25/","rubygems_mfa_required":"true"},"number":"1.25.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"330b7674fd5242a8f10beaebe91098b7f766b3abbbd34000fda57f44a34978d0"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-01-18T00:00:00.000Z","created_at":"2022-01-18T07:45:28.499Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2026973,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.25/","rubygems_mfa_required":"true"},"number":"1.25.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"723149a1d1809a13e61e7352f59b98ecd0f8219b88630030b20a45dc6a712e90"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-12-31T00:00:00.000Z","created_at":"2021-12-31T10:33:10.186Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3488598,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.24/","rubygems_mfa_required":"true"},"number":"1.24.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e01ede58cb413c08e6e5b8c6f4b92ec282e646158774b3f98595ae92c453c7ea"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-12-23T00:00:00.000Z","created_at":"2021-12-23T11:06:39.276Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":618805,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.24/","rubygems_mfa_required":"true"},"number":"1.24.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"104848c84b18417e0c0e7c96670320d028a15a918fe2327ffc86d3c1b83be2c3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-11-15T00:00:00.000Z","created_at":"2021-11-15T08:10:45.792Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4461194,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.23/","rubygems_mfa_required":"true"},"number":"1.23.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b0b110eb9309a750d02f4549dfdc5399d3384ddfd6758cb3e4bd3551a5e3b0e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-27T00:00:00.000Z","created_at":"2021-10-27T13:02:09.306Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2079836,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e10a1a63db9028b173f2b65549477d087a9a23de4d94eb1b89d79db31ee306b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-22T00:00:00.000Z","created_at":"2021-10-22T05:45:22.726Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":506999,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bb760c298b15e5dc1bbbb4e0fb225abf2598b5b30a0c059e805370ce586d0b67"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-04T00:00:00.000Z","created_at":"2021-10-04T03:20:23.304Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1993347,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9171b4a7cea4fc98cb7053df4467ec2ae0bac03e1b6b65802404c84e6a154fa6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-09-29T00:00:00.000Z","created_at":"2021-09-29T07:26:49.236Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":494445,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2784830587b80e019661015ee5c9e030248985dabc590ddd84d7aca0ddc26a81"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-09-13T00:00:00.000Z","created_at":"2021-09-13T13:09:37.203Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1416301,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.21/"},"number":"1.21.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9501707e5d72476e72843242fcd29332a1ccb656a163042462d4b18f2f531abf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-26T00:00:00.000Z","created_at":"2021-08-26T07:51:17.209Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1631684,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.20/"},"number":"1.20.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"46f6c5d45a25f2c75cf8c92149e91e8680dac7f6056ebb92d979f36ff890d17f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T06:55:01.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":917256,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.19/"},"number":"1.19.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c4f8cd8abfd8bb24f4f30a9d9d70118b3bc64a455750c742414b6b540acacbe"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-12T00:00:00.000Z","created_at":"2021-08-12T10:31:19.249Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":486123,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.19/"},"number":"1.19.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ea67b3e0581623e40cfcb58cdb946d11d2aa92b78d42cd050ab6d786d36a716"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-23T00:00:00.000Z","created_at":"2021-07-23T06:12:42.555Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2800474,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.4","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"12c63a283dc90816072392118f7dbfc358febc0648655abd23690905ecbd68d2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-06T00:00:00.000Z","created_at":"2021-07-06T09:15:19.404Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1932748,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3d68b45c160faab94cc544f94d31c0625305ee5faf49415c49edfaa9a9cab110"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-02T00:00:00.000Z","created_at":"2021-07-02T12:18:10.848Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":359662,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b45980977a3adf83ebea10ed31b81611db4713c910b9d4f37144d7e6cff25c2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-30T00:00:00.000Z","created_at":"2021-06-30T05:26:23.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":309363,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33ae45f78d826a5ef9613eebe354a841cee55eb02b826daa4ba7af1fb7d6689c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-29T00:00:00.000Z","created_at":"2021-06-29T05:37:50.088Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":117886,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5de58755d97ca72d25a3cd057cd61ac519a9021787da927f20337ef6676b130"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-15T00:00:00.000Z","created_at":"2021-06-15T10:36:25.983Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1382425,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.17/"},"number":"1.17.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e69e12da57c04241dd7978b43e570e1eed589d486271842b10d9c921a330d052"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-09T00:00:00.000Z","created_at":"2021-06-09T10:46:29.434Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":444164,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.16/"},"number":"1.16.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fd0feb97e7249b890af0d5bf1078d94ac587741a2c88dd0ddfc959b3aa35729a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-01T00:00:00.000Z","created_at":"2021-06-01T07:05:05.867Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1269590,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.16/"},"number":"1.16.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"223c4d1187f34a224ab38e1f180cb390d9209191d268d9040b6315c0bbe65746"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-05-17T00:00:00.000Z","created_at":"2021-05-17T07:17:56.288Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1723486,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.15/"},"number":"1.15.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c783af32a3950d5b5d7b3a59d2517bccc2fce80df44d4cd1baedc6131f20af6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T07:54:36.043Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1665001,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.14/"},"number":"1.14.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f73a95a3aa4999d617678fd5c3559b531d77ef408d44d8ce5dd99d07a2c91232"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-04-20T00:00:00.000Z","created_at":"2021-04-20T08:04:40.949Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1579961,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.13/"},"number":"1.13.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4d24d2557ad91ebf0c316c7da4e4b96c2e293ae32ab6760510bc650e8e91f931"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-04-04T00:00:00.000Z","created_at":"2021-04-04T13:59:28.208Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3355239,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.12/"},"number":"1.12.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2963dc4b3b8e9b2b2d39e8986e5bacbb0246bfb439da03ba4fca5365d4602242"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-03-24T00:00:00.000Z","created_at":"2021-03-24T13:37:11.465Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1118459,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.12/"},"number":"1.12.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dc9150badc782e37fbf572357b132ad3db2a11485635595b269d7bae0c047ec4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-03-01T00:00:00.000Z","created_at":"2021-03-01T07:52:18.929Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2339843,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.11/"},"number":"1.11.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f954e6889e6a5e0b64e973b531e673ec597ff430ddbf50584099d532fad33f7f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-02-15T00:00:00.000Z","created_at":"2021-02-15T13:10:10.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1548449,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.10/"},"number":"1.10.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9fe2014e760ddef3ba9f822a8b6643d175ea8ee622c8240d922204a609378dd9"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-02-01T00:00:00.000Z","created_at":"2021-02-01T07:37:07.234Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1243482,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.9/"},"number":"1.9.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42a43aeea3d87ea429b897c3f18d8b6fddcf99c37d47f413f859f7ebe5f2d71a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-28T00:00:00.000Z","created_at":"2021-01-28T08:18:31.958Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":196991,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.9/"},"number":"1.9.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a99ce92e7b5b2050b75a8885b1ca2a32f7c690222bba3357d566f4495ebee0f3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-11T00:00:00.000Z","created_at":"2021-01-11T11:18:45.376Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1741118,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.8/"},"number":"1.8.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bffc58b0a398bd3fd46ad6f6310befb981e5cd1d706a8f8de18251e981620299"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-07T00:00:00.000Z","created_at":"2021-01-07T08:56:11.791Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":195627,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.8/"},"number":"1.8.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d7a5c2eacd9e1b322a8b910acc1f16c109e793b76f56af435228821b5755989"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-25T00:00:00.000Z","created_at":"2020-12-25T07:22:09.105Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2096631,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.7/"},"number":"1.7.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"343c1b2ebf906a0e889c5135a65227548538e50d8c8aa27b8a150cf8fdf7738a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-10T00:00:00.000Z","created_at":"2020-12-10T07:36:17.340Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1485651,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.6/"},"number":"1.6.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"89b638e3975463d2b0749617ec7a372f3a597bfa2465e1e396aee82824839626"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-09T00:00:00.000Z","created_at":"2020-12-09T12:10:09.487Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":69328,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.6/"},"number":"1.6.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"de769122490a39a283aa99519e54358a4ae84b5a3773d4ed135da750f59dbdef"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-04T00:00:00.000Z","created_at":"2020-12-04T08:48:50.982Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":524422,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e552e6c2a0765a5faea5b0def4c13a6004bcdd2e947eb5693ee3900c5535444c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-02T00:00:00.000Z","created_at":"2020-12-02T16:00:42.960Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":142483,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"481149f40d9e4b45e81ba9df462d943fb1dddadc60b88bf5632e1dcb5278168d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-01T00:00:00.000Z","created_at":"2020-12-01T17:18:15.865Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":42098,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2b1c5101afc230126dc5be1d9a8afa5deda2e9b6a8eb87f032863ab195113ad2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-25T00:00:00.000Z","created_at":"2020-11-25T08:13:43.899Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2324784,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e58c81eb570336047380f2cc179b412eb50ee7560d128395ea535f6e1877fcf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-23T00:00:00.000Z","created_at":"2020-11-23T15:47:06.586Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":274791,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c502ab34cfdffafca465b8ab4338209eaf86f3ac2a015e87caeb49b69e0979f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-23T00:00:00.000Z","created_at":"2020-11-23T09:00:24.039Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":26613,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c01c4658123427d9198c3d20e6fede1d0be555703a84bd8023efdf91dd8a6187"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-16T00:00:00.000Z","created_at":"2020-11-16T08:54:41.526Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":772581,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.3/"},"number":"1.3.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4054ee99368d9e479ef82869e731eccde3055b1a5bcdba02ea077f2411b3eab1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-12T00:00:00.000Z","created_at":"2020-11-12T08:03:01.026Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":232869,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.3/"},"number":"1.3.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7cf281b5e63b87b6caf26a0fc44f98af32b0507898e360ac3a0d8fd824a947ef"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-05T00:00:00.000Z","created_at":"2020-11-05T07:35:20.077Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":601774,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.2/"},"number":"1.2.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"599bb8a001cd4cb0195b8b0b8f055158b93f7bd77fc3a232e5adbdf3bca28715"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-29T00:00:00.000Z","created_at":"2020-10-29T15:18:10.951Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1138970,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.1/"},"number":"1.1.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"146a44a1d0baba33cac6274c0be6a98098cabe38684dff6e1b3929c29f3d88db"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-21T00:00:00.000Z","created_at":"2020-10-21T11:02:00.444Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1129206,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.0/"},"number":"1.0.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c16df6a0a14e370a64ac7de209bba6e8466a0283761373c82b9eff9d0bf988b5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-12T00:00:00.000Z","created_at":"2020-10-12T07:04:17.359Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":17309267,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.93/"},"number":"0.93.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"73b44fbbe872edbd3f14487175b6369a0f48e952c155f305896ffa56c48b195e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-08T00:00:00.000Z","created_at":"2020-10-08T14:53:41.340Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":231477,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.93/"},"number":"0.93.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6a3c6b8e5287ea7b7c729ab51406a163a9894fe0f925f0626b2a9112503c3bdb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-25T00:00:00.000Z","created_at":"2020-09-25T08:12:20.931Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2795477,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.92/"},"number":"0.92.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3653dec299db6290c1f4dd3c4afd47ef76c484185f3642605552547c74672e4b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-23T00:00:00.000Z","created_at":"2020-09-23T09:46:14.960Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2102337,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.91.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"06b08219c476a9507eb8a7f6b026d33f5d463d2a32488a3b80aab06a3e6fd5a6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-15T00:00:00.000Z","created_at":"2020-09-15T05:45:14.063Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":7477294,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.91.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0a836a303d959ba4d35b9c3eb848e4ed54952a4d0037874f0c1067da4721781d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-01T00:00:00.000Z","created_at":"2020-09-01T06:44:59.545Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1644281,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.90.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d3d3acf7dde11cea1c7c18c1baf8cc80124ad02db802eee2a96e03f38c58cf0"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-08-10T00:00:00.000Z","created_at":"2020-08-10T12:17:06.265Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":6383014,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.89.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"30794116b2804aab1abc74780a201fae5160c1d6a21550ce9786abd3ca0e07fa"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-08-05T00:00:00.000Z","created_at":"2020-08-05T19:05:18.634Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":278342,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.89.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ef1aba0c16b4610bfc8e9fdd233707719872b387f4bc9d3fc66829572a9008c2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-13T00:00:00.000Z","created_at":"2020-07-13T12:22:19.339Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3634724,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.88.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d7da9340fce8b64be15077e6ba1f7c60b5b5999901ce2eda9837f9ca08b2fe4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-07T00:00:00.000Z","created_at":"2020-07-07T19:14:41.214Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":628169,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.87.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3df1a0c641feed9004d0dd787e220283cf8a82f8ba24a04a284c4f841dad6029"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-06T00:00:00.000Z","created_at":"2020-07-06T16:12:40.171Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2270072,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.87.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a928b5acff012d15df735ef34978bc099397b12fcaa4025e46c565397e179430"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-22T00:00:00.000Z","created_at":"2020-06-22T07:29:21.381Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":10198589,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.86.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"babe641b554e28d53bad32fd94f90e6d65410fa06fe8a2c511f2aec03b7c83ca"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-07T00:00:00.000Z","created_at":"2020-06-07T15:40:00.351Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1909271,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.85.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d0a0b8a7cf84ed0c5f3a305a48c738b1b8ec8a08affd19e7c5986fd6d5a21bbe"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-01T00:00:00.000Z","created_at":"2020-06-01T15:47:28.436Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":405049,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.85.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3963352c8187a06dbf3f65358ab91eff3502792da8dbb0e8329eeb7fb74715bc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-05-21T00:00:00.000Z","created_at":"2020-05-21T06:57:11.953Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1758131,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.84.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"069f1497ef67aefa360a80aef66375fab2941b85dd09a2a68dcaab3d17a4e5c6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-05-11T00:00:00.000Z","created_at":"2020-05-11T12:28:44.160Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1464282,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.83.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3397a3778ed0fa4d43e69b19f9c421da1925e7a85acc07f5b852aafc7a3c7224"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-04-16T00:00:00.000Z","created_at":"2020-04-16T08:19:59.835Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5393652,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.82.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d6c5bc7d9b9c1ac1e8bb8a724ea761d724661ebec143eb0b92345b5a8e8d25f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-04-01T00:00:00.000Z","created_at":"2020-04-01T07:55:38.383Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4435426,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.81.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3d1ff65d3acf3a4ef1babb4624255268460f5d56ddb8f9c985a731d8ebe80d32"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-02-29T00:00:00.000Z","created_at":"2020-02-29T18:05:39.532Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4071055,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.80.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"485291465f908c08de184932a6ae7a796c8a37dd46020dd5ed21cc46eee117c5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-02-18T00:00:00.000Z","created_at":"2020-02-18T11:59:08.971Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1654053,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.80.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb7ec63f27324162a4d2021104b2d94ea611e7c47995cc8b6f65436ecebeae29"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-01-06T00:00:00.000Z","created_at":"2020-01-06T09:57:25.274Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3872651,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.79.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"325b331102897bd19d08f4e4d18dde806f24cbf5768110663ae16fab1f17a792"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T20:51:20.075Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2073359,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.78.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a013cddb1b1292833fada241aea59b450c2a51d730c556e829572ba69d862bdc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-11-27T00:00:00.000Z","created_at":"2019-11-27T18:03:03.812Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2504506,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.77.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a95b032eeeb52bfd83db802d992a2e98484023b06677f16d5bb5c2f556580855"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-10-28T00:00:00.000Z","created_at":"2019-10-28T14:54:29.237Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3229806,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.76.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"00837450d0eb3d85c7eb32afe909f9536135172df06bdd490ade9c4e7b0ca51f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-10-14T00:00:00.000Z","created_at":"2019-10-14T16:58:16.713Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2144697,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.75.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"360c1d4941881064611feae6b3b9f1535a5e455dd174ced9a4d39b734e0cb868"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-09-30T00:00:00.000Z","created_at":"2019-09-30T17:05:51.523Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1090572,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.75.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4be504c51e6bfbce5070bc853d9bd770a273600eca31820ca1aa3695d66010f4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-07-31T00:00:00.000Z","created_at":"2019-07-31T19:12:04.545Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9937278,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.74.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d3abbf59133f5fce2bea961bb363a3c2f7d2e36ffc30fd11de5c2c9cb456fe72"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-07-16T00:00:00.000Z","created_at":"2019-07-16T08:57:10.832Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1282296,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.73.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0ed89317eba64db6327896303dafad5c1520983e12cb2c21cbb32cac3a62bfac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-06-25T00:00:00.000Z","created_at":"2019-06-25T14:36:09.976Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2975654,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.72.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a20e5b9fe52b337b491d77faea871fe90f8bf2fd5a71b594e76419a852ad5ba4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-30T00:00:00.000Z","created_at":"2019-05-30T13:53:44.134Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2589041,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.71.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb40a9fb646368c867dd3a41753169dee24aa4b819e91f0189a8b8da82cb5e56"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-21T00:00:00.000Z","created_at":"2019-05-21T10:26:46.421Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1374492,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.70.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c938c50fe39ed55458ecf600f316ccbaf51cf5584d1aa83b621ba27ba94f86c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-13T00:00:00.000Z","created_at":"2019-05-13T08:57:55.837Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2838762,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.69.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b1ccb922caf3eb21a97a92fe8cbf62950e4adc215052cde4cfbbc5a8a442bcb2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-30T00:00:00.000Z","created_at":"2019-04-30T19:46:32.378Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2460380,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.68.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af830b7ddf6459700b35225db789e828015df5d96ca40ee438da1115383a39d4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-29T00:00:00.000Z","created_at":"2019-04-29T13:53:42.552Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":441673,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.68.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8a1d642e344ef81164915cf00f021724a2ff1b17ff552369f8be36a7dc672b9c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-05T00:00:00.000Z","created_at":"2019-04-05T07:54:59.405Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1422427,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0029e66eb5c02fca2befdcba5c12c81ca83620c4ad5e1d197fcd35f7a549efb1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-04T00:00:00.000Z","created_at":"2019-04-04T17:13:15.415Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":109969,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c1e929a0aae8b28d75c8ca093a4401e66c2fc91e84f6a8ccb8ad5f22016fd7a2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-04T00:00:00.000Z","created_at":"2019-04-04T15:23:11.383Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":69327,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fe1d716afc92a59180e30e9d62b398a3c069c4ae5bca97b5de6e4d65c6cf9f8c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-03-18T00:00:00.000Z","created_at":"2019-03-18T09:27:01.934Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2638746,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.66.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f05a6896f367765b3f0fba663d0add120444f8de604dada405662b10a0860f5a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-02-19T00:00:00.000Z","created_at":"2019-02-19T08:43:14.568Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2543397,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.65.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c6ffcb57bab1cecbcd0240948c2bba65f422abc1e72bef461fb4f31cd9bbd19a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-02-10T00:00:00.000Z","created_at":"2019-02-10T13:54:58.751Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3548206,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.64.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"726debef2d860b3855f683c5051121046b99197b39459620dd137266a789501f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-22T00:00:00.000Z","created_at":"2019-01-22T03:02:01.872Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2261948,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.63.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e8a8fadbe248ff9c3727b603d66f23658fe1e1965ae07571365b34a390600df"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-16T00:00:00.000Z","created_at":"2019-01-16T16:32:03.430Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":454259,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.63.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"81b091cf498be83ecb01be8ea5c265c0231eed14d9ee00b872cd10859dca8d65"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-01T00:00:00.000Z","created_at":"2019-01-01T08:40:22.886Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1150333,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.62.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"73bb7e9b97e35444c37a9164e5a644518807fba613a790e1e234ae9b7fcfca0e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-12-06T00:00:00.000Z","created_at":"2018-12-06T08:18:53.311Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1913537,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.61.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8650301567ee5a4867dbb9ba9ca9987d7dc8a9166ee3136c41c03906cc935ada"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-12-05T00:00:00.000Z","created_at":"2018-12-05T12:42:54.009Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":117528,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.61.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"18a30bb68d42e8cc3fd1a0aac37c86db46c99fae2edae7bb9dc49eed8f41864c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-10-26T00:00:00.000Z","created_at":"2018-10-26T10:41:04.209Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2214871,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.60.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"31d8b34585456ce0f0e79d6411c3b7e705ac571996876d9815e1d6f1130173c7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-24T00:00:00.000Z","created_at":"2018-09-24T05:19:49.887Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2845536,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.59.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a6888aef273e586226013355db553bca6c7acd81ca5771d749d69a883dc92004"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-15T00:00:00.000Z","created_at":"2018-09-15T07:45:31.993Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":809343,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.59.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b449177a369193559dabbbbd4fff967c1b2bd817bd78134b6082f1d1dd5e443"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-09T00:00:00.000Z","created_at":"2018-09-09T16:24:47.204Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":814558,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.59.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"455597f026940948d5c46a84660a0a944f07d6cf27f497d7147bc49626ced183"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-23T00:00:00.000Z","created_at":"2018-07-23T18:01:18.681Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5832269,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"43dab6c9d6c72844cbd028140ee7c60190c5ee6e30417d63480da3f413778139"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-10T00:00:00.000Z","created_at":"2018-07-10T07:31:15.576Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":851783,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"26ca690212ae00b00435e767f9b3f46ffb1f1143a5f25fe728e638d15ba65868"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-07T00:00:00.000Z","created_at":"2018-07-07T12:38:26.296Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":186151,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e3b24a143239f4752f4a4e5e09ebb6ff41bb302db34771489db6ef4b728d3a24"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-12T00:00:00.000Z","created_at":"2018-06-12T09:05:03.272Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2268800,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"468ca03be186a4c39f75535ad445bb073408cf2c75035105ac6b91dc04d9cbac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-06T00:00:00.000Z","created_at":"2018-06-06T22:57:40.803Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":273581,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad25fe52d9be12bb0662dd32e84cc72067f2ab516a14bb5d557dfec15a74a2e6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-06T00:00:00.000Z","created_at":"2018-06-06T00:53:30.394Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":116952,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cbce208bac27d4368ebe1a7892b37674399ad274b18888259be8b305a368e644"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-05-14T00:00:00.000Z","created_at":"2018-05-14T15:17:56.916Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1890797,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.56.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"687f9418a1475911fdd0cf7c57009620daef2caffe5692b621dc6d1abfb04212"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-04-16T00:00:00.000Z","created_at":"2018-04-16T09:20:00.851Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3726977,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.55.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"21fc1b25eee37a6b601144b02f2b90d608555aa09aafbf57f03636828d99169f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-03-21T00:00:00.000Z","created_at":"2018-03-21T03:01:01.664Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4980214,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.54.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3a2208fe1166b22e109b3a184aa0bd26e04d16e78587b9c714e63980694ade80"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-03-05T00:00:00.000Z","created_at":"2018-03-05T01:51:12.010Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1133004,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.53.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ce9862b128c49183b2bf2b3416825557ca99bddd504eb1a9f815e8039f201b28"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-12-27T00:00:00.000Z","created_at":"2017-12-27T13:31:06.690Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":7027154,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.52.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ec659892e86c64ec25e7a543b4a717f9ee6e9450bdb9541e0d3492b43ce4234"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-12-12T00:00:00.000Z","created_at":"2017-12-12T13:56:04.078Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":944665,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.52.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"291bcca376e76b5bada3ee91c938a4354e384d3d87278ab54b22bde660b520bd"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-10-18T00:00:00.000Z","created_at":"2017-10-18T19:13:19.013Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3324028,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.51.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c131a5c063600cd31cf49c69130c16b94a6bd7d6a35f6f00c587ac6330bdc233"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-09-14T00:00:00.000Z","created_at":"2017-09-14T18:13:15.476Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3320407,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.50.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9f7610b37b6746609c932ec8ac5b1a9b4b56f7526018c941393e79b2d93fedc2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-05-29T00:00:00.000Z","created_at":"2017-05-29T12:34:28.077Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10729177,"metadata":{},"number":"0.49.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bcb37220633a570611b68bf8d4649414624d90fad83a7bf8310940f61df51ed7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-05-24T00:00:00.000Z","created_at":"2017-05-24T05:33:44.287Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":341250,"metadata":{},"number":"0.49.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3af20292590127c5e5a67a08e84642bb9d1f555cb8ed16717980c8b524ed038f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-04-03T00:00:00.000Z","created_at":"2017-04-03T11:29:58.977Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2587737,"metadata":{},"number":"0.48.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"002f6b49013abdc05c68ae75433c48d3ee7f1baa70674d60bf1cc310e210fbd7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-03-26T00:00:00.000Z","created_at":"2017-03-26T09:53:19.789Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":198786,"metadata":{},"number":"0.48.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cca38e2b3ba3496fa63dbe747baa9eff7f9717631df1221467618b54773fd690"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-01-18T00:00:00.000Z","created_at":"2017-01-18T02:22:18.664Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3107764,"metadata":{},"number":"0.47.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a7066a0c553e3bad1f118062deef5f05d050a6cf11cb9c9cda067b2a891a7916"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-01-16T00:00:00.000Z","created_at":"2017-01-16T01:37:21.113Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":94953,"metadata":{},"number":"0.47.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"55d32c0b5b42f7ac5b6ede9ef4f6a1e6605bc28f8cb38db1c796042ad71f5bd3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-11-30T00:00:00.000Z","created_at":"2016-11-30T06:56:04.929Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2006777,"metadata":{},"number":"0.46.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c5087c157b6070319d06cab7594f9f72b5478344a2568b7029875a081c20418"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-31T00:00:00.000Z","created_at":"2016-10-31T09:31:11.908Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":913383,"metadata":{},"number":"0.45.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c579b99be005868127c26d18d8ebfc2e71ed4ebacf781896a837cac6f128248f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-13T00:00:00.000Z","created_at":"2016-10-13T14:55:04.417Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":452029,"metadata":{},"number":"0.44.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2f702937dce43bed412c186dadd3727a769e837bd82263ee7687f37050c324ec"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-13T00:00:00.000Z","created_at":"2016-10-13T14:05:27.902Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5836,"metadata":{},"number":"0.44.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b124c8255b6570964a53e9d17d3861970d71788f8caa7819335cfac291eb8093"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-09-19T00:00:00.000Z","created_at":"2016-09-19T08:02:45.931Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":935620,"metadata":{},"number":"0.43.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"125e352d5ad65cae73f33572fde0f4793ca8ef7823263935e93ff0c2cd265764"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-07-25T00:00:00.000Z","created_at":"2016-07-25T09:16:51.982Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1762837,"metadata":{},"number":"0.42.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1bfd76aa1f6e266d459a7776e5de13956595aca4718758f593b5800c9d809918"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-07-07T00:00:00.000Z","created_at":"2016-07-07T11:55:00.995Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1662643,"metadata":{},"number":"0.41.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9ef6e6a8de0ee0f45305beaae85645bb050e443c237ce91ab488268540ca4d09"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-06-26T00:00:00.000Z","created_at":"2016-06-26T08:50:26.134Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":377179,"metadata":{},"number":"0.41.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f6c7d8a9a9b4fecbe89a851c38bc549c8d1d4744f57bde383aa33884d4ef661"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-06-25T00:00:00.000Z","created_at":"2016-06-25T17:50:26.038Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":51250,"metadata":{},"number":"0.41.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9580eb20ce098b7a0c06730f92e07ff71da25b803b5a28580ea571b17422e008"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-05-09T00:00:00.000Z","created_at":"2016-05-09T17:45:53.078Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1491089,"metadata":{},"number":"0.40.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ddca83f353721240eb3563c2d9b5fb7e9928845058a6a49f23aab79d25ca83f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-03-27T00:00:00.000Z","created_at":"2016-03-27T11:16:21.158Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1656502,"metadata":{},"number":"0.39.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5600c0f7268778520598394cc9ceed69ca3df2a874f2881dfd1d17ba336427bb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-03-09T00:00:00.000Z","created_at":"2016-03-09T15:10:05.281Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":643291,"metadata":{},"number":"0.38.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4094e2c4b9e0827191c55ab59fd8813e41f40f5c83717b5a143f108b4ac1fc61"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-11T00:00:00.000Z","created_at":"2016-02-11T12:50:57.031Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":884482,"metadata":{},"number":"0.37.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d65255d1f072bf737cef74c0cfca50de448bd8428644fa3c4e8880698856be2a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-09T00:00:00.000Z","created_at":"2016-02-09T16:45:33.535Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":63427,"metadata":{},"number":"0.37.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1dbc993cd8c0f1afb90a913b4ef6fa83400809d2b30079a877f52358e498bcc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-04T00:00:00.000Z","created_at":"2016-02-04T06:37:12.148Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":110681,"metadata":{},"number":"0.37.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c8979d3c94088d7e7f38f412efb91a74b2b0c97b3eadf35d7d2645b676508ae1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-01-14T00:00:00.000Z","created_at":"2016-01-14T18:22:21.651Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1303480,"metadata":{},"number":"0.36.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e613b68a72930726a8aab8fba7afffef0b162edaa67b271b491fd18c6c350fec"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-11-10T00:00:00.000Z","created_at":"2015-11-10T17:09:13.947Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1589756,"metadata":{},"number":"0.35.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4f0b3ce1e3f9e6bb2b1409a3c49dbf7e4a682b7b083ee5ff20d5cee6846a38bf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-11-07T00:00:00.000Z","created_at":"2015-11-07T06:46:41.231Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":252121,"metadata":{},"number":"0.35.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c7b4d9f1bfd1dfb4730519979f6fb283518b945ebe3bb7fc21b2a89ecb7979ff"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-21T00:00:00.000Z","created_at":"2015-09-21T14:50:42.260Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1221792,"metadata":{},"number":"0.34.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d387d22b07c8ba54043d742ee7738dd31440808e371e86502e6d06fbf5d22b7a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-09T00:00:00.000Z","created_at":"2015-09-09T11:29:19.149Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":144484,"metadata":{},"number":"0.34.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0d904489dca12ab4005c358d74057e197266a2571c9feafc15a37bbe3c3b13f8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-05T00:00:00.000Z","created_at":"2015-09-05T05:06:00.263Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":60635,"metadata":{},"number":"0.34.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e704f43bc99114ca93d78cef7937d5a7aebde105613bf82ec86612a8efb44bc3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-08-05T00:00:00.000Z","created_at":"2015-08-05T12:17:28.842Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":549755,"metadata":{},"number":"0.33.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8910c66466538d01d0abbf21aa099b15901e4fc9c20394cf1ba9ef9f357b4a8c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-06-24T00:00:00.000Z","created_at":"2015-06-24T06:17:18.900Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":563974,"metadata":{},"number":"0.32.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fa2a1ea1a069436b991ce4d4c4c45682d1e9e83cc9e609dc181eb786e93641d5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-06-06T00:00:00.000Z","created_at":"2015-06-06T09:02:54.433Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":209433,"metadata":{},"number":"0.32.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"091830914416431bd8217855ccf2e23a82865519e97dbe309501184529efe25e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-05-05T00:00:00.000Z","created_at":"2015-05-05T17:06:13.868Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":457915,"metadata":{},"number":"0.31.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f44b741edaa71337b8bce7a08e966630035a178034a4308de483e92cb02989e3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-04-21T00:00:00.000Z","created_at":"2015-04-21T11:54:36.285Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":403211,"metadata":{},"number":"0.30.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f6fbe1c3236e4472365a7c726c2bf4c0f066b241dbecd274a3b296cc19dfbe50"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-04-06T00:00:00.000Z","created_at":"2015-04-06T15:38:28.162Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":263978,"metadata":{},"number":"0.30.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ac19d6befb873d5b16dd10f8000ed5b579708e3a883ba5140bc4c21ae5a93923"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-02-13T00:00:00.000Z","created_at":"2015-02-13T09:44:57.178Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":745802,"metadata":{},"number":"0.29.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fdef20af47f52e8130d39665fb5770fdc7cb72d9c5a5ba56078e0fe2c325f50c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-02-05T00:00:00.000Z","created_at":"2015-02-05T20:28:53.282Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":68163,"metadata":{},"number":"0.29.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ed2b625e9884ff66a606f60d4b725f5bba747c05591c3dca0e426afd35f8135e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-12-10T00:00:00.000Z","created_at":"2014-12-10T17:17:29.029Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":836332,"metadata":{},"number":"0.28.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8db05151c0af7fbb334d0326c587f6515380122a17ed726d0936dc16147cc41e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-11-08T00:00:00.000Z","created_at":"2014-11-08T11:26:10.904Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":538657,"metadata":{},"number":"0.27.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e0f5190a96b82917bd2a15de027d252218830efdfee98bcca3cd3fd8a0e38d24"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-10-30T00:00:00.000Z","created_at":"2014-10-30T16:43:32.213Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":43688,"metadata":{},"number":"0.27.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5729bcce45721e6c9a9139e44df8c26872ff97927fa0df382ed82d1b932593e4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-09-18T00:00:00.000Z","created_at":"2014-09-18T12:10:31.079Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":685934,"metadata":{},"number":"0.26.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c49f376e77808c8b07578c3d4cdfb6c73f1fd530941ba724303a354498d2cabb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-09-03T00:00:00.000Z","created_at":"2014-09-03T12:35:37.840Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":104378,"metadata":{},"number":"0.26.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"773ed161beab33976b5760a2f5db27db3447726dd1389212c60668889f9e6091"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-08-15T00:00:00.000Z","created_at":"2014-08-15T11:19:31.470Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":84177,"metadata":{},"number":"0.25.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8ec2267e73031a0056e3cda5332d81774c3102acb8afb0ec5131f28de26dd662"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-07-03T00:00:00.000Z","created_at":"2014-07-03T11:40:30.994Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":243573,"metadata":{},"number":"0.24.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c58201dcd9e9cb364a5865b71d29c1371379c3c6c6896d6aaef292d0468bc54"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-06-25T00:00:00.000Z","created_at":"2014-06-25T06:50:13.105Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":39968,"metadata":{},"number":"0.24.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d27a16864c907fd7a1ea463c6cc4ccbda6671b12255e497fceaa080315f0c90d"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-06-02T00:00:00.000Z","created_at":"2014-06-02T12:19:23.545Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":221306,"metadata":{},"number":"0.23.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"82de5ffe9e7acd0a4d5846fbad8805303cf7764955ccba375640ff9d6871a2f1"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-05-20T00:00:00.000Z","created_at":"2014-05-20T14:36:31.896Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":39364,"metadata":{},"number":"0.22.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"888b5a1aba5991169ccb8ba81b9880ef1a190f431252c4174dbcd05c366dcb15"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-24T00:00:00.000Z","created_at":"2014-04-24T09:41:19.853Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":143066,"metadata":{},"number":"0.21.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"93667e72149fd96897c5e410827dab5b260a95666549b7885d5b334b1eaadd1e"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:16:27.467Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":86299,"metadata":{},"number":"0.20.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42577cc435ac444c8f9fb8659c99721416b6046a3db499f6434464cd7cb09aa5"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-02T00:00:00.000Z","created_at":"2014-04-02T14:03:48.747Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":18769,"metadata":{},"number":"0.20.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1d9bf34022495497bafc86d30443ba5d9732553d3e966c26250956dc33431627"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-03-17T00:00:00.000Z","created_at":"2014-03-17T15:57:49.176Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":158596,"metadata":{},"number":"0.19.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"271e424a97876d4c94ba07f8b65fc56356d19f1ae8b2c0ef4e767e970dafb352"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-03-13T00:00:00.000Z","created_at":"2014-03-13T16:07:32.092Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":11148,"metadata":{},"number":"0.19.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"37f30df2bfabf7d2e66b6efcbbc6d646db9389c26e94bbc2fa86c1d8e62e563f"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-02-02T00:00:00.000Z","created_at":"2014-02-02T10:11:48.216Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":193027,"metadata":{},"number":"0.18.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a8e35b2f2b25cf5306866b821002f35b2c35d221598c1d376df8d497940ba253"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-01-30T00:00:00.000Z","created_at":"2014-01-30T16:11:12.247Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":15517,"metadata":{},"number":"0.18.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b0e26be25eb9154938b665685aec57fc1b6956d825e7a05d17373bb4b729681"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-01-23T00:00:00.000Z","created_at":"2014-01-23T15:44:06.875Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":29939,"metadata":{},"number":"0.17.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"529e1af94a20544424c6d7603ca62459acdfe10466503416a6eae5c0d3fb67e3"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-12-25T00:00:00.000Z","created_at":"2013-12-25T18:01:42.589Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":58737,"metadata":{},"number":"0.16.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c14fd2a1f918227e105be122e2500b62b94ef9ac454b2e01fc528bbd4da66aa0"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-11-06T00:00:00.000Z","created_at":"2013-11-06T14:55:07.694Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":58828,"metadata":{},"number":"0.15.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"794a5f1839bac8bf728a44291598ba4040a90dd164878adb0d82c192dcd10279"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-10-10T00:00:00.000Z","created_at":"2013-10-10T09:22:35.405Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":62994,"metadata":{},"number":"0.14.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6e164c3d0a55e543012eb814e11b25c431d32a04393b6f86ebbad6d21a493f2c"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-10-07T00:00:00.000Z","created_at":"2013-10-07T11:55:17.164Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":8065,"metadata":{},"number":"0.14.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5d16dd4e7e012b4414afc57691e6ae4902a96cd63f2a3462ac5ca5423a6c78e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-09-19T00:00:00.000Z","created_at":"2013-09-19T11:17:32.222Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":30924,"metadata":{},"number":"0.13.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"53a38480d2217ea4f0076485cc3eddb3baece8e69179e144177af38ab860e4f0"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-09-13T00:00:00.000Z","created_at":"2013-09-13T14:12:11.377Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10563,"metadata":{},"number":"0.13.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"693f24feec332394ff817e95c1d27000ab843802de02ee232c47711e497bddd2"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-23T00:00:00.000Z","created_at":"2013-08-23T08:20:14.993Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":23320,"metadata":{},"number":"0.12.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6935abc7d1cc704bf2c96646b1441270c3415ab8be1a7776686ff36ad3cd38bc"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-12T00:00:00.000Z","created_at":"2013-08-12T08:41:14.761Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":16320,"metadata":{},"number":"0.11.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8b8155e9b786c8e2bb8699875c4351e50b093b9dced4097d1be176b426306981"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-09T00:00:00.000Z","created_at":"2013-08-09T14:44:40.288Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4998,"metadata":{},"number":"0.11.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"edf8fcf8682ccdbf9ff65e4365fcba0f203777471f6afdb58f31a5327881636d"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-17T00:00:00.000Z","created_at":"2013-07-17T18:38:32.352Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":15250,"metadata":{},"number":"0.10.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"5542215006b235d0ade4dda74b23d5d22d47cad02100a0e31bb097d80d7c8431"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-05T00:00:00.000Z","created_at":"2013-07-05T15:13:09.528Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9983,"metadata":{},"number":"0.9.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"cea12e9561a37ca065cd05c613735406fe8ff86d9015cc80cb02d8f9fc4c3131"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-01T00:00:00.000Z","created_at":"2013-07-01T12:57:41.924Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":13648,"metadata":{},"number":"0.9.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"846a289554c4716fd4ff3f890a954ecce2895a9a6e913d4617f21dea5f522361"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-06-18T12:41:29.955Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9723,"metadata":{},"number":"0.8.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"30178ff21ee90e5e760c7ea40f448c46efab17c5ab9263e4f9df470d8ef008e3"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-06-05T11:46:36.612Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":6417,"metadata":{},"number":"0.8.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a853697357734fa301a3594bcc457b068be4056fe19cc420abe68531a771936c"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-30T08:11:17.673Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5339,"metadata":{},"number":"0.8.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7d008670bf5a3aa378e78ea78024670bd83f38b188c82b1b64d1858ab5d6cf29"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-28T09:06:01.240Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5374,"metadata":{},"number":"0.8.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2e7d746c66b0c8d3ab9d1ed9c3ccb827b8c4325cb8ea835d8becec870be2b70f"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-13T07:00:10.330Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10444,"metadata":{},"number":"0.7.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"36c0574cc728e120e593fcf84fa0a01a36aa948096cdccdbd9f3eb3f9a0d3011"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-11T12:01:12.103Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3969,"metadata":{},"number":"0.7.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"5a8fb4c2cb9270b9fc5c325d8bb7f556233e472a82d1b02ab8501041c7c35d16"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-11T05:40:16.929Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3958,"metadata":{},"number":"0.7.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"3a9096d62151fb4dffebc3fd2f672b238172af945890156923ffc60ebe1eef7a"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-28T12:44:09.481Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":5363,"metadata":{},"number":"0.6.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2cc2d86791a143c791ac99b566d99e920873d086e7b7a9daed69fe5546d4dad6"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-23T11:23:04.364Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4895,"metadata":{},"number":"0.6.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"53702a3cd38c916ab3b57e2a84a5a1af68350dedd83e1b5f5a2dfd786612789a"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-17T15:09:32.991Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":10850,"metadata":{},"number":"0.5.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"3ba57b2986af5eb7521aa4f5b4fbc2b6b9b5177b398eecee02bbb1411983d7a6"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-15T00:00:00.000Z","created_at":"2013-04-15T13:21:26.422Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4783,"metadata":{},"number":"0.4.6","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"714b451a1e3cdc7e11e407c06028e3cad0d77c74aa5f1ba623029d2d12c1eca7"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-15T00:00:00.000Z","created_at":"2013-04-15T13:18:31.196Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3797,"metadata":{},"number":"0.4.5","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"e95b05fa17998d7eb195244d8be36d836f28b60d23cd754349684309a5cd7999"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-14T00:00:00.000Z","created_at":"2013-04-14T14:26:04.168Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3934,"metadata":{},"number":"0.4.4","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"aeacff29f694b02465fbff9c089f3bb57c2f27d15734935764e14d3beadfce7b"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-14T00:00:00.000Z","created_at":"2013-04-14T06:10:31.699Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3904,"metadata":{},"number":"0.4.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"81c55e8dae6e379f92ea47898daf0e138ba9d84102225e26a82fa9d51f75e4ec"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-13T00:00:00.000Z","created_at":"2013-04-13T19:20:43.281Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3853,"metadata":{},"number":"0.4.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a4086d3db38c363a0143a8d4ff7b00f03eb91ddc01081604b9812524d50d5991"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-13T00:00:00.000Z","created_at":"2013-04-13T11:20:04.189Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3821,"metadata":{},"number":"0.4.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7173b29a39b02640c4ce5d9b285527978b5f256056b3f85c0f33c894ad476570"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-11T00:00:00.000Z","created_at":"2013-04-11T09:45:55.167Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4375,"metadata":{},"number":"0.4.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"ce4270b896e61800e286def6324c8d471cc13185cc9270ebe98b9390da0ba480"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-06T00:00:00.000Z","created_at":"2013-04-06T17:24:51.540Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3888,"metadata":{},"number":"0.3.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"d3c2ae557b75d78c05624c51fc2ce6e42e41102da11323f164f25581f82a5d4b"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-02-28T00:00:00.000Z","created_at":"2013-02-28T20:45:07.073Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":10386,"metadata":{},"number":"0.3.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"10be88926012cf90ecb86e1289252fd0cd4fd7973e7c34854d03ced3f219f68e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T15:55:45.093Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4241,"metadata":{},"number":"0.3.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a54c7d286347e81af34c0381aa41bd5bfeba13f19d27fdd7b6fc9d81a18faf65"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-01-12T00:00:00.000Z","created_at":"2013-01-12T15:56:50.441Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4273,"metadata":{},"number":"0.2.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7c6fb4f739334b6ab3312b8efe99dc8e8c4ec4965657146287d25f82f4e0459e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-01-02T00:00:00.000Z","created_at":"2013-01-02T19:42:27.672Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3996,"metadata":{},"number":"0.2.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"b4f367fbe644fc6947c07172b7a0a022c726efb5efcfa3390dd1c69e6ee808cc"},{"authors":"Bozhidar
+        Batsov","built_at":"2012-12-20T00:00:00.000Z","created_at":"2012-12-20T09:56:20.974Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":11241,"metadata":{},"number":"0.1.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"68930de9ca68b1efbe8c39c7835b818bfed303c0b13fdd9682b5d2b0f170310c"},{"authors":"Bozhidar
+        Batsov","built_at":"2012-05-03T00:00:00.000Z","created_at":"2012-05-03T12:36:58.944Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4263,"metadata":{},"number":"0.0.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"4d4405e8735e7cc4f310c02eb0085f394f5c235ff6777dfd4cc0e36ba1e5b94f"}]'
+  recorded_at: Fri, 14 Jul 2023 14:19:46 GMT
+recorded_with: VCR 6.1.0

--- a/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_is_only_grouping_minor-_and_patch-level_changes/creates_a_group_PR_for_minor-_and_patch-level_changes_and_individual_PRs_for_major-level_changes.yml
+++ b/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_is_only_grouping_minor-_and_patch-level_changes/creates_a_group_PR_for_minor-_and_patch-level_changes_and_individual_PRs_for_major-level_changes.yml
@@ -2533,4 +2533,2537 @@ http_interactions:
         Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"4d4405e8735e7cc4f310c02eb0085f394f5c235ff6777dfd4cc0e36ba1e5b94f"}]'
   recorded_at: Fri, 14 Jul 2023 14:19:46 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rubocop.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18107'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Thu, 13 Jul 2023 11:02:41 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A856491194179219697
+      X-Request-Id:
+      - dce31ddb-29f9-4f4f-af59-091af1210cea
+      X-Runtime:
+      - '0.083905'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 44.229.71.21:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:55:04 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2992'
+      X-Served-By:
+      - cache-lcy-eglc8600050-LCY
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689346504.449906,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"d1f4378033d6966704eb6a8baacf9507"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Bozhidar Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-13T00:00:00.000Z","created_at":"2023-07-13T11:02:41.121Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":45904,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f9884d2335026b22c6341355da508cecd3762ea4180e2cf65edcdd07553284c1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-04T00:00:00.000Z","created_at":"2023-07-04T07:34:06.364Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":656456,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e4bc497a45928beb95cf5d2688a4bfe8258b4b778bf41921d6118402da5274ee"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-07-01T00:00:00.000Z","created_at":"2023-07-01T08:14:24.868Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":145207,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.54/","rubygems_mfa_required":"true"},"number":"1.54.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1fe1fd463dfe1cae2c57b9ea60c29c780bbdc7ff8b36173a9197cd17e292da0b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-26T00:00:00.000Z","created_at":"2023-06-26T10:56:26.570Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":325005,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.53/","rubygems_mfa_required":"true"},"number":"1.53.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cf1844ecc1e610dc72116dbfeb39ca1d74c609913203c91f539db313e625bed4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-23T00:00:00.000Z","created_at":"2023-06-23T09:44:11.779Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":101651,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.53/","rubygems_mfa_required":"true"},"number":"1.53.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"01e56decdd30c12163c3ec5784ee6f579e61c939c04edb64d2f74c131272f72c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-12T00:00:00.000Z","created_at":"2023-06-12T08:02:12.517Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":882102,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.52/","rubygems_mfa_required":"true"},"number":"1.52.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"908718035c4771f414280412be0d9168a7abd310da1ab859a50d41bece0dac2f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-06-02T00:00:00.000Z","created_at":"2023-06-02T09:27:27.204Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":548523,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.52/","rubygems_mfa_required":"true"},"number":"1.52.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a9860af191f6d51696de9ece6ca8c072643ee6c04af4310242b13e642b11ef91"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-05-13T00:00:00.000Z","created_at":"2023-05-13T07:54:17.418Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1311930,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.51/","rubygems_mfa_required":"true"},"number":"1.51.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"beba4c57242d3dfd9561d67f6588e2568a818445d51d172dda836223bfad2300"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-17T00:00:00.000Z","created_at":"2023-04-17T08:12:58.522Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2847252,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7cfeb0616f686ac61d049beae89f31446792d7e9f5728152657548f70aa78650"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-12T00:00:00.000Z","created_at":"2023-04-12T12:52:35.268Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":315188,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"acfcbf5a410f7afe00d42fa696e752646057731396411d5066078ec26b909242"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-11T00:00:00.000Z","created_at":"2023-04-11T07:14:22.682Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":191319,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.50/","rubygems_mfa_required":"true"},"number":"1.50.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad8ce5c13982a66c4e9c0d54040e96d210f9f88405e903b0e31081bd53e11dbd"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-04-03T00:00:00.000Z","created_at":"2023-04-03T07:00:18.540Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":638754,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.49/","rubygems_mfa_required":"true"},"number":"1.49.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d4c09409555ae24bca5b80cce20954544b057c1e7ec89c361f676aaba4b705b6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T06:59:23.990Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2295222,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.48/","rubygems_mfa_required":"true"},"number":"1.48.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"18cf7216ba8febb2f8a2a5978f36c54cfdf0de4427cb190a20fd0ee38ccdbee8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-06T00:00:00.000Z","created_at":"2023-03-06T09:50:13.745Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":724318,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.48/","rubygems_mfa_required":"true"},"number":"1.48.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2a90d242c2155c6d72cfaaf86d68bbbe58a6816cc8b192ac8c6702466c40c231"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-03-01T00:00:00.000Z","created_at":"2023-03-01T11:21:14.919Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":348356,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.47/","rubygems_mfa_required":"true"},"number":"1.47.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"90c159d8584eca251e90c45112301c4519dea61ecdda11a1ff6e65e4d1f49241"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-22T00:00:00.000Z","created_at":"2023-02-22T18:46:08.467Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":671380,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.46/","rubygems_mfa_required":"true"},"number":"1.46.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad46816d898ceec42babb5564f73d48d95cda7c3950cb4dba61b8252f0404c98"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-08T00:00:00.000Z","created_at":"2023-02-08T17:34:23.239Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1275145,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.45/","rubygems_mfa_required":"true"},"number":"1.45.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5863c6aa3954e62d583f13a51d100bc45040454adca92b5e85ab0e247f251cb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-02-08T00:00:00.000Z","created_at":"2023-02-08T12:27:53.350Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":36871,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.45/","rubygems_mfa_required":"true"},"number":"1.45.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"283f2aaa2bc2a2e9a14f290ac735c284473c47ec0451d539bf55b0cc7f444d5f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T12:34:55.402Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2229817,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.44/","rubygems_mfa_required":"true"},"number":"1.44.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d734ba640caea1b6de27ed49e9ef7c6206f230aa8aa5e35a5b598aec09419638"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-23T00:00:00.000Z","created_at":"2023-01-23T10:46:02.014Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1486788,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.44/","rubygems_mfa_required":"true"},"number":"1.44.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6152012525035a7cdd62c7a6acede84ac7a25f1880f33a3fc5cfee6bf2295228"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-10T00:00:00.000Z","created_at":"2023-01-10T10:32:39.737Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3864615,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.43/","rubygems_mfa_required":"true"},"number":"1.43.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d08127ff6d99b7217b9ac27b51be872270bc7f19151706d799e18a5e4777adc6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2023-01-01T00:00:00.000Z","created_at":"2023-01-01T14:16:25.547Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1444592,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.42/","rubygems_mfa_required":"true"},"number":"1.42.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a8eaa22c3e5c2741229d65804211a9867699fc03e17d3a150fe654b986aa0b6a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-22T00:00:00.000Z","created_at":"2022-12-22T08:40:32.261Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":918564,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.41/","rubygems_mfa_required":"true"},"number":"1.41.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"23fdc9ed8f1f78acda597a4c6d54ace2feafdffc4871fba207ea0afbcc566d57"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-20T00:00:00.000Z","created_at":"2022-12-20T08:41:26.726Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":170228,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.41/","rubygems_mfa_required":"true"},"number":"1.41.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f53c9bbee7ad00e3294379e0f3e702bf4b9a8733bb95c5ff82de6bdd27c77184"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-12-08T00:00:00.000Z","created_at":"2022-12-08T07:50:52.498Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1057425,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.40/","rubygems_mfa_required":"true"},"number":"1.40.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"031881f824594fdb08713d5187c7bf07a11ff83fda869a7dd2d7765f92846a35"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-11-14T00:00:00.000Z","created_at":"2022-11-14T06:09:18.582Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2415285,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.39/","rubygems_mfa_required":"true"},"number":"1.39.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7ce41a7778f3b65d3b8ca9d39ea360bbe58551fe3b7b2ab2f5b5b7860c9efd3d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-11-01T00:00:00.000Z","created_at":"2022-11-01T07:26:18.895Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3091614,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.38/","rubygems_mfa_required":"true"},"number":"1.38.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"64a64a66d746bd417224c0292d08d8bf5affcfe8fbfc3d50a36810ee8c8a1eba"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-10-24T00:00:00.000Z","created_at":"2022-10-24T06:34:17.041Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1034823,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.37/","rubygems_mfa_required":"true"},"number":"1.37.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c1a5dc9b54913531ae03b6856216487734fba881d5673b77249fe8ff054215f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-10-20T00:00:00.000Z","created_at":"2022-10-20T07:55:22.076Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":267503,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.37/","rubygems_mfa_required":"true"},"number":"1.37.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"285b6e8ac2ba7d7651122974669839cfd64b8a960d3ce29270bd1cb598be250f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-09-01T00:00:00.000Z","created_at":"2022-09-01T07:59:06.750Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":6700743,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.36/","rubygems_mfa_required":"true"},"number":"1.36.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"368e47dcab8417419949bbadb11ec41fd94e6b785f8bff4f9cc56a1ddf60ffac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-22T00:00:00.000Z","created_at":"2022-08-22T05:48:01.573Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1735203,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.35/","rubygems_mfa_required":"true"},"number":"1.35.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d5cf370e27d5e44ed4cd6eeabd5224b21faafa677e6ec0cc0836c847ae3db8d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-12T00:00:00.000Z","created_at":"2022-08-12T12:50:07.105Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":726383,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.35/","rubygems_mfa_required":"true"},"number":"1.35.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7fdcffa6eff2272e0e31993743caec05d1d48e9e6de8d0f6c1a57b4e849183f1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-09T00:00:00.000Z","created_at":"2022-08-09T12:00:48.363Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":375882,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.34/","rubygems_mfa_required":"true"},"number":"1.34.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eed2747f54da1414f6a163442ad9c02d07b93c8b3d5a571e52b22b7cb4e508d8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-09T00:00:00.000Z","created_at":"2022-08-09T05:25:37.049Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":44426,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.34/","rubygems_mfa_required":"true"},"number":"1.34.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c794b2713af8017c3e17941ae42c99000d4188fdfc164fb033c67f8dec1e3f0a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-08-04T00:00:00.000Z","created_at":"2022-08-04T09:25:43.239Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":643821,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.33/","rubygems_mfa_required":"true"},"number":"1.33.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7613b5d7bced82209ec8d8455f9f0910732dc623e6717a6c21aec45e6f3a389a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-07-21T00:00:00.000Z","created_at":"2022-07-21T10:33:44.211Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2211863,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.32/","rubygems_mfa_required":"true"},"number":"1.32.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"82d2a9c2995324ee0d27b75f4396d30a021e965c0e82c39162e7041a6a386326"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-07-07T00:00:00.000Z","created_at":"2022-07-07T08:04:49.754Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1564102,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"641f15809e4850d86fc9337f8b783b1accd23c16f19e347608ff35fa270dd2f2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-29T00:00:00.000Z","created_at":"2022-06-29T06:55:06.791Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":767590,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bc8cbc2ca284d31785e3379bad610447e4cb43688a6db38c0c4f50c0c3afca19"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-27T00:00:00.000Z","created_at":"2022-06-27T06:28:07.483Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":517921,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.31/","rubygems_mfa_required":"true"},"number":"1.31.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a20b666d1702649efff1d27f95cf6fbb412a8d162441afce2def2276b7a104f4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-06-06T00:00:00.000Z","created_at":"2022-06-06T07:58:39.398Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1912373,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.30/","rubygems_mfa_required":"true"},"number":"1.30.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e1fcbed368d823ff8bbda00819f0abf0d522a914dfe62499884fcb6df0ff1d21"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-26T00:00:00.000Z","created_at":"2022-05-26T06:05:15.705Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1051616,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.30/","rubygems_mfa_required":"true"},"number":"1.30.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"665a7539677efb17bd644106a463047bd4c6a38963fca98fe50189de504109a2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-12T00:00:00.000Z","created_at":"2022-05-12T11:19:28.982Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1944207,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.29/","rubygems_mfa_required":"true"},"number":"1.29.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2880817bba3d1f7f3418a8f50f12de84580f34750aa33b4560be5ddc75ba5c4c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-05-06T00:00:00.000Z","created_at":"2022-05-06T15:51:42.728Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":575611,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.29/","rubygems_mfa_required":"true"},"number":"1.29.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.6.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eb47f76dbc87b5b6eb449ace51a6f2819df2f1ee49734a866554ef80b8f478cc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-25T00:00:00.000Z","created_at":"2022-04-25T06:44:26.428Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4251892,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-21T00:00:00.000Z","created_at":"2022-04-21T12:36:57.304Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":338743,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d608991e7f0038b0bd3012ba5c6e59aba587dc0451a36ee3f970330c380b59c4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-21T00:00:00.000Z","created_at":"2022-04-21T08:07:06.255Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":50802,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.28/","rubygems_mfa_required":"true"},"number":"1.28.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"40934c4b94f39b9cd1108b4ace5e39584971bd47ab2fe8a806da08d5078f553d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-04-08T00:00:00.000Z","created_at":"2022-04-08T06:05:25.410Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1263052,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.27/","rubygems_mfa_required":"true"},"number":"1.27.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"936a444b2915697e8f1f0e97d92e1682260d15cb6209e5279623f765e9b7a901"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-03-22T00:00:00.000Z","created_at":"2022-03-22T11:02:36.495Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2611593,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.26/","rubygems_mfa_required":"true"},"number":"1.26.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4c91b087a10596529fb82146f214824f952e6b2e15977002df54a85b32f2018"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-03-09T00:00:00.000Z","created_at":"2022-03-09T16:40:38.227Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1495993,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.26/","rubygems_mfa_required":"true"},"number":"1.26.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9939f5ded335c505b4f34d856dbbc11138a74ed7c045a09add8837ec96d9860d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-02-03T00:00:00.000Z","created_at":"2022-02-03T06:44:47.250Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4318750,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.25/","rubygems_mfa_required":"true"},"number":"1.25.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"330b7674fd5242a8f10beaebe91098b7f766b3abbbd34000fda57f44a34978d0"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2022-01-18T00:00:00.000Z","created_at":"2022-01-18T07:45:28.499Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2027012,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.25/","rubygems_mfa_required":"true"},"number":"1.25.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"723149a1d1809a13e61e7352f59b98ecd0f8219b88630030b20a45dc6a712e90"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-12-31T00:00:00.000Z","created_at":"2021-12-31T10:33:10.186Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3488628,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.24/","rubygems_mfa_required":"true"},"number":"1.24.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e01ede58cb413c08e6e5b8c6f4b92ec282e646158774b3f98595ae92c453c7ea"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-12-23T00:00:00.000Z","created_at":"2021-12-23T11:06:39.276Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":618867,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.24/","rubygems_mfa_required":"true"},"number":"1.24.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"104848c84b18417e0c0e7c96670320d028a15a918fe2327ffc86d3c1b83be2c3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-11-15T00:00:00.000Z","created_at":"2021-11-15T08:10:45.792Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":4461250,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.23/","rubygems_mfa_required":"true"},"number":"1.23.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b0b110eb9309a750d02f4549dfdc5399d3384ddfd6758cb3e4bd3551a5e3b0e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-27T00:00:00.000Z","created_at":"2021-10-27T13:02:09.306Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2079895,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e10a1a63db9028b173f2b65549477d087a9a23de4d94eb1b89d79db31ee306b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-22T00:00:00.000Z","created_at":"2021-10-22T05:45:22.726Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":507010,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bb760c298b15e5dc1bbbb4e0fb225abf2598b5b30a0c059e805370ce586d0b67"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-10-04T00:00:00.000Z","created_at":"2021-10-04T03:20:23.304Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1993371,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9171b4a7cea4fc98cb7053df4467ec2ae0bac03e1b6b65802404c84e6a154fa6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-09-29T00:00:00.000Z","created_at":"2021-09-29T07:26:49.236Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":494456,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.22/"},"number":"1.22.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2784830587b80e019661015ee5c9e030248985dabc590ddd84d7aca0ddc26a81"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-09-13T00:00:00.000Z","created_at":"2021-09-13T13:09:37.203Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1416312,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.21/"},"number":"1.21.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9501707e5d72476e72843242fcd29332a1ccb656a163042462d4b18f2f531abf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-26T00:00:00.000Z","created_at":"2021-08-26T07:51:17.209Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1631694,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.20/"},"number":"1.20.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"46f6c5d45a25f2c75cf8c92149e91e8680dac7f6056ebb92d979f36ff890d17f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T06:55:01.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":917256,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.19/"},"number":"1.19.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c4f8cd8abfd8bb24f4f30a9d9d70118b3bc64a455750c742414b6b540acacbe"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-08-12T00:00:00.000Z","created_at":"2021-08-12T10:31:19.249Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":486130,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.19/"},"number":"1.19.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ea67b3e0581623e40cfcb58cdb946d11d2aa92b78d42cd050ab6d786d36a716"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-23T00:00:00.000Z","created_at":"2021-07-23T06:12:42.555Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2800598,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.4","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"12c63a283dc90816072392118f7dbfc358febc0648655abd23690905ecbd68d2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-06T00:00:00.000Z","created_at":"2021-07-06T09:15:19.404Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1932756,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3d68b45c160faab94cc544f94d31c0625305ee5faf49415c49edfaa9a9cab110"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-07-02T00:00:00.000Z","created_at":"2021-07-02T12:18:10.848Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":359664,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b45980977a3adf83ebea10ed31b81611db4713c910b9d4f37144d7e6cff25c2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-30T00:00:00.000Z","created_at":"2021-06-30T05:26:23.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":309363,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33ae45f78d826a5ef9613eebe354a841cee55eb02b826daa4ba7af1fb7d6689c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-29T00:00:00.000Z","created_at":"2021-06-29T05:37:50.088Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":117886,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.18/"},"number":"1.18.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5de58755d97ca72d25a3cd057cd61ac519a9021787da927f20337ef6676b130"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-15T00:00:00.000Z","created_at":"2021-06-15T10:36:25.983Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1382437,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.17/"},"number":"1.17.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e69e12da57c04241dd7978b43e570e1eed589d486271842b10d9c921a330d052"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-09T00:00:00.000Z","created_at":"2021-06-09T10:46:29.434Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":444165,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.16/"},"number":"1.16.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fd0feb97e7249b890af0d5bf1078d94ac587741a2c88dd0ddfc959b3aa35729a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-06-01T00:00:00.000Z","created_at":"2021-06-01T07:05:05.867Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1269600,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.16/"},"number":"1.16.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"223c4d1187f34a224ab38e1f180cb390d9209191d268d9040b6315c0bbe65746"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-05-17T00:00:00.000Z","created_at":"2021-05-17T07:17:56.288Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1723498,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.15/"},"number":"1.15.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c783af32a3950d5b5d7b3a59d2517bccc2fce80df44d4cd1baedc6131f20af6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T07:54:36.043Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1665025,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.14/"},"number":"1.14.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f73a95a3aa4999d617678fd5c3559b531d77ef408d44d8ce5dd99d07a2c91232"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-04-20T00:00:00.000Z","created_at":"2021-04-20T08:04:40.949Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1579971,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.13/"},"number":"1.13.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4d24d2557ad91ebf0c316c7da4e4b96c2e293ae32ab6760510bc650e8e91f931"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-04-04T00:00:00.000Z","created_at":"2021-04-04T13:59:28.208Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3355303,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.12/"},"number":"1.12.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2963dc4b3b8e9b2b2d39e8986e5bacbb0246bfb439da03ba4fca5365d4602242"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-03-24T00:00:00.000Z","created_at":"2021-03-24T13:37:11.465Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1118464,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.12/"},"number":"1.12.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dc9150badc782e37fbf572357b132ad3db2a11485635595b269d7bae0c047ec4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-03-01T00:00:00.000Z","created_at":"2021-03-01T07:52:18.929Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2339861,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop/rubocop/issues","source_code_uri":"https://github.com/rubocop/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.11/"},"number":"1.11.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f954e6889e6a5e0b64e973b531e673ec597ff430ddbf50584099d532fad33f7f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-02-15T00:00:00.000Z","created_at":"2021-02-15T13:10:10.167Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1548538,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.10/"},"number":"1.10.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9fe2014e760ddef3ba9f822a8b6643d175ea8ee622c8240d922204a609378dd9"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-02-01T00:00:00.000Z","created_at":"2021-02-01T07:37:07.234Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1243495,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.9/"},"number":"1.9.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42a43aeea3d87ea429b897c3f18d8b6fddcf99c37d47f413f859f7ebe5f2d71a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-28T00:00:00.000Z","created_at":"2021-01-28T08:18:31.958Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":196993,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.9/"},"number":"1.9.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a99ce92e7b5b2050b75a8885b1ca2a32f7c690222bba3357d566f4495ebee0f3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-11T00:00:00.000Z","created_at":"2021-01-11T11:18:45.376Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1741120,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.8/"},"number":"1.8.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bffc58b0a398bd3fd46ad6f6310befb981e5cd1d706a8f8de18251e981620299"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2021-01-07T00:00:00.000Z","created_at":"2021-01-07T08:56:11.791Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":195627,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.8/"},"number":"1.8.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d7a5c2eacd9e1b322a8b910acc1f16c109e793b76f56af435228821b5755989"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-25T00:00:00.000Z","created_at":"2020-12-25T07:22:09.105Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2096666,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.7/"},"number":"1.7.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"343c1b2ebf906a0e889c5135a65227548538e50d8c8aa27b8a150cf8fdf7738a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-10T00:00:00.000Z","created_at":"2020-12-10T07:36:17.340Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1485662,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.6/"},"number":"1.6.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"89b638e3975463d2b0749617ec7a372f3a597bfa2465e1e396aee82824839626"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-09T00:00:00.000Z","created_at":"2020-12-09T12:10:09.487Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":69328,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.6/"},"number":"1.6.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"de769122490a39a283aa99519e54358a4ae84b5a3773d4ed135da750f59dbdef"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-04T00:00:00.000Z","created_at":"2020-12-04T08:48:50.982Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":524423,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e552e6c2a0765a5faea5b0def4c13a6004bcdd2e947eb5693ee3900c5535444c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-02T00:00:00.000Z","created_at":"2020-12-02T16:00:42.960Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":142483,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"481149f40d9e4b45e81ba9df462d943fb1dddadc60b88bf5632e1dcb5278168d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-12-01T00:00:00.000Z","created_at":"2020-12-01T17:18:15.865Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":42098,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.5/"},"number":"1.5.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2b1c5101afc230126dc5be1d9a8afa5deda2e9b6a8eb87f032863ab195113ad2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-25T00:00:00.000Z","created_at":"2020-11-25T08:13:43.899Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2324841,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e58c81eb570336047380f2cc179b412eb50ee7560d128395ea535f6e1877fcf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-23T00:00:00.000Z","created_at":"2020-11-23T15:47:06.586Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":274791,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c502ab34cfdffafca465b8ab4338209eaf86f3ac2a015e87caeb49b69e0979f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-23T00:00:00.000Z","created_at":"2020-11-23T09:00:24.039Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":26613,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.4/"},"number":"1.4.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c01c4658123427d9198c3d20e6fede1d0be555703a84bd8023efdf91dd8a6187"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-16T00:00:00.000Z","created_at":"2020-11-16T08:54:41.526Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":772584,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.3/"},"number":"1.3.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4054ee99368d9e479ef82869e731eccde3055b1a5bcdba02ea077f2411b3eab1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-12T00:00:00.000Z","created_at":"2020-11-12T08:03:01.026Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":232869,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.3/"},"number":"1.3.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7cf281b5e63b87b6caf26a0fc44f98af32b0507898e360ac3a0d8fd824a947ef"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-11-05T00:00:00.000Z","created_at":"2020-11-05T07:35:20.077Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":601782,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.2/"},"number":"1.2.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"599bb8a001cd4cb0195b8b0b8f055158b93f7bd77fc3a232e5adbdf3bca28715"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-29T00:00:00.000Z","created_at":"2020-10-29T15:18:10.951Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1138977,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.1/"},"number":"1.1.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"146a44a1d0baba33cac6274c0be6a98098cabe38684dff6e1b3929c29f3d88db"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-21T00:00:00.000Z","created_at":"2020-10-21T11:02:00.444Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1129215,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/1.0/"},"number":"1.0.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c16df6a0a14e370a64ac7de209bba6e8466a0283761373c82b9eff9d0bf988b5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-12T00:00:00.000Z","created_at":"2020-10-12T07:04:17.359Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":17309522,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.93/"},"number":"0.93.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"73b44fbbe872edbd3f14487175b6369a0f48e952c155f305896ffa56c48b195e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-10-08T00:00:00.000Z","created_at":"2020-10-08T14:53:41.340Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":231477,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.93/"},"number":"0.93.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6a3c6b8e5287ea7b7c729ab51406a163a9894fe0f925f0626b2a9112503c3bdb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-25T00:00:00.000Z","created_at":"2020-09-25T08:12:20.931Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2795549,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/rubocop/0.92/"},"number":"0.92.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3653dec299db6290c1f4dd3c4afd47ef76c484185f3642605552547c74672e4b"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-23T00:00:00.000Z","created_at":"2020-09-23T09:46:14.960Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2102362,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.91.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"06b08219c476a9507eb8a7f6b026d33f5d463d2a32488a3b80aab06a3e6fd5a6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-15T00:00:00.000Z","created_at":"2020-09-15T05:45:14.063Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":7477307,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.91.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0a836a303d959ba4d35b9c3eb848e4ed54952a4d0037874f0c1067da4721781d"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-09-01T00:00:00.000Z","created_at":"2020-09-01T06:44:59.545Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1644284,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.90.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d3d3acf7dde11cea1c7c18c1baf8cc80124ad02db802eee2a96e03f38c58cf0"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-08-10T00:00:00.000Z","created_at":"2020-08-10T12:17:06.265Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":6383023,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.89.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"30794116b2804aab1abc74780a201fae5160c1d6a21550ce9786abd3ca0e07fa"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-08-05T00:00:00.000Z","created_at":"2020-08-05T19:05:18.634Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":278347,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.89.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ef1aba0c16b4610bfc8e9fdd233707719872b387f4bc9d3fc66829572a9008c2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-13T00:00:00.000Z","created_at":"2020-07-13T12:22:19.339Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":3634732,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.88.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d7da9340fce8b64be15077e6ba1f7c60b5b5999901ce2eda9837f9ca08b2fe4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-07T00:00:00.000Z","created_at":"2020-07-07T19:14:41.214Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":628171,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.87.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3df1a0c641feed9004d0dd787e220283cf8a82f8ba24a04a284c4f841dad6029"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-07-06T00:00:00.000Z","created_at":"2020-07-06T16:12:40.171Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":2270123,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.87.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a928b5acff012d15df735ef34978bc099397b12fcaa4025e46c565397e179430"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-22T00:00:00.000Z","created_at":"2020-06-22T07:29:21.381Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":10198601,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.86.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"babe641b554e28d53bad32fd94f90e6d65410fa06fe8a2c511f2aec03b7c83ca"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-07T00:00:00.000Z","created_at":"2020-06-07T15:40:00.351Z","description":"    RuboCop
+        is a Ruby code style checking and code formatting tool.\n    It aims to enforce
+        the community-driven Ruby Style Guide.\n","downloads_count":1909274,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.85.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d0a0b8a7cf84ed0c5f3a305a48c738b1b8ec8a08affd19e7c5986fd6d5a21bbe"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-06-01T00:00:00.000Z","created_at":"2020-06-01T15:47:28.436Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":405052,"metadata":{"homepage_uri":"https://rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.85.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3963352c8187a06dbf3f65358ab91eff3502792da8dbb0e8329eeb7fb74715bc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-05-21T00:00:00.000Z","created_at":"2020-05-21T06:57:11.953Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1758142,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.84.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"069f1497ef67aefa360a80aef66375fab2941b85dd09a2a68dcaab3d17a4e5c6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-05-11T00:00:00.000Z","created_at":"2020-05-11T12:28:44.160Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1464289,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.83.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3397a3778ed0fa4d43e69b19f9c421da1925e7a85acc07f5b852aafc7a3c7224"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-04-16T00:00:00.000Z","created_at":"2020-04-16T08:19:59.835Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5393689,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.82.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d6c5bc7d9b9c1ac1e8bb8a724ea761d724661ebec143eb0b92345b5a8e8d25f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-04-01T00:00:00.000Z","created_at":"2020-04-01T07:55:38.383Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4435445,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.81.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3d1ff65d3acf3a4ef1babb4624255268460f5d56ddb8f9c985a731d8ebe80d32"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-02-29T00:00:00.000Z","created_at":"2020-02-29T18:05:39.532Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4071069,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.80.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"485291465f908c08de184932a6ae7a796c8a37dd46020dd5ed21cc46eee117c5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-02-18T00:00:00.000Z","created_at":"2020-02-18T11:59:08.971Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1654062,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.80.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb7ec63f27324162a4d2021104b2d94ea611e7c47995cc8b6f65436ecebeae29"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2020-01-06T00:00:00.000Z","created_at":"2020-01-06T09:57:25.274Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3872673,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.79.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"325b331102897bd19d08f4e4d18dde806f24cbf5768110663ae16fab1f17a792"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T20:51:20.075Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2073376,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.78.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a013cddb1b1292833fada241aea59b450c2a51d730c556e829572ba69d862bdc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-11-27T00:00:00.000Z","created_at":"2019-11-27T18:03:03.812Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2504517,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.77.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a95b032eeeb52bfd83db802d992a2e98484023b06677f16d5bb5c2f556580855"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-10-28T00:00:00.000Z","created_at":"2019-10-28T14:54:29.237Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3229813,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.76.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"00837450d0eb3d85c7eb32afe909f9536135172df06bdd490ade9c4e7b0ca51f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-10-14T00:00:00.000Z","created_at":"2019-10-14T16:58:16.713Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2144724,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.75.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"360c1d4941881064611feae6b3b9f1535a5e455dd174ced9a4d39b734e0cb868"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-09-30T00:00:00.000Z","created_at":"2019-09-30T17:05:51.523Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1090579,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.75.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4be504c51e6bfbce5070bc853d9bd770a273600eca31820ca1aa3695d66010f4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-07-31T00:00:00.000Z","created_at":"2019-07-31T19:12:04.545Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9937305,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.74.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d3abbf59133f5fce2bea961bb363a3c2f7d2e36ffc30fd11de5c2c9cb456fe72"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-07-16T00:00:00.000Z","created_at":"2019-07-16T08:57:10.832Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1282311,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.73.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0ed89317eba64db6327896303dafad5c1520983e12cb2c21cbb32cac3a62bfac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-06-25T00:00:00.000Z","created_at":"2019-06-25T14:36:09.976Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2975655,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.72.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a20e5b9fe52b337b491d77faea871fe90f8bf2fd5a71b594e76419a852ad5ba4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-30T00:00:00.000Z","created_at":"2019-05-30T13:53:44.134Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2589048,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.71.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb40a9fb646368c867dd3a41753169dee24aa4b819e91f0189a8b8da82cb5e56"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-21T00:00:00.000Z","created_at":"2019-05-21T10:26:46.421Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1374506,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.70.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c938c50fe39ed55458ecf600f316ccbaf51cf5584d1aa83b621ba27ba94f86c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-05-13T00:00:00.000Z","created_at":"2019-05-13T08:57:55.837Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2838762,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.69.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b1ccb922caf3eb21a97a92fe8cbf62950e4adc215052cde4cfbbc5a8a442bcb2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-30T00:00:00.000Z","created_at":"2019-04-30T19:46:32.378Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2460381,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.68.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af830b7ddf6459700b35225db789e828015df5d96ca40ee438da1115383a39d4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-29T00:00:00.000Z","created_at":"2019-04-29T13:53:42.552Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":441679,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.68.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8a1d642e344ef81164915cf00f021724a2ff1b17ff552369f8be36a7dc672b9c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-05T00:00:00.000Z","created_at":"2019-04-05T07:54:59.405Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1422429,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0029e66eb5c02fca2befdcba5c12c81ca83620c4ad5e1d197fcd35f7a549efb1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-04T00:00:00.000Z","created_at":"2019-04-04T17:13:15.415Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":109969,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c1e929a0aae8b28d75c8ca093a4401e66c2fc91e84f6a8ccb8ad5f22016fd7a2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-04-04T00:00:00.000Z","created_at":"2019-04-04T15:23:11.383Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":69327,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.67.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fe1d716afc92a59180e30e9d62b398a3c069c4ae5bca97b5de6e4d65c6cf9f8c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-03-18T00:00:00.000Z","created_at":"2019-03-18T09:27:01.934Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2638757,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.66.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f05a6896f367765b3f0fba663d0add120444f8de604dada405662b10a0860f5a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-02-19T00:00:00.000Z","created_at":"2019-02-19T08:43:14.568Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2543409,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.65.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c6ffcb57bab1cecbcd0240948c2bba65f422abc1e72bef461fb4f31cd9bbd19a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-02-10T00:00:00.000Z","created_at":"2019-02-10T13:54:58.751Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3548208,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.64.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"726debef2d860b3855f683c5051121046b99197b39459620dd137266a789501f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-22T00:00:00.000Z","created_at":"2019-01-22T03:02:01.872Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2261951,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.63.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5e8a8fadbe248ff9c3727b603d66f23658fe1e1965ae07571365b34a390600df"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-16T00:00:00.000Z","created_at":"2019-01-16T16:32:03.430Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":454260,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.63.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"81b091cf498be83ecb01be8ea5c265c0231eed14d9ee00b872cd10859dca8d65"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2019-01-01T00:00:00.000Z","created_at":"2019-01-01T08:40:22.886Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1150334,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.62.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"73bb7e9b97e35444c37a9164e5a644518807fba613a790e1e234ae9b7fcfca0e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-12-06T00:00:00.000Z","created_at":"2018-12-06T08:18:53.311Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1913557,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.61.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8650301567ee5a4867dbb9ba9ca9987d7dc8a9166ee3136c41c03906cc935ada"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-12-05T00:00:00.000Z","created_at":"2018-12-05T12:42:54.009Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":117529,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.61.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"18a30bb68d42e8cc3fd1a0aac37c86db46c99fae2edae7bb9dc49eed8f41864c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-10-26T00:00:00.000Z","created_at":"2018-10-26T10:41:04.209Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2214874,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.60.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"31d8b34585456ce0f0e79d6411c3b7e705ac571996876d9815e1d6f1130173c7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-24T00:00:00.000Z","created_at":"2018-09-24T05:19:49.887Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2845540,"metadata":{"homepage_uri":"https://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://docs.rubocop.org/"},"number":"0.59.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a6888aef273e586226013355db553bca6c7acd81ca5771d749d69a883dc92004"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-15T00:00:00.000Z","created_at":"2018-09-15T07:45:31.993Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":809343,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.59.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b449177a369193559dabbbbd4fff967c1b2bd817bd78134b6082f1d1dd5e443"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-09-09T00:00:00.000Z","created_at":"2018-09-09T16:24:47.204Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":814558,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.59.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"455597f026940948d5c46a84660a0a944f07d6cf27f497d7147bc49626ced183"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-23T00:00:00.000Z","created_at":"2018-07-23T18:01:18.681Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5832323,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"43dab6c9d6c72844cbd028140ee7c60190c5ee6e30417d63480da3f413778139"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-10T00:00:00.000Z","created_at":"2018-07-10T07:31:15.576Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":851787,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"26ca690212ae00b00435e767f9b3f46ffb1f1143a5f25fe728e638d15ba65868"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-07-07T00:00:00.000Z","created_at":"2018-07-07T12:38:26.296Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":186151,"metadata":{"homepage_uri":"http://www.rubocop.org/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"http://docs.rubocop.org/"},"number":"0.58.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e3b24a143239f4752f4a4e5e09ebb6ff41bb302db34771489db6ef4b728d3a24"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-12T00:00:00.000Z","created_at":"2018-06-12T09:05:03.272Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2268813,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"468ca03be186a4c39f75535ad445bb073408cf2c75035105ac6b91dc04d9cbac"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-06T00:00:00.000Z","created_at":"2018-06-06T22:57:40.803Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":273583,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad25fe52d9be12bb0662dd32e84cc72067f2ab516a14bb5d557dfec15a74a2e6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-06-06T00:00:00.000Z","created_at":"2018-06-06T00:53:30.394Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":116954,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rubocop-hq/rubocop/issues","source_code_uri":"https://github.com/rubocop-hq/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.57.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cbce208bac27d4368ebe1a7892b37674399ad274b18888259be8b305a368e644"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-05-14T00:00:00.000Z","created_at":"2018-05-14T15:17:56.916Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1890840,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.56.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"687f9418a1475911fdd0cf7c57009620daef2caffe5692b621dc6d1abfb04212"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-04-16T00:00:00.000Z","created_at":"2018-04-16T09:20:00.851Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3727109,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.55.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"21fc1b25eee37a6b601144b02f2b90d608555aa09aafbf57f03636828d99169f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-03-21T00:00:00.000Z","created_at":"2018-03-21T03:01:01.664Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4980223,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.54.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3a2208fe1166b22e109b3a184aa0bd26e04d16e78587b9c714e63980694ade80"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2018-03-05T00:00:00.000Z","created_at":"2018-03-05T01:51:12.010Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1133005,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.53.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ce9862b128c49183b2bf2b3416825557ca99bddd504eb1a9f815e8039f201b28"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-12-27T00:00:00.000Z","created_at":"2017-12-27T13:31:06.690Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":7027176,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.52.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ec659892e86c64ec25e7a543b4a717f9ee6e9450bdb9541e0d3492b43ce4234"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-12-12T00:00:00.000Z","created_at":"2017-12-12T13:56:04.078Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":944666,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.52.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"291bcca376e76b5bada3ee91c938a4354e384d3d87278ab54b22bde660b520bd"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-10-18T00:00:00.000Z","created_at":"2017-10-18T19:13:19.013Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3324032,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.51.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.1.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c131a5c063600cd31cf49c69130c16b94a6bd7d6a35f6f00c587ac6330bdc233"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-09-14T00:00:00.000Z","created_at":"2017-09-14T18:13:15.476Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3320413,"metadata":{"homepage_uri":"https://rubocop.readthedocs.io/","changelog_uri":"https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/bbatsov/rubocop/issues","source_code_uri":"https://github.com/bbatsov/rubocop/","documentation_uri":"https://rubocop.readthedocs.io/"},"number":"0.50.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9f7610b37b6746609c932ec8ac5b1a9b4b56f7526018c941393e79b2d93fedc2"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-05-29T00:00:00.000Z","created_at":"2017-05-29T12:34:28.077Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10729198,"metadata":{},"number":"0.49.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bcb37220633a570611b68bf8d4649414624d90fad83a7bf8310940f61df51ed7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-05-24T00:00:00.000Z","created_at":"2017-05-24T05:33:44.287Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":341250,"metadata":{},"number":"0.49.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3af20292590127c5e5a67a08e84642bb9d1f555cb8ed16717980c8b524ed038f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-04-03T00:00:00.000Z","created_at":"2017-04-03T11:29:58.977Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2587754,"metadata":{},"number":"0.48.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"002f6b49013abdc05c68ae75433c48d3ee7f1baa70674d60bf1cc310e210fbd7"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-03-26T00:00:00.000Z","created_at":"2017-03-26T09:53:19.789Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":198787,"metadata":{},"number":"0.48.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cca38e2b3ba3496fa63dbe747baa9eff7f9717631df1221467618b54773fd690"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-01-18T00:00:00.000Z","created_at":"2017-01-18T02:22:18.664Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3107766,"metadata":{},"number":"0.47.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a7066a0c553e3bad1f118062deef5f05d050a6cf11cb9c9cda067b2a891a7916"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2017-01-16T00:00:00.000Z","created_at":"2017-01-16T01:37:21.113Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":94953,"metadata":{},"number":"0.47.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"55d32c0b5b42f7ac5b6ede9ef4f6a1e6605bc28f8cb38db1c796042ad71f5bd3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-11-30T00:00:00.000Z","created_at":"2016-11-30T06:56:04.929Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":2006777,"metadata":{},"number":"0.46.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c5087c157b6070319d06cab7594f9f72b5478344a2568b7029875a081c20418"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-31T00:00:00.000Z","created_at":"2016-10-31T09:31:11.908Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":913383,"metadata":{},"number":"0.45.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c579b99be005868127c26d18d8ebfc2e71ed4ebacf781896a837cac6f128248f"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-13T00:00:00.000Z","created_at":"2016-10-13T14:55:04.417Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":452030,"metadata":{},"number":"0.44.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2f702937dce43bed412c186dadd3727a769e837bd82263ee7687f37050c324ec"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-10-13T00:00:00.000Z","created_at":"2016-10-13T14:05:27.902Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5836,"metadata":{},"number":"0.44.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b124c8255b6570964a53e9d17d3861970d71788f8caa7819335cfac291eb8093"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-09-19T00:00:00.000Z","created_at":"2016-09-19T08:02:45.931Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":935620,"metadata":{},"number":"0.43.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"125e352d5ad65cae73f33572fde0f4793ca8ef7823263935e93ff0c2cd265764"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-07-25T00:00:00.000Z","created_at":"2016-07-25T09:16:51.982Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1762837,"metadata":{},"number":"0.42.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.0.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1bfd76aa1f6e266d459a7776e5de13956595aca4718758f593b5800c9d809918"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-07-07T00:00:00.000Z","created_at":"2016-07-07T11:55:00.995Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1662643,"metadata":{},"number":"0.41.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9ef6e6a8de0ee0f45305beaae85645bb050e443c237ce91ab488268540ca4d09"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-06-26T00:00:00.000Z","created_at":"2016-06-26T08:50:26.134Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":377179,"metadata":{},"number":"0.41.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f6c7d8a9a9b4fecbe89a851c38bc549c8d1d4744f57bde383aa33884d4ef661"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-06-25T00:00:00.000Z","created_at":"2016-06-25T17:50:26.038Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":51250,"metadata":{},"number":"0.41.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9580eb20ce098b7a0c06730f92e07ff71da25b803b5a28580ea571b17422e008"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-05-09T00:00:00.000Z","created_at":"2016-05-09T17:45:53.078Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1491089,"metadata":{},"number":"0.40.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ddca83f353721240eb3563c2d9b5fb7e9928845058a6a49f23aab79d25ca83f6"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-03-27T00:00:00.000Z","created_at":"2016-03-27T11:16:21.158Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1656502,"metadata":{},"number":"0.39.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5600c0f7268778520598394cc9ceed69ca3df2a874f2881dfd1d17ba336427bb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-03-09T00:00:00.000Z","created_at":"2016-03-09T15:10:05.281Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":643291,"metadata":{},"number":"0.38.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4094e2c4b9e0827191c55ab59fd8813e41f40f5c83717b5a143f108b4ac1fc61"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-11T00:00:00.000Z","created_at":"2016-02-11T12:50:57.031Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":884484,"metadata":{},"number":"0.37.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d65255d1f072bf737cef74c0cfca50de448bd8428644fa3c4e8880698856be2a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-09T00:00:00.000Z","created_at":"2016-02-09T16:45:33.535Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":63427,"metadata":{},"number":"0.37.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1dbc993cd8c0f1afb90a913b4ef6fa83400809d2b30079a877f52358e498bcc"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-02-04T00:00:00.000Z","created_at":"2016-02-04T06:37:12.148Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":110681,"metadata":{},"number":"0.37.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c8979d3c94088d7e7f38f412efb91a74b2b0c97b3eadf35d7d2645b676508ae1"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2016-01-14T00:00:00.000Z","created_at":"2016-01-14T18:22:21.651Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1303482,"metadata":{},"number":"0.36.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e613b68a72930726a8aab8fba7afffef0b162edaa67b271b491fd18c6c350fec"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-11-10T00:00:00.000Z","created_at":"2015-11-10T17:09:13.947Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1589759,"metadata":{},"number":"0.35.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4f0b3ce1e3f9e6bb2b1409a3c49dbf7e4a682b7b083ee5ff20d5cee6846a38bf"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-11-07T00:00:00.000Z","created_at":"2015-11-07T06:46:41.231Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":252121,"metadata":{},"number":"0.35.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c7b4d9f1bfd1dfb4730519979f6fb283518b945ebe3bb7fc21b2a89ecb7979ff"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-21T00:00:00.000Z","created_at":"2015-09-21T14:50:42.260Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":1221792,"metadata":{},"number":"0.34.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d387d22b07c8ba54043d742ee7738dd31440808e371e86502e6d06fbf5d22b7a"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-09T00:00:00.000Z","created_at":"2015-09-09T11:29:19.149Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":144484,"metadata":{},"number":"0.34.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0d904489dca12ab4005c358d74057e197266a2571c9feafc15a37bbe3c3b13f8"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-09-05T00:00:00.000Z","created_at":"2015-09-05T05:06:00.263Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":60635,"metadata":{},"number":"0.34.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e704f43bc99114ca93d78cef7937d5a7aebde105613bf82ec86612a8efb44bc3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-08-05T00:00:00.000Z","created_at":"2015-08-05T12:17:28.842Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":549755,"metadata":{},"number":"0.33.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8910c66466538d01d0abbf21aa099b15901e4fc9c20394cf1ba9ef9f357b4a8c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-06-24T00:00:00.000Z","created_at":"2015-06-24T06:17:18.900Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":563974,"metadata":{},"number":"0.32.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fa2a1ea1a069436b991ce4d4c4c45682d1e9e83cc9e609dc181eb786e93641d5"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-06-06T00:00:00.000Z","created_at":"2015-06-06T09:02:54.433Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":209433,"metadata":{},"number":"0.32.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"091830914416431bd8217855ccf2e23a82865519e97dbe309501184529efe25e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-05-05T00:00:00.000Z","created_at":"2015-05-05T17:06:13.868Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":457916,"metadata":{},"number":"0.31.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f44b741edaa71337b8bce7a08e966630035a178034a4308de483e92cb02989e3"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-04-21T00:00:00.000Z","created_at":"2015-04-21T11:54:36.285Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":403211,"metadata":{},"number":"0.30.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f6fbe1c3236e4472365a7c726c2bf4c0f066b241dbecd274a3b296cc19dfbe50"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-04-06T00:00:00.000Z","created_at":"2015-04-06T15:38:28.162Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":263978,"metadata":{},"number":"0.30.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ac19d6befb873d5b16dd10f8000ed5b579708e3a883ba5140bc4c21ae5a93923"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-02-13T00:00:00.000Z","created_at":"2015-02-13T09:44:57.178Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":745803,"metadata":{},"number":"0.29.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fdef20af47f52e8130d39665fb5770fdc7cb72d9c5a5ba56078e0fe2c325f50c"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2015-02-05T00:00:00.000Z","created_at":"2015-02-05T20:28:53.282Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":68163,"metadata":{},"number":"0.29.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ed2b625e9884ff66a606f60d4b725f5bba747c05591c3dca0e426afd35f8135e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-12-10T00:00:00.000Z","created_at":"2014-12-10T17:17:29.029Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":836332,"metadata":{},"number":"0.28.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8db05151c0af7fbb334d0326c587f6515380122a17ed726d0936dc16147cc41e"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-11-08T00:00:00.000Z","created_at":"2014-11-08T11:26:10.904Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":538658,"metadata":{},"number":"0.27.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e0f5190a96b82917bd2a15de027d252218830efdfee98bcca3cd3fd8a0e38d24"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-10-30T00:00:00.000Z","created_at":"2014-10-30T16:43:32.213Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":43688,"metadata":{},"number":"0.27.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5729bcce45721e6c9a9139e44df8c26872ff97927fa0df382ed82d1b932593e4"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-09-18T00:00:00.000Z","created_at":"2014-09-18T12:10:31.079Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":685937,"metadata":{},"number":"0.26.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c49f376e77808c8b07578c3d4cdfb6c73f1fd530941ba724303a354498d2cabb"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-09-03T00:00:00.000Z","created_at":"2014-09-03T12:35:37.840Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":104378,"metadata":{},"number":"0.26.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"773ed161beab33976b5760a2f5db27db3447726dd1389212c60668889f9e6091"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-08-15T00:00:00.000Z","created_at":"2014-08-15T11:19:31.470Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":84177,"metadata":{},"number":"0.25.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8ec2267e73031a0056e3cda5332d81774c3102acb8afb0ec5131f28de26dd662"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-07-03T00:00:00.000Z","created_at":"2014-07-03T11:40:30.994Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":243573,"metadata":{},"number":"0.24.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c58201dcd9e9cb364a5865b71d29c1371379c3c6c6896d6aaef292d0468bc54"},{"authors":"Bozhidar
+        Batsov, Jonas Arvidsson, Yuji Nakayama","built_at":"2014-06-25T00:00:00.000Z","created_at":"2014-06-25T06:50:13.105Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":39968,"metadata":{},"number":"0.24.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d27a16864c907fd7a1ea463c6cc4ccbda6671b12255e497fceaa080315f0c90d"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-06-02T00:00:00.000Z","created_at":"2014-06-02T12:19:23.545Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":221306,"metadata":{},"number":"0.23.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"82de5ffe9e7acd0a4d5846fbad8805303cf7764955ccba375640ff9d6871a2f1"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-05-20T00:00:00.000Z","created_at":"2014-05-20T14:36:31.896Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":39364,"metadata":{},"number":"0.22.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"888b5a1aba5991169ccb8ba81b9880ef1a190f431252c4174dbcd05c366dcb15"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-24T00:00:00.000Z","created_at":"2014-04-24T09:41:19.853Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":143066,"metadata":{},"number":"0.21.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"93667e72149fd96897c5e410827dab5b260a95666549b7885d5b334b1eaadd1e"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:16:27.467Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":86299,"metadata":{},"number":"0.20.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42577cc435ac444c8f9fb8659c99721416b6046a3db499f6434464cd7cb09aa5"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-04-02T00:00:00.000Z","created_at":"2014-04-02T14:03:48.747Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":18769,"metadata":{},"number":"0.20.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1d9bf34022495497bafc86d30443ba5d9732553d3e966c26250956dc33431627"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-03-17T00:00:00.000Z","created_at":"2014-03-17T15:57:49.176Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":158596,"metadata":{},"number":"0.19.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"271e424a97876d4c94ba07f8b65fc56356d19f1ae8b2c0ef4e767e970dafb352"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-03-13T00:00:00.000Z","created_at":"2014-03-13T16:07:32.092Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":11148,"metadata":{},"number":"0.19.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"37f30df2bfabf7d2e66b6efcbbc6d646db9389c26e94bbc2fa86c1d8e62e563f"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-02-02T00:00:00.000Z","created_at":"2014-02-02T10:11:48.216Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":193027,"metadata":{},"number":"0.18.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a8e35b2f2b25cf5306866b821002f35b2c35d221598c1d376df8d497940ba253"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-01-30T00:00:00.000Z","created_at":"2014-01-30T16:11:12.247Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":15517,"metadata":{},"number":"0.18.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b0e26be25eb9154938b665685aec57fc1b6956d825e7a05d17373bb4b729681"},{"authors":"Bozhidar
+        Batsov","built_at":"2014-01-23T00:00:00.000Z","created_at":"2014-01-23T15:44:06.875Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":29939,"metadata":{},"number":"0.17.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"529e1af94a20544424c6d7603ca62459acdfe10466503416a6eae5c0d3fb67e3"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-12-25T00:00:00.000Z","created_at":"2013-12-25T18:01:42.589Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":58737,"metadata":{},"number":"0.16.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c14fd2a1f918227e105be122e2500b62b94ef9ac454b2e01fc528bbd4da66aa0"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-11-06T00:00:00.000Z","created_at":"2013-11-06T14:55:07.694Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":58828,"metadata":{},"number":"0.15.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"794a5f1839bac8bf728a44291598ba4040a90dd164878adb0d82c192dcd10279"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-10-10T00:00:00.000Z","created_at":"2013-10-10T09:22:35.405Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":62994,"metadata":{},"number":"0.14.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6e164c3d0a55e543012eb814e11b25c431d32a04393b6f86ebbad6d21a493f2c"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-10-07T00:00:00.000Z","created_at":"2013-10-07T11:55:17.164Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":8065,"metadata":{},"number":"0.14.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5d16dd4e7e012b4414afc57691e6ae4902a96cd63f2a3462ac5ca5423a6c78e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-09-19T00:00:00.000Z","created_at":"2013-09-19T11:17:32.222Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":30924,"metadata":{},"number":"0.13.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"53a38480d2217ea4f0076485cc3eddb3baece8e69179e144177af38ab860e4f0"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-09-13T00:00:00.000Z","created_at":"2013-09-13T14:12:11.377Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10563,"metadata":{},"number":"0.13.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"693f24feec332394ff817e95c1d27000ab843802de02ee232c47711e497bddd2"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-23T00:00:00.000Z","created_at":"2013-08-23T08:20:14.993Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":23320,"metadata":{},"number":"0.12.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6935abc7d1cc704bf2c96646b1441270c3415ab8be1a7776686ff36ad3cd38bc"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-12T00:00:00.000Z","created_at":"2013-08-12T08:41:14.761Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":16320,"metadata":{},"number":"0.11.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8b8155e9b786c8e2bb8699875c4351e50b093b9dced4097d1be176b426306981"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-08-09T00:00:00.000Z","created_at":"2013-08-09T14:44:40.288Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":4998,"metadata":{},"number":"0.11.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"edf8fcf8682ccdbf9ff65e4365fcba0f203777471f6afdb58f31a5327881636d"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-17T00:00:00.000Z","created_at":"2013-07-17T18:38:32.352Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":15250,"metadata":{},"number":"0.10.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"5542215006b235d0ade4dda74b23d5d22d47cad02100a0e31bb097d80d7c8431"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-05T00:00:00.000Z","created_at":"2013-07-05T15:13:09.528Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9983,"metadata":{},"number":"0.9.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"cea12e9561a37ca065cd05c613735406fe8ff86d9015cc80cb02d8f9fc4c3131"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-07-01T00:00:00.000Z","created_at":"2013-07-01T12:57:41.924Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":13648,"metadata":{},"number":"0.9.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"846a289554c4716fd4ff3f890a954ecce2895a9a6e913d4617f21dea5f522361"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-06-18T12:41:29.955Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":9723,"metadata":{},"number":"0.8.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"30178ff21ee90e5e760c7ea40f448c46efab17c5ab9263e4f9df470d8ef008e3"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-06-05T11:46:36.612Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":6417,"metadata":{},"number":"0.8.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a853697357734fa301a3594bcc457b068be4056fe19cc420abe68531a771936c"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-30T08:11:17.673Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5339,"metadata":{},"number":"0.8.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7d008670bf5a3aa378e78ea78024670bd83f38b188c82b1b64d1858ab5d6cf29"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-28T09:06:01.240Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":5374,"metadata":{},"number":"0.8.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2e7d746c66b0c8d3ab9d1ed9c3ccb827b8c4325cb8ea835d8becec870be2b70f"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-13T07:00:10.330Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":10444,"metadata":{},"number":"0.7.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"36c0574cc728e120e593fcf84fa0a01a36aa948096cdccdbd9f3eb3f9a0d3011"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-11T12:01:12.103Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3969,"metadata":{},"number":"0.7.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"5a8fb4c2cb9270b9fc5c325d8bb7f556233e472a82d1b02ab8501041c7c35d16"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-05-11T05:40:16.929Z","description":"    Automatic
+        Ruby code style checking tool.\n    Aims to enforce the community-driven Ruby
+        Style Guide.\n","downloads_count":3958,"metadata":{},"number":"0.7.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"3a9096d62151fb4dffebc3fd2f672b238172af945890156923ffc60ebe1eef7a"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-28T12:44:09.481Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":5363,"metadata":{},"number":"0.6.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2cc2d86791a143c791ac99b566d99e920873d086e7b7a9daed69fe5546d4dad6"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-23T11:23:04.364Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4895,"metadata":{},"number":"0.6.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 1.9.2","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"53702a3cd38c916ab3b57e2a84a5a1af68350dedd83e1b5f5a2dfd786612789a"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-17T00:00:00.000Z","created_at":"2013-04-17T15:09:32.991Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":10850,"metadata":{},"number":"0.5.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"3ba57b2986af5eb7521aa4f5b4fbc2b6b9b5177b398eecee02bbb1411983d7a6"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-15T00:00:00.000Z","created_at":"2013-04-15T13:21:26.422Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4783,"metadata":{},"number":"0.4.6","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"714b451a1e3cdc7e11e407c06028e3cad0d77c74aa5f1ba623029d2d12c1eca7"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-15T00:00:00.000Z","created_at":"2013-04-15T13:18:31.196Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3797,"metadata":{},"number":"0.4.5","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"e95b05fa17998d7eb195244d8be36d836f28b60d23cd754349684309a5cd7999"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-14T00:00:00.000Z","created_at":"2013-04-14T14:26:04.168Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3934,"metadata":{},"number":"0.4.4","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"aeacff29f694b02465fbff9c089f3bb57c2f27d15734935764e14d3beadfce7b"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-14T00:00:00.000Z","created_at":"2013-04-14T06:10:31.699Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3904,"metadata":{},"number":"0.4.3","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"81c55e8dae6e379f92ea47898daf0e138ba9d84102225e26a82fa9d51f75e4ec"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-13T00:00:00.000Z","created_at":"2013-04-13T19:20:43.281Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3853,"metadata":{},"number":"0.4.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a4086d3db38c363a0143a8d4ff7b00f03eb91ddc01081604b9812524d50d5991"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-13T00:00:00.000Z","created_at":"2013-04-13T11:20:04.189Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3821,"metadata":{},"number":"0.4.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7173b29a39b02640c4ce5d9b285527978b5f256056b3f85c0f33c894ad476570"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-11T00:00:00.000Z","created_at":"2013-04-11T09:45:55.167Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4375,"metadata":{},"number":"0.4.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"ce4270b896e61800e286def6324c8d471cc13185cc9270ebe98b9390da0ba480"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-04-06T00:00:00.000Z","created_at":"2013-04-06T17:24:51.540Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3888,"metadata":{},"number":"0.3.2","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"d3c2ae557b75d78c05624c51fc2ce6e42e41102da11323f164f25581f82a5d4b"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-02-28T00:00:00.000Z","created_at":"2013-02-28T20:45:07.073Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":10386,"metadata":{},"number":"0.3.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"10be88926012cf90ecb86e1289252fd0cd4fd7973e7c34854d03ced3f219f68e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T15:55:45.093Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4241,"metadata":{},"number":"0.3.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"a54c7d286347e81af34c0381aa41bd5bfeba13f19d27fdd7b6fc9d81a18faf65"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-01-12T00:00:00.000Z","created_at":"2013-01-12T15:56:50.441Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4273,"metadata":{},"number":"0.2.1","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"7c6fb4f739334b6ab3312b8efe99dc8e8c4ec4965657146287d25f82f4e0459e"},{"authors":"Bozhidar
+        Batsov","built_at":"2013-01-02T00:00:00.000Z","created_at":"2013-01-02T19:42:27.672Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":3996,"metadata":{},"number":"0.2.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"b4f367fbe644fc6947c07172b7a0a022c726efb5efcfa3390dd1c69e6ee808cc"},{"authors":"Bozhidar
+        Batsov","built_at":"2012-12-20T00:00:00.000Z","created_at":"2012-12-20T09:56:20.974Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":11241,"metadata":{},"number":"0.1.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"68930de9ca68b1efbe8c39c7835b818bfed303c0b13fdd9682b5d2b0f170310c"},{"authors":"Bozhidar
+        Batsov","built_at":"2012-05-03T00:00:00.000Z","created_at":"2012-05-03T12:36:58.944Z","description":"Automatic
+        Ruby code style checking tool. Aims to enforce the community-driven Ruby Style
+        Guide.","downloads_count":4263,"metadata":{},"number":"0.0.0","summary":"Automatic
+        Ruby code style checking tool.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"4d4405e8735e7cc4f310c02eb0085f394f5c235ff6777dfd4cc0e36ba1e5b94f"}]'
+  recorded_at: Fri, 14 Jul 2023 14:55:04 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/toml-rb.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2641'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Fri, 15 Jul 2022 09:00:06 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A2662739463154181364
+      X-Request-Id:
+      - 72e46342-286e-4828-bc0e-e05921891825
+      X-Runtime:
+      - '0.019904'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 52.24.74.243:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:55:52 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-lhr7351-LHR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1689346552.955063,VS0,VE612
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"7b4f06968d50f51f6a290ce7dacf9e78"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Emiliano Mancuso, Lucas Tolchinsky","built_at":"2022-07-15T00:00:00.000Z","created_at":"2022-07-15T09:00:06.684Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":5840054,"metadata":{},"number":"2.2.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1e2c54ac3cc9d49861004f75f0648b3622ac03a76abe105358c31553227d9a6"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2022-01-27T00:00:00.000Z","created_at":"2022-01-27T10:12:59.502Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":801015,"metadata":{},"number":"2.1.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ced902c8de778cf3556b0c335a383ce24af7b214b57140a2bace51cd2c5f30a2"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2022-01-19T00:00:00.000Z","created_at":"2022-01-19T17:59:09.198Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":27894,"metadata":{},"number":"2.1.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"915ef9d397a0b58413bcffc1a2303e5be1223a34d5debe2330ee4a4b30faca0c"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2021-11-01T00:00:00.000Z","created_at":"2021-11-01T10:37:10.046Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":412300,"metadata":{},"number":"2.1.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"595bc99fda33682dd7e9d18f632444a00bc33ed6960ea35fa2c9d5a7124339d7"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2021-11-01T00:00:00.000Z","created_at":"2021-11-01T10:28:17.330Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":36499,"metadata":{},"number":"2.0.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5715daa5d05ca424829fb54d9e049bf9b2f3687ab1c0261540c027e9945596e"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2019-11-18T00:00:00.000Z","created_at":"2019-11-18T09:46:24.255Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":10358682,"metadata":{},"number":"2.0.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5016c6c77ac72bca5fe67c372722bdfdd4479a6fe1a1c4ff2a486e247849b274"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2019-10-25T00:00:00.000Z","created_at":"2019-10-25T15:21:19.133Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":17614,"metadata":{},"number":"2.0.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        2.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"967f44df7882d6494ec773f7126b26803704bc04a20c0cfb78d654220620aa43"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2018-08-16T00:00:00.000Z","created_at":"2018-08-16T10:38:02.132Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":727371,"metadata":{},"number":"1.1.2","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        1.9","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e70993afeddfee6fc5f01cd168870603a2878011baa0d2c0fcb997724a96047d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-11-25T00:00:00.000Z","created_at":"2017-11-25T12:26:27.634Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":463604,"metadata":{},"number":"1.1.1","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c43f188f68a8cefa790950e8eb02100164710479c6f6d189cb30098e6b212665"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-10-01T00:00:00.000Z","created_at":"2017-10-02T02:15:21.004Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":248655,"metadata":{},"number":"1.1.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4a674f4d815aabf20f2ed97f7271261f77aabe3b2380b1174fabb5875954c727"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2017-06-14T00:00:00.000Z","created_at":"2017-06-14T14:54:10.984Z","description":"A
+        Toml parser using Citrus parsing library. ","downloads_count":10768798,"metadata":{},"number":"1.0.0","summary":"Toml
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d440e2c075ba681d73c0537938a04f7d280896d75f4352123dbe6c36af8e65f"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-10-22T00:00:00.000Z","created_at":"2016-10-22T21:03:58.526Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":1474462,"metadata":{},"number":"0.3.15","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2e937e6a2ffbe094e166cd662079bd8a4e99703cec9397e02a39c491c21c590f"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-04-18T00:00:00.000Z","created_at":"2016-04-18T12:36:25.934Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":32316,"metadata":{},"number":"0.3.14","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ea2824e01479b653e4648c4a66e1cf5620af8f87e67614b75346b269c23bd5dd"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-04-02T00:00:00.000Z","created_at":"2016-04-02T21:31:13.069Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4018,"metadata":{},"number":"0.3.13","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a5442186b21abb3c9b20e08f1aef4ba469c302c13f0f9c3c3f7d39334d1b6c2b"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-03-10T00:00:00.000Z","created_at":"2016-03-10T13:52:13.108Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":18847,"metadata":{},"number":"0.3.12","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5c605fded9badfd6ee84ef25cda294084235b47312e3b0e5d38560a871ab84f2"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-03-08T00:00:00.000Z","created_at":"2016-03-09T00:00:11.277Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2304,"metadata":{},"number":"0.3.11","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"caf6b55302f4de162fa6a3aeb806792cf3017672ffafae7c7139e0a2632ab48d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2016-02-23T00:00:00.000Z","created_at":"2016-02-23T15:47:50.855Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":3475,"metadata":{},"number":"0.3.10","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3db4a604458446d2372a0923f38e40eae7d158991c4bf59948a1dc162ec808cf"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-12-28T00:00:00.000Z","created_at":"2015-12-28T15:06:15.159Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":6341,"metadata":{},"number":"0.3.9","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"799894ebffe778b4e7ee121a9aec890548581bb546bd10e7812c3a58886b8c8d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-06-12T00:00:00.000Z","created_at":"2015-06-12T12:34:31.349Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":8230,"metadata":{},"number":"0.3.8","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5c2bf7d0b6545dacef67832aa6008abfb1f8d1faf15f2a93879bcab2dfac7cf3"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-06-08T00:00:00.000Z","created_at":"2015-06-09T01:20:16.618Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2039,"metadata":{},"number":"0.3.7","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"aa66498e2e5ddf60be95ddcdf93e847738d1b430f0d5efac4fde5154c6ae6624"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-22T00:00:00.000Z","created_at":"2015-05-22T20:49:50.980Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2364,"metadata":{},"number":"0.3.6","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d1accad4caa1f0ae44475a04cdad11240b66a38df974898c0db0a7e222bd929"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-14T00:00:00.000Z","created_at":"2015-05-15T00:22:52.510Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2161,"metadata":{},"number":"0.3.5","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b8b137b7e741ce53865cf19898342584ef79e6dbc7d37e3ec40c77eebc52da72"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-05-13T00:00:00.000Z","created_at":"2015-05-13T23:11:35.823Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2041,"metadata":{},"number":"0.3.4","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af8e3e5894ad875fb3a46cacef4ddece4eba24b6f03e97cb9af7efe4d5414834"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-04-17T00:00:00.000Z","created_at":"2015-04-18T01:08:02.325Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2919,"metadata":{},"number":"0.3.3","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3652aaa990a837ddbe1cd0269ba9d9f1a57e03e7e929eb48877f41ab7f9df103"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-02-19T00:00:00.000Z","created_at":"2015-02-19T14:04:46.429Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4655,"metadata":{},"number":"0.3.0","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"39ab52eb9575a8d7c6e07250cf3fb2194a0dfab72a93233f4dea42e6012d76e8"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-02-05T00:00:00.000Z","created_at":"2015-02-05T12:02:24.579Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2344,"metadata":{},"number":"0.2.1","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"542f9a144200c00fad32ed6d9bd81bf2c4f0a42091b3b159c54ed514a33b5499"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2015-01-31T00:00:00.000Z","created_at":"2015-01-31T13:21:32.125Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2063,"metadata":{},"number":"0.2.0","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ce285781f13c04dcfff200925c893cdf59f421bb959882683c58482062c4d8b"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2014-03-26T00:00:00.000Z","created_at":"2014-03-26T15:10:52.601Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":4838,"metadata":{},"number":"0.1.6","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
+        0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0541beef8203204a243603f42964958810d33629a6c38a3231936dc28afe6e2d"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2014-03-16T00:00:00.000Z","created_at":"2014-03-16T16:57:58.913Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":2447,"metadata":{},"number":"0.1.5","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f8df352a62984084c26764adfb0a4a048e8bfa4617ed90edf57063ac65ae05a1"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-10-15T00:00:00.000Z","created_at":"2013-10-15T14:08:12.587Z","description":"A
+        TOML parser using Citrus parsing library. ","downloads_count":5757,"metadata":{},"number":"0.1.4","summary":"TOML
+        parser in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4812e0672c7beacb291d4a13b08f0d6ce8c5f392453145896a92b626356f737"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-05-07T00:00:00.000Z","created_at":"2013-05-07T03:49:35.472Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":3224,"metadata":{},"number":"0.1.3","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"04f0a7a1c46ecde6c89bf4bb1f9556bf4336d0fc850333836837b513fa2cae29"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-04-12T00:00:00.000Z","created_at":"2013-04-12T20:23:35.014Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":2538,"metadata":{},"number":"0.1.2","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"509881e2e820c77145f1258669f93b8eea9e5d0dfd4cd1ce3d806077732c386a"},{"authors":"Emiliano
+        Mancuso, Lucas Tolchinsky","built_at":"2013-04-03T00:00:00.000Z","created_at":"2013-04-03T14:37:25.812Z","description":"A
+        TOML parser using Citrus parsing library. Formerly known as ''toml_parser-ruby''.
+        ","downloads_count":2475,"metadata":{},"number":"0.1.0","summary":"TOML parser
+        in ruby, for ruby.","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"2bbf858d9f55251df8522671c54972d7b6a3a43e407cd6baa3f7d0a5a5862b2a"}]'
+  recorded_at: Fri, 14 Jul 2023 14:55:52 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rack.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.221.0 excon/0.99.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '9123'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Wed, 14 Jun 2023 02:01:53 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Ab84d830e7d8427dcd318a58f4239a320f03a4199%2Cenv%3Aproduction%2Ctrace_id%3A813968022550758481
+      X-Request-Id:
+      - ab73d4e8-e559-4c6e-93b0-276bd319095a
+      X-Runtime:
+      - '0.045197'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 34.223.193.61:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 14 Jul 2023 14:55:52 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '541'
+      X-Served-By:
+      - cache-lhr7362-LHR
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689346553.796126,VS0,VE5
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"d036bd62fd9be73c96e87b117101398b"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Leah Neukirchen","built_at":"2023-06-14T00:00:00.000Z","created_at":"2023-06-14T02:01:53.401Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1109874,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.8","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c2c912fb7bb367ddeea98193fc51f2aa526733066d0846911aaddb13a457248"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-16T00:00:00.000Z","created_at":"2023-03-16T02:22:59.785Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":3728537,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.7","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4383a019926cfd250c3027f8cc7064f6859e478871b4e09b9cf967800947e7ce"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:10:08.055Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":266212,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.6.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a3f89e07502bda2f4c866a2fe37f416458c9e1defadc05cd6d8e3991ca63f960"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T06:00:02.662Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":37084,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.6","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"431f49518ddcd70913767aef2327830388eff1de94b3c5be40044af297784d20"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-12T00:00:00.000Z","created_at":"2023-03-12T06:28:17.816Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":25605,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.5","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fb590ecd5ba8a047b18fc991c5235d1501e2dc1be2976e6dac14a63599847adc"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:31.330Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":446519,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5e3f987030d83c8e9477e2002410531943f441df6b8224113039eb3f91fdbb4"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:39.596Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1816927,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6fe0042b786617e966ebc082f76dba624f5167f70acb741209805b216e0d07d7"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-16T00:00:00.000Z","created_at":"2023-01-16T22:41:09.758Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":42128,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"93008e4e29af4ac220ec19ed814f288f0cc27e14b1a4b27216e6e4b7e1e73cf6"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-26T00:00:00.000Z","created_at":"2022-12-26T20:20:10.238Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":685056,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3a3b430e04eb9c5eb1e93502ce80e1c534eb20586eca8d2fbfb1b99960aad300"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-05T00:00:00.000Z","created_at":"2022-12-05T05:13:22.496Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":799377,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7313e1a28e8301e08f86de3ee0c82d9e3e1602586683007fdd018abe5e818420"},{"authors":"Leah
+        Neukirchen","built_at":"2022-11-18T00:00:00.000Z","created_at":"2022-11-18T20:59:51.381Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":587889,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0fe3e8d68b2a4684bcdff0b1fecb0a5e201b7ea3f6fac868fa18d596035eff3c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-09-06T00:00:00.000Z","created_at":"2022-09-06T16:28:59.486Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":2909973,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.4.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"197adbbe5d585dca1909fe6c544f369919d795d54fc76f86b6ce458008f6e29c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-09-04T00:00:00.000Z","created_at":"2022-09-04T23:52:01.005Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":847,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0.rc1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.4.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"9ded32f01d520c16076c72649873229fcd83a18e79d9ebd696fc22d34e484088"},{"authors":"Leah
+        Neukirchen","built_at":"2022-08-08T00:00:00.000Z","created_at":"2022-08-08T20:34:51.637Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":1902,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/main/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"3.0.0.beta1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.4.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"293cd882966e417d38329ff96b62f3ce1be14cc534cdec22a9150e93ec803cc9"},{"authors":"Leah
+        Neukirchen","built_at":"2023-04-24T00:00:00.000Z","created_at":"2023-04-24T23:22:24.296Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":9530472,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.7","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b3377e8b2227b8ffa6b617ef8649ffb5e265e46ca8fa1f31244c809fe609829b"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:10:14.661Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":11444016,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d3d92be402b5881058caccc0975e6d67a1e0ba929d1d144a43daf689169bfce1"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:25.059Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":3138859,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"421648340bfe81e20fc766304129e08c92d7a661a856466ec2f1c224784a8f9f"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T21:22:23.931Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":11183429,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4be320c0fdea6651f0247dbd4182c1bd8acc06606a6b8935a19ad6a504347763"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:33.530Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":16801,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"252ebd625fa53bbc5aa5aa43cb658d3d92342850898b5f0592dc170d20b8ba88"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-16T00:00:00.000Z","created_at":"2023-01-16T21:05:52.483Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":248892,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.6","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d903a6529095f624bb7bd3b6b0e29a1aa0fdcd85d476033648d93e7a68760308"},{"authors":"Leah
+        Neukirchen","built_at":"2022-12-26T00:00:00.000Z","created_at":"2022-12-26T20:19:38.461Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":2678119,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.5","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"724426d0d1dd60f35247024413af93f8e1071c7cfe2c012e59503e5bd7f4b293"},{"authors":"Leah
+        Neukirchen","built_at":"2022-06-30T00:00:00.000Z","created_at":"2022-06-30T22:22:23.466Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":40348880,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.4","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ea2232b638cbd919129c8c8ad8012ecaccc09f848152a7e705d2139d0137ac2b"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:55.752Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":28461282,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.3.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c728da28f6d800c3839d226fdbce702c94eeb68e25e752b6c2f2be7c1d338ac"},{"authors":"Leah
+        Neukirchen","built_at":"2020-06-15T00:00:00.000Z","created_at":"2020-06-15T22:25:14.574Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":169339301,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.3","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2638e7eb6689a5725c7e16f30cc4aa4e31694dc3ca30d790952526781bd0bb44"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-10T00:00:00.000Z","created_at":"2020-02-10T22:25:17.510Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":17003160,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.2","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"77f51f9a1409e388a7c002612311fc8cef06f70309eba90800dc6a8d884eb782"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-09T00:00:00.000Z","created_at":"2020-02-09T06:20:24.822Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":194727,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.1","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"da7f8ccc5dcdc4a25a6fc7086e6969f32ded6d70ae3d79bb8fe6c30c4bd67fbc"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:26:43.205Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby. By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n","downloads_count":46343,"metadata":{"changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.2.0","summary":"A
+        modular Ruby webserver interface.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.3.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"740433e3a52f9862f508db646e7d324eb209db02572a633de01e406483c29cf3"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:19.576Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":41970,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9b421416c3dd3ea788bcfe642ce9da7622cd5a7fd684fdc7262f5f6028f50f85"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:28.897Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":86358,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"42eff000e8df7e9ac284deb30b9140570592be565582d84768825e2354a9b77c"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:49.864Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":431391,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af609439fca4ac98fb3d9a5f82800d37c2758ebe50c2bbeb4d4d1db568ebe47d"},{"authors":"Leah
+        Neukirchen","built_at":"2020-06-15T00:00:00.000Z","created_at":"2020-06-15T22:24:45.579Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":3088718,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bfae1fd43aab62bb60b268329c860f214d2ffb15c4bca48931135a2dea52e2f4"},{"authors":"Leah
+        Neukirchen","built_at":"2020-05-12T00:00:00.000Z","created_at":"2020-05-12T21:44:50.346Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":137081,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f8088454a5ad6974e5710cb7441c233773bb2871610aa802009c6e86c0f2f916"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-27T00:00:00.000Z","created_at":"2020-01-27T22:42:41.077Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":3340156,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c45c0dac286ae71afe8d74265ccfb39a2ba36950e44b8ebe4ae43237c060a13"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-11T00:00:00.000Z","created_at":"2020-01-11T22:18:36.652Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":1685073,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dc6653775cc44febfc82132783e0a7d7284cf248d42c0c13bd77ecc327b79375"},{"authors":"Leah
+        Neukirchen","built_at":"2020-01-10T00:00:00.000Z","created_at":"2020-01-10T17:49:19.823Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":93279,"metadata":{"homepage_uri":"https://rack.github.io","changelog_uri":"https://github.com/rack/rack/blob/master/CHANGELOG.md","bug_tracker_uri":"https://github.com/rack/rack/issues","source_code_uri":"https://github.com/rack/rack","mailing_list_uri":"https://groups.google.com/forum/#!forum/rack-devel","documentation_uri":"https://rubydoc.info/github/rack/rack"},"number":"2.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9d0a52989ce13125be491dd30e6b6c23c539ecf0cc404b2cb5d862dddbcb3e68"},{"authors":"Leah
+        Neukirchen","built_at":"2023-03-02T00:00:00.000Z","created_at":"2023-03-02T22:57:12.585Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":73934,"metadata":{},"number":"2.0.9.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c38013104cf9f83d645bd7ad9c036e96d0e8ee4dfc6891cde4480274bfbbd79"},{"authors":"Leah
+        Neukirchen","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T20:48:23.635Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":49755,"metadata":{},"number":"2.0.9.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b1cfbe2f35832ce9d06e9bf52d5d5b2ef75f0960ce90f3d8c8890ed71bdd93e"},{"authors":"Leah
+        Neukirchen","built_at":"2022-05-27T00:00:00.000Z","created_at":"2022-05-27T15:31:43.757Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":643127,"metadata":{},"number":"2.0.9.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3cc510b7943eb9d963ad028438501f06c6f909377ffe58206339fa2b73cd61d3"},{"authors":"Leah
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:21:51.799Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":6450912,"metadata":{},"number":"2.0.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"733a9e53a7470c472d58b94532d70d6e31edb49245ca6449333f53df4598bfd7"},{"authors":"Leah
+        Neukirchen","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T18:08:51.732Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":10774893,"metadata":{},"number":"2.0.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f98171fb30e104950abe1e9fb97c177d8bb5643dd649bc2ed837864eb596a0c5"},{"authors":"Leah
+        Neukirchen","built_at":"2019-04-02T00:00:00.000Z","created_at":"2019-04-02T16:54:37.554Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":36329428,"metadata":{},"number":"2.0.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5158fb64313c17fb2535c8e5def3de7e8b38baf2ab9e4c90155ebed5a9db207d"},{"authors":"Leah
+        Neukirchen","built_at":"2018-11-05T00:00:00.000Z","created_at":"2018-11-05T20:00:33.151Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":25266958,"metadata":{},"number":"2.0.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f5874ac9c2223ecc65fcad3120c884fc2a868c1c18f548ff676a6eb21bda8fdd"},{"authors":"Leah
+        Neukirchen","built_at":"2018-04-23T00:00:00.000Z","created_at":"2018-04-23T17:47:56.538Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":20603493,"metadata":{},"number":"2.0.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"81e3ece3d36e7507ff6a05666cc2ff759bdd08a96aefb8c5fd6c309a8f5d1095"},{"authors":"Christian
+        Neukirchen","built_at":"2018-01-31T00:00:00.000Z","created_at":"2018-01-31T18:17:19.593Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see https://rack.github.io/.\n","downloads_count":7674814,"metadata":{},"number":"2.0.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2700d52bdc681b103e161d1da2b3767850e58f3de80e87d16e232491058fd9d5"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-15T00:00:00.000Z","created_at":"2017-05-15T16:50:19.287Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":16195028,"metadata":{},"number":"2.0.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8c1c9bbafd74f11c78a29bd87c72a70e7b5b872712d1768ab83b33fec57d9fcd"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-08T00:00:00.000Z","created_at":"2017-05-08T17:08:46.316Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":24832807,"metadata":{},"number":"2.0.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b9009b9acbefd85bea220ca13011e6f0f76630169289d9e433a0558dc73542d2"},{"authors":"Christian
+        Neukirchen","built_at":"2016-06-30T00:00:00.000Z","created_at":"2016-06-30T17:34:18.298Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":9677867,"metadata":{},"number":"2.0.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"61f78033bf5b1cd0221549ecce7c7b73205d4634b0e63c66e1f295dcf3c26b14"},{"authors":"Christian
+        Neukirchen","built_at":"2016-05-06T00:00:00.000Z","created_at":"2016-05-06T20:52:56.316Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":162357,"metadata":{},"number":"2.0.0.rc1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f5b00b0977166f79073c79b2b1d11fc7fe335697e05eafde380379ddf253ba77"},{"authors":"Christian
+        Neukirchen","built_at":"2015-12-17T00:00:00.000Z","created_at":"2015-12-17T21:34:53.915Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":249234,"metadata":{},"number":"2.0.0.alpha","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f6d4e7b7673f1d3d09e52c9b0d7fbfd7702f23f6d14f82e8283e19460bb223f9"},{"authors":"Christian
+        Neukirchen","built_at":"2020-02-08T00:00:00.000Z","created_at":"2020-02-08T18:19:58.581Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":18428882,"metadata":{},"number":"1.6.13","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"207e60f917a7b47cb858a6e813500bc6042a958c2ca9eeb64631b19cde702173"},{"authors":"Christian
+        Neukirchen","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T18:08:57.819Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2228086,"metadata":{},"number":"1.6.12","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"928527a0897796d2575e8cacdfa526341dc4c55d05e09b31c39b3704c80738e6"},{"authors":"Christian
+        Neukirchen","built_at":"2018-11-05T00:00:00.000Z","created_at":"2018-11-05T20:00:22.853Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":19109228,"metadata":{},"number":"1.6.11","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ee2016b1ddf820f6e5ee437d10a85319506b60c0d493da1d15815361a91129bd"},{"authors":"Christian
+        Neukirchen","built_at":"2018-04-23T00:00:00.000Z","created_at":"2018-04-23T17:52:31.754Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":9663917,"metadata":{},"number":"1.6.10","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"58e8ae09c502f219a6ad2e7f932072faf2d2b38ce6fd0251ac7ff3096c55c046"},{"authors":"Christian
+        Neukirchen","built_at":"2018-02-27T00:00:00.000Z","created_at":"2018-02-27T17:19:24.605Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2484256,"metadata":{},"number":"1.6.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0764d8edafbd52a1055966045a27d1c73fb572a18db5151c000887444bcc810f"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-16T00:00:00.000Z","created_at":"2017-05-16T21:29:10.758Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":23132506,"metadata":{},"number":"1.6.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eae37ccb7686b2c672f64bc6be366cfda4d828ea58e1086cb82766b17a54a7a6"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-15T00:00:00.000Z","created_at":"2017-05-15T16:47:41.052Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":49529,"metadata":{},"number":"1.6.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"485c1bf52521ff354be7dd2a9f529423ee976a51ddec5aace4cf2eebc2ce9c59"},{"authors":"Christian
+        Neukirchen","built_at":"2017-05-08T00:00:00.000Z","created_at":"2017-05-08T17:07:35.278Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":1610849,"metadata":{},"number":"1.6.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5d098ff67ab8c44a9a9007a445fac67db7f53075d943bda0ec6439fc64366d1c"},{"authors":"Christian
+        Neukirchen","built_at":"2016-11-10T00:00:00.000Z","created_at":"2016-11-10T21:55:00.409Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":10723986,"metadata":{},"number":"1.6.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ff9d8fc9e89af3f59ba1708d5dec642e3ec421dbeca567bc460b5b8ba0efe48c"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T21:51:38.677Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":38305985,"metadata":{},"number":"1.6.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"455ec4545a54b40dae9937bc5f61ee0e32134191cc1ef9a7959a19ec4b127a25"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T18:45:14.478Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":15971,"metadata":{},"number":"1.6.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4da0c396487e0914cd380c9ec43d4511992756d2c0fa079f70de0a03651cd783"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T17:59:02.851Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":499504,"metadata":{},"number":"1.6.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"89278d4842d0ecdd1e79cbf7a894dc86f976e6d25debc6814343298fd19ed017"},{"authors":"Christian
+        Neukirchen","built_at":"2015-05-06T00:00:00.000Z","created_at":"2015-05-06T18:37:48.080Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":2791352,"metadata":{},"number":"1.6.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f4017a0a84dd36f1a6b38baa081731e3696a356f8f83ed74a09ff109afd9e338"},{"authors":"Christian
+        Neukirchen","built_at":"2014-12-18T00:00:00.000Z","created_at":"2014-12-18T22:45:11.060Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":25591748,"metadata":{},"number":"1.6.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b6941d48013bc605538fc453006a9df18114ddf0757a3cd69cfbd5c3b72a7b8"},{"authors":"Christian
+        Neukirchen","built_at":"2014-11-27T00:00:00.000Z","created_at":"2014-11-27T18:52:53.658Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":101988,"metadata":{},"number":"1.6.0.beta2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"078f2babefc7c659f1833f08e03ca79cb1a8ab80f2a6cb6fec057b9f60e7a494"},{"authors":"Christian
+        Neukirchen","built_at":"2014-08-18T00:00:00.000Z","created_at":"2014-08-18T19:02:15.332Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.io/.\n","downloads_count":350115,"metadata":{},"number":"1.6.0.beta","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":"\u003e= 0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"fbfe6d3f321a863809ade0c8fb5db95721ddd95831d01342623123789c596125"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T18:46:19.771Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":9136291,"metadata":{},"number":"1.5.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ae4a74f555008ecc541060515c37baa9e16f131538447a668c0bf52117c43b7"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T17:58:54.690Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":258311,"metadata":{},"number":"1.5.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"401f8725be81ca60a4c8366fca674a9f18e9bc577b6ad4f42c9f66d763107e6e"},{"authors":"Christian
+        Neukirchen","built_at":"2015-05-06T00:00:00.000Z","created_at":"2015-05-06T18:43:23.519Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":498786,"metadata":{},"number":"1.5.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b4cbe46b77cd1887c8175bd5f08b1644ab4397122edc1bb1551c9e14390100f"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:14:13.517Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":45811788,"metadata":{},"number":"1.5.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"e64af00234e8faaa69ea81ef4e3800f40743c69560f0dda8fc9969660e775fa7"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-28T00:00:00.000Z","created_at":"2013-01-28T22:52:21.850Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":477889,"metadata":{},"number":"1.5.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"398896c8a109b402d4f62b7fc3b93f65249b3ffd8024ca8127a763a1a0fa6f84"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-22T00:00:00.000Z","created_at":"2013-01-22T07:40:50.789Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":209690,"metadata":{},"number":"1.5.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"d0ac19e607aae98dc2ebe9e45b0d07405efae90a43874cfa5b7a47e4f76af624"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:10:44.503Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":5134,"metadata":{},"number":"1.5.0.beta.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":[],"requirements":null,"sha":"9e6b45061429c21a9c50fe5252efb83f3faf1f54e2bfcf629d1a9d5a2340c2ed"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-11T00:00:00.000Z","created_at":"2013-01-11T22:58:13.295Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":4940,"metadata":{},"number":"1.5.0.beta.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":[],"requirements":null,"sha":"92a8748082af00c11b47df71f66ce04e96b724d8a67c51dc301b56a955312468"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-18T00:00:00.000Z","created_at":"2015-06-18T21:12:18.862Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":11907043,"metadata":{},"number":"1.4.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":[],"requirements":[],"sha":"fa06e970605808834fc7e5a8b9babd4871d7d4c23a4d9d61cb94cbd4c15de5e6"},{"authors":"Christian
+        Neukirchen","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T20:47:05.112Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":99390,"metadata":{},"number":"1.4.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":[],"requirements":[],"sha":"f65ad9022e83e6517d6e3e37cecb781cd172061e769068334bab142d3435f13d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:13:08.844Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":17810145,"metadata":{},"number":"1.4.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"f7bf3faa8e09a2ff26475372de36a724e7470d6bdc33d189a0ec34b49605f308"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:07:50.276Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":872298,"metadata":{},"number":"1.4.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"7f8b61b0d1f65279474f09e0a92d121dfd0d0651843755a0f152e8f02c281dc0"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T18:49:46.932Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":582717,"metadata":{},"number":"1.4.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"e16392baa87833c0eb51afcec13f96a521339af183032fa211b6d31e57f320df"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:43:24.200Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":34391,"metadata":{},"number":"1.4.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"cf09934534722129318d8049fdc98bf319a3e9254565e0edc31529fed889b840"},{"authors":"Christian
+        Neukirchen","built_at":"2012-01-23T00:00:00.000Z","created_at":"2012-01-23T06:51:48.577Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":9621709,"metadata":{},"number":"1.4.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2005d0cee536e76b5d0dc853778e3f7840e98c38380265d6d2c45e44dee7a3b3"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:56:39.698Z","description":"Rack
+        provides a minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":225509,"metadata":{},"number":"1.4.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"09b3fbc957e182b00db573b0693014065745432f4bc53920e8d019e4a7cfb896"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:11:09.654Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":817315,"metadata":{},"number":"1.3.10","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"7a7e3e07181d05dc39bdfa566c4025c126a1eb9ac0f434848a9ea0a9c127d9b6"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:07:05.217Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":53130,"metadata":{},"number":"1.3.9","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"c75023e17509f4fdee8f62f86140175c8dd279e0e0b489fd9e2662226640243f"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T18:49:00.051Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":46998,"metadata":{},"number":"1.3.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"977aef187206d8706b074a3f900b1ac1dcdf86eccbfc7fc4b234d821ee1b8015"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:42:07.617Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.github.com/.\n","downloads_count":6141,"metadata":{},"number":"1.3.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"258d673aedab569c5f9ed6f6bd5c19907b6d948aa92a25aac83afc8a35cc46b9"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:52:24.315Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1064012,"metadata":{},"number":"1.3.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d4090f47205a8af4e602be73cf6e5f94f0c91951cfb4e4682e93fc17b2e670e2"},{"authors":"Christian
+        Neukirchen","built_at":"2011-10-18T00:00:00.000Z","created_at":"2011-10-18T05:33:18.912Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1279978,"metadata":{},"number":"1.3.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"1722c36ea1200116560f7e8973a7675a27e6fc2e08a5cc1c146523351ab6e5e1"},{"authors":"Christian
+        Neukirchen","built_at":"2011-10-01T00:00:00.000Z","created_at":"2011-10-01T20:50:43.592Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":238408,"metadata":{},"number":"1.3.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"347f9bc51d2ecba71caa31e0fe2a0cddf88c0877ba0047ffaa365ee474a0919f"},{"authors":"Christian
+        Neukirchen","built_at":"2011-09-16T00:00:00.000Z","created_at":"2011-09-16T23:32:21.895Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":233257,"metadata":{},"number":"1.3.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"8a32cf05128c1d89f6899ef67826ead71ec44a9c9ff4b7cafcb82eae50cc7e47"},{"authors":"Christian
+        Neukirchen","built_at":"2011-07-26T00:00:00.000Z","created_at":"2011-07-26T01:40:42.197Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1880599,"metadata":{},"number":"1.3.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"f3fc568ecab28b26473c97e5e3a3ff36368128db157d95931b8c28247d263ae3"},{"authors":"Christian
+        Neukirchen","built_at":"2011-07-13T00:00:00.000Z","created_at":"2011-07-13T23:20:57.656Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":79757,"metadata":{},"number":"1.3.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d64b700e33f156fb6e7ddfbafcd6a962b441394f04c31f559e2078c45ceb6b68"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-22T07:00:00.000Z","created_at":"2011-05-23T06:08:16.127Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":384326,"metadata":{},"number":"1.3.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"98c4aa69ea449c54bcb6f5a7417e2bdad1b34a0de20608c0fe8c621b01914aa4"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-19T04:00:00.000Z","created_at":"2011-05-19T17:16:00.870Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":70978,"metadata":{},"number":"1.3.0.beta2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"2ba51abc21a6543d117f1a31318bc3acf41ed90cc5397090857746c01f187555"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-03T07:00:00.000Z","created_at":"2011-05-03T10:39:20.440Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":14792,"metadata":{},"number":"1.3.0.beta","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"a5f8a8a2233e43636c4164c35fe837364a1fb673e52a578c5a73485e5acd2057"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:09:59.888Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1098620,"metadata":{},"number":"1.2.8","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4b0414a7267d6426d61a105f0ccd75ed0c94cf3ceebb25a0740d3894dbca5cc6"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:05:30.848Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":106723,"metadata":{},"number":"1.2.7","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"107cee2cda7b9cd4231c849dc9dcf06867beb7c67b64a4066502452908847ac0"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:39:13.764Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":68223,"metadata":{},"number":"1.2.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"673af82991bd3f51f7f063b701abe910c4eca7711b34821a31cee743e48357d7"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:48:19.240Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":849030,"metadata":{},"number":"1.2.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2722169809a6fcd73b395a405e43985af24d0cc005a3f9ec389967ecfc6f2c6c"},{"authors":"Christian
+        Neukirchen","built_at":"2011-09-16T00:00:00.000Z","created_at":"2011-09-17T00:00:17.782Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":516000,"metadata":{},"number":"1.2.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"2f0d158a077e40f2150922d0049e33fb21854b1b2d4a795c0bed0a2872fda002"},{"authors":"Christian
+        Neukirchen","built_at":"2011-05-23T07:00:00.000Z","created_at":"2011-05-23T07:42:19.332Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1056324,"metadata":{},"number":"1.2.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d1c6f65e54facecd0cd3f06ea60c63a81c8f36497e6ebb575d48cf015b13847f"},{"authors":"Christian
+        Neukirchen","built_at":"2011-03-12T23:00:00.000Z","created_at":"2011-03-13T14:03:14.786Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":4952007,"metadata":{},"number":"1.2.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"6463a86f1d86fa9850f24d32bb398889103c4bca0a1ad34c3f1e6a1cd77e51b3"},{"authors":"Christian
+        Neukirchen","built_at":"2010-06-14T22:00:00.000Z","created_at":"2010-06-15T09:57:28.836Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":3175102,"metadata":{},"number":"1.2.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"72014a9f5b565bd088735f54e6d601a715c5d4d89c89bc387f9ddb9d6f749a2f"},{"authors":"Christian
+        Neukirchen","built_at":"2010-06-12T22:00:00.000Z","created_at":"2010-06-13T17:53:23.974Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":24263,"metadata":{},"number":"1.2.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"dede6fbef9c9f00435d68c90e404e18988dd9e22d4bf3317e7d29b0fa4562f2d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-02-08T00:00:00.000Z","created_at":"2013-02-08T03:08:42.626Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1636361,"metadata":{},"number":"1.1.6","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"fd0aaca346d52758e4b152783418c5b6e04861862001c54a0d3715ed08e0ecb8"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-13T00:00:00.000Z","created_at":"2013-01-13T22:03:48.342Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":68411,"metadata":{},"number":"1.1.5","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"49cf6108fb5aa606cd121d63a16ba40bd56af83b8e12d9ea06edafdd58a4926d"},{"authors":"Christian
+        Neukirchen","built_at":"2013-01-07T00:00:00.000Z","created_at":"2013-01-07T02:21:38.382Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":43613,"metadata":{},"number":"1.1.4","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4d8a7504ac93a872712275e4d5a2b6274ea6e17b7e30dd92d49ec73f329b1909"},{"authors":"Christian
+        Neukirchen","built_at":"2011-12-28T00:00:00.000Z","created_at":"2011-12-28T02:37:38.280Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":506518,"metadata":{},"number":"1.1.3","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"e774004d0229a82835d21fcfed2feda1b0df1fe7e609d3d4324660890a57ac3e"},{"authors":"Christian
+        Neukirchen","built_at":"2011-03-12T23:00:00.000Z","created_at":"2011-03-13T14:02:46.405Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":506171,"metadata":{},"number":"1.1.2","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"0caaa479982622042c4af7411a3f9b9748c9b3a5a03b60a0991c7e44a22f15f5"},{"authors":"Christian
+        Neukirchen","built_at":"2011-02-28T08:00:00.000Z","created_at":"2011-03-01T06:04:51.617Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":86804,"metadata":{},"number":"1.1.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"89c18ffce62358c17ba8a4674b500635f6a9debb0bd612d816c998ae16be7148"},{"authors":"Christian
+        Neukirchen","built_at":"2011-02-09T08:00:00.000Z","created_at":"2011-02-10T03:12:48.548Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":5420,"metadata":{},"number":"1.1.1.pre","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"ea26b77b9b55d364ec38d649a98901abbd5ab2317906a947532fd96facfc568c"},{"authors":"Christian
+        Neukirchen","built_at":"2010-01-03T23:00:00.000Z","created_at":"2010-01-03T23:15:29.326Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing\nweb applications
+        in Ruby.  By wrapping HTTP requests and responses in\nthe simplest way possible,
+        it unifies and distills the API for web\nservers, web frameworks, and software
+        in between (the so-called\nmiddleware) into a single method call.\n\nAlso
+        see http://rack.rubyforge.org.\n","downloads_count":1849970,"metadata":{},"number":"1.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"96c618247e5f53c20ad51de0b7682ca589abe7070ce5325502054f80ed29011f"},{"authors":"Christian
+        Neukirchen","built_at":"2009-10-18T01:00:00.000Z","created_at":"2009-10-18T22:45:05.531Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":1793680,"metadata":{},"number":"1.0.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"78b9d7d82d40a3c2e361fdc93db8652c527d397b4a4eda99e6873e14190ec612"},{"authors":"Christian
+        Neukirchen","built_at":"2009-04-24T22:00:00.000Z","created_at":"2009-07-25T18:02:12.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":88785,"metadata":{},"number":"1.0.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"b1147fd2991884dfbac9b101b0c88a0f0fc71abbd1bd24fb29cde3fdfc8ebd77"},{"authors":"Christian
+        Neukirchen","built_at":"2009-01-08T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":23606,"metadata":{},"number":"0.9.1","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"0b10d9a9ae7dec712abb18a4e684a660e80c095ee03062dfa48a15f7a643720b"},{"authors":"Christian
+        Neukirchen","built_at":"2009-01-05T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":5198,"metadata":{},"number":"0.9.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"412426b5b2c95d60f014469baabf5ed50fc6cca2ec098b5ad32c24eddfab63de"},{"authors":"Christian
+        Neukirchen","built_at":"2008-08-20T22:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":8556,"metadata":{},"number":"0.4.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"720ce53dfe04ab32724871f135d9fe6b9af79070ab4c2b2b22aaf93aa7fa52dd"},{"authors":"Christian
+        Neukirchen","built_at":"2008-02-25T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":6297,"metadata":{},"number":"0.3.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"344a154a0aeaeff1b7114a62263cd42e902521ff6869e6d7159d76e3df066d82"},{"authors":"Christian
+        Neukirchen","built_at":"2007-05-15T22:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":4830,"metadata":{},"number":"0.2.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"865666f11c3016e89e689078358edb895691170b11482ec252e42ae9c08b0772"},{"authors":"Christian
+        Neukirchen","built_at":"2007-03-02T23:00:00.000Z","created_at":"2009-07-25T18:02:13.000Z","description":"Rack
+        provides minimal, modular and adaptable interface for developing web applications
+        in Ruby.  By wrapping HTTP requests and responses in the simplest way possible,
+        it unifies and distills the API for web servers, web frameworks, and software
+        in between (the so-called middleware) into a single method call.  Also see
+        http://rack.rubyforge.org.","downloads_count":6878,"metadata":{},"number":"0.1.0","summary":"a
+        modular Ruby webserver interface","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"ae2a16ef7744acf003a2f1adc0d8c5cbb3dfa614f6f70f7b99165ba5fad3c0ac"}]'
+  recorded_at: Fri, 14 Jul 2023 14:55:52 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
This is an exploration of adding an `update-type` option to Dependency Groups.

I've approached is as an ignore rule inversion problem - if a Dependency Group only wants Minor and Patch-level updates, then we should ignore Major versions.

This allows us to [re-|ab]use `IgnoreCondition` objects to generate ignored versions based on any given Dependency that disallow ranges which would result in a Major version update for the duration of the group.

I just need to figure out the right away to combine any configuration-based ignores with these injected ignores, I think de-duplication is sufficient and if we end up in a situation where all versions are ignored, that is a normal 'all versions ignored' outcome 🤔 .

The only case I think that might require some additional handling is if we have an outcome where every version of every dependency is ignored as that suggests a conflict between `ignore` and `group` values.