### PR TITLE
Let RuboCop inspect files in ecosystem bin folders

### DIFF
--- a/common/bin/git-credential-store-immutable
+++ b/common/bin/git-credential-store-immutable
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "shellwords"
 

--- a/omnibus/.rubocop.yml
+++ b/omnibus/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   DisplayCopNames: true
   Exclude:
     - "../*/vendor/**/*"
-    - "../*/bin/**/*"
     - "../**/tmp/**/*"
     - "../*/spec/fixtures/**/*"
     - "../vendor/**/*"

--- a/updater/bin/update_files.rb
+++ b/updater/bin/update_files.rb
@@ -22,5 +22,5 @@ end
 begin
   Dependabot::UpdateFilesCommand.new.run
 rescue Dependabot::RunFailure
-   exit 1
+  exit 1
 end


### PR DESCRIPTION
I don't see why not.