### PR TITLE
Delete unused method `error_certainly_bad_python_version?`

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -301,17 +301,6 @@ module Dependabot
           env
         end
 
-        def error_certainly_bad_python_version?(message)
-          return true if message.include?("UnsupportedPythonVersion")
-
-          unless message.include?('"python setup.py egg_info" failed') ||
-                 message.include?("exit status 1: python setup.py egg_info")
-            return false
-          end
-
-          message.include?("SyntaxError")
-        end
-
         def write_temporary_dependency_files(updated_req: nil,
                                              update_requirement: true)
           dependency_files.each do |file|


### PR DESCRIPTION
This method is not called anywhere in our codebase.

`git blame` shows it was added 4 years ago and used at that time, but the python version detection code has been heavily refactored since then so I didn't bother to trace where it's usage got removed.

So let's nuke it.