### PR TITLE
Fix `ecosystem_version` blowing up on deprecated python version

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -45,18 +45,17 @@ module Dependabot
         # the user-specified range of versions, not the version Dependabot chose to run.
         python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)
         language_version_manager = LanguageVersionManager.new(python_requirement_parser: python_requirement_parser)
-        {
-          languages: {
-            python: {
-              # TODO: alternatively this could use `python_requirement_parser.user_specified_requirements` which
-              # returns an array... which we could flip to return a hash of manifest name => version
-              # string and then check for min/max versions... today it simply defaults to
-              # array.first which seems rather arbitrary.
-              "raw" => language_version_manager.user_specified_python_version || "unknown",
-              "max" => language_version_manager.python_major_minor || "unknown"
-            }
-          }
-        }
+        # TODO: alternatively this could use `python_requirement_parser.user_specified_requirements` which
+        # returns an array... which we could flip to return a hash of manifest name => version
+        # string and then check for min/max versions... today it simply defaults to
+        # array.first which seems rather arbitrary.
+        raw = language_version_manager.user_specified_python_version || "unknown"
+        max = Python::Version.new(raw).segments[0..1].join(".") || "unknown"
+        { languages:
+          { python: {
+            "raw" => raw,
+            "max" => max
+          } } }
       end
 
       private

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -512,10 +512,13 @@ RSpec.describe Dependabot::Python::FileFetcher do
 
       it "exposes the expected ecosystem_versions metric" do
         expect(file_fetcher_instance.ecosystem_versions).to eq({
-          languages: { python: { "max" => "3.11", "raw" => "unknown" } }
+          languages: { python: { "raw" => "unknown", "max" => "unknown" } }
         })
       end
     end
+
+    # TODO add a test that a deprecated version of python such as 3.7 is correctly sent as a metric and no
+    # exception raised
 
     context "with a requirements.txt, a setup.py and a requirements folder" do
       let(:repo_contents) do

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 require "dependabot/python/file_fetcher"
+require "dependabot/python/file_parser/python_requirement_parser"
+require "dependabot/python/language_version_manager"
 require_common_spec "file_fetchers/shared_examples_for_file_fetchers"
 
 RSpec.describe Dependabot::Python::FileFetcher do


### PR DESCRIPTION
`LanguageVersionManager#python_major_minor` internally calls `#python_version_from_supported_versions` which meant that it blew up if the Python version is deprecated/unsupported.

So instead copy the major.minor truncation code into `ecosystem_version`.

I considered creating a helper and re-using it both places, but decided that since it's a relatively short/simple 1-liner that copy/pasting was fine. Jake would be proud of me for not forcing DRY. :grin: