### PR TITLE
Fix incorrect memoizations

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -69,13 +69,15 @@ module Dependabot
       end
 
       def gemfile
-        @gemfile ||= fetch_file_if_present("gems.rb") ||
-                     fetch_file_if_present("Gemfile")
+        return @gemfile if defined?(@gemfile)
+
+        @gemfile = fetch_file_if_present("gems.rb") || fetch_file_if_present("Gemfile")
       end
 
       def lockfile
-        @lockfile ||= fetch_file_if_present("gems.locked") ||
-                      fetch_file_if_present("Gemfile.lock")
+        return @lockfile if defined?(@lockfile)
+
+        @lockfile = fetch_file_if_present("gems.locked") || fetch_file_if_present("Gemfile.lock")
       end
 
       def gemspecs

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -312,20 +312,20 @@ module Dependabot
       end
 
       def cargo_lock
-        @cargo_lock ||= fetch_file_if_present("Cargo.lock")
+        return @cargo_lock if defined?(@cargo_lock)
+
+        @cargo_lock = fetch_file_if_present("Cargo.lock")
       end
 
       def rust_toolchain
         return @rust_toolchain if defined?(@rust_toolchain)
 
-        @rust_toolchain = fetch_file_if_present("rust-toolchain")&.
-                            tap { |f| f.support_file = true }
+        @rust_toolchain = fetch_support_file("rust-toolchain")
 
         # Per https://rust-lang.github.io/rustup/overrides.html the file can
         # have a `.toml` extension, but the non-extension version is preferred.
         # Renaming here to simplify finding it later in the code.
-        @rust_toolchain ||= fetch_file_if_present("rust-toolchain.toml")&.
-                            tap { |f| f.support_file = true }&.
+        @rust_toolchain ||= fetch_support_file("rust-toolchain.toml")&.
                             tap { |f| f.name = "rust-toolchain" }
       end
     end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -108,6 +108,10 @@ module Dependabot
 
       private
 
+      def fetch_support_file(name)
+        fetch_file_if_present(name)&.tap { |f| f.support_file = true }
+      end
+
       def fetch_file_if_present(filename, fetch_submodules: false)
         unless repo_contents_path.nil?
           begin

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1413,7 +1413,9 @@ RSpec.describe Dependabot::FileFetchers::Base do
               end
 
               def optional
-                @optional ||= fetch_file_if_present("not-present.txt")
+                return @optional if defined?(@optional)
+
+                @optional = fetch_file_if_present("not-present.txt")
               end
             end
           end

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -48,8 +48,9 @@ module Dependabot
 
       # NOTE: This is fetched but currently unused
       def auth_json
-        @auth_json ||= fetch_file_if_present("auth.json")&.
-                       tap { |f| f.support_file = true }
+        return @auth_json if defined?(@auth_json)
+
+        @auth_json = fetch_support_file("auth.json")
       end
 
       def path_dependencies

--- a/elm/lib/dependabot/elm/file_fetcher.rb
+++ b/elm/lib/dependabot/elm/file_fetcher.rb
@@ -37,7 +37,9 @@ module Dependabot
       end
 
       def elm_json
-        @elm_json ||= fetch_file_if_present("elm.json")
+        return @elm_json if defined?(@elm_json)
+
+        @elm_json = fetch_file_if_present("elm.json")
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -49,11 +49,15 @@ module Dependabot
       end
 
       def go_mod
-        @go_mod ||= fetch_file_if_present("go.mod")
+        return @go_mod if defined?(@go_mod)
+
+        @go_mod = fetch_file_if_present("go.mod")
       end
 
       def go_sum
-        @go_sum ||= fetch_file_if_present("go.sum")
+        return @go_sum if defined?(@go_sum)
+
+        @go_sum = fetch_file_if_present("go.sum")
       end
 
       def recurse_submodules_when_cloning?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -217,8 +217,9 @@ module Dependabot
       end
 
       def npmrc
-        @npmrc ||= fetch_file_if_present(".npmrc")&.
-                   tap { |f| f.support_file = true }
+        return @npmrc if defined?(@npmrc)
+
+        @npmrc = fetch_support_file(".npmrc")
 
         return @npmrc if @npmrc || directory == "/"
 
@@ -236,8 +237,9 @@ module Dependabot
       end
 
       def yarnrc
-        @yarnrc ||= fetch_file_if_present(".yarnrc")&.
-                   tap { |f| f.support_file = true }
+        return @yarnrc if defined?(@yarnrc)
+
+        @yarnrc = fetch_support_file(".yarnrc")
 
         return @yarnrc if @yarnrc || directory == "/"
 
@@ -255,18 +257,21 @@ module Dependabot
       end
 
       def yarnrc_yml
-        @yarnrc_yml ||= fetch_file_if_present(".yarnrc.yml")&.
-                       tap { |f| f.support_file = true }
+        return @yarnrc_yml if defined?(@yarnrc_yml)
+
+        @yarnrc_yml = fetch_support_file(".yarnrc.yml")
       end
 
       def pnpm_workspace_yaml
-        @pnpm_workspace_yaml ||= fetch_file_if_present("pnpm-workspace.yaml")&.
-                                tap { |f| f.support_file = true }
+        return @pnpm_workspace_yaml if defined?(@pnpm_workspace_yaml)
+
+        @pnpm_workspace_yaml = fetch_support_file("pnpm-workspace.yaml")
       end
 
       def lerna_json
-        @lerna_json ||= fetch_file_if_present("lerna.json")&.
-                        tap { |f| f.support_file = true }
+        return @lerna_json if defined?(@lerna_json)
+
+        @lerna_json = fetch_support_file("lerna.json")
       end
 
       def workspace_package_jsons

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -243,17 +243,23 @@ module Dependabot
       end
 
       def global_json
-        @global_json ||= fetch_file_if_present("global.json")
+        return @global_json if defined?(@global_json)
+
+        @global_json = fetch_file_if_present("global.json")
       end
 
       def dotnet_tools_json
-        @dotnet_tools_json ||= fetch_file_if_present(".config/dotnet-tools.json")
+        return @dotnet_tools_json if defined?(@dotnet_tools_json)
+
+        @dotnet_tools_json = fetch_file_if_present(".config/dotnet-tools.json")
       rescue Dependabot::DependencyFileNotFound
         nil
       end
 
       def packages_props
-        @packages_props ||= fetch_file_if_present("Packages.props")
+        return @packages_props if defined?(@packages_props)
+
+        @packages_props = fetch_file_if_present("Packages.props")
       end
 
       def imported_property_files

--- a/pub/lib/dependabot/pub/file_fetcher.rb
+++ b/pub/lib/dependabot/pub/file_fetcher.rb
@@ -37,7 +37,9 @@ module Dependabot
       end
 
       def pubspec_lock
-        @pubspec_lock ||= fetch_file_if_present("pubspec.lock")
+        return @pubspec_lock if defined?(@pubspec_lock)
+
+        @pubspec_lock = fetch_file_if_present("pubspec.lock")
       end
     end
   end

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -116,21 +116,27 @@ module Dependabot
       end
 
       def setup_file
-        @setup_file ||= fetch_file_if_present("setup.py")
+        return @setup_file if defined?(@setup_file)
+
+        @setup_file = fetch_file_if_present("setup.py")
       end
 
       def setup_cfg_file
-        @setup_cfg_file ||= fetch_file_if_present("setup.cfg")
+        return @setup_cfg_file if defined?(@setup_cfg_file)
+
+        @setup_cfg_file = fetch_file_if_present("setup.cfg")
       end
 
       def pip_conf
-        @pip_conf ||= fetch_file_if_present("pip.conf")&.
-                      tap { |f| f.support_file = true }
+        return @pip_conf if defined?(@pip_conf)
+
+        @pip_conf = fetch_support_file("pip.conf")
       end
 
       def python_version_file
-        @python_version_file ||= fetch_file_if_present(".python-version")&.
-                            tap { |f| f.support_file = true }
+        return @python_version_file if defined?(@python_version_file)
+
+        @python_version_file = fetch_support_file(".python-version")
 
         return @python_version_file if @python_version_file
         return if [".", "/"].include?(directory)
@@ -138,33 +144,44 @@ module Dependabot
         # Check the top-level for a .python-version file, too
         reverse_path = Pathname.new(directory[0]).relative_path_from(directory)
         @python_version_file ||=
-          fetch_file_if_present(File.join(reverse_path, ".python-version"))&.
-          tap { |f| f.support_file = true }&.
+          fetch_support_file(File.join(reverse_path, ".python-version"))&.
           tap { |f| f.name = ".python-version" }
       end
 
       def pipfile
-        @pipfile ||= fetch_file_if_present("Pipfile")
+        return @pipfile if defined?(@pipfile)
+
+        @pipfile = fetch_file_if_present("Pipfile")
       end
 
       def pipfile_lock
-        @pipfile_lock ||= fetch_file_if_present("Pipfile.lock")
+        return @pipfile_lock if defined?(@pipfile_lock)
+
+        @pipfile_lock = fetch_file_if_present("Pipfile.lock")
       end
 
       def pyproject
-        @pyproject ||= fetch_file_if_present("pyproject.toml")
+        return @pyproject if defined?(@pyproject)
+
+        @pyproject = fetch_file_if_present("pyproject.toml")
       end
 
       def pyproject_lock
-        @pyproject_lock ||= fetch_file_if_present("pyproject.lock")
+        return @pyproject_lock if defined?(@pyproject_lock)
+
+        @pyproject_lock = fetch_file_if_present("pyproject.lock")
       end
 
       def poetry_lock
-        @poetry_lock ||= fetch_file_if_present("poetry.lock")
+        return @poetry_lock if defined?(@poetry_lock)
+
+        @poetry_lock = fetch_file_if_present("poetry.lock")
       end
 
       def pdm_lock
-        @pdm_lock ||= fetch_file_if_present("pdm.lock")
+        return @pdm_lock if defined?(@pdm_lock)
+
+        @pdm_lock = fetch_file_if_present("pdm.lock")
       end
 
       def requirements_txt_files

--- a/terraform/lib/dependabot/terraform/file_fetcher.rb
+++ b/terraform/lib/dependabot/terraform/file_fetcher.rb
@@ -81,7 +81,9 @@ module Dependabot
       end
 
       def lock_file
-        @lock_file ||= fetch_file_if_present(".terraform.lock.hcl")
+        return @lock_file if defined?(@lock_file)
+
+        @lock_file = fetch_file_if_present(".terraform.lock.hcl")
       end
     end
   end


### PR DESCRIPTION
The `fetch_file_if_present` method returns `nil` if the file is not present. That means we can't use `||=` for memoizing its result, and we'll end up retrying every time.