### PR TITLE
`pip` no longer requires a range

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,4 +1,4 @@
-pip>=21.3.1,<23.3.0  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
+pip==23.2.0
 pip-tools==7.2.0
 hashin==0.17.0
 pipenv==2022.4.8


### PR DESCRIPTION
The range was specified because newer versions of `pip` don't support
`python` `3.6`.

So now that we've dropped support for `3.6` here in Dependabot, we can
go back to pinning to a single version.

Blocked on:
* #7702 