### PR TITLE
Replace deprecated `pipenv lock` with `pipenv requirements`

### DIFF
--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -92,7 +92,7 @@ module Dependabot
 
           # Find any requirement files that list the same dependencies as
           # the (old) Pipfile.lock. Any such files were almost certainly
-          # generated using `pipenv lock -r`
+          # generated using `pipenv requirements`
           requirements_files.select do |req_file|
             deps = []
             req_file.content.scan(regex) { deps << Regexp.last_match }
@@ -237,12 +237,12 @@ module Dependabot
 
         def generate_updated_requirements_files
           req_content = run_pipenv_command(
-            "pyenv exec pipenv lock -r"
+            "pyenv exec pipenv requirements"
           )
           File.write("req.txt", req_content)
 
           dev_req_content = run_pipenv_command(
-            "pyenv exec pipenv lock -r -d"
+            "pyenv exec pipenv requirements --dev"
           )
           File.write("dev-req.txt", dev_req_content)
         end

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -406,7 +406,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
     context "with a requirements.txt" do
       let(:dependency_files) { [pipfile, lockfile, requirements_file] }
 
-      context "that looks like the output of `pipenv lock -r`" do
+      context "that looks like the output of `pipenv requirements`" do
         let(:pipfile_fixture_name) { "hard_names" }
         let(:lockfile_fixture_name) { "hard_names.lock" }
         let(:requirements_file) do
@@ -471,7 +471,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
         end
       end
 
-      context "that looks like the output of `pipenv lock -r -d`" do
+      context "that looks like the output of `pipenv requirements --dev`" do
         let(:requirements_file) do
           Dependabot::DependencyFile.new(
             name: "req-dev.txt",


### PR DESCRIPTION
In the versions between what we are currently on in `dependaobt-core` and the latest versions of `pipenv`, they deprecated and then completely removed the `pipenv lock [-d]` command in favor of `pipenv requirements [--dev]` command.

Since our current version of `pipenv` supports the `pipenv requirements` command, let's proactively switch to it now. That will make the future upgrade in https://github.com/dependabot/dependabot-core/pull/7715 easier.

More context:
* https://github.com/pypa/pipenv/pull/5069
* https://github.com/pypa/pipenv/pull/5091
* https://github.com/pypa/pipenv/issues/5198
* https://github.com/pypa/pipenv/pull/5200