### PR TITLE
fix PR unable to create with grouped updates

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -33,6 +33,8 @@ module Dependabot
         pr_message_max_length = Dependabot::PullRequestCreator::Codecommit::PR_DESCRIPTION_MAX_LENGTH
       when "bitbucket"
         pr_message_max_length = Dependabot::PullRequestCreator::Bitbucket::PR_DESCRIPTION_MAX_LENGTH
+      else
+        pr_message_max_length = Dependabot::PullRequestCreator::Github::PR_DESCRIPTION_MAX_LENGTH
       end
 
       @pr_message = Dependabot::PullRequestCreator::MessageBuilder.new(

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -23,7 +23,7 @@ module Dependabot
     def pr_message
       return @pr_message if defined?(@pr_message)
 
-      case job.source.provider
+      case job.source&.provider
       when "github"
         pr_message_max_length = Dependabot::PullRequestCreator::Github::PR_DESCRIPTION_MAX_LENGTH
       when "azure"

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -23,6 +23,18 @@ module Dependabot
     def pr_message
       return @pr_message if defined?(@pr_message)
 
+      case job.source.provider
+      when "github"
+        pr_message_max_length = Dependabot::PullRequestCreator::Github::PR_DESCRIPTION_MAX_LENGTH
+      when "azure"
+        pr_message_max_length = Dependabot::PullRequestCreator::Azure::PR_DESCRIPTION_MAX_LENGTH
+        pr_message_encoding = Dependabot::PullRequestCreator::Azure::PR_DESCRIPTION_ENCODING
+      when "codecommit"
+        pr_message_max_length = Dependabot::PullRequestCreator::Codecommit::PR_DESCRIPTION_MAX_LENGTH
+      when "bitbucket"
+        pr_message_max_length = Dependabot::PullRequestCreator::Bitbucket::PR_DESCRIPTION_MAX_LENGTH
+      end
+
       @pr_message = Dependabot::PullRequestCreator::MessageBuilder.new(
         source: job.source,
         dependencies: updated_dependencies,
@@ -30,6 +42,8 @@ module Dependabot
         credentials: job.credentials,
         commit_message_options: job.commit_message_options,
         dependency_group: dependency_group,
+        pr_message_max_length: pr_message_max_length,
+        pr_message_encoding: pr_message_encoding,
         ignore_conditions: job.ignore_conditions
       ).message
     end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Dependabot::DependencyChange do
           commit_message_options: commit_message_options,
           dependency_group: nil,
           pr_message_encoding: nil,
-          pr_message_max_length: 65535,
+          pr_message_max_length: 65_535,
           ignore_conditions: []
         )
 
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::DependencyChange do
             commit_message_options: commit_message_options,
             dependency_group: group,
             pr_message_encoding: nil,
-            pr_message_max_length: 65535,
+            pr_message_max_length: 65_535,
             ignore_conditions: []
           )
 

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe Dependabot::DependencyChange do
 
   describe "#pr_message" do
     let(:github_source) do
-      {
-        "provider" => "github",
-        "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
-        "directory" => "/",
-        "branch" => nil,
-        "api-endpoint" => "https://api.github.com/",
-        "hostname" => "github.com"
-      }
+      Dependabot::Source.new(
+        provider: "github",
+        repo: "dependabot-fixtures/dependabot-test-ruby-package",
+        directory: "/",
+        branch: nil,
+        api_endpoint: "https://api.github.com/",
+        hostname: "github.com"
+      )
     end
 
     let(:job_credentials) do
@@ -101,6 +101,8 @@ RSpec.describe Dependabot::DependencyChange do
           credentials: job_credentials,
           commit_message_options: commit_message_options,
           dependency_group: nil,
+          pr_message_encoding: nil,
+          pr_message_max_length: 65535,
           ignore_conditions: []
         )
 
@@ -126,6 +128,8 @@ RSpec.describe Dependabot::DependencyChange do
             credentials: job_credentials,
             commit_message_options: commit_message_options,
             dependency_group: group,
+            pr_message_encoding: nil,
+            pr_message_max_length: 65535,
             ignore_conditions: []
           )
 


### PR DESCRIPTION
fixes https://github.com/dependabot/dependabot-core/issues/7743

We're seeing large updates that have large PR bodies fail to create on GitHub with a 422. I think this is due to [this change](https://github.com/dependabot/dependabot-core/pull/7487) moving the truncation from the `PullRequestCreator.create` to the `MessageBuilder`, and also we started recently using the `MessageBuilder` here in the `DependencyChange` class. It didn't get the new truncation settings passed in.

For now I copy-pasted the PullRequestCreator's new switch case to add in the limit to get PRs flowing again. This code seems like it could use a refactor. 