### PR TITLE
Revert latest Bundler upgrade

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -97,7 +97,7 @@ COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/lo
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
-ARG BUNDLER_V2_VERSION=2.4.17
+ARG BUNDLER_V2_VERSION=2.4.14
 
 # We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 20.04 has a bug.
 # Once Ubuntu base image pulls in a new enough yaml version, we may not need to

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -94,7 +94,7 @@ WORKDIR $DEPENDABOT_HOME/dependabot-updater
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
 COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/local
 
-# When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --lock --bundler`
+# When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.4.17

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -329,4 +329,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.17
+   2.4.14


### PR DESCRIPTION
We're getting quite frequent CI failures in the Bundler suite since the Bundler upgrade. I want to roll it back to confirm it's the culprit.