### PR TITLE
Stop checking deprecated `bugtrack_url`

### DIFF
--- a/python/lib/dependabot/python/metadata_finder.rb
+++ b/python/lib/dependabot/python/metadata_finder.rb
@@ -27,7 +27,6 @@ module Dependabot
         potential_source_urls = [
           pypi_listing.dig("info", "project_urls", "Source"),
           pypi_listing.dig("info", "home_page"),
-          pypi_listing.dig("info", "bugtrack_url"),
           pypi_listing.dig("info", "download_url"),
           pypi_listing.dig("info", "docs_url")
         ].compact

--- a/python/spec/fixtures/pypi/pypi_response_pendulum.json
+++ b/python/spec/fixtures/pypi/pypi_response_pendulum.json
@@ -2,7 +2,7 @@
     "info": {
         "author": "Sébastien Eustace",
         "author_email": "sebastien@eustace.io",
-        "bugtrack_url": "",
+        "bugtrack_url": null,
         "classifiers": [
             "License :: OSI Approved :: MIT License",
             "Programming Language :: Python :: 2",


### PR DESCRIPTION
Per the [Warehouse PyPI docs](https://warehouse.pypa.io/api-reference/json.html#project):
> The `bugtrack_url` key on this response should be considered deprecated.
>
> It currently always returns `null` and in the future, the `bugtrack_url` key may be removed from this response.