### PR TITLE
Remove CodeQL warning

### DIFF
--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -47,8 +47,10 @@ module Dependabot
       if ref == "HEAD"
         # Remove the opening clause of the upload pack as this isn't always
         # followed by a line break. When it isn't (e.g., with Bitbucket) it
-        # causes problems for our `sha_for_update_pack_line` logic
-        line = upload_pack.gsub(/.*git-upload-pack/, "").
+        # causes problems for our `sha_for_update_pack_line` logic. The format
+        # of this opening clause is documented at
+        # https://git-scm.com/docs/http-protocol#_smart_server_response
+        line = upload_pack.gsub(/^[0-9a-f]{4}# service=git-upload-pack/, "").
                lines.find { |l| l.include?(" HEAD") }
         return sha_for_update_pack_line(line) if line
       end


### PR DESCRIPTION
In #7789, CodeQL signaled an issue with this regexp.

I can't think of a way this can be exploited, but we can use a more performant 
regexp that matches the smart protocol
documentation at https://git-scm.com/docs/http-protocol#_smart_server_response.

In particular:

> Clients MUST validate the first five bytes of the response entity
> matches the regex ^[0-9a-f]{4}#. If this test fails, clients MUST NOT
> continue.

and:

> Clients MUST verify the first pkt-line is # service=$servicename.
> Servers MUST set $servicename to be the request parameter value. Servers
> SHOULD include an LF at the end of this line. Clients MUST ignore an LF
> at the end of the line.