### PR TITLE
Teach DependencyGroup to calculate the ranges we should ignore when looking for versions that fall outside the group

### DIFF
--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -46,9 +46,9 @@ module Dependabot
       matches_pattern?(dependency.name) && matches_dependency_type?(dependency)
     end
 
-    # This method generates ignored versions for the given Dependency based on
-    # the any update-types we have defined.
-    def ignored_versions_for(dependency)
+    # This method generates ignored version ranges for the given Dependency
+    # based on the any update-types we have defined.
+    def ignored_version_ranges_for(dependency)
       @ignore_condition.ignored_versions(dependency, SECURITY_UPDATES_ONLY)
     end
 

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Dependabot::DependencyGroup do
     end
   end
 
-  describe "#ignored_versions_for with experimental rules enabled" do
+  describe "#ignored_version_ranges_for with experimental rules enabled" do
     let(:dependency) do
       Dependabot::Dependency.new(
         name: "business",
@@ -227,7 +227,7 @@ RSpec.describe Dependabot::DependencyGroup do
 
     context "the group has not defined an update-types rule" do
       it "returns an empty array as nothing should be ignored" do
-        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to be_empty
       end
     end
 
@@ -239,7 +239,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns an empty array as nothing should be ignored" do
-        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to be_empty
       end
     end
 
@@ -251,7 +251,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns a range which ignores major versions" do
-        expect(dependency_group.ignored_versions_for(dependency)).to eql([
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to eql([
           ">= 2.a"
         ])
       end
@@ -265,7 +265,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns ranges which ignore major and minor updates" do
-        expect(dependency_group.ignored_versions_for(dependency)).to eql([
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to eql([
           ">= 2.a",
           ">= 1.9.a, < 2"
         ])
@@ -305,7 +305,7 @@ RSpec.describe Dependabot::DependencyGroup do
     end
   end
 
-  describe "#ignored_versions_for with experimental rules disabled" do
+  describe "#ignored_version_ranges_for with experimental rules disabled" do
     let(:dependency) do
       Dependabot::Dependency.new(
         name: "business",
@@ -319,7 +319,7 @@ RSpec.describe Dependabot::DependencyGroup do
 
     context "the group has not defined an update-types rule" do
       it "returns an empty array as nothing should be ignored" do
-        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to be_empty
       end
     end
 
@@ -331,7 +331,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns an empty array as nothing should be ignored" do
-        expect(dependency_group.ignored_versions_for(dependency)).to be_empty
+        expect(dependency_group.ignored_version_ranges_for(dependency)).to be_empty
       end
     end
   end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -187,7 +187,7 @@ module Dependabot
         # It returns verion ranges which implement IgnoreCondition objects' rules
         # not the objects themselves so this is a little misleading.
         versions_ignored_from_configuration = job.ignore_conditions_for(dependency)
-        versions_ignored_from_group = dependency_group.ignored_versions_for(dependency)
+        versions_ignored_from_group = dependency_group.ignored_version_ranges_for(dependency)
 
         (versions_ignored_from_configuration + versions_ignored_from_group).uniq
       end


### PR DESCRIPTION
This is a follow up on our experiment with SemVer grouping in #7581 

The current implementation is _very alpha_ where we will:
1. Correctly prevent the group from updating beyond the desired SemVer range(s) configured
2. Attempt a second ungrouped update on any dependencies where we haven't addressed the highest possible version in-group

The behaviour for (2) is currently not fully implemented so it essentially results in us creating the highest version available **as well** as the group PR.

The next step is to improve how we process the separate updates in two ways:
- We should make best effort _not_ to attempt a second upgrade if we know the highest version is within the group for a dependency
- We should explicitly ignore any version ranges that fall **within** the group when doing this separate update.

This Pull Request is a baby step towards the latter which adds a new method to `DependencyGroup`:

```ruby
dependency_group.ignored_version_ranges_for_ungrouped_versions_of(dependency)
```

This method is essentially the opposite of `DependencyGroup#ignored_version_ranges_for` providing ignored ranges that fall within the group.

This branch does not wire this new behaviour up yet as we need a new way to collect and perform the dependencies that need to be updated which is aware of the DependencyGroup object so it can collect this information as part of the job.