### PR TITLE
`fetch_file_if_present` should ignore all "Not Found" errors

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -132,8 +132,7 @@ module Dependabot
 
         fetch_file_from_host(filename, fetch_submodules: fetch_submodules)
       rescue *CLIENT_NOT_FOUND_ERRORS
-        path = Pathname.new(File.join(directory, filename)).cleanpath.to_path
-        raise Dependabot::DependencyFileNotFound, path
+        nil
       end
 
       def load_cloned_file_if_present(filename)

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -90,9 +90,6 @@ module Dependabot
         return nil unless root_dir == "."
 
         gradle_toml_file(root_dir)
-      rescue Dependabot::DependencyFileNotFound
-        # Catalog file is optional for Gradle
-        nil
       end
 
       # rubocop:disable Metrics/PerceivedComplexity

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -36,11 +36,7 @@ module Dependabot
       def extensions
         return @extensions if defined?(@extensions)
 
-        begin
-          fetch_file_if_present(".mvn/extensions.xml")
-        rescue Dependabot::DependencyFileNotFound
-          nil
-        end
+        fetch_file_if_present(".mvn/extensions.xml")
       end
 
       def child_poms

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -252,8 +252,6 @@ module Dependabot
         return @dotnet_tools_json if defined?(@dotnet_tools_json)
 
         @dotnet_tools_json = fetch_file_if_present(".config/dotnet-tools.json")
-      rescue Dependabot::DependencyFileNotFound
-        nil
       end
 
       def packages_props


### PR DESCRIPTION
The `fetch_file_if_present` method is used for fetching optional files. So it should tolerate "Not found" errors. Currently it does tolerate them, except when they are caused by a missing folder. For example, when looking for `.mvn/extensions.xml` and a `.mvn` directory is not there.

This PR makes it consistently ignore all "Not found" errors.