### PR TITLE
Fix missed error matching on composer

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -40,7 +40,7 @@ module Dependabot
         SOURCE_TIMED_OUT_REGEX =
           /The "(?<url>[^"]+packages\.json)".*timed out/
         FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --(mirror|checkout)[^']*'(?<url>.*?)'/
-        FAILED_GIT_CLONE = /Failed to clone (?<url>.*?) via/
+        FAILED_GIT_CLONE = /Failed to clone (?<url>.*?)/
 
         def initialize(credentials:, dependency:, dependency_files:,
                        requirements_to_unlock:, latest_allowable_version:)


### PR DESCRIPTION
For some reason, while working on #6590, I found a spec that was failing with a

```
Dependabot::SharedHelpers::HelperSubprocessFailed: Failed to clone https://github.com/no-exist-sorry/monolog to read package information from it
```

instead of the expected Dependabot::GitDependenciesNotReachable error.

It seems composer is raising a slightly different error under some situations, so tweaked the regexp to handle that.