### PR TITLE
Show ignore conditions in a request  body

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -526,18 +526,23 @@ module Dependabot
           "| #{ic[:dependency_name]} | [#{ic[:version_requirement]}] |"
         end
       
+        summary = "Most Recent Ignore Conditions Applied to This Pull Request"
         # Define the table structure
         table_header = "| Dependency Name | Ignore Conditions |"
         table_divider = "| --- | --- |"
         table_body = table_rows.join("\n")
 
-        "\n#{[table_header, table_divider, table_body].join("\n")}\n"
+        body = "\n#{[table_header, table_divider, table_body].join("\n")}\n"
 
-        # Build the collapsible section
-        details = "<details>\n<summary>Most Recent Ignore Conditions Applied to This Pull Request</summary>\n" \
-                  "#{[table_header, table_divider, table_body].join("\n")}\n\n</details>"
+        if !%w(azure bitbucket codecommit).include?(source.provider)
+          # Build the collapsible section
+          msg = "<details>\n<summary>#{summary}</summary>\n\n" \
+                    "#{[table_header, table_divider, table_body].join("\n")}\n</details>"
 
-        "\n\n#{details}\n\n"
+          "\n#{msg}\n"
+        else
+          "\n##{summary}\n\n#{body}"
+        end
       end
 
       def changelog_url(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -509,8 +509,11 @@ module Dependabot
         # Return an empty string if ignore_conditions is empty
         return "" if @ignore_conditions.empty?
 
-        # Filter out the conditions where from_config_file is false
-        valid_ignore_conditions = @ignore_conditions.select { |ic| !ic[:from_config_file] }
+        # Filter out the conditions where from_config_file is false and dependency is in @dependencies
+        # valid_ignore_conditions = @ignore_conditions.select { |ic| !ic[:from_config_file] }
+        valid_ignore_conditions = @ignore_conditions.select do |ic| 
+          !ic[:from_config_file] && dependencies.any? { |dep| dep.name == ic[:dependency_name] }
+        end
 
         # Return an empty string if no valid ignore conditions after filtering
         return "" if valid_ignore_conditions.empty?

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -510,7 +510,7 @@ module Dependabot
         return "" if @ignore_conditions.empty?
 
         # Filter out the conditions where from_config_file is false
-        valid_ignore_conditions = @ignore_conditions.select { |ic| ic[:from_config_file] }
+        valid_ignore_conditions = @ignore_conditions.select { |ic| !ic[:from_config_file] }
 
         # Return an empty string if no valid ignore conditions after filtering
         return "" if valid_ignore_conditions.empty?
@@ -520,7 +520,7 @@ module Dependabot
 
         # Map each condition to a row string
         table_rows = sorted_ignore_conditions.map do |ic|
-          "| #{ic[:dependency_name]} | #{ic[:version_requirement]} |"
+          "| #{ic[:dependency_name]} | [#{ic[:version_requirement]}] |"
         end
       
         # Define the table structure
@@ -528,17 +528,11 @@ module Dependabot
         table_divider = "| --- | --- |"
         table_body = table_rows.join("\n")
 
-        "\n\n#{[table_header, table_divider, table_body].join("\n")}\n\n"
+        "\n#{[table_header, table_divider, table_body].join("\n")}\n"
 
         # Build the collapsible section
-        details = %{
-          <details>
-            <summary>Most Recent 20 Ignore Conditions Applied to This Pull Request</summary>
-        
-            #{[table_header, table_divider, table_body].join("\n")}
-            
-          </details>
-        }
+        details = "<details>\n<summary>Most Recent Ignore Conditions Applied to This Pull Request</summary>\n" \
+                  "#{[table_header, table_divider, table_body].join("\n")}\n\n</details>"
 
         "\n\n#{details}\n\n"
       end

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -58,15 +58,29 @@ module Dependabot
       end
 
       def pr_message
-        msg = "#{suffixed_pr_message_header}" \
-              "#{commit_message_intro}" \
-              "#{metadata_cascades}" \
-              "#{ignore_conditions_table}" \
-              "#{prefixed_pr_message_footer}"
+        # TODO: Remove unignore_commands? feature flag once we are confident
+        # that it is working as expected
+        msg = if unignore_commands?
+                "#{suffixed_pr_message_header}" \
+                  "#{commit_message_intro}" \
+                  "#{metadata_cascades}" \
+                  "#{ignore_conditions_table}" \
+                  "#{prefixed_pr_message_footer}"
+              else
+                "#{suffixed_pr_message_header}" \
+                  "#{commit_message_intro}" \
+                  "#{metadata_cascades}" \
+                  "#{prefixed_pr_message_footer}"
+              end
+
         truncate_pr_message(msg)
       rescue StandardError => e
         Dependabot.logger.error("Error while generating PR message: #{e.message}")
         suffixed_pr_message_header + prefixed_pr_message_footer
+      end
+
+      def unignore_commands?
+        Experiments.enabled?(:unignore_commands)
       end
 
       # Truncate PR message as determined by the pr_message_max_length and pr_message_encoding instance variables

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -510,7 +510,6 @@ module Dependabot
         return "" if @ignore_conditions.empty?
 
         # Filter out the conditions where from_config_file is false and dependency is in @dependencies
-        # valid_ignore_conditions = @ignore_conditions.select { |ic| !ic[:from_config_file] }
         valid_ignore_conditions = @ignore_conditions.select do |ic| 
           !ic[:from_config_file] && dependencies.any? { |dep| dep.name == ic[:dependency_name] }
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2301,13 +2301,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 ignore_conditions.concat([
                     { 
                       dependency_name: "business#{i}", 
-                      version_requirement: "> 1.8.0", 
-                      from_config_file: false, 
-                      updated_at: Time.now, 
-                      created_at: Time.now - 86400 
-                    },
-                    { 
-                      dependency_name: "business#{i}", 
                       version_requirement: "<= 1.#{i}.0", 
                       from_config_file: false, 
                       updated_at: Time.now, 
@@ -2321,10 +2314,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             expect(pr_message).to include(
               "| Dependency Name | Ignore Conditions |\n" \
               "| --- | --- |\n" \
-              "| business2 | [> 1.8.0] |\n" \
               "| business2 | [<= 1.2.0] |\n" \
-              "| business3 | [> 1.8.0] |\n" \
-              "| business3 | [<= 1.3.0] |\n"
+              "| business3 | [<= 1.3.0] |\n" \
+              "| business4 | [<= 1.4.0] |\n" \
+              "| business5 | [<= 1.5.0] |\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2216,7 +2216,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with ignore conditions", :vcr do
+        context "with ignore conditions when feature flag is enabled", :vcr do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2297,6 +2297,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                   headers: {
                     "content-type" => "application/x-git-upload-pack-advertisement"
                   }
+
                 )
               ignore_conditions.push(
                 {
@@ -2308,6 +2309,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 }
               )
             end
+            Dependabot::Experiments.register(:unignore_commands, true)
           end
 
           it "has the correct message" do
@@ -2319,6 +2321,107 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "| business4 | [<= 1.4.0] |\n" \
               "| business5 | [<= 1.5.0] |\n"
             )
+          end
+        end
+
+        context "with ignore conditions when feature flag is disabled", :vcr do
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency3) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency4) do
+            Dependabot::Dependency.new(
+              name: "business4",
+              version: "2.1.1",
+              previous_version: "2.1.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency5) do
+            Dependabot::Dependency.new(
+              name: "business5",
+              version: "0.17.0",
+              previous_version: "0.16.2",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5] }
+
+          before do
+            (2..5).each do |i|
+              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
+
+              stub_request(:get, repo_url).
+                to_return(status: 200,
+                          body: fixture("github", "business_repo.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/contents/").
+                to_return(status: 200,
+                          body: fixture("github", "business_files.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/releases?per_page=100").
+                to_return(status: 200,
+                          body: fixture("github", "business_releases.json"),
+                          headers: json_header)
+              stub_request(:get, "https://api.github.com/repos/gocardless/" \
+                                 "business#{i}/contents/CHANGELOG.md?ref=master").
+                to_return(status: 200,
+                          body: fixture("github", "changelog_contents.json"),
+                          headers: json_header)
+              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json").
+                to_return(
+                  status: 200,
+                  body: fixture("ruby", "rubygems_response_statesman.json")
+                )
+
+              service_pack_url =
+                "https://github.com/gocardless/business#{i}.git/info/refs" \
+                "?service=git-upload-pack"
+
+              stub_request(:get, service_pack_url).
+                to_return(
+                  status: 200,
+                  body: fixture("git", "upload_packs", "no_tags"),
+                  headers: {
+                    "content-type" => "application/x-git-upload-pack-advertisement"
+                  }
+
+                )
+              ignore_conditions.push(
+                {
+                  dependency_name: "business#{i}",
+                  version_requirement: "<= 1.#{i}.0",
+                  from_config_file: false,
+                  updated_at: Time.now,
+                  created_at: Time.now - (i * 86_400)
+                }
+              )
+            end
+            Dependabot::Experiments.register(:unignore_commands, false)
+          end
+
+          it "does not include the ignore conditions section in the message" do
+            expect(pr_message).not_to include("Most Recent Ignore Conditions Applied to This Pull Request")
           end
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       commit_message_options: commit_message_options,
       vulnerabilities_fixed: vulnerabilities_fixed,
       github_redirection_service: github_redirection_service,
-      dependency_group: dependency_group
+      dependency_group: dependency_group,
+      ignore_conditions: ignore_conditions
     )
   end
 
@@ -48,6 +49,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   let(:vulnerabilities_fixed) { { "business" => [] } }
   let(:github_redirection_service) { "redirect.github.com" }
   let(:dependency_group) { nil }
+  let(:ignore_conditions) { [] }
 
   let(:gemfile) do
     Dependabot::DependencyFile.new(
@@ -2210,6 +2212,119 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "| [business3](https://github.com/gocardless/business3) | 1.4.0 to 1.5.0 |\n" \
               "| [business4](https://github.com/gocardless/business4) | 2.1.0 to 2.1.1 |\n" \
               "| [business5](https://github.com/gocardless/business5) | 0.16.2 to 0.17.0 |"
+            )
+          end
+        end
+
+        context "with ignore conditions", :vcr do
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency3) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency4) do
+            Dependabot::Dependency.new(
+              name: "business4",
+              version: "2.1.1",
+              previous_version: "2.1.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency5) do
+            Dependabot::Dependency.new(
+              name: "business5",
+              version: "0.17.0",
+              previous_version: "0.16.2",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5] }
+
+          before do
+            (2..5).each do |i|
+              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
+
+              stub_request(:get, repo_url).
+                to_return(status: 200,
+                          body: fixture("github", "business_repo.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/contents/").
+                to_return(status: 200,
+                          body: fixture("github", "business_files.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/releases?per_page=100").
+                to_return(status: 200,
+                          body: fixture("github", "business_releases.json"),
+                          headers: json_header)
+              stub_request(:get, "https://api.github.com/repos/gocardless/" \
+                                 "business#{i}/contents/CHANGELOG.md?ref=master").
+                to_return(status: 200,
+                          body: fixture("github", "changelog_contents.json"),
+                          headers: json_header)
+              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json").
+                to_return(
+                  status: 200,
+                  body: fixture("ruby", "rubygems_response_statesman.json")
+                )
+
+              service_pack_url =
+                "https://github.com/gocardless/business#{i}.git/info/refs" \
+                "?service=git-upload-pack"
+
+              stub_request(:get, service_pack_url).
+                to_return(
+                  status: 200,
+                  body: fixture("git", "upload_packs", "no_tags"),
+                  headers: {
+                    "content-type" => "application/x-git-upload-pack-advertisement"
+                  }
+                )
+                ignore_conditions.concat([
+                    { 
+                      dependency_name: "business#{i}", 
+                      version_requirement: "> 1.8.0", 
+                      from_config_file: false, 
+                      updated_at: Time.now, 
+                      created_at: Time.now - 86400 
+                    },
+                    { 
+                      dependency_name: "business#{i}", 
+                      version_requirement: "<= 1.#{i}.0", 
+                      from_config_file: false, 
+                      updated_at: Time.now, 
+                      created_at: Time.now - i * 86400
+                    }
+                  ])
+            end
+          end
+
+          it "has the correct message" do
+            expect(pr_message).to include(
+              "| Dependency Name | Ignore Conditions |\n" \
+              "| --- | --- |\n" \
+              "| business2 | [> 1.8.0] |\n" \
+              "| business2 | [<= 1.2.0] |\n" \
+              "| business3 | [> 1.8.0] |\n" \
+              "| business3 | [<= 1.3.0] |\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2322,6 +2322,76 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
+        context "without ignore conditions", :vcr do
+          let(:dependency1) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency1, dependency2] }
+        
+          before do
+            (2..5).each do |i|
+              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
+        
+              stub_request(:get, repo_url).
+                to_return(status: 200,
+                          body: fixture("github", "business_repo.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/contents/").
+                to_return(status: 200,
+                          body: fixture("github", "business_files.json"),
+                          headers: json_header)
+              stub_request(:get, "#{repo_url}/releases?per_page=100").
+                to_return(status: 200,
+                          body: fixture("github", "business_releases.json"),
+                          headers: json_header)
+              stub_request(:get, "https://api.github.com/repos/gocardless/" \
+                                 "business#{i}/contents/CHANGELOG.md?ref=master").
+                to_return(status: 200,
+                          body: fixture("github", "changelog_contents.json"),
+                          headers: json_header)
+              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json").
+                to_return(
+                  status: 200,
+                  body: fixture("ruby", "rubygems_response_statesman.json")
+                )
+        
+              service_pack_url =
+                "https://github.com/gocardless/business#{i}.git/info/refs" \
+                "?service=git-upload-pack"
+        
+              stub_request(:get, service_pack_url).
+                to_return(
+                  status: 200,
+                  body: fixture("git", "upload_packs", "no_tags"),
+                  headers: {
+                    "content-type" => "application/x-git-upload-pack-advertisement"
+                  }
+                )
+            end
+          end
+        
+          it "does not include the ignore conditions section in the message" do
+            expect(pr_message).not_to include("Most Recent Ignore Conditions Applied to This Pull Request")
+          end
+        end        
+
         context "with a directory specified" do
           let(:gemfile) do
             Dependabot::DependencyFile.new(

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2298,15 +2298,15 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                     "content-type" => "application/x-git-upload-pack-advertisement"
                   }
                 )
-                ignore_conditions.concat([
-                    { 
-                      dependency_name: "business#{i}", 
-                      version_requirement: "<= 1.#{i}.0", 
-                      from_config_file: false, 
-                      updated_at: Time.now, 
-                      created_at: Time.now - i * 86400
-                    }
-                  ])
+              ignore_conditions.push(
+                {
+                  dependency_name: "business#{i}",
+                  version_requirement: "<= 1.#{i}.0",
+                  from_config_file: false,
+                  updated_at: Time.now,
+                  created_at: Time.now - (i * 86_400)
+                }
+              )
             end
           end
 
@@ -2344,11 +2344,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { [dependency1, dependency2] }
-        
+
           before do
             (2..5).each do |i|
               repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-        
+
               stub_request(:get, repo_url).
                 to_return(status: 200,
                           body: fixture("github", "business_repo.json"),
@@ -2371,11 +2371,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                   status: 200,
                   body: fixture("ruby", "rubygems_response_statesman.json")
                 )
-        
+
               service_pack_url =
                 "https://github.com/gocardless/business#{i}.git/info/refs" \
                 "?service=git-upload-pack"
-        
+
               stub_request(:get, service_pack_url).
                 to_return(
                   status: 200,
@@ -2386,11 +2386,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 )
             end
           end
-        
+
           it "does not include the ignore conditions section in the message" do
             expect(pr_message).not_to include("Most Recent Ignore Conditions Applied to This Pull Request")
           end
-        end        
+        end
 
         context "with a directory specified" do
           let(:gemfile) do

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -29,7 +29,8 @@ module Dependabot
         files: updated_dependency_files,
         credentials: job.credentials,
         commit_message_options: job.commit_message_options,
-        dependency_group: dependency_group
+        dependency_group: dependency_group,
+        ignore_conditions: job.ignore_conditions
       ).message
     end
 

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Dependabot::ApiClient do
                       source: nil,
                       credentials: [],
                       commit_message_options: [],
-                      updating_a_pull_request?: false)
+                      updating_a_pull_request?: false,
+                      ignore_conditions: [])
     end
     let(:dependencies) do
       [dependency]

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::DependencyChange do
   end
 
   let(:job) do
-    instance_double(Dependabot::Job)
+    instance_double(Dependabot::Job, ignore_conditions: [])
   end
 
   let(:updated_dependencies) do
@@ -100,7 +100,8 @@ RSpec.describe Dependabot::DependencyChange do
           dependencies: updated_dependencies,
           credentials: job_credentials,
           commit_message_options: commit_message_options,
-          dependency_group: nil
+          dependency_group: nil,
+          ignore_conditions: []
         )
 
       expect(dependency_change.pr_message).to eql("Hello World!")
@@ -124,7 +125,8 @@ RSpec.describe Dependabot::DependencyChange do
             dependencies: updated_dependencies,
             credentials: job_credentials,
             commit_message_options: commit_message_options,
-            dependency_group: group
+            dependency_group: group,
+            ignore_conditions: []
           )
 
         expect(dependency_change.pr_message).to eql("Hello World!")


### PR DESCRIPTION
## Context

To remove ignore conditions on the dependencies on a given pull request user needs to have option to view those conditions. This task is to implement that for the user.  The PR body should look something like below:

**PR Body**
Dependabot Ignore Conditions Applied on the Pull Request
|Dependency Name| Ignore Condition|
|-|-|
business| [< 1.9, >1.8.0]|
business| [< 1.6.0, >1.3.0]|
statesmen| [< 1.2.0, >1.1.0]|

The user will use the ignore condition mentioned in the PR body and will use the upcoming new [unignore command](https://github.com/github/dependabot-updates/issues/4424) to remove those conditions on a specific dependency.

Fixes: https://github.com/github/dependabot-updates/issues/4478

## Approach

In the PR body, displaying top 20 lasted ignore conditions (if any) sorted by `created_at` or `updated_at` for dependencies in the pull request. 

The reason for the limiting to show only 20 ignore conditions on the PR is body is because at this moment "GitHub limits PR/comment descriptions to a max of 65,536 characters". More detailed discussion on this topic is [here](https://github.com/github/dependabot-updates/issues/4478#issuecomment-1650558908)