### PR TITLE
Test that unsupported Python versions raise the expected error

### DIFF
--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -218,9 +218,21 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
         it { is_expected.to eq(Gem::Version.new("3.2.4")) }
 
-        context "that disallows the latest version" do
+        context "that is set to the oldest version of python supported by Dependabot" do
           let(:python_version_content) { "3.5.3\n" }
           it { is_expected.to eq(Gem::Version.new("2.2.24")) }
+        end
+
+        context "that is set to a python version no longer supported by Dependabot" do
+          let(:python_version_content) { "3.4.0\n" }
+          it "raises a Dependabot::DependencyFileNotResolvable error" do
+            expect { checker.latest_resolvable_version }.
+              to raise_error(Dependabot::DependencyFileNotResolvable) do |err|
+              expect(err.message).to start_with(
+                "Dependabot detected the following Python requirement for your project: '3.4.0'."
+              )
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Since we'll be dropping 3.6/3.7 soon, we want to ensure that users on unsupported python versions get a clearly understandable error and not a random traceback.