### PR TITLE
Don't double-install packages required for building Python.

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -55,11 +55,11 @@ USER dependabot
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 
-FROM python-core as python-3.10
-RUN pyenv install $PY_3_10 \
-  && bash /opt/python/helpers/build $PY_3_10 \
+FROM python-core as python-3.8
+RUN pyenv install $PY_3_8 \
+  && bash /opt/python/helpers/build $PY_3_8 \
   && cd /usr/local/.pyenv \
-  && tar czf 3.10.tar.gz versions/$PY_3_10
+  && tar czf 3.8.tar.gz versions/$PY_3_8
 
 FROM python-core as python-3.9
 RUN pyenv install $PY_3_9 \
@@ -67,57 +67,13 @@ RUN pyenv install $PY_3_9 \
   && cd /usr/local/.pyenv \
   && tar czf 3.9.tar.gz versions/$PY_3_9
 
-FROM python-core as python-3.8
-RUN pyenv install $PY_3_8 \
-  && bash /opt/python/helpers/build $PY_3_8 \
+FROM python-core as python-3.10
+RUN pyenv install $PY_3_10 \
+  && bash /opt/python/helpers/build $PY_3_10 \
   && cd /usr/local/.pyenv \
-  && tar czf 3.8.tar.gz versions/$PY_3_8
+  && tar czf 3.10.tar.gz versions/$PY_3_10
 
-FROM ghcr.io/dependabot/dependabot-updater-core
-ARG PY_3_11
-ARG PYENV_VERSION
-USER root
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-    dirmngr \
-    zlib1g-dev \
-    liblzma-dev \
-    libgdbm-dev \
-    bison \
-    tzdata \
-    zip \
-    openssh-client \
-    build-essential \
-    make \
-    libpq-dev \
-    libssl-dev \
-    libbz2-dev \
-    libffi-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    libcurl4-openssl-dev \
-    llvm \
-    libncurses5-dev \
-    libncursesw5-dev \
-    libmysqlclient-dev \
-    xz-utils \
-    tk-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    libgeos-dev \
-    python3-enchant \
-  && rm -rf /var/lib/apt/lists/*
-
-### PYTHON
-COPY --chown=dependabot:dependabot python/helpers /opt/python/helpers
-USER root
-ENV PYENV_ROOT=/usr/local/.pyenv \
-  PATH="/usr/local/.pyenv/bin:$PATH"
-RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
-USER dependabot
-ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
+FROM python-core
 RUN pyenv install $PY_3_11 \
   && pyenv global $PY_3_11 \
   && bash /opt/python/helpers/build $PY_3_11
@@ -125,6 +81,8 @@ RUN pyenv install $PY_3_11 \
 COPY --from=python-3.10 /usr/local/.pyenv/3.10.tar.gz /usr/local/.pyenv/3.10.tar.gz
 COPY --from=python-3.9 /usr/local/.pyenv/3.9.tar.gz /usr/local/.pyenv/3.9.tar.gz
 COPY --from=python-3.8 /usr/local/.pyenv/3.8.tar.gz /usr/local/.pyenv/3.8.tar.gz
+
+USER dependabot
 
 COPY --chown=dependabot:dependabot python $DEPENDABOT_HOME/python
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common


### PR DESCRIPTION
I don't see a reason to double-install these apt packages. If we instead change the base for `python` `3.11` to be `python-core`, then we pick this up for free. It won't be cheaper in wall clock time since the jobs are parallel, but it saves network bandwidth/CPU/IOPS.

More importantly, it reduces the chance of developer mistakes if we accidentally add or remove a package from one place and forget to copy/paste that change.