### PR TITLE
Use dependency-type and semver grouping for dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       aws-sdk:
         patterns:
           - "aws-sdk-*"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,10 @@ updates:
       time: "16:00"
     groups:
       dev-dependencies:
-        patterns:
-          - "friendsofphp/php-cs-fixer"
-          - "phpstan/phpstan"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "composer"
     directory: "/composer/helpers/v2"
     schedule:
@@ -31,9 +32,10 @@ updates:
       time: "16:00"
     groups:
       dev-dependencies:
-        patterns:
-          - "friendsofphp/php-cs-fixer"
-          - "phpstan/phpstan"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -81,10 +83,10 @@ updates:
           - "@pnpm/lockfile-file"
           - "@pnpm/dependency-path"
       dev-dependencies:
-        patterns:
-          - "*eslint*"
-          - "*jest*"
-          - "*prettier"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "npm"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Instead of specifying individual dependencies, we can now leverage the dependency-type config option for these, and while we're at it, let's ensure we don't include major updates in these groups, as they tend to be harder to merge and addressing them separately is usually the better option.