### PR TITLE
Simplify Bundler native helper runners

### DIFF
--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -21,25 +21,11 @@ require "resolver_spec_group_sane_eql"
 
 require "functions"
 
-MAX_BUNDLER_VERSION = "2.0.0"
-
-def validate_bundler_version!
-  return true if correct_bundler_version?
-
-  raise StandardError, "Called with Bundler '#{Bundler::VERSION}', expected < '#{MAX_BUNDLER_VERSION}'"
-end
-
-def correct_bundler_version?
-  Gem::Version.new(Bundler::VERSION) < Gem::Version.new(MAX_BUNDLER_VERSION)
-end
-
 def output(obj)
   print JSON.dump(obj)
 end
 
 begin
-  validate_bundler_version!
-
   request = JSON.parse($stdin.read)
 
   function = request["function"]

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -19,25 +19,11 @@ require "git_source_patch"
 
 require "functions"
 
-MIN_BUNDLER_VERSION = "2.1.0"
-
-def validate_bundler_version!
-  return true if correct_bundler_version?
-
-  raise StandardError, "Called with Bundler '#{Bundler::VERSION}', expected >= '#{MIN_BUNDLER_VERSION}'"
-end
-
-def correct_bundler_version?
-  Gem::Version.new(Bundler::VERSION) >= Gem::Version.new(MIN_BUNDLER_VERSION)
-end
-
 def output(obj)
   print JSON.dump(obj)
 end
 
 begin
-  validate_bundler_version!
-
   request = JSON.parse($stdin.read)
 
   function = request["function"]

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "bundler", "~> 2.3"
+gem "bundler", "~> 2.4"
 require "bundler"
 require "json"
 


### PR DESCRIPTION
Since https://github.com/dependabot/dependabot-core/pull/4973, we explicitly activate the proper Bundler version of top of the runner, with either `gem "bundler", "~> 1.17"` or `gem "bundler", "~> 2.3"`, depending on whether its the v1 or v2 helper.

That will error out if the proper version can't be activated.

That means we don't really need to check for versions explicitly.

Since I was at it, I also bumped the activation line for v2 to `gem "bundler", "~> 2.4"`, since that's where we are now.