### PR TITLE
Update dependabot.yml to capture by package manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,7 @@ updates:
           - "semver"
         exclude-patterns:
           - "aws-sdk"
+          - "detect-indent"
       yarn-dependencies:
         patterns:
           - "@dependabot/yarn-lib"
@@ -83,7 +84,7 @@ updates:
           - "*jest*"
           - "*prettier"
     ignore:
-      - dependency-name: "*"
+      - dependency-name: "npm"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/python/helpers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,7 +68,7 @@ updates:
           - "npm"
           - "semver"
         exclude-patterns:
-          - "detect-indent"
+          - "detect-indent"  # temp excluded due to https://github.com/dependabot/dependabot-core/pull/5683#issuecomment-1243468605
       yarn-dependencies:
         patterns:
           - "@dependabot/yarn-lib"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,16 +61,22 @@ updates:
       day: "sunday"
       time: "16:00"
     groups:
-      dependencies:
+      npm-dependencies:
         patterns:
-          - "@dependabot/yarn-lib"
           - "@npmcli/arborist"
           - "detect-indent"
           - "nock"
           - "npm"
+          - "semver"
+        exclude-patterns:
+          - "aws-sdk"
+      yarn-dependencies:
+        patterns:
+          - "@dependabot/yarn-lib"
+      pnpm-dependencies:
+        patterns:
           - "@pnpm/lockfile-file"
           - "@pnpm/dependency-path"
-          - "semver"
       dev-dependencies:
         patterns:
           - "*eslint*"
@@ -78,6 +84,8 @@ updates:
           - "*prettier"
     ignore:
       - dependency-name: "npm"
+        update-types: ["version-update:semver-major"]      
+      - dependency-name: "detect-indent"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/python/helpers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,12 +64,10 @@ updates:
       npm-dependencies:
         patterns:
           - "@npmcli/arborist"
-          - "detect-indent"
           - "nock"
           - "npm"
           - "semver"
         exclude-patterns:
-          - "aws-sdk"
           - "detect-indent"
       yarn-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,9 +83,7 @@ updates:
           - "*jest*"
           - "*prettier"
     ignore:
-      - dependency-name: "npm"
-        update-types: ["version-update:semver-major"]      
-      - dependency-name: "detect-indent"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/python/helpers"


### PR DESCRIPTION
Excluding `detect-indent` for this reason: see https://github.com/dependabot/dependabot-core/pull/5683#issuecomment-1243468605