### PR TITLE
Add missing `require`

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -6,6 +6,7 @@ require "dependabot/file_fetchers/base"
 module Dependabot
   module Gradle
     class FileFetcher < Dependabot::FileFetchers::Base
+      require_relative "file_parser"
       require_relative "file_fetcher/settings_file_parser"
 
       SUPPORTED_BUILD_FILE_NAMES =


### PR DESCRIPTION
It doesn't get in the middle of real usage, but when running file fetcher specs in isolation, it bites you:

#### Before

```
[dependabot-core-dev] ~/dependabot-core/gradle $ rspec spec/dependabot/gradle/file_fetcher_spec.rb:345 

Run options: include {:locations=>{"./spec/dependabot/gradle/file_fetcher_spec.rb"=>[345]}}

Randomized with seed 62369
F

Failures:

  1) Dependabot::Gradle::FileFetcher with a script plugin fetches the buildfile and the dependencies script
     Failure/Error:
       FileParser.find_include_names(buildfile(root_dir)).
       reject { |path| path.include?("://") }.
       reject { |path| !path.include?("/") && path.split(".").count > 2 }.
       select { |filename| filename.include?("dependencies") }.
       map { |path| path.gsub("$rootDir", ".") }.
       map { |path| File.join(root_dir, path) }.
       uniq
     
     NameError:
       uninitialized constant Dependabot::Gradle::FileFetcher::FileParser
     
                 FileParser.find_include_names(buildfile(root_dir)).
                 ^^^^^^^^^^
       Did you mean?  FileTest
     # ./lib/dependabot/gradle/file_fetcher.rb:100:in `dependency_script_plugins'
     # ./lib/dependabot/gradle/file_fetcher.rb:42:in `all_buildfiles_in_build'
     # ./lib/dependabot/gradle/file_fetcher.rb:34:in `fetch_files'
     # /home/dependabot/dependabot-core/common/lib/dependabot/file_fetchers/base.rb:75:in `files'
     # ./spec/dependabot/gradle/file_fetcher_spec.rb:346:in `block (3 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/common/spec/spec_helper.rb:45:in `block (2 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 0.07334 seconds (files took 2.21 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/gradle/file_fetcher_spec.rb:345 # Dependabot::Gradle::FileFetcher with a script plugin fetches the buildfile and the dependencies script

Randomized with seed 62369
```

#### After

```
[dependabot-core-dev] ~/dependabot-core/gradle $ rspec spec/dependabot/gradle/file_fetcher_spec.rb:345 
Run options: include {:locations=>{"./spec/dependabot/gradle/file_fetcher_spec.rb"=>[345]}}

Randomized with seed 34259
.

Finished in 0.06201 seconds (files took 2.44 seconds to load)
1 example, 0 failures

Randomized with seed 34259
```