### PR TITLE
Fix some swift updates failing when `directory` is configured

### DIFF
--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -107,7 +107,8 @@ module Dependabot
             manifest.content,
             old_requirements: old_requirements,
             new_requirements: new_requirements
-          ).updated_manifest_content
+          ).updated_manifest_content,
+          directory: manifest.directory
         )
       end
 

--- a/swift/lib/dependabot/swift/update_checker/version_resolver.rb
+++ b/swift/lib/dependabot/swift/update_checker/version_resolver.rb
@@ -34,7 +34,8 @@ module Dependabot
 
           updated_lockfile = DependencyFile.new(
             name: "Package.resolved",
-            content: updated_lockfile_content
+            content: updated_lockfile_content,
+            directory: manifest.directory
           )
 
           dependency_parser(manifest, updated_lockfile).parse.find do |parsed_dep|

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     )
   end
   let(:project_name) { "ReactiveCocoa" }
+  let(:directory) { "/" }
   let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
-  let(:dependency_files) { project_dependency_files(project_name) }
+  let(:dependency_files) { project_dependency_files(project_name, directory: directory) }
   let(:security_advisories) { [] }
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
@@ -108,6 +109,34 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     let(:name) { "github.com/quick/nimble" }
     let(:url) { "https://github.com/Quick/Nimble" }
     let(:upload_pack_fixture) { "nimble" }
+
+    before { stub_upload_pack }
+
+    describe "#can_update?" do
+      subject { checker.can_update?(requirements_to_unlock: :own) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    describe "#latest_version" do
+      subject { checker.latest_version }
+
+      it { is_expected.to eq("12.0.1") }
+    end
+
+    describe "#latest_resolvable_version" do
+      subject { checker.latest_resolvable_version }
+
+      it { is_expected.to eq("12.0.1") }
+    end
+  end
+
+  context "when dependencies located in a project subfolder" do
+    let(:name) { "github.com/quick/nimble" }
+    let(:url) { "https://github.com/Quick/Nimble" }
+    let(:upload_pack_fixture) { "nimble" }
+    let(:directory) { "subfolder" }
+    let(:project_name) { "ReactiveCocoaNested" }
 
     before { stub_upload_pack }
 

--- a/swift/spec/fixtures/projects/ReactiveCocoaNested/subfolder/Package.resolved
+++ b/swift/spec/fixtures/projects/ReactiveCocoaNested/subfolder/Package.resolved
@@ -1,0 +1,52 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "e206b8deba0d01fce70388a6d9dc66cba5603958",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "package": "ReactiveSwift",
+        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
+        "state": {
+          "branch": null,
+          "revision": "40c465af19b993344e84355c00669ba2022ca3cd",
+          "version": "7.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/swift/spec/fixtures/projects/ReactiveCocoaNested/subfolder/Package.swift
+++ b/swift/spec/fixtures/projects/ReactiveCocoaNested/subfolder/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "ReactiveCocoa",
+    platforms: [
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)
+    ],
+    products: [
+        .library(name: "ReactiveCocoa", targets: ["ReactiveCocoa"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "ReactiveCocoa",
+            dependencies: []
+        )
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
The update checker temporarily tries to update versions, and then parses to resulting lockfile to figure out what the latest resolvable version is.

To do this, it uses a modified manifest with unlocked depencies.

This modified manifest was not inheriting the `directory` property from the original manifest and that was causing swift to be run from the wrong folder, and thus reparsing of the updated lockfile fail.

To fix that, make sure manifests used by the UpdateChecker inherit the `directory` property from the original manifests.