### PR TITLE
Upgrade `pip-tools` to `7.2.0`

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,5 +1,5 @@
 pip>=21.3.1,<23.3.0  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
-pip-tools>=6.4.0,<=6.14.0  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
+pip-tools==7.2.0
 hashin==0.17.0
 pipenv==2022.4.8
 pipfile==0.0.2

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -250,9 +250,6 @@ module Dependabot
           # TODO: Stop explicitly specifying `allow-unsafe` once it becomes the default:
           # https://github.com/jazzband/pip-tools/issues/989#issuecomment-1661254701
           options += ["--allow-unsafe"]
-          # TODO: This is the default as of https://github.com/jazzband/pip-tools/releases/tag/7.0.0
-          # so stop explicitly specifying it as soon as we upgrade
-          options += ["--resolver backtracking"]
 
           if (requirements_file = compiled_file_for_filename(filename))
             options << "--output-file=#{requirements_file.name}"


### PR DESCRIPTION
Relevant breaking changes: https://github.com/jazzband/pip-tools/releases/tag/7.0.0

> Backwards Incompatible Changes:
> 
> - Default to --resolver=backtracking (https://github.com/jazzband/pip-tools/pull/1897). 
> - Drop support for Python 3.7 (https://github.com/jazzband/pip-tools/pull/1879).

So this is blocked by:
* #7702 