### PR TITLE
Remove leftover `puts` debugging message

### DIFF
--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -317,7 +317,6 @@ RSpec.describe namespace::PoetryVersionResolver do
         it "raises a helpful error" do
           expect { subject }.
             to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-              puts error.message
               expect(error.message).
                 to include("depends on black (^18), version solving failed")
             end


### PR DESCRIPTION
This was only used for debugging and isn't actually needed for the test to pass.

It's been present in the test suite for [3 years](https://github.com/dependabot/dependabot-core/commit/1138e3e2653227c99813f34def3f769831f055a3#diff-a69831aad5bd135bcf841608405707f49ec05cc61685a29e887f8dc8be233a96R295). Don't know if I should laugh or cry. :joy: