### PR TITLE
Fixing Yarn1 erroring with failed to replace env

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -380,12 +380,10 @@ module Dependabot
           dirs.pop
           while dirs.any?
             npmrc = dirs.join("/") + "/.npmrc"
-
             if File.exist?(npmrc)
               # If the .npmrc file exists, clean it
               File.write(npmrc, File.read(npmrc).gsub(/\$\{.*?\}/, ""))
             end
-
             dirs.pop
           end
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -380,9 +380,12 @@ module Dependabot
           dirs.pop
           while dirs.any?
             npmrc = dirs.join("/") + "/.npmrc"
-            break unless File.exist?(npmrc)
 
-            File.write(npmrc, File.read(npmrc).gsub(/\$\{.*\}/, ""))
+            if File.exist?(npmrc)
+              # If the .npmrc file exists, clean it
+              File.write(npmrc, File.read(npmrc).gsub(/\$\{.*?\}/, ""))
+            end
+
             dirs.pop
           end
         end


### PR DESCRIPTION
## Context

 If a repo has multiple .npmrc files, Dependabot only rewrites one of them to remove variables. NPM doesn't have an issue but Yarn 1 is not ok and errors out. 
 
 This issue was fixed in the [PR](https://github.com/dependabot/dependabot-core/pull/6883) but one of the edge case was to leading to raise the issue again.

**Edge case:** 
User root dir contained the `.npmrc` file with it's sub-dir (foo/bar/foo1/bar1/yarn.lock). The Dependabot npm job was failing for  path `/foo/bar/foo1/bar1 ` with the below error:
```bash
updater | 2023/07/13 16:04:33 ERROR <job_694149843> Failed to replace env in config: ${ARTIFACTORY_PASSWORD}
updater | 2023/07/13 16:04:33 ERROR <job_694149843> /home/dependabot/common/lib/dependabot/shared_helpers.rb:131:in `run_helper_subprocess'
updater | 2023/07/13 16:04:33 ERROR <job_694149843> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb:191:in `run_yarn_top_level_updater'
updater | 2023/07/13 16:04:33 ERROR <job_694149843> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb:114:in `block (2 levels) in run_yarn_updater'

```

## Approach
The modified code now checks all the parent directories for `.npmrc files`, whereas the previous code used to stopped, if a directory did not have one. Now I have removed the break statement and continually performing dirs.pop in each iteration, the loop in the modified code advances up to the root directory. This modification make sures that all relevant `.npmrc files` are addressed. Also a minor regex change was done in the gsub technique for non-greedy matching. 
