### PR TITLE
Add `requires` necessary for `ecosystem_versions` test

### DIFF
--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 require "dependabot/python/file_fetcher"
+require "dependabot/python/file_parser/python_requirement_parser"
+require "dependabot/python/language_version_manager"
 require_common_spec "file_fetchers/shared_examples_for_file_fetchers"
 
 RSpec.describe Dependabot::Python::FileFetcher do


### PR DESCRIPTION
The `ecosystem_versions` test in this file fails because of these two missing `require`s. I don't think CI is failing because it gets initialized earlier in a different test, but when running the specific test locally it failes with:
```shell
[dependabot-core-dev] ~/dependabot-core/python $ rspec ./spec/dependabot/python/file_fetcher_spec.rb:511
...

Failures:

  1) Dependabot::Python::FileFetcher#files with a setup.py and a setup.cfg exposes the expected ecosystem_versions metric
     Failure/Error: python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)

     NameError:
       uninitialized constant Dependabot::Python::FileParser::PythonRequirementParser

               python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
     # ./lib/dependabot/python/file_fetcher.rb:46:in `ecosystem_versions'
     # ./spec/dependabot/python/file_fetcher_spec.rb:512:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:24:in `block (2 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/common/spec/spec_helper.rb:45:in `block (2 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```