### PR TITLE
Unify memoization

### DIFF
--- a/common/lib/dependabot/metadata_finders/base.rb
+++ b/common/lib/dependabot/metadata_finders/base.rb
@@ -117,9 +117,8 @@ module Dependabot
       end
 
       def source
-        return @source if @source_lookup_attempted
+        return @source if defined?(@source)
 
-        @source_lookup_attempted = true
         @source = look_up_source
       end
 

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -41,10 +41,9 @@ module Dependabot
       end
 
       def composer_lock
-        return @composer_lock if @composer_lock_lookup_attempted
+        return @composer_lock if defined?(@composer_lock)
 
-        @composer_lock_lookup_attempted = true
-        @composer_lock ||= fetch_file_if_present("composer.lock")
+        @composer_lock = fetch_file_if_present("composer.lock")
       end
 
       # NOTE: This is fetched but currently unused

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -94,18 +94,17 @@ module Dependabot
       end
 
       def all_versions
-        return @all_versions if @version_lookup_attempted
+        @all_versions ||= fetch_all_versions
+      end
 
-        @version_lookup_attempted = true
-
+      def fetch_all_versions
         response = Dependabot::RegistryClient.get(
           url: "https://package.elm-lang.org/packages/#{dependency.name}/releases.json"
         )
 
-        return @all_versions = [] unless response.status == 200
+        return [] unless response.status == 200
 
-        @all_versions =
-          JSON.parse(response.body).
+        JSON.parse(response.body).
           keys.
           map { |v| version_class.new(v) }.
           sort

--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -36,10 +36,13 @@ module Dependabot
       end
 
       def lockfile
-        return @lockfile if @lockfile_lookup_attempted
+        return @lockfile if defined?(@lockfile)
 
-        @lockfile_lookup_attempted = true
-        @lockfile ||= fetch_file_from_host("mix.lock")
+        @lockfile = fetch_lockfile
+      end
+
+      def fetch_lockfile
+        fetch_file_from_host("mix.lock")
       rescue Dependabot::DependencyFileNotFound
         nil
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -261,25 +261,25 @@ module Dependabot
         end
 
         def npm_details
-          return @npm_details if @npm_details_lookup_attempted
+          return @npm_details if defined?(@npm_details)
 
-          @npm_details_lookup_attempted = true
-          @npm_details ||=
-            begin
-              npm_response = fetch_npm_response
+          @npm_details = fetch_npm_details
+        end
 
-              check_npm_response(npm_response)
-              JSON.parse(npm_response.body)
-            rescue JSON::ParserError,
-                   Excon::Error::Timeout,
-                   Excon::Error::Socket,
-                   RegistryError => e
-              if git_dependency?
-                nil
-              else
-                raise_npm_details_error(e)
-              end
-            end
+        def fetch_npm_details
+          npm_response = fetch_npm_response
+
+          check_npm_response(npm_response)
+          JSON.parse(npm_response.body)
+        rescue JSON::ParserError,
+               Excon::Error::Timeout,
+               Excon::Error::Socket,
+               RegistryError => e
+          if git_dependency?
+            nil
+          else
+            raise_npm_details_error(e)
+          end
         end
 
         def fetch_npm_response

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -103,11 +103,12 @@ module Dependabot
       # rubocop:enable Metrics/PerceivedComplexity
 
       def directory_build_files
-        return @directory_build_files if @directory_build_files_checked
+        @directory_build_files ||= fetch_directory_build_files
+      end
 
-        @directory_build_files_checked = true
+      def fetch_directory_build_files
         attempted_paths = []
-        @directory_build_files = []
+        directory_build_files = []
 
         # Don't need to insert "." here, because Directory.Build.props files
         # can only be used by project files (not packages.config ones)
@@ -131,11 +132,11 @@ module Dependabot
 
             attempted_paths << path
             file = fetch_file_if_present(path)
-            @directory_build_files << file if file
+            directory_build_files << file if file
           end
         end
 
-        @directory_build_files
+        directory_build_files
       end
 
       def possible_build_file_paths(base)

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -37,9 +37,6 @@ module Dependabot
         end
 
         def updated_dependency_files
-          return @updated_dependency_files if @update_already_attempted
-
-          @update_already_attempted = true
           @updated_dependency_files ||= fetch_updated_dependency_files
         end
 

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -30,9 +30,6 @@ module Dependabot
         end
 
         def updated_dependency_files
-          return @updated_dependency_files if @update_already_attempted
-
-          @update_already_attempted = true
           @updated_dependency_files ||= fetch_updated_dependency_files
         end
 

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -28,9 +28,6 @@ module Dependabot
         end
 
         def updated_dependency_files
-          return @updated_dependency_files if @update_already_attempted
-
-          @update_already_attempted = true
           @updated_dependency_files ||= fetch_updated_dependency_files
         end
 

--- a/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
@@ -20,9 +20,6 @@ module Dependabot
         end
 
         def updated_dependency_files
-          return @updated_dependency_files if @update_already_attempted
-
-          @update_already_attempted = true
           @updated_dependency_files ||= fetch_updated_dependency_files
         end
 


### PR DESCRIPTION
We seem to be using different techniques to memoize results of methods.

I tried to unify this around:

* Use standard `||=` for methods that should never return nil like `updated_dependency_files`.
* Use a `defined?` guard for methods that may return nil, like the ones for fetching files if they are present.