### PR TITLE
Don't try to diff if there's nothing to diff

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -258,6 +258,7 @@ jobs:
 
     - name: ${{ matrix.suite.name }}
       if: steps.changes.outputs[matrix.suite.name] == 'true'
+      id: test
       env:
         LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -271,7 +272,7 @@ jobs:
           2>&1 | tee -a log.txt
 
     - name: Diff
-      if: always()
+      if: steps.test.outcome != 'skipped'
       continue-on-error: true
       run: diff --ignore-space-change smoke.yaml result.yaml && echo "Contents are identical"
 


### PR DESCRIPTION
On a passing smoke test workflow, you still get some Red Cross annotations.

They don't make the build fail, but can be distracting.

Trying to not run them when not necessary.