### PR TITLE
Produce smaller Python builds

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -45,32 +45,28 @@ RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --
 
 FROM python-core as python-3.8
 # GCC - Do not add symbols to objects
-ENV LDFLAGS="-Wl,--strip-all"
-RUN pyenv install $PY_3_8 \
+RUN env LDFLAGS_NODIST="-Wl,--strip-all" pyenv install $PY_3_8 \
   && bash /opt/python/helpers/build $PY_3_8 \
   && cd /usr/local/.pyenv \
   && tar czf 3.8.tar.gz versions/$PY_3_8
 
 FROM python-core as python-3.9
 # GCC - Do not add symbols to objects
-ENV LDFLAGS="-Wl,--strip-all"
-RUN pyenv install $PY_3_9 \
+RUN env LDFLAGS_NODIST="-Wl,--strip-all" pyenv install $PY_3_9 \
   && bash /opt/python/helpers/build $PY_3_9 \
   && cd /usr/local/.pyenv \
   && tar czf 3.9.tar.gz versions/$PY_3_9
 
 FROM python-core as python-3.10
 # GCC - Do not add symbols to objects
-ENV LDFLAGS="-Wl,--strip-all"
-RUN pyenv install $PY_3_10 \
+RUN env LDFLAGS_NODIST="-Wl,--strip-all" pyenv install $PY_3_10 \
   && bash /opt/python/helpers/build $PY_3_10 \
   && cd /usr/local/.pyenv \
   && tar czf 3.10.tar.gz versions/$PY_3_10
 
 FROM python-core
 # GCC - Do not add symbols to objects
-ENV LDFLAGS="-Wl,--strip-all"
-RUN pyenv install $PY_3_11 \
+RUN env LDFLAGS_NODIST='-Wl,--strip-all' pyenv install $PY_3_11 \
   && pyenv global $PY_3_11 \
   && bash /opt/python/helpers/build $PY_3_11
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -44,24 +44,32 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 
 FROM python-core as python-3.8
+# GCC - Do not add symbols to objects
+ENV LDFLAGS="-Wl,--strip-all"
 RUN pyenv install $PY_3_8 \
   && bash /opt/python/helpers/build $PY_3_8 \
   && cd /usr/local/.pyenv \
   && tar czf 3.8.tar.gz versions/$PY_3_8
 
 FROM python-core as python-3.9
+# GCC - Do not add symbols to objects
+ENV LDFLAGS="-Wl,--strip-all"
 RUN pyenv install $PY_3_9 \
   && bash /opt/python/helpers/build $PY_3_9 \
   && cd /usr/local/.pyenv \
   && tar czf 3.9.tar.gz versions/$PY_3_9
 
 FROM python-core as python-3.10
+# GCC - Do not add symbols to objects
+ENV LDFLAGS="-Wl,--strip-all"
 RUN pyenv install $PY_3_10 \
   && bash /opt/python/helpers/build $PY_3_10 \
   && cd /usr/local/.pyenv \
   && tar czf 3.10.tar.gz versions/$PY_3_10
 
 FROM python-core
+# GCC - Do not add symbols to objects
+ENV LDFLAGS="-Wl,--strip-all"
 RUN pyenv install $PY_3_11 \
   && pyenv global $PY_3_11 \
   && bash /opt/python/helpers/build $PY_3_11

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -19,3 +19,11 @@ cp -r \
 
 cd "$install_dir"
 PYENV_VERSION=$1 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+
+# Remove the extra objects. Based on https://github.com/docker-library/python/blob/master/Dockerfile-linux.template
+# And the image docker.io/library/python
+find "${PYENV_ROOT:-/usr/local/.pyenv}/versions" -depth \
+    \( \
+    \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+    -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
+    \) -exec rm -rf '{}' +


### PR DESCRIPTION
This PR seeks to reduce the size of the Python image:
* LD Flags prevent symbols from being added
* The helper script deletes the extra pyc and .a files

This doesn't entirely produce identical layers because the tar files still have differing timestamps. Thoughts for changing that behaviour include passing a consistent date to `--mtime` as an argument to `tar(1)` or changing the output itself, in the build helper
```
find /usr/local/.pyenv -exec touch -d '2000-01-01' -h {} +
```

rspec tests passed:
```

Finished in 11 minutes 50 seconds (files took 1.1 seconds to load)
1149 examples, 0 failures, 19 pending

Randomized with seed 25745
```