### PR TITLE
Allow gem does not exist in RubyGems case

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -123,7 +123,7 @@ end
 def rubygems_release_exists?(name, version)
   uri = URI.parse("https://rubygems.org/api/v1/versions/#{name}.json")
   response = Net::HTTP.get_response(uri)
-  abort "Gem #{name} doesn't exist on rubygems" if response.code != "200"
+  return false if response.code != "200"
 
   body = JSON.parse(response.body)
   existing_versions = body.map { |b| b["number"] }


### PR DESCRIPTION
It will happen the first time we release a new ecosystem.

I don't see any harm in allowing it?