### PR TITLE
Add `name` key to `sources` in `Pipfile`s

### DIFF
--- a/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
@@ -130,9 +130,12 @@ module Dependabot
 
         def config_variable_sources(credentials)
           @config_variable_sources ||=
-            credentials.
-            select { |cred| cred["type"] == "python_index" }.
-            map { |c| { "url" => AuthedUrlBuilder.authed_url(credential: c) } }
+            credentials.select { |cred| cred["type"] == "python_index" }.map.with_index do |c, i|
+              {
+                "name" => "dependabot-inserted-index-#{i}",
+                "url" => AuthedUrlBuilder.authed_url(credential: c)
+              }
+            end
         end
       end
     end

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -179,6 +179,34 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
       end
     end
 
+    context "with a source not included in the original Pipfile" do
+      let(:credentials) do
+        [
+          {
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          },
+          {
+            "type" => "python_index",
+            "index-url" => "https://pypi.posrip.com/pypi/"
+          }
+        ]
+      end
+
+      it "the source is not included in the final updated files" do
+        expect(updated_files.map(&:name)).to eq(%w(Pipfile.lock)) # because Pipfile shouldn't have changed
+
+        updated_lockfile = updated_files.find { |f| f.name == "Pipfile.lock" }
+        expect(updated_lockfile.content).not_to include("dependabot-inserted-index")
+        expect(updated_lockfile.content).not_to include("https://pypi.posrip.com/pypi/")
+
+        json_lockfile = JSON.parse(updated_lockfile.content)
+        expect(json_lockfile["_meta"]["sources"]).to eq(JSON.parse(lockfile.content)["_meta"]["sources"])
+      end
+    end
+
     context "when the Pipfile included an environment variable source" do
       let(:pipfile_fixture_name) { "environment_variable_source" }
       let(:lockfile_fixture_name) { "environment_variable_source.lock" }

--- a/python/spec/dependabot/python/file_updater/pipfile_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_preparer_spec.rb
@@ -135,8 +135,11 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfilePreparer do
     let(:lockfile_fixture_name) { "version_not_specified.lock" }
 
     it "adds the source" do
-      expect(updated_content).
-        to include("https://username:password@pypi.posrip.com/pypi/")
+      expect(updated_content).to include(
+        "[[source]]\n" \
+        "name = \"dependabot-inserted-index-0\"\n" \
+        "url = \"https://username:password@pypi.posrip.com/pypi/\"\n"
+      )
     end
 
     context "with auth details provided as a token" do
@@ -154,8 +157,11 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfilePreparer do
       end
 
       it "adds the source" do
-        expect(updated_content).
-          to include("https://username:password@pypi.posrip.com/pypi/")
+        expect(updated_content).to include(
+          "[[source]]\n" \
+          "name = \"dependabot-inserted-index-0\"\n" \
+          "url = \"https://username:password@pypi.posrip.com/pypi/\"\n"
+        )
       end
     end
 
@@ -178,7 +184,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfilePreparer do
       it "keeps source config" do
         expect(updated_content).to include(
           "[[source]]\n" \
-          "name = \"pypi\"\n" \
+          "name = \"internal-pypi\"\n" \
           "url = \"https://username:password@pypi.posrip.com/pypi/\"\n" \
           "verify_ssl = true\n"
         )

--- a/python/spec/fixtures/pipfile_files/arbitrary_equality
+++ b/python/spec/fixtures/pipfile_files/arbitrary_equality
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/conflict_at_current
+++ b/python/spec/fixtures/pipfile_files/conflict_at_current
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/conflict_at_latest
+++ b/python/spec/fixtures/pipfile_files/conflict_at_latest
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/environment_variable_source
+++ b/python/spec/fixtures/pipfile_files/environment_variable_source
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/${ENV_VAR}"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/exact_version
+++ b/python/spec/fixtures/pipfile_files/exact_version
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/extra_subdependency
+++ b/python/spec/fixtures/pipfile_files/extra_subdependency
@@ -1,7 +1,7 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
-name = "pypi"
 
 [packages]
 flask = "==1.0.*"

--- a/python/spec/fixtures/pipfile_files/git_source
+++ b/python/spec/fixtures/pipfile_files/git_source
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/git_source_bad_ref
+++ b/python/spec/fixtures/pipfile_files/git_source_bad_ref
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/git_source_no_ref
+++ b/python/spec/fixtures/pipfile_files/git_source_no_ref
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/git_source_unreachable
+++ b/python/spec/fixtures/pipfile_files/git_source_unreachable
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/hard_names
+++ b/python/spec/fixtures/pipfile_files/hard_names
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/not_in_lockfile
+++ b/python/spec/fixtures/pipfile_files/not_in_lockfile
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/only_dev
+++ b/python/spec/fixtures/pipfile_files/only_dev
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/path_dependency
+++ b/python/spec/fixtures/pipfile_files/path_dependency
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/path_dependency_not_self
+++ b/python/spec/fixtures/pipfile_files/path_dependency_not_self
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/private_source
+++ b/python/spec/fixtures/pipfile_files/private_source
@@ -1,4 +1,5 @@
 [[source]]
+name = "internal-pypi"
 url = "https://some.internal.registry.com/pypi/"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/private_source_auth
+++ b/python/spec/fixtures/pipfile_files/private_source_auth
@@ -1,7 +1,7 @@
 [[source]]
+name = "internal-pypi"
 url = "https://${ENV_USER}:${ENV_PASSWORD}@pypi.posrip.com/pypi/"
 verify_ssl = true
-name = "pypi"
 
 [dev-packages]
 pytest = "==3.4.0"

--- a/python/spec/fixtures/pipfile_files/prod_and_dev
+++ b/python/spec/fixtures/pipfile_files/prod_and_dev
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/prod_and_dev_different
+++ b/python/spec/fixtures/pipfile_files/prod_and_dev_different
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/required_python
+++ b/python/spec/fixtures/pipfile_files/required_python
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/required_python_implicit
+++ b/python/spec/fixtures/pipfile_files/required_python_implicit
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/required_python_invalid
+++ b/python/spec/fixtures/pipfile_files/required_python_invalid
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/required_python_unsupported
+++ b/python/spec/fixtures/pipfile_files/required_python_unsupported
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/unparseable
+++ b/python/spec/fixtures/pipfile_files/unparseable
@@ -1,8 +1,7 @@
 [[source]]
-
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
-name = "pypi"
 
 [dev-packages]
 

--- a/python/spec/fixtures/pipfile_files/unsupported_dep
+++ b/python/spec/fixtures/pipfile_files/unsupported_dep
@@ -1,7 +1,7 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
-name = "pypi"
 
 [packages]
 requests = "==2.18.0"

--- a/python/spec/fixtures/pipfile_files/version_hash
+++ b/python/spec/fixtures/pipfile_files/version_hash
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/version_not_specified
+++ b/python/spec/fixtures/pipfile_files/version_not_specified
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/version_not_specified.lock
+++ b/python/spec/fixtures/pipfile_files/version_not_specified.lock
@@ -1,12 +1,13 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c402ea48092e9d467af51a483bb8dd8ad0620e11c94f009dcd433f97a99d45db"
+            "sha256": "e76ae491d793d659f05c7f7eab261fd6167dc062efcba08f17be68e73eb87665"
         },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [
             {
+                "name": "pypi",
                 "url": "https://pypi.org/simple",
                 "verify_ssl": true
             }

--- a/python/spec/fixtures/pipfile_files/version_table
+++ b/python/spec/fixtures/pipfile_files/version_table
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/wildcard
+++ b/python/spec/fixtures/pipfile_files/wildcard
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/with_quotes
+++ b/python/spec/fixtures/pipfile_files/with_quotes
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 

--- a/python/spec/fixtures/pipfile_files/yanked
+++ b/python/spec/fixtures/pipfile_files/yanked
@@ -1,4 +1,5 @@
 [[source]]
+name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 


### PR DESCRIPTION
Newer versions of `pipenv` require any specified `sources` to be
explicitly `name`'d.

More context here: https://github.com/pypa/pipenv/discussions/5370#discussioncomment-3701061

This has been true since at least Sept 2022. Our version of `pipenv` is
from April of 2022, so it doesn't complain. But it will as soon as we upgrade.

Also, for sources that :dependabot: dynamically injects into the
`Pipfile`, they need a name. These sources are stripped from the final
`Pipfile` / `Pipfile.lock` during the `FileUpdater#post_process_lockfile`
method, so all we need is a placeholder `name` to placate `pipenv`.

Long term, we may want to add custom error handling to flag this
missing key as a `Dependabot::DependencyFileNotResolvable` error.

But I decided that was out of scope for now as this PR does not generate
the error... that will not happen until we upgrade to newer `pipenv`.
And even at that point, our first priority will be upgrading, and then
from there handling any new errors that start popping up.

And even then, most of the active users of `pipenv` are unlikely to see this
error because they're likely running a newer version of `pipenv`.
