### PR TITLE
Don't copy .rubocop.yml file to updater's home folder

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -57,7 +57,6 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
-COPY --chown=dependabot:dependabot .rubocop.yml .rubocop.yml
 COPY --chown=dependabot:dependabot .ruby-version .ruby-version
 COPY --chown=dependabot:dependabot omnibus omnibus
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/


### PR DESCRIPTION
This fixes an issue where if you introduce a RuboCop offense at `bin/dry-run.rb` and run RuboCop inside a development shell, no offenses will be detected.

The explanation of why this happens is a bit complicated.

This is how a dev shell looks like

```
$ bin/docker-dev-shell bundler
[dependabot-core-dev] ~/dependabot-core $ cat .rubocop.yml
---
inherit_from: omnibus/.rubocop.yml
[dependabot-core-dev] ~/dependabot-core $ cat ../.rubocop.yml
---
inherit_from: omnibus/.rubocop.yml
[dependabot-core-dev] ~/dependabot-core $
```

There's a duplicated RuboCop configuration.

This duplication may seem harmless, but results in weird behavior of RuboCop.

In particular, exclusions are not correctly interpreted, because they are resolved using the current directory as a base, not the directory of the configuration file itself.

So the following exclusion in `omnibus/.rubocop.yml`, which was originally meant for ignoring bin directory of ecosystem folders:

```yaml
---
AllCops:
  DisplayCopNames: true
  Exclude:
    - "../*/bin/**/*"
```

is interpreted as an exclusion for `~/dependabot-core/bin/**/*`, which is incorrect, since for example `bin/dry-run.rb` should be inspected.

The reason for this is that a `~/.rubocop.yml` configuration (located at the HOME folder) has special behavior with respect to exclusions. Normally, this file is shared as a base configuration for all your applications, so the special behavior of making exclude patterns be based on the PWD instead of on the path to the configuration itself makes sense to me. BUT, it breaks our particular case.

For the curious, this is where RuboCop special cases this:

https://github.com/rubocop/rubocop/blob/a643eaaa00dd65ba5aacff98b027e5b5a40c1561/lib/rubocop/config.rb#L219

Anyways, RuboCop is just a development tool, so this file does not need to be permanently copied to the image and can just be mounted for development.