### PR TITLE
build(deps): bump NPM from 9.5.1 to 9.8.1

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -11,7 +11,7 @@ ARG NODEJS_VERSION=18.x
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well
-ARG NPM_VERSION=9.5.1
+ARG NPM_VERSION=9.8.1
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_$NODEJS_VERSION | bash - \


### PR DESCRIPTION
There have been some serious bug fixes in later minor and patch versions of NPM v9.

[Diff: v9.5.1...v9.8.1](https://github.com/npm/cli/compare/v9.5.1...v9.8.1)
[Changelog](https://github.com/npm/cli/blob/v9.8.1/CHANGELOG.md)