### PR TITLE
Fix private source authentication error message

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -19,7 +19,9 @@ module Dependabot
         PATH_REGEX = /The path `(?<path>.*)` does not exist/
 
         module BundlerErrorPatterns
-          MISSING_AUTH_REGEX = /bundle config (?<source>.*) username:password/
+          # The `set --global` optional part can be made required when Bundler 1 support is dropped
+          MISSING_AUTH_REGEX = /bundle config (?:set --global )?(?<source>.*) username:password/
+
           BAD_AUTH_REGEX = /Bad username or password for (?<source>.*)\.$/
           BAD_CERT_REGEX = /verify the SSL certificate for (?<source>.*)\.$/
           HTTP_ERR_REGEX = /Could not fetch specs from (?<source>.*)$/

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
   describe "#latest_resolvable_version_details" do
     subject { resolver.latest_resolvable_version_details }
 
+    context "with an unconfigured private rubygems source" do
+      let(:dependency_files) { bundler_project_dependency_files("private_gem_source") }
+
+      it "raises a PrivateSourceAuthenticationFailure error" do
+        expect { subject }.
+          to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect(error.message).to include(": rubygems.pkg.github.com")
+        end
+      end
+    end
+
     context "with a rubygems source" do
       context "with a ~> version specified constraining the update" do
         let(:requirement_string) { "~> 1.4.0" }

--- a/bundler/spec/fixtures/projects/bundler1/private_gem_source/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/private_gem_source/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "prius", source: "https://rubygems.pkg.github.com/dsp-testing"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/private_gem_source/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/private_gem_source/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  remote: https://rubygems.pkg.github.com/dsp-testing
+  specs:
+    business (1.4.0)
+    prius (1.0.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler2/private_gem_source/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/private_gem_source/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "prius", source: "https://rubygems.pkg.github.com/dsp-testing"
+gem "statesman", "~> 1.2.0"


### PR DESCRIPTION
Recent Bundler versions include `bundle config set --global <source> username:password` in the error message, instead of `bundle config <source> username:password`.

But our regexp had not been updated, so the source was getting parsed as `set --global <source>`.