### PR TITLE
Point at the correct `Dockerfile` for python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -7,23 +7,25 @@ Python support for [`dependabot-core`][core-repo].
 We rely on `pyenv` to manage Python's versions.
 
 Updating the list of known versions might be tricky, here are the steps:
-1. Update `pyenv` version in our [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/Dockerfile), you may use commit hash if new `pyenv` version is not released yet
-2. Then, update `pyenv global` version in `Dockerfile`, we always use the latest (and the greatest) Python version there is
-3. Now, update the list of known Python version in [`python_versions.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb)
-4. The last step is to tweak our tests, if required. The easiest way to determine which one to tweak is just by analyzing the failing output
 
-[Example PR](https://github.com/dependabot/dependabot-core/pull/3440) that does all these things.
+1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
+2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
+3. Update the list of known Python versions in [`python_versions.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/python_versions.rb).
+4. Fix any broken tests.
+
+[Example PR](https://github.com/dependabot/dependabot-core/pull/7412) that does all these things.
 
 ### Running locally
 
 1. Start a development shell
 
-  ```
+  ```shell
   $ bin/docker-dev-shell python
   ```
 
 2. Run tests
-   ```
+
+   ```shell
    [dependabot-core-dev] ~/dependabot-core $ cd python && rspec
    ```
 


### PR DESCRIPTION
We broke the monolithic docker image into per-language images. So point the link at the Python one.

Also update to a PR that bumped python using this new dockerfile so that we have a better example. It's not perfect as it doesn't bump the `pyenv global` var, but it's the best we've got right now. We can replace it with the [`3.12` PR in October](https://peps.python.org/pep-0693/).