### PR TITLE
Fixup `pip_version_resolver` specs

### DIFF
--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -208,20 +208,15 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
         end
       end
 
-      context "that is unsupported" do
+      context "that is set to a python version no longer supported by Dependabot" do
         let(:pipfile_fixture_name) { "required_python_unsupported" }
 
         it "raises a helpful error" do
-          expect { subject }.
-            to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-              expect(error.message).
-                to start_with("Dependabot detected the following Python")
-              expect(error.message).to include("3.4.*")
-              expect(error.message).
-                to include(
-                  "supported in Dependabot: 3.11.4, 3.11.3, 3.11.2, 3.11.1, 3.11.0, 3.10.12, 3.10.11, 3.10.10, 3.10.9"
-                )
-            end
+          expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable) do |err|
+            expect(err.message).to start_with(
+              "Dependabot detected the following Python requirement for your project: '3.4.*'."
+            )
+          end
         end
       end
 

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -225,9 +225,8 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
         context "that is set to a python version no longer supported by Dependabot" do
           let(:python_version_content) { "3.4.0\n" }
-          it "raises a Dependabot::DependencyFileNotResolvable error" do
-            expect { checker.latest_resolvable_version }.
-              to raise_error(Dependabot::DependencyFileNotResolvable) do |err|
+          it "raises a helpful error" do
+            expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable) do |err|
               expect(err.message).to start_with(
                 "Dependabot detected the following Python requirement for your project: '3.4.0'."
               )


### PR DESCRIPTION
While working on the PR to drop support for Python 3.6, I noticed these specs could use some tidying up:
1. `3.7` will soon be dropped, so bumped the "latest" version to `3.11`.
2. We had no explicit test of what happens when an outdated Python version was specified.

Finally, the biggest change is removing the test of "old python version supported by Dependabot but not supported by a newer version of the library". The problem is that the test scenario, while nice to have, is becoming less realistic. 

Overall (and I say this as someone who helps maintain several popular Python open source libraries) the Python ecosystem has been aligning pretty closely to the upstream version support lifecycle. Ie, library maintainers are starting to align when they drop support for old python versions with the upstream EOL cycle. 

Similarly, we're moving towards here in Dependabot.

So it's going to be really hard to find an example of a library that releases a new version dropping support for a Python version that isn't EOL'd... or if it is EOL'd, then most likely we've dropped support for that Python version here in Dependabot.

And even if I do manage to track down a library doing this, or mock a fake response from PyPI, it'll be a brittle test because every year we'll be dropping support for that old version.

So instead I think the test of "that is set to a python version no longer supported by Dependabot" is a more realistic test scenario.

This is similar to the changes I already made for other Python package managers over in:
* https://github.com/dependabot/dependabot-core/pull/7691
* https://github.com/dependabot/dependabot-core/pull/7692