### PR TITLE
Use the new base image

### DIFF
--- a/.devcontainer/core-dev/devcontainer.json
+++ b/.devcontainer/core-dev/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "core-dev",
   "build": {
     "dockerfile": "../../Dockerfile.development",
-    "cacheFrom": "ghcr.io/dependabot/dependabot-core-development"
+    "cacheFrom": "ghcr.io/dependabot/dependabot-updater-core"
   },
 
   "workspaceFolder": "/home/dependabot/dependabot-core",

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=dependabot/dependabot-core
+ARG FROM_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM $FROM_IMAGE
 
 # Temporarily switch to root user in order to install packages


### PR DESCRIPTION
We split the monolith docker image into per-ecosystem images. The `dependabot/dependabot-core` image was replaced by `dependabot/dependabot-updater-core`.

Additionally, we don't publish this new image to Dockerhub, but only to GHCR.

So this corrects the references to it.

This is mostly the great work of @dwc0011 from:
* https://github.com/dependabot/dependabot-core/pull/7458

However, the scope of that PR is starting to get a bit larger, and we'll need to have more conversations about the best way forward. It's unclear if we should even have a default `FROM` value vs always forcing it to be set. But that's a bigger conversation.

So for now I extracted this smaller set of changes out so we can at least stop referencing an old Dockerfile that we no longer update.