### PR TITLE
Report gradle security update errors when dependency not found in repository

### DIFF
--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -41,7 +41,14 @@ module Dependabot
         # something we should make much more intentional in future.
         def perform
           Dependabot.logger.info("Starting security update job for #{job.source.repo}")
-          dependency_snapshot.job_dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+
+          target_dependencies = dependency_snapshot.job_dependencies
+
+          if target_dependencies.empty?
+            record_security_update_dependency_not_found
+          else
+            target_dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+          end
         end
 
         private

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -40,7 +40,7 @@ module Dependabot
         # risk, so we'll maintain the interface as-is for now, but this is
         # something we should make much more intentional in future.
         def perform
-          Dependabot.logger.info("Starting update job for #{job.source.repo}")
+          Dependabot.logger.info("Starting security update job for #{job.source.repo}")
           dependency_snapshot.job_dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
         end
 

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -120,6 +120,13 @@ module Dependabot
         )
       end
 
+      def record_security_update_dependency_not_found
+        service.record_update_job_error(
+          error_type: "security_update_dependency_not_found",
+          error_details: {}
+        )
+      end
+
       def earliest_fixed_version_message(lowest_non_vulnerable_version)
         if lowest_non_vulnerable_version
           "The earliest fixed version is #{lowest_non_vulnerable_version}."


### PR DESCRIPTION
Currently uploading dependencies through the Gradle Dependency Submission API fills the Dependency Graph with _all_ project dependencies (direct or indirect), even if the indirect ones won't appear on any dependency files.

This changes the updater to record a better error in this case.