### PR TITLE
Use dockerignore rules that play better with recent docker versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,11 +13,10 @@
 /tmp
 **/.bundle
 **/coverage
-**/Gemfile.lock
+/Gemfile.lock
+*/Gemfile.lock
 !updater/Gemfile.lock
-!updater/spec/fixtures/**/Gemfile.lock
 **/node_modules
-!**/spec/fixtures/*
 git.store
 .DS_Store
 *.pyc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           filters: |
             bundler:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -66,6 +67,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'bundler/**'
             cargo:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -73,10 +75,12 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'cargo/**'
             common:
+              - .dockerignore
               - Dockerfile.updater-core
               - '**/**'
               - '.github/workflows/ci.yml'
             composer:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -84,6 +88,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'composer/**'
             docker:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -91,6 +96,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'docker/**'
             elm:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -98,6 +104,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'elm/**'
             git_submodules:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -105,6 +112,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'git_submodules/**'
             github_actions:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -112,12 +120,14 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'github_actions/**'
             go_modules:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
               - 'go_modules/**'
               - '.github/workflows/ci.yml'
             gradle:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -126,6 +136,7 @@ jobs:
               - 'maven/**'
               - 'gradle/**'
             hex:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -133,12 +144,14 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'hex/**'
             maven:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
               - 'maven/**'
               - '.github/workflows/ci.yml'
             npm_and_yarn:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -146,6 +159,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'npm_and_yarn/**'
             nuget:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -153,6 +167,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'nuget/**'
             pub:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -160,6 +175,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'pub/**'
             python:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -167,6 +183,7 @@ jobs:
               - 'python/**'
               - '.github/workflows/ci.yml'
             swift:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'
@@ -174,6 +191,7 @@ jobs:
               - 'swift/**'
               - '.github/workflows/ci.yml'
             terraform:
+              - .dockerignore
               - Dockerfile.updater-core
               - 'common/**'
               - 'updater/Gemfil*'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -65,180 +65,210 @@ jobs:
         filters: |
           actions:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'github_actions/**'
           bundler:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
           bundler-group-rules:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
           cargo:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'cargo/**'
           composer:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'composer/**'
           docker:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'docker/**'
           elm:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'elm/**'
           go:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           'go-close-pr':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           'go-security':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           'go-update-pr':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           gradle:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'gradle/**'
           'gradle-version-catalog':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'gradle/**'
           hex:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'hex/**'
           maven:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'maven/**'
           npm:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           'npm-remove-transitive':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           nuget:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'nuget/**'
           pip:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           'pip-compile':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pipenv:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pnpm:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           poetry:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pub:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'pub/**'
           submodules:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'git_submodules/**'
           swift:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'swift/**'
           terraform:
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'terraform/**'
           'yarn':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           'yarn-berry':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           'yarn-berry-workspaces':
             - .github/workflows/smoke.yml
+            - .dockerignore
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'


### PR DESCRIPTION
Apparently new versions on Docker (at least on v23) no longer include Gemfile.lock files inside `bundler/spec/fixtures` in the build image.
    
Reading our current `.dockerignore`, it seems that the new behaviour prioritizes more explicit rules (not ending with `*`) even if they appear earlier in the file.
    
I'm not sure if this is expected, or a bug, but we can change the entries to not be ambiguous and simplify them.
