### PR TITLE
Only add `"v"` prefix for the helper path

### DIFF
--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -16,13 +16,13 @@ module Dependabot
       def self.composer_version(composer_json, parsed_lockfile = nil)
         if parsed_lockfile && parsed_lockfile["plugin-api-version"]
           version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
-          return version.canonical_segments.first == 1 ? "v1" : "v2"
+          return version.canonical_segments.first == 1 ? "1" : "2"
         else
-          return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
-          return "v1" if invalid_v2_requirement?(composer_json)
+          return "1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
+          return "1" if invalid_v2_requirement?(composer_json)
         end
 
-        "v2"
+        "2"
       end
 
       def self.invalid_v2_requirement?(composer_json)

--- a/composer/lib/dependabot/composer/native_helpers.rb
+++ b/composer/lib/dependabot/composer/native_helpers.rb
@@ -3,8 +3,8 @@
 module Dependabot
   module Composer
     module NativeHelpers
-      def self.composer_helper_path(composer_version: "v2")
-        File.join(composer_helpers_dir, composer_version, "bin/run")
+      def self.composer_helper_path(composer_version: "2")
+        File.join(composer_helpers_dir, "v#{composer_version}", "bin/run")
       end
 
       def self.composer_helpers_dir

--- a/composer/spec/dependabot/composer/helpers_spec.rb
+++ b/composer/spec/dependabot/composer/helpers_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe Dependabot::Composer::Helpers do
       JSON
     end
 
-    it "uses v2 for a manifest that specifies a platform dependency without lockfile" do
+    it "uses '2' for a manifest that specifies a platform dependency without lockfile" do
       composer_json = JSON.parse(composer_v2_content)
 
-      expect(described_class.composer_version(composer_json)).to eq("v2")
+      expect(described_class.composer_version(composer_json)).to eq("2")
     end
 
-    it "uses v1 when one of the packages has an invalid name" do
+    it "uses '1' when one of the packages has an invalid name" do
       composer_json = JSON.parse(composer_v1_content)
 
-      expect(described_class.composer_version(composer_json)).to eq("v1")
+      expect(described_class.composer_version(composer_json)).to eq("1")
     end
   end
 end


### PR DESCRIPTION
The `"v"` prefix isn't part of the version, for example if we report metrics on it. It's only needed for building the path to the helper.

Extracted from:
* https://github.com/dependabot/dependabot-core/pull/7323