### PR TITLE
build(deps): bump Yarn to 3.6.1

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG PNPM_VERSION=8.6.7
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
-ARG YARN_VERSION=3.6.0
+ARG YARN_VERSION=3.6.1
 
 # See https://github.com/nodesource/distributions#installation-instructions
 ARG NODEJS_VERSION=18.x


### PR DESCRIPTION
It seems that the Yarn team stopped publishing release notes for some reason. [My issue](https://github.com/yarnpkg/berry/issues/5369) is still waiting an official response 

In the meantime, we need to trust our tests :/ 

Changes : https://github.com/yarnpkg/berry/compare/@yarnpkg/cli/3.6.0...@yarnpkg/cli/3.6.1