### PR TITLE
Tweak `ecosystem_versions` schema to be consistent

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -26,7 +26,11 @@ module Dependabot
       def ecosystem_versions
         {
           package_managers: {
-            "bundler" => Helpers.detected_bundler_version(lockfile)
+            bundler: {
+              # TODO: Today this method returns only the major version, but long term it'll return the full string, at
+              # which point we'll need to move that to "raw" key and then coerce it to major.minor for "max"/"min".
+              "max" => Helpers.detected_bundler_version(lockfile)
+            }
           }
         }
       end

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -29,7 +29,15 @@ module Dependabot
 
         {
           package_managers: {
-            "cargo" => channel
+            cargo: {
+              # ecosystem_versions data gets turned into metrics dashboards. We want those dashboard queries to be
+              # generic across ecosystems and other ecosystems allow specifying a range of supported versions, so
+              # specify max/min even though `Cargo.toml` only specifies a single version, ie max == min.
+              #
+              # TODO: need to round the channel from raw version to `major.minor` for easier grouping in dashboards
+              "max" => channel,
+              "min" => channel
+            }
           }
         }
       rescue TomlRB::ParseError

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
 
     it "provides the Rust channel" do
       expect(file_fetcher_instance.ecosystem_versions).to eq({
-        package_managers: { "cargo" => "default" }
+        package_managers: { cargo: { "max" => "default", "min" => "default" } }
       })
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
 
     it "provides the Rust channel" do
       expect(file_fetcher_instance.ecosystem_versions).to eq({
-        package_managers: { "cargo" => "1.2.3" }
+        package_managers: { cargo: { "max" => "1.2.3", "min" => "1.2.3" } }
       })
     end
   end

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -20,7 +20,11 @@ module Dependabot
       def ecosystem_versions
         {
           package_managers: {
-            "composer" => Helpers.composer_version(parsed_composer_json, parsed_lockfile) || "unknown"
+            composer: {
+              # TODO: Today this method returns only the major version, but long term it'll return the full string, at
+              # which point we'll need to move that to "raw" key and then coerce it to major.minor for "max"/"min".
+              "max" => Helpers.composer_version(parsed_composer_json, parsed_lockfile)
+            }
           }
         }
       end

--- a/composer/spec/dependabot/composer/file_fetcher_spec.rb
+++ b/composer/spec/dependabot/composer/file_fetcher_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Dependabot::Composer::FileFetcher do
 
   it "provides the composer version" do
     expect(file_fetcher_instance.ecosystem_versions).to eq({
-      package_managers: { "composer" => "1" }
+      package_managers: { composer: { "max" => "1" } }
     })
   end
 
@@ -85,7 +85,7 @@ RSpec.describe Dependabot::Composer::FileFetcher do
 
     it "provides the composer version" do
       expect(file_fetcher_instance.ecosystem_versions).to eq({
-        package_managers: { "composer" => "1" }
+        package_managers: { composer: { "max" => "1" } }
       })
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -17,9 +17,16 @@ module Dependabot
       def ecosystem_versions
         return nil unless go_mod
 
+        go_version_string = go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
         {
           package_managers: {
-            "gomod" => go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
+            gomod: {
+              # ecosystem_versions data gets turned into metrics dashboards. We want those dashboard queries to be
+              # generic across ecosystems and other ecosystems allow specifying a range of supported versions, so
+              # specify max/min even though `go.mod` only specifies a single version, ie max == min.
+              "max" => go_version_string,
+              "min" => go_version_string
+            }
           }
         }
       end

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
 
   it "provides the Go modules version" do
     expect(file_fetcher_instance.ecosystem_versions).to eq({
-      package_managers: { "gomod" => "unknown" }
+      package_managers: { gomod: { "max" => "unknown", "min" => "unknown" } }
     })
   end
 
@@ -78,7 +78,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
 
     it "provides the Go modules version" do
       expect(file_fetcher_instance.ecosystem_versions).to eq({
-        package_managers: { "gomod" => "1.19" }
+        package_managers: { gomod: { "max" => "1.19", "min" => "1.19" } }
       })
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -55,11 +55,11 @@ module Dependabot
       def ecosystem_versions
         package_managers = {}
 
-        package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock
-        package_managers["yarn"] = yarn_version if yarn_version
-        package_managers["pnpm"] = pnpm_version if pnpm_version
-        package_managers["shrinkwrap"] = 1 if shrinkwrap
-        package_managers["unknown"] = 1 if package_managers.empty?
+        package_managers[:npm] = { "max" => Helpers.npm_version_numeric(package_lock.content) } if package_lock
+        package_managers[:yarn] = { "max" => yarn_version } if yarn_version
+        package_managers[:pnpm] = { "max" => pnpm_version } if pnpm_version
+        package_managers[:shrinkwrap] = { "max" => 1 } if shrinkwrap
+        package_managers[:unknown] = { "max" => 1 } if package_managers.empty?
 
         {
           package_managers: package_managers

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -282,9 +282,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the yarn lockfile" do
-      expect(file_fetcher_instance.ecosystem_versions).to eq(
-        { package_managers: { "yarn" => 1 } }
-      )
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
+        package_managers: { yarn: { "max" => 1 } }
+      })
     end
 
     context "with a .yarnrc file" do
@@ -340,9 +340,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the shrinkwrap file" do
-      expect(file_fetcher_instance.ecosystem_versions).to eq(
-        { package_managers: { "shrinkwrap" => 1 } }
-      )
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
+        package_managers: { shrinkwrap: { "max" => 1 } }
+      })
     end
   end
 
@@ -373,9 +373,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the npm lockfile" do
-      expect(file_fetcher_instance.ecosystem_versions).to eq(
-        { package_managers: { "npm" => 6 } }
-      )
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
+        package_managers: { npm: { "max" => 6 } }
+      })
     end
   end
 
@@ -410,9 +410,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the package manager version" do
-      expect(file_fetcher_instance.ecosystem_versions).to eq(
-        { package_managers: { "npm" => 6, "yarn" => 1 } }
-      )
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
+        package_managers: { npm: { "max" => 6 }, yarn: { "max" => 1 } }
+      })
     end
   end
 


### PR DESCRIPTION
We want to know three things for every ecosystem component:

1. The raw version string and the name of the manifest file that it was pulled from. This provides great fidelity, especially if there are multiple sources of versions (looking at you Python with `.python-version` + `setup.py` etc in the same repo)
2. "rounded" / summarized versions of the above that are easy to write comparison queries against. Ie, `max`/`min` supported versions that are rounded to decimals rather than semver so that in a SQL-like query language we can easily write comparison queries.

So this starts the process of transforming our existing metrics to this format.