### PR TITLE
Mount .ruby-version in the dev image instead of copying it

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -57,7 +57,6 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
-COPY --chown=dependabot:dependabot .ruby-version .ruby-version
 COPY --chown=dependabot:dependabot omnibus omnibus
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -116,6 +116,7 @@ mkdir -p dry-run tmp
 docker run --rm -ti \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
+  -v "$(pwd)/.ruby-version:$CODE_DIR/.ruby-version" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \
   -v "$(pwd)/bundler/.rubocop.yml:$CODE_DIR/bundler/.rubocop.yml" \
   -v "$(pwd)/bundler/Gemfile:$CODE_DIR/bundler/Gemfile" \


### PR DESCRIPTION
Putting it together with the rubocop configuration may illustrate better that these files are used together.

One more follow up to #7835 and previous PRs.

I could also add a comment here, but I'm scared to break this jumbo command 😆.