### PR TITLE
[Grouped Updates] Refactor how SemVer groups are configured

### DIFF
--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -225,18 +225,16 @@ RSpec.describe Dependabot::DependencyGroup do
       Dependabot::Experiments.reset!
     end
 
-    context "the group has not defined a highest-semver-allowed rule" do
-      it "ignores major versions by default" do
-        expect(dependency_group.ignored_versions_for(dependency)).to eql([
-          ">= 2.a"
-        ])
+    context "the group has not defined an update-types rule" do
+      it "returns an empty array as nothing should be ignored" do
+        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
       end
     end
 
-    context "the group permits major or lower" do
+    context "the group permits all update-types" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "major"
+          "update-types" => %w(major minor patch)
         }
       end
 
@@ -248,7 +246,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "the group permits minor or lower" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "minor"
+          "update-types" => %w(minor patch)
         }
       end
 
@@ -262,7 +260,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the group only permits patch versions" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "patch"
+          "update-types" => ["patch"]
         }
       end
 
@@ -274,10 +272,10 @@ RSpec.describe Dependabot::DependencyGroup do
       end
     end
 
-    context "when the group has garbage update-types" do
+    context "when the group has empty update-types" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "revision"
+          "update-types" => []
         }
       end
 
@@ -285,7 +283,23 @@ RSpec.describe Dependabot::DependencyGroup do
         expect { dependency_group }.
           to raise_error(
             ArgumentError,
-            starting_with("The #{name} group has an unexpected value for highest-semver-allowed:")
+            starting_with("The #{name} group has specified an empty array for update-types.")
+          )
+      end
+    end
+
+    context "when the group has garbage update-types" do
+      let(:rules) do
+        {
+          "update-types" => "revision"
+        }
+      end
+
+      it "raises an exception when created" do
+        expect { dependency_group }.
+          to raise_error(
+            ArgumentError,
+            starting_with("The #{name} group has an unexpected value for update-types:")
           )
       end
     end
@@ -303,16 +317,16 @@ RSpec.describe Dependabot::DependencyGroup do
       )
     end
 
-    context "the group has not defined a highest-semver-allowed rule" do
+    context "the group has not defined an update-types rule" do
       it "returns an empty array as nothing should be ignored" do
         expect(dependency_group.ignored_versions_for(dependency)).to be_empty
       end
     end
 
-    context "the group has defined a highest-semver-allowed rule" do
+    context "the group has defined an update-types rule" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "patch"
+          "update-types" => "patch"
         }
       end
 
@@ -331,14 +345,14 @@ RSpec.describe Dependabot::DependencyGroup do
       Dependabot::Experiments.reset!
     end
 
-    it "is false by default" do
-      expect(dependency_group).not_to be_targets_highest_versions_possible
+    it "is true by default" do
+      expect(dependency_group).to be_targets_highest_versions_possible
     end
 
     context "when the highest level is major" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "major"
+          "update-types" => %w(major minor patch)
         }
       end
 
@@ -350,7 +364,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the highest level is minor" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "minor"
+          "update-types" => %w(minor)
         }
       end
 
@@ -362,7 +376,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the highest level is patch" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "patch"
+          "update-types" => %w(patch)
         }
       end
 
@@ -380,7 +394,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the highest level is major" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "major"
+          "update-types" => %w(major minor patch)
         }
       end
 
@@ -392,7 +406,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the highest level is minor" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "minor"
+          "update-types" => %w(minor)
         }
       end
 
@@ -404,7 +418,7 @@ RSpec.describe Dependabot::DependencyGroup do
     context "when the highest level is patch" do
       let(:rules) do
         {
-          "highest-semver-allowed" => "patch"
+          "update-types" => %w(patch)
         }
       end
 

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -268,8 +268,8 @@ RSpec.describe Dependabot::DependencyGroupEngine do
         ]
       end
 
-      it "considers all matched dependencies as ungrouped as well" do
-        expect(dependency_group_engine.ungrouped_dependencies.map(&:name)).to match_array(dependencies.map(&:name))
+      it "does not consider any matched dependencies as ungrouped" do
+        expect(dependency_group_engine.ungrouped_dependencies.map(&:name)).to match_array(["ungrouped_pkg"])
       end
     end
 
@@ -280,7 +280,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
             "name" => "group",
             "rules" => {
               "patterns" => ["dummy-pkg-*"],
-              "highest-semver-allowed" => "major"
+              "update-types" => ["major"]
             }
           }
         ]
@@ -298,7 +298,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
             "name" => "group",
             "rules" => {
               "patterns" => ["dummy-pkg-*"],
-              "highest-semver-allowed" => "patch"
+              "update-types" => ["patch"]
             }
           }
         ]
@@ -319,7 +319,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
                 dummy-pkg-a
                 dummy-pkg-b
               ),
-              "highest-semver-allowed" => "major"
+              "update-types" => ["major"]
             }
           },
           {
@@ -329,7 +329,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
                 dummy-pkg-b
                 dummy-pkg-c
               ),
-              "highest-semver-allowed" => "patch"
+              "update-types" => ["patch"]
             }
           }
         ]

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_by_dependency_type.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_by_dependency_type.yaml
@@ -38,9 +38,7 @@ job:
   - name: dev-dependencies
     rules:
       dependency-type: "development"
-      highest-semver-allowed: "major"
   - name: production-dependencies
     rules:
       dependency-type: "production"
-      highest-semver-allowed: "major"
 

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping.yaml
@@ -35,4 +35,6 @@ job:
   dependency-groups:
   - name: small-bumps
     rules:
-      highest-semver-allowed: "minor"
+      update-types:
+      - "minor"
+      - "patch"

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping_with_global_ignores.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping_with_global_ignores.yaml
@@ -37,4 +37,5 @@ job:
   dependency-groups:
   - name: patches
     rules:
-      highest-semver-allowed: "patch"
+      update-types:
+      - "patch"


### PR DESCRIPTION
This merges into #7581 and changes the way this rule is configured:

```yaml
groups:
   rails:
     patterns:
     - "rails*"
     update-types: ["minor", "patch"]
```

If `update-types` is not specified, we default to `["major", "minor", "patch"]`, i.e. all versions.