### PR TITLE
Match the smoke test invocation of CLI/proxy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -245,9 +245,7 @@ jobs:
     - name: Download cache
       if: steps.changes.outputs[matrix.suite.name] == 'true'
       run: |
-        mkdir cache
-        cd cache
-        gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite.name }}
+        gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite.name }} --dir cache
 
     - name: Build ecosystem image
       if: steps.changes.outputs[matrix.suite.name] == 'true'


### PR DESCRIPTION
This updates the command to match the smoke invocation used in the CLI and proxy.

This should hopefully reduce mistakes creeping in like https://github.com/dependabot/cli/pull/148 where I copy/pasted not realizing there was a slight difference between the two repos.

Related:
* https://github.com/dependabot/cli/pull/150
* https://github.com/dependabot/cli/pull/148