### PR TITLE
Stop coercing Pipfile source URL's to have trailing slashes

### DIFF
--- a/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
@@ -109,9 +109,7 @@ module Dependabot
         end
 
         def pipfile_sources
-          @pipfile_sources ||=
-            TomlRB.parse(pipfile_content).fetch("source", []).
-            map { |h| h.dup.merge("url" => h["url"].gsub(%r{/*$}, "") + "/") }
+          @pipfile_sources ||= TomlRB.parse(pipfile_content).fetch("source", [])
         end
 
         def sub_auth_url(source, credentials)


### PR DESCRIPTION
I had to stare at this code golf for a little bit to realize that it's enforcing that every source URL has one-and-only-one trailing slash.

I started to tweak it a little to make it more readable, but I decided instead that this is business we really shouldn't be in... Dependabot is the tool that runs the package manager, not the package manager itself. 

So if a package manager doesn't like a URL that lacks a trailing slash, it should be the one handling the coercing or raising the error, and then we transparently forward that to the user.

There are some use cases where we need to handle URL normalization for deduping purposes within Dependabot internals, but I poked around a bit and as far as I can tell they don't apply here.

So let's trust the user / package managers to do the right thing (which may mean giving us a clear error).