### PR TITLE
Fix typo in method name in Swift update checker

### DIFF
--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -94,7 +94,7 @@ module Dependabot
       end
 
       def single_version_declaration?
-        up_to_next_major? || up_to_next_major_deprecated? || up_to_next_minor? ||
+        up_to_next_major? || up_to_next_major_deprecated? || up_to_next_minor_deprecated? ||
           exact_version? || exact_version_deprecated?
       end
 

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
 
       it { is_expected.to eq("7.0.2") }
     end
+
+    describe "#updated_requirements" do
+      subject { checker.updated_requirements }
+
+      it "does not update them" do
+        expect(subject.first[:requirement]).to eq(">= 7.0.0, < 8.0.0")
+      end
+    end
   end
 
   context "with a dependency that needs manifest changes to get updated" do
@@ -128,6 +136,14 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
       subject { checker.latest_resolvable_version }
 
       it { is_expected.to eq("12.0.1") }
+    end
+
+    describe "#updated_requirements" do
+      subject { checker.updated_requirements }
+
+      it "updates them to match new version" do
+        expect(subject.first[:requirement]).to eq("= 12.0.1")
+      end
     end
   end
 

--- a/swift/spec/fixtures/projects/ReactiveCocoa/Package.swift
+++ b/swift/spec/fixtures/projects/ReactiveCocoa/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "7.0.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "9.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", .exact("9.2.1")),
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
I changed this method name in the last minute, and somehow forgot to update all usages 🤷‍♂️.

This typo would cause errors when updating requirements whenever the previous two conditions were not met (`from:`, or `.upToNextMajor` not used).