### PR TITLE
Update ignore condition table

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -529,7 +529,7 @@ module Dependabot
 
         # Filter out the conditions where from_config_file is false and dependency is in @dependencies
         valid_ignore_conditions = @ignore_conditions.select do |ic|
-          ic["source"] == "@dependabot ignore command" && dependencies.any? { |dep| dep.name == ic["dependency-name"] }
+          ic["source"] =~ /\A@dependabot ignore/ && dependencies.any? { |dep| dep.name == ic["dependency-name"] }
         end
 
         # Return an empty string if no valid ignore conditions after filtering

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -529,18 +529,18 @@ module Dependabot
 
         # Filter out the conditions where from_config_file is false and dependency is in @dependencies
         valid_ignore_conditions = @ignore_conditions.select do |ic|
-          !ic[:from_config_file] && dependencies.any? { |dep| dep.name == ic[:dependency_name] }
+          ic["source"] == "@dependabot ignore command" && dependencies.any? { |dep| dep.name == ic["dependency-name"] }
         end
 
         # Return an empty string if no valid ignore conditions after filtering
         return "" if valid_ignore_conditions.empty?
 
         # Sort them by updated_at (or created_at if updated_at is nil), taking the latest 20
-        sorted_ignore_conditions = valid_ignore_conditions.sort_by { |ic| ic[:updated_at] || ic[:created_at] }.last(20)
+        sorted_ignore_conditions = valid_ignore_conditions.sort_by { |ic| ic["updated-at"] }.last(20)
 
         # Map each condition to a row string
         table_rows = sorted_ignore_conditions.map do |ic|
-          "| #{ic[:dependency_name]} | [#{ic[:version_requirement]}] |"
+          "| #{ic['dependency-name']} | [#{ic['version-requirement']}] |"
         end
 
         summary = "Most Recent Ignore Conditions Applied to This Pull Request"

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2301,11 +2301,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 )
               ignore_conditions.push(
                 {
-                  dependency_name: "business#{i}",
-                  version_requirement: "<= 1.#{i}.0",
-                  from_config_file: false,
-                  updated_at: Time.now,
-                  created_at: Time.now - (i * 86_400)
+                  "dependency-name" => "business#{i}",
+                  "version-requirement" => "<= 1.#{i}.0",
+                  "source" => "@dependabot ignore command",
+                  "updated_at" => Time.now
                 }
               )
             end
@@ -2409,11 +2408,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 )
               ignore_conditions.push(
                 {
-                  dependency_name: "business#{i}",
-                  version_requirement: "<= 1.#{i}.0",
-                  from_config_file: false,
-                  updated_at: Time.now,
-                  created_at: Time.now - (i * 86_400)
+                  "dependency-name" => "business#{i}",
+                  "version-requirement" => "<= 1.#{i}.0",
+                  "source" => "@dependabot ignore command",
+                  "updated_at" => Time.now
                 }
               )
             end


### PR DESCRIPTION
Previously the ignore conditions weren't showing, because we were assuming symbol keys, when these keys are strings and formatted in kebab-case.