### PR TITLE
Rename `python_version` -> `python_version_file` for clarity

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -52,7 +52,7 @@ module Dependabot
         fetched_files << setup_cfg_file if setup_cfg_file
         fetched_files += path_setup_files
         fetched_files << pip_conf if pip_conf
-        fetched_files << python_version if python_version
+        fetched_files << python_version_file if python_version_file
 
         check_required_files_present
         uniq_files(fetched_files)
@@ -106,16 +106,16 @@ module Dependabot
                       tap { |f| f.support_file = true }
       end
 
-      def python_version
-        @python_version ||= fetch_file_if_present(".python-version")&.
+      def python_version_file
+        @python_version_file ||= fetch_file_if_present(".python-version")&.
                             tap { |f| f.support_file = true }
 
-        return @python_version if @python_version
+        return @python_version_file if @python_version_file
         return if [".", "/"].include?(directory)
 
         # Check the top-level for a .python-version file, too
         reverse_path = Pathname.new(directory[0]).relative_path_from(directory)
-        @python_version ||=
+        @python_version_file ||=
           fetch_file_if_present(File.join(reverse_path, ".python-version"))&.
           tap { |f| f.support_file = true }&.
           tap { |f| f.name = ".python-version" }


### PR DESCRIPTION
While working on adding python version metric to the file fetcher, it was starting to get confusing what the pre-existing `python_version` var referred to... so rename it to be explicit that it refers to the `.python-version` _file_.