### PR TITLE
Document why we pin `wheel`

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -4,6 +4,8 @@ hashin==0.17.0
 pipenv==2022.4.8
 pipfile==0.0.2
 poetry>=1.1.15,<1.6.0
+# For now we chose to pin `wheel` even though we don't import it directly.
+# Background context: https://github.com/dependabot/dependabot-core/pull/5597
 wheel==0.37.1
 
 # Some dependencies will only install if Cython is present


### PR DESCRIPTION
I couldn't figure out why we pinned `wheel` because it's not directly `import`'d until I stumbled across myself asking the same question  a year ago:
* https://github.com/dependabot/dependabot-core/pull/5597

🤣 

So let's document it to save myself from re-asking the question a year from now.