### PR TITLE
Switch from pipfile to plette lib

### DIFF
--- a/python/helpers/lib/hasher.py
+++ b/python/helpers/lib/hasher.py
@@ -1,6 +1,6 @@
 import hashin
 import json
-import pipfile
+import plette
 from poetry.factory import Factory
 
 
@@ -15,9 +15,10 @@ def get_dependency_hash(dependency_name, dependency_version, algorithm):
 
 
 def get_pipfile_hash(directory):
-    p = pipfile.load(directory + '/Pipfile')
+    with open(directory + '/Pipfile') as f:
+        pipfile = plette.Pipfile.load(f)
 
-    return json.dumps({"result": p.hash})
+    return json.dumps({"result": pipfile.get_hash().value})
 
 
 def get_pyproject_hash(directory):

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools==7.3.0
 flake8==6.1.0
 hashin==0.17.0
 pipenv==2022.4.8
-pipfile==0.0.2
+plette==0.4.4
 poetry==1.6.1
 
 # Some dependencies will only install if Cython is present


### PR DESCRIPTION
`plette` requires `python 3.7`, so blocked on:
* #6299 

The main user of `pipfile` is `pipenv`, and _not_ any of the other
python package managers.

However, `pipfile` library has been pretty much unmaintained, so
`pipenv` switched to using `plette` for parsing/validation of
`Pipfile`'s:
* https://github.com/pypa/pipenv/issues/5310
* https://github.com/pypa/pipenv/pull/5339

So let's switch our usage as well. Today we only use `pipfile` for
generating hashes, so this is effectively a silent no-op. However, down
the road we could leverage `plette` for `Pipfile` parsing/validation...
for example see how it's flagging things here:
https://github.com/dependabot/dependabot-core/pull/6104#issuecomment-1356403336