### PR TITLE
Restore version schema with <version> and <build_number> with words between them

### DIFF
--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -5,8 +5,8 @@ require "dependabot/docker/file_parser"
 module Dependabot
   module Docker
     class Tag
-      BRANCH_WITH_BUILD = /(?:(?:-[a-z]+)+-[0-9]+)+/
-      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|#{BRANCH_WITH_BUILD}|-(?:kb)?[0-9]+)*)/i
+      WORDS_WITH_BUILD = /(?:(?:-[a-z]+)+-[0-9]+)+/
+      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|#{WORDS_WITH_BUILD}|-(?:kb)?[0-9]+)*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
       VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
@@ -99,8 +99,8 @@ module Dependabot
         # That means only "22-ea-7" will be considered as a viable update
         # candidate for "21-ea-32", since it's the only one that respects that
         # format.
-        if version.match?(BRANCH_WITH_BUILD)
-          return :"<version>#{version.match(BRANCH_WITH_BUILD).to_s.gsub(/-[0-9]+/, "-<build_num>")}"
+        if version.match?(WORDS_WITH_BUILD)
+          return :"<version>#{version.match(WORDS_WITH_BUILD).to_s.gsub(/-[0-9]+/, "-<build_num>")}"
         end
 
         :normal

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -30,6 +30,10 @@ module Dependabot
         name.match?(FileParser::DIGEST)
       end
 
+      def looks_like_prerelease?
+        numeric_version.gsub(/kb/i, "").match?(/[a-zA-Z]/)
+      end
+
       def comparable_to?(other)
         return false unless comparable?
 

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -81,6 +81,10 @@ module Dependabot
         name.match(NAME_WITH_VERSION).named_captures.fetch("suffix")
       end
 
+      def version
+        name.match(NAME_WITH_VERSION).named_captures.fetch("version")
+      end
+
       def format
         return :year_month if numeric_version.match?(/^[12]\d{3}(?:[.\-]|$)/)
         return :year_month_day if numeric_version.match?(/^[12]\d{5}(?:[.\-]|$)/)
@@ -93,7 +97,7 @@ module Dependabot
       def numeric_version
         return unless comparable?
 
-        name.match(NAME_WITH_VERSION).named_captures.fetch("version").gsub(/-[a-z]+/, "").downcase
+        version.gsub(/-[a-z]+/, "").downcase
       end
 
       def precision

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -5,7 +5,7 @@ require "dependabot/docker/file_parser"
 module Dependabot
   module Docker
     class Tag
-      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|-[a-z]+-[0-9]+|-(?:kb)?[0-9]+)*)/i
+      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|(?:-[a-z]+)+-[0-9]+|-(?:kb)?[0-9]+)*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
       VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
@@ -89,7 +89,7 @@ module Dependabot
       def numeric_version
         return unless comparable?
 
-        name.match(NAME_WITH_VERSION).named_captures.fetch("version").downcase
+        name.match(NAME_WITH_VERSION).named_captures.fetch("version").gsub(/-[a-z]+/, "").downcase
       end
 
       def precision

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -30,6 +30,21 @@ module Dependabot
         name.match?(FileParser::DIGEST)
       end
 
+      def comparable_to?(other)
+        return false unless comparable?
+
+        other_prefix = other.prefix
+        other_suffix = other.suffix
+        other_format = other.format
+
+        equal_prefix = prefix == other_prefix
+        equal_format = format == other_format
+        return equal_prefix && equal_format if other_format == :sha_suffixed
+
+        equal_suffix = suffix == other_suffix
+        equal_prefix && equal_format && equal_suffix
+      end
+
       def comparable?
         name.match?(NAME_WITH_VERSION)
       end

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -5,7 +5,7 @@ require "dependabot/docker/file_parser"
 module Dependabot
   module Docker
     class Tag
-      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|-(?:kb)?[0-9]+)*)/i
+      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|-[a-z]+-[0-9]+|-(?:kb)?[0-9]+)*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
       VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -5,7 +5,7 @@ require "dependabot/docker/file_parser"
 module Dependabot
   module Docker
     class Tag
-      BRANCH_WITH_BUILD = /(?:-[a-z]+)+-[0-9]+/
+      BRANCH_WITH_BUILD = /(?:(?:-[a-z]+)+-[0-9]+)+/
       VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|#{BRANCH_WITH_BUILD}|-(?:kb)?[0-9]+)*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
@@ -100,7 +100,7 @@ module Dependabot
         # candidate for "21-ea-32", since it's the only one that respects that
         # format.
         if version.match?(BRANCH_WITH_BUILD)
-          return :"<version>#{version.match(BRANCH_WITH_BUILD).to_s.gsub(/-[0-9]+\z/, "")}-<build_num>"
+          return :"<version>#{version.match(BRANCH_WITH_BUILD).to_s.gsub(/-[0-9]+/, "-<build_num>")}"
         end
 
         :normal

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -82,10 +82,7 @@ module Dependabot
 
         latest_tag = latest_tag_from(version)
 
-        old_v = version_tag.numeric_version
-        latest_v = latest_tag.numeric_version
-
-        version_class.new(latest_v) <= version_class.new(old_v)
+        comparable_version_from(latest_tag) <= comparable_version_from(version_tag)
       end
 
       def digest_up_to_date?

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -258,9 +258,7 @@ module Dependabot
       def prerelease?(tag)
         return true if tag.looks_like_prerelease?
 
-        # If we're dealing with a numeric version we can compare it against
-        # the digest for the `latest` tag.
-        return false unless tag.numeric_version
+        # Compare the numeric version against the version of the `latest` tag.
         return false unless latest_digest
         return false unless version_of_latest_tag
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -151,18 +151,7 @@ module Dependabot
       end
 
       def comparable_tags_from_registry(original_tag)
-        original_prefix = original_tag.prefix
-        original_suffix = original_tag.suffix
-        original_format = original_tag.format
-
-        candidate_tags =
-          tags_from_registry.
-          select(&:comparable?).
-          select { |tag| tag.prefix == original_prefix }.
-          select { |tag| tag.format == original_format }
-        return candidate_tags if original_format == :sha_suffixed
-
-        candidate_tags.select { |tag| tag.suffix == original_suffix }
+        tags_from_registry.select { |tag| tag.comparable_to?(original_tag) }
       end
 
       def remove_version_downgrades(candidate_tags, version_tag)

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -256,7 +256,7 @@ module Dependabot
       end
 
       def prerelease?(tag)
-        return true if tag.numeric_version.gsub(/kb/i, "").match?(/[a-zA-Z]/)
+        return true if tag.looks_like_prerelease?
 
         # If we're dealing with a numeric version we can compare it against
         # the digest for the `latest` tag.

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("jdk-11.0.2.9-alpine-slim") }
     end
 
-    context "when the dependency's version has a <version>-<branch>-<build> format" do
+    context "when the dependency's version has a <version>-<words>-<build_num> format" do
       let(:dependency_name) { "foo/bar" }
       let(:version) { "3.10-master-777" }
       let(:tags_fixture_name) { "bar.json" }
@@ -549,7 +549,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("3.10-master-999") }
     end
 
-    context "when the dependency's version has a <version>-<branch>-<build> format, and multiple hyphens" do
+    context "when the dependency's version has a <version>-<words>-<build_num> format, and multiple hyphens" do
       let(:dependency_name) { "foo/baz" }
       let(:version) { "11-jdk-master-111" }
       let(:tags_fixture_name) { "baz.json" }
@@ -574,7 +574,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("11-jdk-master-222") }
     end
 
-    context "when the dependency's version has a <version>-<branch>-<build> format, and different branch formats" do
+    context "when the dependency's version has a <version>-<words>-<build> format, and different word formats" do
       let(:dependency_name) { "openjdk" }
       let(:version) { "21-ea-32" }
       let(:tags_fixture_name) { "openjdk.json" }
@@ -599,7 +599,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("22-ea-7") }
     end
 
-    context "when the dependency's version has a <version>-<branch>-<build> format, and multiple intermediate words" do
+    context "when the dependency's version has a <version>-<words>-<build> format, and multiple intermediate words" do
       let(:dependency_name) { "openjdk" }
       let(:tags_fixture_name) { "multiple-intermediate-words.json" }
       let(:repo_url) do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -524,6 +524,31 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("jdk-11.0.2.9-alpine-slim") }
     end
 
+    context "when the dependency's version has a <version>-<branch>-<build> format" do
+      let(:dependency_name) { "foo/bar" }
+      let(:version) { "3.10-master-777" }
+      let(:tags_fixture_name) { "bar.json" }
+      let(:repo_url) do
+        "https://registry.hub.docker.com/v2/foo/bar/"
+      end
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+
+        stub_request(:head, repo_url + "manifests/#{version}").
+          and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+      end
+
+      it { is_expected.to eq("3.10-master-999") }
+    end
+
     context "when the dependencies have an underscore" do
       let(:dependency_name) { "eclipse-temurin" }
       let(:tags_fixture_name) { "eclipse-temurin.json" }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -574,6 +574,31 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("11-jdk-master-222") }
     end
 
+    context "when the dependency's version has a <version>-<branch>-<build> format, and different branch formats" do
+      let(:dependency_name) { "openjdk" }
+      let(:version) { "21-ea-32" }
+      let(:tags_fixture_name) { "openjdk.json" }
+      let(:repo_url) do
+        "https://registry.hub.docker.com/v2/library/openjdk/"
+      end
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+
+        stub_request(:head, repo_url + "manifests/#{version}").
+          and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+      end
+
+      it { is_expected.to eq("22-ea-7") }
+    end
+
     context "when the dependencies have an underscore" do
       let(:dependency_name) { "eclipse-temurin" }
       let(:tags_fixture_name) { "eclipse-temurin.json" }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -599,6 +599,40 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("22-ea-7") }
     end
 
+    context "when the dependency's version has a <version>-<branch>-<build> format, and multiple intermediate words" do
+      let(:dependency_name) { "openjdk" }
+      let(:tags_fixture_name) { "multiple-intermediate-words.json" }
+      let(:repo_url) do
+        "https://registry.hub.docker.com/v2/library/openjdk/"
+      end
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+
+        stub_request(:head, repo_url + "manifests/#{version}").
+          and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+      end
+
+      context "when not the current version" do
+        let(:version) { "21-ea-32" }
+
+        it { is_expected.to eq("22-ea-7") }
+      end
+
+      context "when the current version" do
+        let(:version) { "22-ea-7-windowsservercore-1809" }
+
+        it { is_expected.to eq("22-ea-9-windowsservercore-1809") }
+      end
+    end
+
     context "when the dependencies have an underscore" do
       let(:dependency_name) { "eclipse-temurin" }
       let(:tags_fixture_name) { "eclipse-temurin.json" }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -549,6 +549,31 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("3.10-master-999") }
     end
 
+    context "when the dependency's version has a <version>-<branch>-<build> format, and multiple hyphens" do
+      let(:dependency_name) { "foo/baz" }
+      let(:version) { "11-jdk-master-111" }
+      let(:tags_fixture_name) { "baz.json" }
+      let(:repo_url) do
+        "https://registry.hub.docker.com/v2/foo/baz/"
+      end
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+
+        stub_request(:head, repo_url + "manifests/#{version}").
+          and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+      end
+
+      it { is_expected.to eq("11-jdk-master-222") }
+    end
+
     context "when the dependencies have an underscore" do
       let(:dependency_name) { "eclipse-temurin" }
       let(:tags_fixture_name) { "eclipse-temurin.json" }

--- a/docker/spec/fixtures/docker/registry_tags/bar.json
+++ b/docker/spec/fixtures/docker/registry_tags/bar.json
@@ -1,0 +1,7 @@
+{
+    "name": "foo/bar",
+    "tags": [
+        "3.10-master-777",
+        "3.10-master-999"
+    ]
+}

--- a/docker/spec/fixtures/docker/registry_tags/baz.json
+++ b/docker/spec/fixtures/docker/registry_tags/baz.json
@@ -1,0 +1,7 @@
+{
+    "name": "foo/baz",
+    "tags": [
+        "11-jdk-master-111",
+        "11-jdk-master-222"
+    ]
+}

--- a/docker/spec/fixtures/docker/registry_tags/multiple-intermediate-words.json
+++ b/docker/spec/fixtures/docker/registry_tags/multiple-intermediate-words.json
@@ -1,0 +1,10 @@
+{
+    "name": "openjdk",
+    "tags": [
+        "21-ea-32",
+        "22-ea-7",
+        "22-ea-7-windowsservercore-1809",
+        "22-ea-jdk-nanoserver-1809",
+        "22-ea-9-windowsservercore-1809"
+    ]
+}

--- a/docker/spec/fixtures/docker/registry_tags/openjdk.json
+++ b/docker/spec/fixtures/docker/registry_tags/openjdk.json
@@ -1,0 +1,8 @@
+{
+    "name": "openjdk",
+    "tags": [
+        "21-ea-32",
+        "22-ea-7",
+        "22-ea-jdk-nanoserver-1809"
+    ]
+}


### PR DESCRIPTION
This is not sustainable in the long term, since we can't properly support any version schema anybody decides to use.

But it sounds like we did support this one before and unintentionally broke it, so trying to restore it.

In the future, I think we should allow people teach Dependabot what their tags look like.