### PR TITLE
Stop manually installing python

### DIFF
--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -14,22 +14,9 @@ module Dependabot
         # The leading space is important in the version check
         return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor}.")
 
-        if File.exist?("/usr/local/.pyenv/#{python_major_minor}.tar.gz")
-          SharedHelpers.run_shell_command(
-            "tar xzf /usr/local/.pyenv/#{python_major_minor}.tar.gz -C /usr/local/.pyenv/"
-          )
-          return if SharedHelpers.run_shell_command("pyenv versions").
-                    include?(" #{python_major_minor}.")
-        end
-
-        Dependabot.logger.info("Installing required Python #{python_version}.")
-        start = Time.now
-        SharedHelpers.run_shell_command("pyenv install -s #{python_version}")
-        SharedHelpers.run_shell_command("pyenv exec pip install --upgrade pip")
-        SharedHelpers.run_shell_command("pyenv exec pip install -r" \
-                                        "#{NativeHelpers.python_requirements_path}")
-        time_taken = Time.now - start
-        Dependabot.logger.info("Installing Python #{python_version} took #{time_taken}s.")
+        SharedHelpers.run_shell_command(
+          "tar xzf /usr/local/.pyenv/#{python_major_minor}.tar.gz -C /usr/local/.pyenv/"
+        )
       end
 
       def python_major_minor


### PR DESCRIPTION
Depends on:
* https://github.com/dependabot/dependabot-core/pull/7610

In the python dockerfile, we pre-install python 3.7-3.11, then `tar` it
to save space.

Now that we're not supporting python <= 3.6, we no longer have any
reason to run `pyenv install`, so we can dop that and simplify our code.