### PR TITLE
build(deps): bump npm from 9.5.1 to 9.6.5

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -11,7 +11,8 @@ ARG NODEJS_VERSION=18.x
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well
-ARG NPM_VERSION=9.5.1
+# TODO: Upgrade to 9.6.7 depending on the outcome of https://github.com/npm/cli/issues/6742
+ARG NPM_VERSION=9.6.5
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_$NODEJS_VERSION | bash - \


### PR DESCRIPTION
The latest version of Node 18 installs npm `9.6.7` but we need more information before we can proceed. See https://github.com/npm/cli/issues/6742

In the meantime, I believe that it adds value to upgrade to `9.6.5` as we're behind

Closes https://github.com/dependabot/dependabot-core/pull/7659