### PR TITLE
Revert "Don't copy ruby version file into the updater image (#7802)"

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -57,6 +57,7 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
+COPY --chown=dependabot:dependabot .ruby-version .ruby-version
 COPY --chown=dependabot:dependabot omnibus omnibus
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 


### PR DESCRIPTION
This reverts commit a89b3acef9b2965df6a3006851e8a5fc6a20fa41.

Turns out this is also used by rubocop in order to decide whether to apply cops that depend on specific ruby versions or not. Without this, running RuboCop inside a development shell does not run cleanly.