### PR TITLE
Do not attempt to group git dependencies as semver

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -205,6 +205,9 @@ module Dependabot
         # There are no group rules defined, so this dependency can be included in the group.
         return true unless group.rules["update-types"]
 
+        # git dependencies are not SemVer compatible so we cannot include them in the group
+        return false if git_dependency?(dependency)
+
         version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).new(dependency.version.to_s)
         # Not every version class implements .major, .minor, .patch so we calculate it here from the segments
         latest = semver_segments(checker.latest_version)
@@ -236,6 +239,13 @@ module Dependabot
         else
           :update_not_possible
         end
+      end
+
+      def git_dependency?(dependency)
+        GitCommitChecker.new(
+          dependency: dependency,
+          credentials: job.credentials
+        ).git_dependency?
       end
 
       def log_requirements_for_update(requirements_to_unlock, checker)

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -101,7 +101,7 @@ module Dependabot
         # Having created the dependency_change, we need to determine the right strategy to apply it to the project:
         # - Replace existing PR if the dependencies involved have changed
         # - Update the existing PR if the dependencies and the target versions remain the same
-        # - Supersede the existing PR if the dependencies are the same but the target verisons have changed
+        # - Supersede the existing PR if the dependencies are the same but the target versions have changed
         def upsert_pull_request(dependency_change)
           if dependency_change.should_replace_existing_pr?
             Dependabot.logger.info("Dependencies have changed, closing existing Pull Request")

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -262,6 +262,35 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
   end
 
+  context "when the snapshot contains a git dependency" do
+    let(:job_definition) do
+      job_definition_fixture("bundler/version_updates/group_update_all_semver_grouping")
+    end
+
+    let(:dependency_files) do
+      original_bundler_files(fixture: "bundler_git")
+    end
+
+    it "creates individual PRs since git dependencies cannot be grouped as semver",
+       vcr: { allow_unused_http_interactions: true } do
+      expect(mock_service).to receive(:create_pull_request).with(
+        an_object_having_attributes(
+          dependency_group: nil,
+          updated_dependencies: [
+            an_object_having_attributes(
+              name: "dummy-git-dependency",
+              version: "c0e25c2eb332122873f73acb3b61fb2e261cfd8f",
+              previous_version: "20151f9b67c8a04461fa0ee28385b6187b86587b"
+            )
+          ]
+        ),
+        "mock-sha"
+      )
+
+      group_update_all.perform
+    end
+  end
+
   context "when the snapshot is only grouping minor- and patch-level changes", :vcr do
     let(:job_definition) do
       job_definition_fixture("bundler/version_updates/group_update_all_semver_grouping")

--- a/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_contains_a_git_dependency/creates_individual_PRs_since_git_dependencies_cannot_be_grouped_as_semver.yml
+++ b/updater/spec/fixtures/vcr_cassettes/Dependabot_Updater_Operations_GroupUpdateAllVersions/when_the_snapshot_contains_a_git_dependency/creates_individual_PRs_since_git_dependencies_cannot_be_grouped_as_semver.yml
@@ -1,0 +1,505 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/dummy-git-dependency.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '384'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Mon, 14 Dec 2020 17:08:06 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A14ac2664a203aa4e56def33f9dc1ac9d9bf71c88%2Cenv%3Aproduction%2Ctrace_id%3A93572498929242322
+      X-Request-Id:
+      - '05101318-b593-4f70-a9ec-752da6231f5b'
+      X-Runtime:
+      - '0.017212'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 35.81.98.222:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 15 Aug 2023 12:07:29 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-ams21038-AMS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1692101249.628574,VS0,VE437
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"f59670cf8622242bfb55afc03a027238"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Dependabot","built_at":"2019-11-22T00:00:00.000Z","created_at":"2019-11-22T15:24:24.964Z","description":null,"downloads_count":2090,"metadata":{},"number":"1.1.0","summary":"A
+        dummy package for testing Dependabot","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c1b71569ef54c120b0c1d47704409bf9c63de0d581ad6bbb9521634063d7e2d"},{"authors":"Dependabot","built_at":"2019-11-22T00:00:00.000Z","created_at":"2019-11-22T15:24:41.638Z","description":null,"downloads_count":1517,"metadata":{},"number":"1.0.0","summary":"A
+        dummy package for testing Dependabot","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c020db324e8d21ee9f0e16ffcdc3c025b6da796c4d62e24e952725b76e2b0088"}]'
+  recorded_at: Tue, 15 Aug 2023 12:07:29 GMT
+- request:
+    method: get
+    uri: https://github.com/dependabot-fixtures/ruby-dummy-git-dependency.git/info/refs?service=git-upload-pack
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub-Babel/3.0
+      Content-Type:
+      - application/x-git-upload-pack-advertisement
+      Content-Security-Policy:
+      - default-src 'none'; sandbox
+      Expires:
+      - Fri, 01 Jan 1980 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, max-age=0, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Tue, 15 Aug 2023 12:07:28 GMT
+      X-Frame-Options:
+      - DENY
+      X-Github-Request-Id:
+      - D311:B3FC:4DE913E:4F14650:64DB6A81
+    body:
+      encoding: ASCII-8BIT
+      string: "001e# service=git-upload-pack\n00000155f229d172c826b95f464a82d8ddf8b3efce3825b0
+        HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since
+        deepen-not deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want
+        allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/master filter
+        object-format=sha1 agent=git/github-32046c9f808f\n003ff229d172c826b95f464a82d8ddf8b3efce3825b0
+        refs/heads/master\n003e20151f9b67c8a04461fa0ee28385b6187b86587b refs/tags/v1.0.0\n003ec0e25c2eb332122873f73acb3b61fb2e261cfd8f
+        refs/tags/v1.1.0\n0000"
+  recorded_at: Tue, 15 Aug 2023 12:07:29 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/gems/dummy-git-dependency.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '445'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A14ac2664a203aa4e56def33f9dc1ac9d9bf71c88%2Cenv%3Aproduction%2Ctrace_id%3A2302961586161028526
+      X-Request-Id:
+      - 448e293b-7426-45ea-a71b-7de7631116b1
+      X-Runtime:
+      - '0.023034'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 52.24.74.243:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 15 Aug 2023 12:07:30 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-ams21059-AMS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1692101249.438226,VS0,VE621
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"b2b2df644984fa222ec351016a6a0037"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '{"name":"dummy-git-dependency","downloads":3607,"version":"1.1.0","version_created_at":"2019-11-22T15:24:24.964Z","version_downloads":2090,"platform":"ruby","authors":"Dependabot","info":"A
+        dummy package for testing Dependabot","licenses":["MIT"],"metadata":{},"yanked":false,"sha":"3c1b71569ef54c120b0c1d47704409bf9c63de0d581ad6bbb9521634063d7e2d","project_uri":"https://rubygems.org/gems/dummy-git-dependency","gem_uri":"https://rubygems.org/gems/dummy-git-dependency-1.1.0.gem","homepage_uri":"http://github.com/dependabot/dummy-git-dependency","wiki_uri":null,"documentation_uri":"https://www.rubydoc.info/gems/dummy-git-dependency/1.1.0","mailing_list_uri":null,"source_code_uri":null,"bug_tracker_uri":null,"changelog_uri":null,"funding_uri":null,"dependencies":{"development":[],"runtime":[]}}'
+  recorded_at: Tue, 15 Aug 2023 12:07:29 GMT
+- request:
+    method: get
+    uri: https://github.com/dependabot/dummy-git-dependency.git/info/refs?service=git-upload-pack
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - GitHub-Babel/3.0
+      Content-Security-Policy:
+      - default-src 'none'; sandbox
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Www-Authenticate:
+      - Basic realm="GitHub"
+      Content-Length:
+      - '21'
+      Date:
+      - Tue, 15 Aug 2023 12:07:30 GMT
+      X-Frame-Options:
+      - DENY
+      X-Github-Request-Id:
+      - D313:CB32:4F223FA:504D973:64DB6A82
+    body:
+      encoding: ASCII-8BIT
+      string: Repository not found.
+  recorded_at: Tue, 15 Aug 2023 12:07:30 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/dummy-git-dependency.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '384'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Mon, 14 Dec 2020 17:08:06 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A14ac2664a203aa4e56def33f9dc1ac9d9bf71c88%2Cenv%3Aproduction%2Ctrace_id%3A93572498929242322
+      X-Request-Id:
+      - '05101318-b593-4f70-a9ec-752da6231f5b'
+      X-Runtime:
+      - '0.017212'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 35.81.98.222:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 15 Aug 2023 12:07:30 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2'
+      X-Served-By:
+      - cache-ams21065-AMS
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1692101251.759070,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"f59670cf8622242bfb55afc03a027238"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '[{"authors":"Dependabot","built_at":"2019-11-22T00:00:00.000Z","created_at":"2019-11-22T15:24:24.964Z","description":null,"downloads_count":2090,"metadata":{},"number":"1.1.0","summary":"A
+        dummy package for testing Dependabot","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3c1b71569ef54c120b0c1d47704409bf9c63de0d581ad6bbb9521634063d7e2d"},{"authors":"Dependabot","built_at":"2019-11-22T00:00:00.000Z","created_at":"2019-11-22T15:24:41.638Z","description":null,"downloads_count":1517,"metadata":{},"number":"1.0.0","summary":"A
+        dummy package for testing Dependabot","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c020db324e8d21ee9f0e16ffcdc3c025b6da796c4d62e24e952725b76e2b0088"}]'
+  recorded_at: Tue, 15 Aug 2023 12:07:30 GMT
+- request:
+    method: get
+    uri: https://github.com/dependabot-fixtures/ruby-dummy-git-dependency.git/info/refs?service=git-upload-pack
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub-Babel/3.0
+      Content-Type:
+      - application/x-git-upload-pack-advertisement
+      Content-Security-Policy:
+      - default-src 'none'; sandbox
+      Expires:
+      - Fri, 01 Jan 1980 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, max-age=0, must-revalidate
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Tue, 15 Aug 2023 12:07:30 GMT
+      X-Frame-Options:
+      - DENY
+      X-Github-Request-Id:
+      - D316:E95B:4F937F3:50BEC2D:64DB6A82
+    body:
+      encoding: ASCII-8BIT
+      string: "001e# service=git-upload-pack\n00000155f229d172c826b95f464a82d8ddf8b3efce3825b0
+        HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since
+        deepen-not deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want
+        allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/master filter
+        object-format=sha1 agent=git/github-32046c9f808f\n003ff229d172c826b95f464a82d8ddf8b3efce3825b0
+        refs/heads/master\n003e20151f9b67c8a04461fa0ee28385b6187b86587b refs/tags/v1.0.0\n003ec0e25c2eb332122873f73acb3b61fb2e261cfd8f
+        refs/tags/v1.1.0\n0000"
+  recorded_at: Tue, 15 Aug 2023 12:07:30 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/gems/dummy-git-dependency.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '445'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=60, public
+      Content-Encoding:
+      - ''
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A14ac2664a203aa4e56def33f9dc1ac9d9bf71c88%2Cenv%3Aproduction%2Ctrace_id%3A2302961586161028526
+      X-Request-Id:
+      - 448e293b-7426-45ea-a71b-7de7631116b1
+      X-Runtime:
+      - '0.023034'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 52.24.74.243:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 15 Aug 2023 12:07:31 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '1'
+      X-Served-By:
+      - cache-ams21066-AMS
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1692101251.086141,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"b2b2df644984fa222ec351016a6a0037"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '{"name":"dummy-git-dependency","downloads":3607,"version":"1.1.0","version_created_at":"2019-11-22T15:24:24.964Z","version_downloads":2090,"platform":"ruby","authors":"Dependabot","info":"A
+        dummy package for testing Dependabot","licenses":["MIT"],"metadata":{},"yanked":false,"sha":"3c1b71569ef54c120b0c1d47704409bf9c63de0d581ad6bbb9521634063d7e2d","project_uri":"https://rubygems.org/gems/dummy-git-dependency","gem_uri":"https://rubygems.org/gems/dummy-git-dependency-1.1.0.gem","homepage_uri":"http://github.com/dependabot/dummy-git-dependency","wiki_uri":null,"documentation_uri":"https://www.rubydoc.info/gems/dummy-git-dependency/1.1.0","mailing_list_uri":null,"source_code_uri":null,"bug_tracker_uri":null,"changelog_uri":null,"funding_uri":null,"dependencies":{"development":[],"runtime":[]}}'
+  recorded_at: Tue, 15 Aug 2023 12:07:30 GMT
+- request:
+    method: get
+    uri: https://github.com/dependabot/dummy-git-dependency.git/info/refs?service=git-upload-pack
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - dependabot-core/0.225.0 excon/0.100.0 ruby/3.1.4 (x86_64-linux) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - GitHub-Babel/3.0
+      Content-Security-Policy:
+      - default-src 'none'; sandbox
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Www-Authenticate:
+      - Basic realm="GitHub"
+      Content-Length:
+      - '21'
+      Date:
+      - Tue, 15 Aug 2023 12:07:30 GMT
+      X-Frame-Options:
+      - DENY
+      X-Github-Request-Id:
+      - D318:E95B:4F939CA:50BEE1A:64DB6A83
+    body:
+      encoding: ASCII-8BIT
+      string: Repository not found.
+  recorded_at: Tue, 15 Aug 2023 12:07:31 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
By definitions, git dependencies do not follow semver, as their version number is a hash, so these should never be included in the semver group