### PR TITLE
Remove mount of folder that does not exist

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -212,7 +212,6 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/Gemfile:$CODE_DIR/omnibus/Gemfile" \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
-  -v "$(pwd)/omnibus/script:$CODE_DIR/omnibus/script" \
   -v "$(pwd)/pub/.rubocop.yml:$CODE_DIR/pub/.rubocop.yml" \
   -v "$(pwd)/pub/Gemfile:$CODE_DIR/pub/Gemfile" \
   -v "$(pwd)/pub/dependabot-pub.gemspec:$CODE_DIR/pub/dependabot-pub.gemspec" \


### PR DESCRIPTION
Run into the following error when running `rubocop` in a dev shell:

```
[dependabot-core-dev] ~/dependabot-core $ rubocop
No such file or directory @ rb_check_realpath_internal - /home/dependabot/dependabot-core/omnibus/script/
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:109:in `realpath'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:109:in `symlink_excluded_or_infinite_loop?'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:103:in `block in wanted_dir_patterns'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:99:in `reject'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:99:in `wanted_dir_patterns'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:105:in `block in wanted_dir_patterns'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:105:in `each'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:105:in `flat_map'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:105:in `wanted_dir_patterns'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:87:in `find_files'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:59:in `target_files_in_dir'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/target_finder.rb:32:in `find'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/runner.rb:111:in `find_target_files'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/runner.rb:68:in `run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/command.rb:11:in `run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli/environment.rb:18:in `run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli.rb:118:in `run_command'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli.rb:125:in `execute_runners'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli.rb:51:in `block in run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli.rb:77:in `profile_if_needed'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/lib/rubocop/cli.rb:43:in `run'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/exe/rubocop:19:in `block in <top (required)>'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/benchmark-0.2.1/lib/benchmark.rb:311:in `realtime'
/home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/rubocop-1.50.2/exe/rubocop:19:in `<top (required)>'
/home/dependabot/dependabot-core/omnibus/.bundle/bin/rubocop:27:in `load'
/home/dependabot/dependabot-core/omnibus/.bundle/bin/rubocop:27:in `<main>'
```