### PR TITLE
Fix CI

### DIFF
--- a/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     rack (2.1.4.3)
     rainbow (3.1.1)
     regexp_parser (2.8.1)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rubocop (1.54.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)


### PR DESCRIPTION
Recent release of rexml 3.2.6 broke one test.

Our tests should not be broken by external changes, but I lack context for fixing this in a better way so for now I just adapted the expectation.