### PR TITLE
Fix encoding option value for gitlab commit creation

### DIFF
--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -7,6 +7,11 @@ module Dependabot
     class GitlabWithRetries
       RETRYABLE_ERRORS = [Gitlab::Error::BadGateway].freeze
 
+      class ContentEncoding
+        BASE64 = "base64"
+        TEXT = "text"
+      end
+
       #######################
       # Constructor methods #
       #######################
@@ -60,6 +65,24 @@ module Dependabot
         @client = ::Gitlab::Client.new(args)
       end
 
+      # Create commit in gitlab repo with correctly mapped file actions
+      #
+      # @param [String] repo
+      # @param [String] branch_name
+      # @param [String] commit_message
+      # @param [Array<Dependabot::DependencyFile>] files
+      # @param [Hash] options
+      # @return [Gitlab::ObjectifiedHash]
+      def create_commit(repo, branch_name, commit_message, files, **options)
+        @client.create_commit(
+          repo,
+          branch_name,
+          commit_message,
+          file_actions(files),
+          **options
+        )
+      end
+
       def method_missing(method_name, *args, &block)
         retry_connection_failures do
           if @client.respond_to?(method_name)
@@ -84,6 +107,47 @@ module Dependabot
           retry_attempt += 1
           retry_attempt <= @max_retries ? retry : raise
         end
+      end
+
+      private
+
+      # Array of file actions for a commit
+      #
+      # @param [Array<Dependabot::DependencyFile>] files
+      # @return [Array<Hash>]
+      def file_actions(files)
+        files.map do |file|
+          {
+            action: file_action(file),
+            encoding: file_encoding(file),
+            file_path: file.type == "symlink" ? file.symlink_target : file.path,
+            content: file.content
+          }
+        end
+      end
+
+      # Single file action
+      #
+      # @param [Dependabot::DependencyFile] file
+      # @return [String]
+      def file_action(file)
+        if file.operation == Dependabot::DependencyFile::Operation::DELETE
+          "delete"
+        elsif file.operation == Dependabot::DependencyFile::Operation::CREATE
+          "create"
+        else
+          "update"
+        end
+      end
+
+      # Encoding option for gitlab commit operation
+      #
+      # @param [Dependabot::DependencyFile] file
+      # @return [String]
+      def file_encoding(file)
+        return ContentEncoding::BASE64 if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
+
+        ContentEncoding::TEXT
       end
     end
   end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -99,30 +99,8 @@ module Dependabot
           source.repo,
           branch_name,
           commit_message,
-          file_actions
+          files
         )
-      end
-
-      def file_actions
-        files.map do |file|
-          {
-            action: file_action(file),
-            file_path: file.type == "symlink" ? file.symlink_target : file.path,
-            content: file.content,
-            encoding: file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64 ? "base64" : "text"
-          }
-        end
-      end
-
-      # @param [DependencyFile] file
-      def file_action(file)
-        if file.operation == Dependabot::DependencyFile::Operation::DELETE
-          "delete"
-        elsif file.operation == Dependabot::DependencyFile::Operation::CREATE
-          "create"
-        else
-          "update"
-        end
       end
 
       def create_submodule_update_commit

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -109,7 +109,7 @@ module Dependabot
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
             content: file.content,
-            encoding: file.content_encoding
+            encoding: file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64 ? "base64" : "text"
           }
         end
       end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -80,7 +80,7 @@ module Dependabot
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
             content: file.content,
-            encoding: file.content_encoding
+            encoding: file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64 ? "base64" : "text"
           }
         end
       end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -68,32 +68,10 @@ module Dependabot
           source.repo,
           merge_request.source_branch,
           commit_being_updated.title,
-          file_actions,
+          files,
           force: true,
           start_branch: merge_request.target_branch
         )
-      end
-
-      def file_actions
-        files.map do |file|
-          {
-            action: file_action(file),
-            file_path: file.type == "symlink" ? file.symlink_target : file.path,
-            content: file.content,
-            encoding: file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64 ? "base64" : "text"
-          }
-        end
-      end
-
-      # @param [DependencyFile] file
-      def file_action(file)
-        if file.operation == Dependabot::DependencyFile::Operation::DELETE
-          "delete"
-        elsif file.operation == Dependabot::DependencyFile::Operation::CREATE
-          "create"
-        else
-          "update"
-        end
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -149,25 +149,25 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
                 action: "update",
                 file_path: gemfile.path,
                 content: gemfile.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "update",
                 file_path: gemfile_lock.path,
                 content: gemfile_lock.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "create",
                 file_path: created_file.path,
                 content: created_file.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: "",
-                encoding: "utf-8"
+                encoding: "text"
               }
             ]
           }
@@ -309,7 +309,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
                   action: "update",
                   file_path: files[0].symlink_target,
                   content: files[0].content,
-                  encoding: "utf-8"
+                  encoding: "text"
                 }
               ]
             }

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -158,25 +158,25 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
                 action: "update",
                 file_path: gemfile.path,
                 content: gemfile.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "update",
                 file_path: gemfile_lock.path,
                 content: gemfile_lock.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "create",
                 file_path: created_file.path,
                 content: created_file.content,
-                encoding: "utf-8"
+                encoding: "text"
               },
               {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: "",
-                encoding: "utf-8"
+                encoding: "text"
               }
             ],
             force: true,
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
                   action: "update",
                   file_path: files[0].symlink_target,
                   content: files[0].content,
-                  encoding: "utf-8"
+                  encoding: "text"
                 }
               ],
               force: true,


### PR DESCRIPTION
This fixes broken commit creation for gitlab that was introduced by: https://github.com/dependabot/dependabot-core/pull/7381

The issue here is that gitlab api only supports 2 encoding values, `base64` and `text`. Current implementation will try to pass `utf-8` as indicated by unit tests which will raise an error like: `Server responded with code 400, message: actions[0][encoding] does not have a valid value, actions[1][encoding] does not have a valid value`.

Gitlab api doc for refernce: https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions