### PR TITLE
build(deps): bump pnpm from 8.6.7 to 8.6.12

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=8.6.7
+ARG PNPM_VERSION=8.6.12
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
 ARG YARN_VERSION=3.6.1


### PR DESCRIPTION
Release notes : 

https://github.com/pnpm/pnpm/releases/tag/v8.6.12
https://github.com/pnpm/pnpm/releases/tag/v8.6.11
https://github.com/pnpm/pnpm/releases/tag/v8.6.10
https://github.com/pnpm/pnpm/releases/tag/v8.6.9
https://github.com/pnpm/pnpm/releases/tag/v8.6.8