### PR TITLE
Don't copy ruby version file into the updater image

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -57,7 +57,6 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
-COPY --chown=dependabot:dependabot .ruby-version .ruby-version
 COPY --chown=dependabot:dependabot omnibus omnibus
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 


### PR DESCRIPTION
We have a single ruby in there and don't use any version manager, so it´s not necessary.

This file is only needed to hint actions using `ruby/setup-ruby` the ruby version they should use.