### PR TITLE
Simplify handling all versions metadata on NPM

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -122,26 +122,10 @@ module Dependabot
       end
 
       def self.dependencies_with_all_versions_metadata(dependency_set)
-        working_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
-        dependencies = []
-
-        names = dependency_set.dependencies.map(&:name)
-        names.each do |name|
-          all_versions = dependency_set.all_versions_for_name(name)
-          all_versions.each do |dep|
-            metadata_versions = dep.metadata.fetch(:all_versions, [])
-            if metadata_versions.any?
-              metadata_versions.each { |a| working_set << a }
-            else
-              working_set << dep
-            end
-          end
-          dependency = working_set.dependency_for_name(name)
-          dependency.metadata[:all_versions] = working_set.all_versions_for_name(name)
-          dependencies << dependency
+        dependency_set.dependencies.map do |dependency|
+          dependency.metadata[:all_versions] = dependency_set.all_versions_for_name(dependency.name)
+          dependency
         end
-
-        dependencies
       end
     end
   end


### PR DESCRIPTION
I'm getting a weird test failure at #7819.

I haven't yet figured it out, but during investigation I noticed this method for adding `:all_versions` metadata to dependencies seems more complicated than necessary.