### PR TITLE
Remove `3.6` guard when setting `poetry config experimental.system-git-client`

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools>=6.4.0,<=6.14.0  # Range maintains py36 support TODO: Review python 3.
 hashin==0.17.0
 pipenv==2022.4.8
 pipfile==0.0.2
-poetry>=1.1.15,<1.6.0
+poetry>=1.2,<1.6.0
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.0

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -185,9 +185,7 @@ module Dependabot
               language_version_manager.install_required_python
 
               # use system git instead of the pure Python dulwich
-              unless language_version_manager.python_version&.start_with?("3.6")
-                run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
-              end
+              run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
 
               run_poetry_update_command
 

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -95,9 +95,7 @@ module Dependabot
                 language_version_manager.install_required_python
 
                 # use system git instead of the pure Python dulwich
-                unless language_version_manager.python_version&.start_with?("3.6")
-                  run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
-                end
+                run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
 
                 # Shell out to Poetry, which handles everything for us.
                 run_poetry_update_command


### PR DESCRIPTION
Depends on:
* https://github.com/dependabot/dependabot-core/pull/7610

We no longer support Python 3.6, so this now always needs to happen.

I also bumped the minimum version of `poetry` up to `1.2` as that's when
the flag was added. It shouldn't matter, as python will default to the
highest version allowed by that version of python, and now that we only
support `3.7` onwards that will be the upper bound.