### PR TITLE
Mount `updater/bin` into the docker dev shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -235,6 +235,7 @@ docker run --rm -ti \
   -v "$(pwd)/terraform/spec:$CODE_DIR/terraform/spec" \
   -v "$(pwd)/tmp:/$CODE_DIR/tmp" \
   -v "$(pwd)/updater/.rubocop.yml:$CODE_DIR/updater/.rubocop.yml" \
+  -v "$(pwd)/updater/bin:$CODE_DIR/updater/bin" \
   -v "$(pwd)/updater/Gemfile.lock:$CODE_DIR/updater/Gemfile.lock" \
   -v "$(pwd)/updater/Gemfile:$CODE_DIR/updater/Gemfile" \
   -v "$(pwd)/updater/lib:$CODE_DIR/updater/lib" \


### PR DESCRIPTION
I found it handy to have access to these while debugging some `updater` code.