### PR TITLE
Nishnha/revert docker version regexp

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -15,7 +15,7 @@ module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       VERSION_REGEX =
-        /v?(?<version>[0-9]+(?:\.[_a-z0-9]+|-(?:kb)?[0-9]+)*)/i
+        /v?(?<version>[0-9]+(?:(?:\.[_a-z0-9]+)|(?:-(?:kb)?[0-9]+))*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/i
       VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -16,8 +16,8 @@ module Dependabot
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       VERSION_REGEX =
         /v?(?<version>[0-9]+(?:\.[_a-z0-9]+|-(?:kb)?[0-9]+)*)/i
-      VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
-      VERSION_WITH_PFX = /^(?<prefix>[a-z0-9][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
+      VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/i
+      VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/i
       VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
       NAME_WITH_VERSION =
         /

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -14,6 +14,18 @@ require "dependabot/docker/utils/credentials_finder"
 module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
+      VERSION_REGEX =
+        /v?(?<version>[0-9]+(?:\.[_a-z0-9]+|-(?:kb)?[0-9]+)*)/i
+      VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
+      VERSION_WITH_PFX = /^(?<prefix>[a-z0-9][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
+      VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
+      NAME_WITH_VERSION =
+        /
+          #{VERSION_WITH_PFX}|
+          #{VERSION_WITH_SFX}|
+          #{VERSION_WITH_PFX_AND_SFX}
+      /x
+
       def latest_version
         latest_version_from(dependency.version)
       end


### PR DESCRIPTION
reverts https://github.com/dependabot/dependabot-core/pull/6080 to see what tests fail. We may have been overmatching regexpessions earlier, but now some common docker tags are not being detected correctly, like

`org/image-name:3.10-master-999`

which is a combination of `<name-with-owner>:<version>-<branch>-<build>`