### PR TITLE
Group Dependabot `aws-sdk-*` PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    groups:
+      aws-sdk:
+        patterns:
+        - "aws-sdk-*"
 
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"


### PR DESCRIPTION
We run the full CI suite for any PR's against `/updater`, so it can be pretty time consuming.

Let's run the `aws-sdk-*` PR's together to save CI/engineering review cycles.