### PR TITLE
Improve `fetch_file_if_present` to make a single API request instead of two

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -128,8 +128,7 @@ module Dependabot
 
         fetch_file_from_host(filename, fetch_submodules: fetch_submodules)
       rescue *CLIENT_NOT_FOUND_ERRORS
-        path = Pathname.new(File.join(directory, filename)).cleanpath.to_path
-        raise Dependabot::DependencyFileNotFound, path
+        nil
       end
 
       def load_cloned_file_if_present(filename)

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -117,18 +117,11 @@ module Dependabot
           end
         end
 
-        dir = File.dirname(filename)
-        basename = File.basename(filename)
-
-        repo_includes_basename =
-          repo_contents(dir: dir, fetch_submodules: fetch_submodules).
-          reject { |f| f.type == "dir" }.
-          map(&:name).include?(basename)
-        return unless repo_includes_basename
-
-        fetch_file_from_host(filename, fetch_submodules: fetch_submodules)
-      rescue *CLIENT_NOT_FOUND_ERRORS
-        nil
+        begin
+          fetch_file_from_host(filename, fetch_submodules: fetch_submodules)
+        rescue Dependabot::DependencyFileNotFound
+          nil
+        end
       end
 
       def load_cloned_file_if_present(filename)

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -90,9 +90,6 @@ module Dependabot
         return nil unless root_dir == "."
 
         gradle_toml_file(root_dir)
-      rescue Dependabot::DependencyFileNotFound
-        # Catalog file is optional for Gradle
-        nil
       end
 
       # rubocop:disable Metrics/PerceivedComplexity

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -6,6 +6,7 @@ require "dependabot/file_fetchers/base"
 module Dependabot
   module Gradle
     class FileFetcher < Dependabot::FileFetchers::Base
+      require_relative "file_parser"
       require_relative "file_fetcher/settings_file_parser"
 
       SUPPORTED_BUILD_FILE_NAMES =

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -48,12 +48,11 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
   context "with a basic buildfile" do
     before do
-      stub_no_content_request("gradle?ref=sha")
       stub_content_request("?ref=sha", "contents_java.json")
-      stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
     end
 
     it "fetches the buildfile" do
+      stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
       expect(file_fetcher_instance.files.count).to eq(1)
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(%w(build.gradle))
@@ -61,7 +60,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "with version catalog" do
       before do
-        stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+        stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
         stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
       end
 
@@ -74,7 +73,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "with a settings.gradle" do
       before do
-        stub_content_request("?ref=sha", "contents_java_with_settings.json")
+        stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
         stub_content_request("settings.gradle?ref=sha", "contents_java_simple_settings.json")
         stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
       end
@@ -101,7 +100,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
       context "whith versions catalog" do
         before do
-          stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
           stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
         end
 
@@ -116,6 +114,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
     context "with included builds" do
       context "when has buildSrc" do
         before do
+          stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_content_request("buildSrc?ref=sha", "contents_java.json")
           stub_content_request("buildSrc/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
         end
@@ -132,7 +131,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
           context "with version catalog" do
             before do
-              stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
               stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
             end
 
@@ -278,8 +276,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "only a settings.gradle" do
       before do
-        stub_content_request("?ref=sha", "contents_java_only_settings.json")
-        stub_content_request("app?ref=sha", "contents_java_subproject.json")
         stub_content_request("settings.gradle?ref=sha", "contents_java_simple_settings.json")
         stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
       end
@@ -292,7 +288,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
       context "with version catalog" do
         before do
-          stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
           stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
         end
 
@@ -305,7 +300,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "with kotlin" do
       before do
-        stub_content_request("?ref=sha", "contents_kotlin.json")
         stub_content_request("build.gradle.kts?ref=sha", "contents_kotlin_basic_buildfile.json")
         stub_request(:get, File.join(url, "settings.gradle.kts?ref=sha")).
           with(headers: { "Authorization" => "token token" }).
@@ -320,7 +314,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
       context "with a settings.gradle.kts" do
         before do
-          stub_content_request("?ref=sha", "contents_kotlin_with_settings.json")
           stub_content_request("settings.gradle.kts?ref=sha", "contents_kotlin_simple_settings.json")
           stub_content_request("app/build.gradle.kts?ref=sha", "contents_kotlin_basic_buildfile.json")
         end
@@ -362,14 +355,11 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "that can't be found" do
       before do
-        stub_content_request("?ref=sha", "contents_java.json")
         stub_request(
           :get,
           File.join(url, "gradle/dependencies.gradle?ref=sha")
         ).with(headers: { "Authorization" => "token token" }).
           to_return(status: 404)
-
-        stub_content_request("gradle?ref=sha", "contents_with_settings.json")
       end
 
       it "raises a DependencyFileNotFound error" do

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -37,11 +37,7 @@ module Dependabot
         return @extensions if defined?(@extensions)
         return @extensions if defined?(@extensions)
 
-        begin
-          fetch_file_if_present(".mvn/extensions.xml")
-        rescue Dependabot::DependencyFileNotFound
-          nil
-        end
+        fetch_file_if_present(".mvn/extensions.xml")
       end
 
       def child_poms

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -248,8 +248,6 @@ module Dependabot
 
       def dotnet_tools_json
         @dotnet_tools_json ||= fetch_file_if_present(".config/dotnet-tools.json")
-      rescue Dependabot::DependencyFileNotFound
-        nil
       end
 
       def packages_props


### PR DESCRIPTION
I noticed this file does two requests: One to check whether the file is present inside it's folder, then other one to actually fetch the file.

I wonder why it can't just fetch the file directly.

I believe this would result in:

* Simpler code.
* More performant fetching.
* Easier fetcher specs since there's less requests to mock.
* Less cluttered logs.

Opening a PoC PR to see what's I'm missing.