### PR TITLE
Pin poetry to specific version

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools>=6.4.0,<=6.14.0  # Range maintains py36 support TODO: Review python 3.
 hashin==0.17.0
 pipenv==2022.4.8
 pipfile==0.0.2
-poetry>=1.2,<1.6.0
+poetry==1.5.1
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.0


### PR DESCRIPTION
The range existed because newer versions of `poetry` had dropped
`python` `3.6` support.

Now that we've dropped `3.6`, we can go back to pinning to a
specific version for more deterministic builds.

Blocked on:
* #6299 