### PR TITLE
Suppress error output when evaluating invalid Ruby during tests

### DIFF
--- a/bundler/spec/dependabot/bundler/file_fetcher/child_gemfile_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher/child_gemfile_finder_spec.rb
@@ -60,9 +60,11 @@ RSpec.describe Dependabot::Bundler::FileFetcher::ChildGemfileFinder do
         let(:gemfile) { bundler_project_dependency_file("invalid_ruby", filename: "Gemfile") }
 
         it "raises a helpful error" do
-          expect { finder.child_gemfile_paths }.to raise_error do |error|
-            expect(error).to be_a(Dependabot::DependencyFileNotParseable)
-            expect(error.file_name).to eq("Gemfile")
+          suppress_output do
+            expect { finder.child_gemfile_paths }.to raise_error do |error|
+              expect(error).to be_a(Dependabot::DependencyFileNotParseable)
+              expect(error.file_name).to eq("Gemfile")
+            end
           end
         end
       end

--- a/bundler/spec/dependabot/bundler/file_fetcher/gemspec_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher/gemspec_finder_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Dependabot::Bundler::FileFetcher::GemspecFinder do
       let(:gemfile) { bundler_project_dependency_file("invalid_ruby", filename: "Gemfile") }
 
       it "raises a helpful error" do
-        expect { finder.gemspec_directories }.to raise_error do |error|
-          expect(error).to be_a(Dependabot::DependencyFileNotParseable)
-          expect(error.file_name).to eq("Gemfile")
+        suppress_output do
+          expect { finder.gemspec_directories }.to raise_error do |error|
+            expect(error).to be_a(Dependabot::DependencyFileNotParseable)
+            expect(error.file_name).to eq("Gemfile")
+          end
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_fetcher/path_gemspec_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher/path_gemspec_finder_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe Dependabot::Bundler::FileFetcher::PathGemspecFinder do
       let(:gemfile) { bundler_project_dependency_file("invalid_ruby", filename: "Gemfile") }
 
       it "raises a helpful error" do
-        expect { finder.path_gemspec_paths }.to raise_error do |error|
-          expect(error).to be_a(Dependabot::DependencyFileNotParseable)
-          expect(error.file_name).to eq("Gemfile")
+        suppress_output do
+          expect { finder.path_gemspec_paths }.to raise_error do |error|
+            expect(error).to be_a(Dependabot::DependencyFileNotParseable)
+            expect(error.file_name).to eq("Gemfile")
+          end
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_fetcher/require_relative_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher/require_relative_finder_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe Dependabot::Bundler::FileFetcher::RequireRelativeFinder do
       let(:file_body) { bundler_project_dependency_file("invalid_ruby", filename: "Gemfile").content }
 
       it "raises a helpful error" do
-        expect { finder.require_relative_paths }.to raise_error do |error|
-          expect(error).to be_a(Dependabot::DependencyFileNotParseable)
-          expect(error.file_name).to eq("Gemfile")
+        suppress_output do
+          expect { finder.require_relative_paths }.to raise_error do |error|
+            expect(error).to be_a(Dependabot::DependencyFileNotParseable)
+            expect(error.file_name).to eq("Gemfile")
+          end
         end
       end
     end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -44,6 +44,17 @@ def bundler_build_tmp_repo(project)
   build_tmp_repo(project, path: "projects/bundler1")
 end
 
+def suppress_output
+  original_stderr = $stderr.clone
+  original_stdout = $stdout.clone
+  $stderr.reopen(File.new(File::NULL, "w"))
+  $stdout.reopen(File.new(File::NULL, "w"))
+  yield
+ensure
+  $stdout.reopen(original_stdout)
+  $stderr.reopen(original_stderr)
+end
+
 RSpec.configure do |config|
   config.around do |example|
     if PackageManagerHelper.use_bundler_2? && example.metadata[:bundler_v1_only]


### PR DESCRIPTION
Before:

```
[dependabot-core-dev] ~/dependabot-core/bundler $ rspec -e "with invalid Ruby"
Run options: include {:full_description=>/with\ invalid\ Ruby/}

Randomized with seed 12398
(string):2:20: error: unexpected token tUMINUS
(string):2:     ruby -rubygems -e 'require "jekyll-import";
(string):2:                    ^                           
.(string):2:20: error: unexpected token tUMINUS
(string):2:     ruby -rubygems -e 'require "jekyll-import";
(string):2:                    ^                           
.(string):2:20: error: unexpected token tUMINUS
(string):2:     ruby -rubygems -e 'require "jekyll-import";
(string):2:                    ^                           
.(string):2:20: error: unexpected token tUMINUS
(string):2:     ruby -rubygems -e 'require "jekyll-import";
(string):2:                    ^                           
.

Finished in 0.04749 seconds (files took 1.39 seconds to load)
4 examples, 0 failures

Randomized with seed 12398
```

After:

```
[dependabot-core-dev] ~/dependabot-core/bundler $ rspec -e "with invalid Ruby"
Run options: include {:full_description=>/with\ invalid\ Ruby/}

Randomized with seed 3840
....

Finished in 0.04951 seconds (files took 1.26 seconds to load)
4 examples, 0 failures

Randomized with seed 3840
```