### PR TITLE
Aggressively group prod and dev dependencies for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,12 +53,14 @@ updates:
     groups:
       dependencies:
         patterns:
-          - "*yarn*"
-          - "*arborist*"
-          - "*nock*"
-          - "*npm*"
-          - "*semver*"
+          - "@dependabot/yarn-lib"
+          - "@npmcli/arborist"
           - "detect-indent"
+          - "nock"
+          - "npm"
+          - "@pnpm/lockfile-file"
+          - "@pnpm/dependency-path"
+          - "semver"
       dev-dependencies:
         patterns:
           - "*eslint*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,20 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    groups:
+      dependencies:
+        patterns:
+          - "*yarn*"
+          - "*arborist*"
+          - "*nock*"
+          - "*npm*"
+          - "*semver*"
+          - "detect-indent"
+      dev-dependencies:
+        patterns:
+          - "*eslint*"
+          - "*jest*"
+          - "*prettier"
     ignore:
       - dependency-name: "npm"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Use wildcard matching to aggregate prod and dev updates into two separate groups