### PR TITLE
Enable `--verbose` when running specs

### DIFF
--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,7 +3,7 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose
 
 # NOTE: Don't use `if` branches without `else` part, since the code in some of
 # then seems to not abort the script regardless of `set -e`

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -4,7 +4,7 @@ set -e
 
 bundle install
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose
 
 # Should we only run these on one of the CI_NODE_INDEX's?
 cd /opt/npm_and_yarn && npm run lint && cd -

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose

--- a/swift/script/ci-test
+++ b/swift/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
+bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose


### PR DESCRIPTION
That prints the actual RSpec command that gets run under the hood. If the current CI flakies are order dependent, it should allow us to reproduce them.