### PR TITLE
Simplify development images

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,6 +1,8 @@
 ARG FROM_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM $FROM_IMAGE
 
+ARG ECOSYSTEM
+
 # Temporarily switch to root user in order to install packages
 USER root
 RUN apt-get update \
@@ -20,48 +22,17 @@ USER dependabot
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \
   echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 
-ARG HOME=/home/dependabot
-ARG CODE_DIR=${HOME}/dependabot-core
+WORKDIR $DEPENDABOT_HOME
 
-# Prepare the common & omnibus gems
-COPY --chown=dependabot:dependabot common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
-COPY --chown=dependabot:dependabot common/lib/dependabot.rb ${CODE_DIR}/common/lib/
-COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
-
-# Prepare the ecosystem gems
-COPY --chown=dependabot:dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
-COPY --chown=dependabot:dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
-COPY --chown=dependabot:dependabot composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
-COPY --chown=dependabot:dependabot docker/Gemfile docker/dependabot-docker.gemspec ${CODE_DIR}/docker/
-COPY --chown=dependabot:dependabot elm/Gemfile elm/dependabot-elm.gemspec ${CODE_DIR}/elm/
-COPY --chown=dependabot:dependabot git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec ${CODE_DIR}/git_submodules/
-COPY --chown=dependabot:dependabot github_actions/Gemfile github_actions/dependabot-github_actions.gemspec ${CODE_DIR}/github_actions/
-COPY --chown=dependabot:dependabot go_modules/Gemfile go_modules/dependabot-go_modules.gemspec ${CODE_DIR}/go_modules/
-COPY --chown=dependabot:dependabot gradle/Gemfile gradle/dependabot-gradle.gemspec ${CODE_DIR}/gradle/
-COPY --chown=dependabot:dependabot hex/Gemfile hex/dependabot-hex.gemspec ${CODE_DIR}/hex/
-COPY --chown=dependabot:dependabot maven/Gemfile maven/dependabot-maven.gemspec ${CODE_DIR}/maven/
-COPY --chown=dependabot:dependabot npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec ${CODE_DIR}/npm_and_yarn/
-COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec ${CODE_DIR}/nuget/
-COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
-COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec ${CODE_DIR}/pub/
-COPY --chown=dependabot:dependabot swift/Gemfile swift/dependabot-swift.gemspec ${CODE_DIR}/swift/
-COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
-
-# Prepare the updater project
-COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock ${CODE_DIR}/updater/
-
-WORKDIR ${CODE_DIR}
-
-RUN for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 -name 'Gemfile' | xargs dirname`; do \
-  cd $d && bundle config path ${CODE_DIR}/omnibus/.bundle; \
-done
+RUN cd $ECOSYSTEM \
+  && bundle config path ${DEPENDABOT_HOME}/omnibus/.bundle
 
 RUN cd omnibus \
   && bundle install \
   && BUNDLE_BIN=.bundle/bin bundle binstubs --all \
   && rm .bundle/bin/bundle # let RubyGems manage Bundler
 
-ENV PATH="${CODE_DIR}/omnibus/.bundle/bin:$PATH"
+ENV PATH="${DEPENDABOT_HOME}/omnibus/.bundle/bin:$PATH"
 
 # Create directory for volume containing VS Code extensions, to avoid reinstalling on image rebuilds
 RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders

--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ Next, run the developer shell, specifying the desired ecosystem _using the top-l
 ```shell
 $ bin/docker-dev-shell go_modules
 => running docker development shell
-[dependabot-core-dev] ~/dependabot-core $
-[dependabot-core-dev] ~/dependabot-core $ cd go_modules && rspec spec # to run tests for a particular package
+[dependabot-core-dev] ~ $ cd go_modules && rspec spec # to run tests for a particular package
 ```
 
 ### Building Images from Scratch

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -62,6 +62,7 @@ build_image() {
   docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --build-arg "FROM_IMAGE=$UPDATER_IMAGE_NAME" \
+    --build-arg "ECOSYSTEM=$ECOSYSTEM" \
     -t "$IMAGE_NAME" \
     -f "$DOCKERFILE" \
     .
@@ -110,7 +111,7 @@ if [ "$#" -gt "1" ]; then
 fi
 
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
-CODE_DIR="/home/dependabot/dependabot-core"
+CODE_DIR="/home/dependabot"
 touch .core-bash_history
 mkdir -p dry-run tmp
 docker run --rm -ti \
@@ -240,12 +241,12 @@ docker run --rm -ti \
   -v "$(pwd)/terraform/script:$CODE_DIR/terraform/script" \
   -v "$(pwd)/terraform/spec:$CODE_DIR/terraform/spec" \
   -v "$(pwd)/tmp:/$CODE_DIR/tmp" \
-  -v "$(pwd)/updater/.rubocop.yml:$CODE_DIR/updater/.rubocop.yml" \
-  -v "$(pwd)/updater/bin:$CODE_DIR/updater/bin" \
-  -v "$(pwd)/updater/Gemfile.lock:$CODE_DIR/updater/Gemfile.lock" \
-  -v "$(pwd)/updater/Gemfile:$CODE_DIR/updater/Gemfile" \
-  -v "$(pwd)/updater/lib:$CODE_DIR/updater/lib" \
-  -v "$(pwd)/updater/spec:$CODE_DIR/updater/spec" \
+  -v "$(pwd)/updater/.rubocop.yml:$CODE_DIR/dependabot-updater/.rubocop.yml" \
+  -v "$(pwd)/updater/bin:$CODE_DIR/dependabot-updater/bin" \
+  -v "$(pwd)/updater/Gemfile.lock:$CODE_DIR/dependabot-updater/Gemfile.lock" \
+  -v "$(pwd)/updater/Gemfile:$CODE_DIR/dependabot-updater/Gemfile" \
+  -v "$(pwd)/updater/lib:$CODE_DIR/dependabot-updater/lib" \
+  -v "$(pwd)/updater/spec:$CODE_DIR/dependabot-updater/spec" \
   --name "$CONTAINER_NAME" \
   --env "LOCAL_GITHUB_ACCESS_TOKEN=$LOCAL_GITHUB_ACCESS_TOKEN" \
   --env "DEPENDABOT_TEST_ACCESS_TOKEN" \

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -12,7 +12,7 @@ Ruby (bundler) support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd bundler && rspec
+   [dependabot-core-dev] ~ $ cd bundler && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/cargo/README.md
+++ b/cargo/README.md
@@ -12,7 +12,7 @@ Rust (Cargo) support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd cargo && rspec
+   [dependabot-core-dev] ~ $ cd cargo && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/composer/README.md
+++ b/composer/README.md
@@ -12,7 +12,7 @@ PHP (Composer) support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd composer && rspec
+   [dependabot-core-dev] ~ $ cd composer && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ Docker support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd docker && rspec
+   [dependabot-core-dev] ~ $ cd docker && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/elm/README.md
+++ b/elm/README.md
@@ -12,7 +12,7 @@ Elm support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd elm && rspec
+   [dependabot-core-dev] ~ $ cd elm && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/git_submodules/README.md
+++ b/git_submodules/README.md
@@ -12,7 +12,7 @@ Git Submodules support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd git_submodules && rspec
+   [dependabot-core-dev] ~ $ cd git_submodules && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/github_actions/README.md
+++ b/github_actions/README.md
@@ -12,7 +12,7 @@ GitHub Actions support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd github_actions && rspec
+   [dependabot-core-dev] ~ $ cd github_actions && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/go_modules/README.md
+++ b/go_modules/README.md
@@ -12,7 +12,7 @@ Go modules support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd go_modules && rspec
+   [dependabot-core-dev] ~ $ cd go_modules && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -12,7 +12,7 @@ Gradle support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd gradle && rspec
+   [dependabot-core-dev] ~ $ cd gradle && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/hex/README.md
+++ b/hex/README.md
@@ -12,7 +12,7 @@ Elixir support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd hex && rspec
+   [dependabot-core-dev] ~ $ cd hex && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/maven/README.md
+++ b/maven/README.md
@@ -12,7 +12,7 @@ Maven support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd maven && rspec
+   [dependabot-core-dev] ~ $ cd maven && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/npm_and_yarn/README.md
+++ b/npm_and_yarn/README.md
@@ -12,7 +12,7 @@ Yarn and npm support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd npm_and_yarn && rspec
+   [dependabot-core-dev] ~ $ cd npm_and_yarn && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -12,7 +12,7 @@ NuGet support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd nuget && rspec
+   [dependabot-core-dev] ~ $ cd nuget && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/pub/README.md
+++ b/pub/README.md
@@ -26,7 +26,7 @@ Dart (pub) support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd pub && rspec
+   [dependabot-core-dev] ~ $ cd pub && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@ Updating the list of known versions might be tricky, here are the steps:
 2. Run tests
 
    ```shell
-   [dependabot-core-dev] ~/dependabot-core $ cd python && rspec
+   [dependabot-core-dev] ~ $ cd python && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/swift/README.md
+++ b/swift/README.md
@@ -12,7 +12,7 @@ Swift Package Manager support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd swift && rspec
+   [dependabot-core-dev] ~ $ cd swift && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,7 +12,7 @@ Terraform support for [`dependabot-core`][core-repo].
 
 2. Run tests
    ```
-   [dependabot-core-dev] ~/dependabot-core $ cd terraform && rspec
+   [dependabot-core-dev] ~ $ cd terraform && rspec
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/updater/README.md
+++ b/updater/README.md
@@ -15,8 +15,8 @@ To work on the Updater, you will need to start a Docker dev shell:
 
 ```zsh
 ➜ bin/docker-dev-shell updater  # the docker-dev-shell internally maps 'updater' to the 'bundler' ecosystem image
-[dependabot-core-dev] ~/dependabot-core $ cd updater/
-[dependabot-core-dev] ~/dependabot-core/updater $ bundle
+[dependabot-core-dev] ~ $ cd dependabot-updater/
+[dependabot-core-dev] ~/dependabot-updater $ bundle
 ```
 
 ## Tests
@@ -24,13 +24,13 @@ To work on the Updater, you will need to start a Docker dev shell:
 We run [rspec](https://rspec.info/) tests in the docker dev shell:
 
 ```zsh
-[dependabot-core-dev] ~/dependabot-core/updater $ bundle exec rspec
+[dependabot-core-dev] ~/dependabot-updater $ bundle exec rspec
 ```
 
 You can run an individual test file like so:
 
 ```zsh
-[dependabot-core-dev] ~/dependabot-core/updater $ bundle exec rspec spec/dependabot/integration_spec.rb
+[dependabot-core-dev] ~/dependabot-updater $ bundle exec rspec spec/dependabot/integration_spec.rb
 ```
 
 A small number of tests hit the GitHub API, so you will need to set the envvar
@@ -59,7 +59,7 @@ If you are adding a new test that makes network calls, please ensure you record 
 If you've added a new test which has the `vcr: true` metadata, you can record a fixture for just those changes like so:
 
 ```zsh
-[dependabot-core-dev] ~/dependabot-core/updater $ VCR=new_episodes bundle exec rspec
+[dependabot-core-dev] ~/dependabot-updater $ VCR=new_episodes bundle exec rspec
 ```
 
 #### Updating existing fixtures
@@ -67,5 +67,5 @@ If you've added a new test which has the `vcr: true` metadata, you can record a 
 If you need to upadate existing fixtures, you can use the `all` flag like so:
 
 ```zsh
-[dependabot-core-dev] ~/dependabot-core/updater $ VCR=new_episodes bundle exec rspec
+[dependabot-core-dev] ~/dependabot-updater $ VCR=new_episodes bundle exec rspec
 ```


### PR DESCRIPTION
Right now, if you jump into a development shell, you'll notice this:

```
[dependabot-core-dev] ~/dependabot-core $ ls ../docker/
dependabot-docker.gemspec  Dockerfile  Gemfile  lib  README.md  script  spec
[dependabot-core-dev] ~/dependabot-core $ ls docker/
dependabot-docker.gemspec  Gemfile  lib  script  spec
```

This seems a bit strange.

I think we can use the same structure as in the production updater image for development, simplifying also the Dockerfile and making the image a bit thinner (~ 50Mb).