### PR TITLE
build(deps): bump npm from 9.5.1 to 9.8.1

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -11,7 +11,7 @@ ARG NODEJS_VERSION=18.x
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well
-ARG NPM_VERSION=9.5.1
+ARG NPM_VERSION=9.8.1
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_$NODEJS_VERSION | bash - \


### PR DESCRIPTION
Release notes : 

https://github.com/npm/cli/blob/latest/CHANGELOG.md

This is a relatively big jump. If you think that it is safer to do it incrementally, we can do that too. Otherwise can we trust our tests 

@jeffwidman Please let me know what you think and we can act accordingly 
