### PR TITLE
Make sure Bundler group vendoring smoke tests get actually run, and pass

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -84,6 +84,13 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
+          bundler-group-vendoring:
+            - .github/workflows/smoke.yml
+            - .dockerignore
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'bundler/**'
           cargo:
             - .github/workflows/smoke.yml
             - .dockerignore

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -92,10 +92,10 @@ module Functions
     def prune_gem_cache(resolve, cache_path, updated_gems)
       cached_gems = Dir["#{cache_path}/*.gem"]
 
-      outdated_gems = cached_gems.reject do |path|
+      outdated_gems = cached_gems.select do |path|
         spec = Bundler.rubygems.spec_from_gem path
 
-        !updated_gems.include?(spec.name) || resolve.any? do |s|
+        updated_gems.include?(spec.name) && resolve.none? do |s|
           s.name == spec.name && s.version == spec.version &&
             !s.source.is_a?(Bundler::Source::Git)
         end

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -95,10 +95,14 @@ module Functions
       outdated_gems = cached_gems.select do |path|
         spec = Bundler.rubygems.spec_from_gem path
 
-        updated_gems.include?(spec.name) && resolve.none? do |s|
+        caused_by_update = updated_gems.include?(spec.name) && resolve.none? do |s|
           s.name == spec.name && s.version == spec.version &&
             !s.source.is_a?(Bundler::Source::Git)
         end
+
+        caused_by_removal = resolve.none? { |s| s.name == spec.name }
+
+        caused_by_update || caused_by_removal
       end
 
       return unless outdated_gems.any?


### PR DESCRIPTION
~I will revert #7295 as part of this PR and retry it with fixed smoke tests.~

Fixes a regression introduced by #7295 and makes sure bundler group vendoring smoke tests get run so that they'll catch the same thing going forward.