### PR TITLE
Delete deprecated `host-environment-markers` key

### DIFF
--- a/python/spec/fixtures/lockfiles/edited.lock
+++ b/python/spec/fixtures/lockfiles/edited.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "c402ea48092e9d467af51a483bb8dd8ad0620e11c94f009dcd433f97a99d45db"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/edited_array.lock
+++ b/python/spec/fixtures/lockfiles/edited_array.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "c402ea48092e9d467af51a483bb8dd8ad0620e11c94f009dcd433f97a99d45db"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/environment_variable_source.lock
+++ b/python/spec/fixtures/lockfiles/environment_variable_source.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "60e573c7eb5986a35673614ffd23a685f76846f0ac9f4fa4a4577377e98545a6"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.1",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "3.6.1",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/git_source.lock
+++ b/python/spec/fixtures/lockfiles/git_source.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "ab083473c9e4abf940ab40d0b5e2882d1d69cf2e8b3739e21131f90ffde8c04f"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/git_source_bad_ref.lock
+++ b/python/spec/fixtures/lockfiles/git_source_bad_ref.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "76257e8b1a36ef923d9e0a4f4b3c06ab5bdb727ff0b05b700d24c105bca0c9f3"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/git_source_unreachable.lock
+++ b/python/spec/fixtures/lockfiles/git_source_unreachable.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "76257e8b1a36ef923d9e0a4f4b3c06ab5bdb727ff0b05b700d24c105bca0c9f3"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/hard_names.lock
+++ b/python/spec/fixtures/lockfiles/hard_names.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "b35b2b4af6b053fab50a6301d4b2ab00380f258a47dba073de49bb64586d7e7a"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.1",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "3.6.1",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/version_hash.lock
+++ b/python/spec/fixtures/lockfiles/version_hash.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "53fe2c356a1edfc7e1f5281b4f86c8f08ed9050eecf621217d5d40282ca21ace"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.1",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "3.6.1",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [

--- a/python/spec/fixtures/lockfiles/version_not_specified.lock
+++ b/python/spec/fixtures/lockfiles/version_not_specified.lock
@@ -3,19 +3,6 @@
         "hash": {
             "sha256": "c402ea48092e9d467af51a483bb8dd8ad0620e11c94f009dcd433f97a99d45db"
         },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "0",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Wed Oct  4 00:17:00 PDT 2017; root:xnu-3789.71.6~1/RELEASE_X86_64",
-            "python_full_version": "2.7.13",
-            "python_version": "2.7",
-            "sys_platform": "darwin"
-        },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [


### PR DESCRIPTION
Our `pipenv` fixtures are a bit outdated... when I tried to delete Python 3.6, they started failing because we've got some code that reads the python version and tries to use that to guess at what version of python to run.

However, when I tried regenerating one of these lockfiles under a newer Python, I was surprised that the entire `host-environment-markers` key disappeared.

After a little digging, I found that this key was removed in 2018, which also explains why only the older fixtures have it and not the more recent fixtures. More historical context:
* https://github.com/pypa/pipenv/issues/753
* https://github.com/pypa/pipenv/commit/ecf78424c1740bae3511c731c032a3768154072c#r28870534
* https://github.com/pypa/pipenv/commit/ecf78424c1740bae3511c731c032a3768154072c#diff-ef852c4ac364f946819f765a6bc26f04f1b0968f31fc512949a60fa2ab0685e8L1201

In order to update our lockfiles, I first started by running `PYENV_VERSION=3.11.4 pyenv exec pipenv lock`... However, I ran into some problems because:
1. Some of the lockfiles are simply unresolvable by design in order to stress test our code. So they have to be manually munged around.
2. We are currently pinned to an olde version of `pipenv` due to conflicts with Python `3.6`, etc: https://github.com/dependabot/dependabot-core/pull/6104

Since we will soon be dropping Python 3.6, 3.7, and then planning to update `pipenv` version, I decided it would be more efficient from an engineering perspective to hack my way through the jungle with a machete for a little bit by:
1. Manually delete the key from the lockfiles (that's what this PR does)
2. File a ticket to track regenerating the `pipenv` lockfiles: https://github.com/dependabot/dependabot-core/issues/7697
3. Finish the work of deprecating EOL'd python versions and updating `pipenv`
4. Then finally regenerate the fixtures using `pipenv lock`.

So in this PR I manually deleted the key... but note that I was forced to do so manually not programmatically, so these fixtures may still be outdated in other ways.