### PR TITLE
Remove manual exclusion of specific packages

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -325,13 +325,6 @@ module Dependabot
             # dependency is no longer required and is just cruft in the
             # composer.json. In this case we just ignore the dependency.
             nil
-          elsif error.message.include?("stefandoorn/sitemap-plugin-1.0.0.0") ||
-                error.message.include?("simplethings/entity-audit-bundle-1.0.0")
-            # We get a recurring error when attempting to update these repos
-            # which doesn't recur locally and we can't figure out how to fix!
-            #
-            # Package is not installed: stefandoorn/sitemap-plugin-1.0.0.0
-            nil
           elsif error.message.include?("does not match the expected JSON schema")
             msg = "Composer failed to parse your composer.json as it does not match the expected JSON schema.\n" \
                   "Run `composer validate` to check your composer.json and composer.lock files.\n\n" \


### PR DESCRIPTION
The exclusion for these two packages was added years ago by Grey, back when Dependabot ran on a completely different service back-end.

Since then, much of our internal infra has been completely rewritten and any failures with deps in prod can invariably be repro'd locally, so it no longer makes sense to carve out these exclusions.

I suspect the underlying issue in `composer` that led to this problem has likely been fixed (at least in `composer 2`) so we won't see this problem.

But if for some reason we do, than we should investigate further to see what the _root_ problem is rather than swallowing it.