### PR TITLE
Add apt lists clean up to python Dockerfile

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update \
     libxml2-dev \
     libxmlsec1-dev \
     libgeos-dev \
-    python3-enchant
+    python3-enchant \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=dependabot:dependabot python/helpers /opt/python/helpers
 USER root
@@ -112,7 +113,8 @@ RUN apt-get update \
     libxml2-dev \
     libxmlsec1-dev \
     libgeos-dev \
-    python3-enchant
+    python3-enchant \
+  && rm -rf /var/lib/apt/lists/*
 
 ### PYTHON
 COPY --chown=dependabot:dependabot python/helpers /opt/python/helpers


### PR DESCRIPTION
Deletes the apt lists for the python image.

From test:
```

Finished in 11 minutes 15 seconds (files took 1.18 seconds to load)
1146 examples, 0 failures, 22 pending

Randomized with seed 46973
```
cc dependabot/dependabot-core#946 dependabot/dependabot-core#3896