### PR TITLE
Add `truncate_to_major_minor` helper method

### DIFF
--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -33,8 +33,7 @@ module Dependabot
       end
 
       def python_major_minor
-        @python ||= Python::Version.new(python_version)
-        "#{@python.segments[0]}.#{@python.segments[1]}"
+        @python_major_minor ||= Python::Version.new(python_version).truncate_to_major_minor
       end
 
       def python_version
@@ -67,12 +66,10 @@ module Dependabot
           find { |v| requirement.satisfied_by?(Python::Version.new(v)) }
         return version if version
 
-        # If not, and we're dealing with a simple version string
-        # and changing the patch version would fix things, we do that
-        # as the patch version is unlikely to affect resolution
+        # If not, and we're dealing with a simple version string and changing the patch version would fix things,
+        # we do that as the patch version is unlikely to affect resolution
         if requirement_string.start_with?(/\d/)
-          requirement =
-            Python::Requirement.new(requirement_string.gsub(/\.\d+$/, ".*"))
+          requirement = Python::Version.new(requirement_string).truncate_to_major_minor
           version =
             PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.
             find { |v| requirement.satisfied_by?(Python::Version.new(v)) }

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -66,6 +66,10 @@ module Dependabot
         local_version_comparison(other)
       end
 
+      def truncate_to_major_minor
+        Python::Version.new(segments[0..1].join("."))
+      end
+
       private
 
       def epoch_comparison(other)

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -149,6 +149,40 @@ RSpec.describe Dependabot::Python::Version do
         it { is_expected.to eq(false) }
       end
     end
+
+    describe "#truncate_to_major_minor" do
+      subject { version.truncate_to_major_minor }
+
+      context "with a prerelease" do
+        let(:version_string) { "1.0.0alpha" }
+        it { is_expected.to eq("1.0") }
+      end
+
+      context "with a normal release" do
+        let(:version_string) { "1.2.3" }
+        it { is_expected.to eq("1.2") }
+      end
+
+      context "with a post release" do
+        let(:version_string) { "1.0.0-post1" }
+        it { is_expected.to eq("1.0") }
+
+        context "that is implicit" do
+          let(:version_string) { "1.0.0-1" }
+          it { is_expected.to eq("1.0") }
+        end
+
+        context "that uses a dot" do
+          let(:version_string) { "1.0.0.post1" }
+          it { is_expected.to eq("1.0") }
+        end
+
+        context "that is already truncated" do
+          let(:version_string) { "1.2" }
+          it { is_expected.to eq("1.2") }
+        end
+      end
+    end
   end
 
   describe "compatibility with Gem::Requirement" do


### PR DESCRIPTION
Add a major/minor helper. Technically this may change behavior slightly if we start seeing versions that were successfully parsed by the regex but can't be parsed by `Python::Version.new()`, but in that case we should fix `Python::Version.new()` so that our string-> version parsing logic is consistent everywhere.

But as long as CI is happy than we should go with this unless we start seeing oddball python version strings showing up in our error logs.