### PR TITLE
build(deps): bump regclient from 0.5.0 to 0.5.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,11 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # Install regctl. See https://github.com/regclient/regclient/releases for updates
-ARG REGCTL_VERSION=0.5.0
+ARG REGCTL_VERSION=0.5.1
 
 # These are manually calculated as they are not provided by the maintainer
-ARG REGCTL_AMD64_CHECKSUM=0378f7ed0a330ded959c8feea17f0bdc192fe8259e873a48f018b2259281c4f1
-ARG REGCTL_ARM64_CHECKSUM=1a6274526eaab761edeb45b9bd696f57bc5a62b2eeeaec947ba4456c9afbd06b
+ARG REGCTL_AMD64_CHECKSUM=484f98e99c90341336b1be99b2b333e7129fde3535b54ef97b4673e8fb2b1d6c
+ARG REGCTL_ARM64_CHECKSUM=17312dadc43ed24886076b0669bc36a9d790c26140fbacb66b0b89f5f96ece52
 
 ENV PATH=/opt/bin:$PATH
 RUN cd /tmp \


### PR DESCRIPTION
Release notes https://github.com/regclient/regclient/releases/tag/v0.5.1


> Features:
> 
> Add options to regctl index create for artifactType and subject (https://github.com/regclient/regclient/pull/490)
> Add --latest flag to regctl artifact get and regctl artifact list (https://github.com/regclient/regclient/pull/507)
> Add in memory caching support. (https://github.com/regclient/regclient/pull/510)
> Fixes:
> 
> Fix typo in OCI annotations (https://github.com/regclient/regclient/pull/485)
> Support multiple dashes in repo names. (https://github.com/regclient/regclient/pull/489)
> Fix auth failures, do not trigger a backoff (https://github.com/regclient/regclient/pull/492)
> Update Go dependencies from all subdirectories and used in tests (https://github.com/regclient/regclient/pull/495)
> Warning header log message is fixed. (https://github.com/regclient/regclient/pull/497)
> Include version annotation in regclient images (https://github.com/regclient/regclient/pull/499)
> Fix digest check when running regctl image get-file (https://github.com/regclient/regclient/pull/503)
> Switch org.opencontainers.artifact.* to org.opencontainers.image.* annotations in regclient images. (https://github.com/regclient/regclient/pull/506)
> Chores:
> 
> Sync OCI types to align with upstream sources. (https://github.com/regclient/regclient/pull/488)
> Add OSV vulnerability scanner (https://github.com/regclient/regclient/pull/498)