### PR TITLE
Move `ecosystem_versions` to `FileParser` class

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -802,7 +802,7 @@ StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
 puts "🌍 Total requests made: '#{$network_trace_count}'"
-ecosystem_versions = fetcher.ecosystem_versions
+ecosystem_versions = parser.ecosystem_versions
 puts "🎈 Ecosystem Versions log: #{ecosystem_versions}" unless ecosystem_versions.nil?
 
 # rubocop:enable Metrics/BlockLength

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -23,14 +23,6 @@ module Dependabot
         "Repo must contain either a Gemfile, a gemspec, or a gems.rb."
       end
 
-      def ecosystem_versions
-        {
-          package_managers: {
-            "bundler" => Helpers.detected_bundler_version(lockfile)
-          }
-        }
-      end
-
       private
 
       def fetch_files

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -27,6 +27,14 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      def ecosystem_versions
+        {
+          package_managers: {
+            "bundler" => Helpers.detected_bundler_version(lockfile)
+          }
+        }
+      end
+
       private
 
       def check_external_code(dependencies)

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -20,25 +20,6 @@ module Dependabot
         "Repo must contain a Cargo.toml."
       end
 
-      def ecosystem_versions
-        channel = if rust_toolchain
-                    TomlRB.parse(rust_toolchain.content).fetch("toolchain", nil)&.fetch("channel", nil)
-                  else
-                    "default"
-                  end
-
-        {
-          package_managers: {
-            "cargo" => channel
-          }
-        }
-      rescue TomlRB::ParseError
-        raise Dependabot::DependencyFileNotParseable.new(
-          rust_toolchain.path,
-          "only rust-toolchain files formatted as TOML are supported, the non-TOML format was deprecated by Rust"
-        )
-      end
-
       private
 
       def fetch_files

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -39,6 +39,25 @@ module Dependabot
         end
       end
 
+      def ecosystem_versions
+        channel = if rust_toolchain
+                    TomlRB.parse(rust_toolchain.content).fetch("toolchain", nil)&.fetch("channel", nil)
+                  else
+                    "default"
+                  end
+
+        {
+          package_managers: {
+            "cargo" => channel
+          }
+        }
+      rescue TomlRB::ParseError
+        raise Dependabot::DependencyFileNotParseable.new(
+          rust_toolchain.path,
+          "only rust-toolchain files formatted as TOML are supported, the non-TOML format was deprecated by Rust"
+        )
+      end
+
       private
 
       def check_rust_workspace_root

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -102,10 +102,6 @@ module Dependabot
         raise Dependabot::RepoNotFound, source
       end
 
-      def ecosystem_versions
-        nil
-      end
-
       private
 
       def fetch_file_if_present(filename, fetch_submodules: false)

--- a/common/lib/dependabot/file_parsers/base.rb
+++ b/common/lib/dependabot/file_parsers/base.rb
@@ -21,6 +21,10 @@ module Dependabot
         raise NotImplementedError
       end
 
+      def ecosystem_versions
+        nil
+      end
+
       private
 
       def check_required_files

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -17,14 +17,6 @@ module Dependabot
         "Repo must contain a composer.json."
       end
 
-      def ecosystem_versions
-        {
-          package_managers: {
-            "composer" => Helpers.composer_version(parsed_composer_json, parsed_lockfile) || "unknown"
-          }
-        }
-      end
-
       private
 
       def fetch_files

--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -32,6 +32,14 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      def ecosystem_versions
+        {
+          package_managers: {
+            "composer" => Helpers.composer_version(parsed_composer_json, parsed_lockfile) || "unknown"
+          }
+        }
+      end
+
       private
 
       def manifest_dependencies

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -14,16 +14,6 @@ module Dependabot
         "Repo must contain a go.mod."
       end
 
-      def ecosystem_versions
-        return nil unless go_mod
-
-        {
-          package_managers: {
-            "gomod" => go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
-          }
-        }
-      end
-
       private
 
       def fetch_files

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -22,6 +22,16 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      def ecosystem_versions
+        return nil unless go_mod
+
+        {
+          package_managers: {
+            "gomod" => go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
+          }
+        }
+      end
+
       private
 
       def go_mod

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -52,20 +52,6 @@ module Dependabot
         end
       end
 
-      def ecosystem_versions
-        package_managers = {}
-
-        package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock
-        package_managers["yarn"] = yarn_version if yarn_version
-        package_managers["pnpm"] = pnpm_version if pnpm_version
-        package_managers["shrinkwrap"] = 1 if shrinkwrap
-        package_managers["unknown"] = 1 if package_managers.empty?
-
-        {
-          package_managers: package_managers
-        }
-      end
-
       private
 
       def fetch_files

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -51,6 +51,20 @@ module Dependabot
         end
       end
 
+      def ecosystem_versions
+        package_managers = {}
+
+        package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock
+        package_managers["yarn"] = yarn_version if yarn_version
+        package_managers["pnpm"] = pnpm_version if pnpm_version
+        package_managers["shrinkwrap"] = 1 if shrinkwrap
+        package_managers["unknown"] = 1 if package_managers.empty?
+
+        {
+          package_managers: package_managers
+        }
+      end
+
       private
 
       def manifest_dependencies

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -37,28 +37,6 @@ module Dependabot
           "or a Pipfile."
       end
 
-      def ecosystem_versions
-        # Hmm... it's weird that this calls file parser methods, but here we are in the file fetcher... for all
-        # ecosystems our goal is to extract the user specified versions, so we'll need to do file parsing... so should
-        # we move this `ecosystem_versions` metrics method to run in the file parser for all ecosystems? Downside is if
-        # file parsing blows up, this metric isn't emitted, but reality is we have to parse anyway... as we want to know
-        # the user-specified range of versions, not the version Dependabot chose to run.
-        python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)
-        language_version_manager = LanguageVersionManager.new(python_requirement_parser: python_requirement_parser)
-        {
-          languages: {
-            python: {
-              # TODO: alternatively this could use `python_requirement_parser.user_specified_requirements` which
-              # returns an array... which we could flip to return a hash of manifest name => version
-              # string and then check for min/max versions... today it simply defaults to
-              # array.first which seems rather arbitrary.
-              "raw" => language_version_manager.user_specified_python_version || "unknown",
-              "max" => language_version_manager.python_major_minor || "unknown"
-            }
-          }
-        }
-      end
-
       private
 
       def fetch_files

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -46,6 +46,28 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      def ecosystem_versions
+        # Hmm... it's weird that I have to instantiate a PythonRequirementParser rather than just use this existing
+        # FileParser... that kinda defeats the whole purpose of moving this to fileparser... maybe instead I should move
+        # the logic of ecosystem_versions down into PythonRequirementParser so it can access everything internally and
+        # then surface it up??
+        # check how it'd work in other ecosystems...
+        python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: dependency_files)
+        language_version_manager = LanguageVersionManager.new(python_requirement_parser: python_requirement_parser)
+        {
+          languages: {
+            python: {
+              # TODO: alternatively this could use `python_requirement_parser.user_specified_requirements` which
+              # returns an array... which we could flip to return a hash of manifest name => version
+              # string and then check for min/max versions... today it simply defaults to
+              # array.first which seems rather arbitrary.
+              "raw" => language_version_manager.user_specified_python_version || "unknown",
+              "max" => language_version_manager.python_major_minor || "unknown"
+            }
+          }
+        }
+      end
+
       private
 
       def requirement_files

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -83,7 +83,15 @@ module Dependabot
       @base_commit_sha = base_commit_sha
       @dependency_files = dependency_files
 
-      @dependencies = parse_files!
+      parser = dependency_file_parser
+
+      # We don't set this flag in GHES because there's no point in recording versions since we can't access that data.
+      if Experiments.enabled?(:record_ecosystem_versions)
+        ecosystem_versions = parser.ecosystem_versions
+        api_client.record_ecosystem_versions(ecosystem_versions) unless ecosystem_versions.nil?
+      end
+
+      @dependencies = parser.parse
 
       return unless Dependabot::Experiments.enabled?(:grouped_updates_prototype)
 
@@ -92,10 +100,6 @@ module Dependabot
     end
 
     attr_reader :job
-
-    def parse_files!
-      dependency_file_parser.parse
-    end
 
     def dependency_file_parser
       Dependabot::FileParsers.for_package_manager(job.package_manager).new(

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -21,12 +21,6 @@ module Dependabot
         @base_commit_sha = file_fetcher.commit
         raise "base commit SHA not found" unless @base_commit_sha
 
-        # We don't set this flag in GHES because there's no point in recording versions since we can't access that data.
-        if Experiments.enabled?(:record_ecosystem_versions)
-          ecosystem_versions = file_fetcher.ecosystem_versions
-          api_client.record_ecosystem_versions(ecosystem_versions) unless ecosystem_versions.nil?
-        end
-
         dependency_files
       rescue StandardError => e
         @base_commit_sha ||= "unknown"

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Dependabot::FileFetcherCommand do
 
     allow(api_client).to receive(:mark_job_as_processed)
     allow(api_client).to receive(:record_update_job_error)
-    allow(api_client).to receive(:record_ecosystem_versions)
 
     allow(Dependabot::Environment).to receive(:output_path).and_return(File.join(Dir.mktmpdir, "output.json"))
     allow(Dependabot::Environment).to receive(:job_id).and_return(job_id)


### PR DESCRIPTION
The intent of `ecosystem_versions` is to report the range of versions supported by the target repo, _not the version that Dependabot chose to use_.

In order to do that, we need to parse the manifest files for any lines indicating the range of supported versions.

Intuitively, this sounds like `FileParser`, not `FileFetcher`.

Historically though, the code has lived in `FileFetcher`, where it sorta grew organically. So as we systematize this, it makes more sense to move it to the `FileParser`.