### PR TITLE
Remove `slow` test designation from Python tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           - { path: nuget, name: nuget, ecosystem: nuget }
           - { path: pub, name: pub, ecosystem: pub }
           - { path: python, name: python, ecosystem: pip }
-          - { path: python, name: python_slow, ecosystem: pip }
           - { path: swift, name: swift, ecosystem: swift }
           - { path: terraform, name: terraform, ecosystem: terraform }
 

--- a/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       let(:generated_fixture_name) { "pip_compile_imports_setup.txt" }
       let(:setup_fixture_name) { "small.py" }
 
-      it "updates the requirements.txt", :slow do
+      it "updates the requirements.txt" do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).to include("attrs==18.1.0")
         expect(updated_files.first.content).
@@ -235,7 +235,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content).to_not include("--hash=sha")
       end
 
-      context "that needs sanitizing", :slow do
+      context "that needs sanitizing" do
         let(:setup_fixture_name) { "small_needs_sanitizing.py" }
         it "updates the requirements.txt" do
           expect(updated_files.count).to eq(1)
@@ -497,7 +497,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       let(:dependency_requirements) { [] }
       let(:dependency_previous_requirements) { [] }
 
-      it "raises an error indicating the dependencies are not resolvable", :slow do
+      it "raises an error indicating the dependencies are not resolvable" do
         expect { updated_files }.to raise_error(Dependabot::DependencyFileNotResolvable) do |err|
           expect(err.message).to include(
             "There are incompatible versions in the resolved dependencies:\n  pyyaml==6.0.1"

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
         let(:lockfile_fixture_name) { "git_source_no_ref.lock" }
 
         context "when updating the non-git dependency" do
-          it "doesn't update the git dependency", :slow do
+          it "doesn't update the git dependency" do
             expect(json_lockfile["default"]["requests"]["version"]).
               to eq("==2.18.4")
             expect(json_lockfile["default"]["pythonfinder"]).
@@ -347,7 +347,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
         end
       end
 
-      context "with a path dependency", :slow do
+      context "with a path dependency" do
         let(:dependency_files) { [pipfile, lockfile, setupfile] }
         let(:setupfile) do
           Dependabot::DependencyFile.new(
@@ -447,7 +447,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
           )
         end
 
-        it "updates the lockfile and the requirements.txt", :slow do
+        it "updates the lockfile and the requirements.txt" do
           expect(updated_files.map(&:name)).
             to match_array(%w(Pipfile.lock requirements.txt))
 

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
       end
     end
 
-    context "with the oldest python version currently supported by Dependabot", :slow do
+    context "with the oldest python version currently supported by Dependabot" do
       let(:python_version) { "3.8.17" }
       let(:pyproject_fixture_name) { "python_38.toml" }
       let(:lockfile_fixture_name) { "python_38.lock" }

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe namespace::PipCompileVersionResolver do
         }]
       end
 
-      it "raises a helpful error", :slow do
+      it "raises a helpful error" do
         expect { subject }.
           to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             expect(error.message).
@@ -280,7 +280,7 @@ RSpec.describe namespace::PipCompileVersionResolver do
       it { is_expected.to be >= Gem::Version.new("40.6.2") }
     end
 
-    context "with an import of the setup.py", :slow do
+    context "with an import of the setup.py" do
       let(:dependency_files) do
         [manifest_file, generated_file, setup_file, pyproject]
       end
@@ -318,7 +318,7 @@ RSpec.describe namespace::PipCompileVersionResolver do
       end
     end
 
-    context "with native dependencies that are not pre-built", :slow do
+    context "with native dependencies that are not pre-built" do
       let(:manifest_fixture_name) { "native_dependencies.in" }
       let(:generated_fixture_name) { "pip_compile_native_dependencies.txt" }
       let(:dependency_name) { "cryptography" }

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
       end
     end
 
-    context "with a path dependency", :slow do
+    context "with a path dependency" do
       let(:dependency_files) { [pipfile, lockfile, setupfile] }
       let(:setupfile) do
         Dependabot::DependencyFile.new(
@@ -244,7 +244,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
         end
       end
 
-      context "for a resolution that has caused trouble in the past", :slow do
+      context "for a resolution that has caused trouble in the past" do
         let(:dependency_files) { [pipfile] }
         let(:pipfile_fixture_name) { "problematic_resolution" }
         let(:dependency_name) { "twilio" }

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe namespace::PoetryVersionResolver do
       it { is_expected.to eq(Gem::Version.new("2.15.1")) }
     end
 
-    context "resolvable only if git references are preserved", :slow do
+    context "resolvable only if git references are preserved" do
       let(:pyproject_fixture_name) { "git_conflict.toml" }
       let(:lockfile_fixture_name) { "git_conflict.lock" }
       let(:dependency_name) { "django-widget-tweaks" }

--- a/python/spec/spec_helper.rb
+++ b/python/spec/spec_helper.rb
@@ -10,22 +10,6 @@ end
 
 require "#{common_dir}/spec/spec_helper.rb"
 
-module SlowTestHelper
-  def self.slow_tests?
-    ENV["SUITE_NAME"] == "python_slow"
-  end
-end
-
 RSpec.configure do |config|
-  config.around do |example|
-    if SlowTestHelper.slow_tests? && example.metadata[:slow]
-      example.run
-    elsif !SlowTestHelper.slow_tests? && !example.metadata[:slow]
-      example.run
-    else
-      example.skip
-    end
-  end
-
   config.profile_examples = 10
 end


### PR DESCRIPTION
These were originally split out separate from the other Python tests because they are extra slow... typically because they shell out to the underlying package manager which may have to do a buncho of work such as downloading/compiling/installing packages.

However, with the recent switch to `parallel_tests` in https://github.com/dependabot/dependabot-core/pull/6590, this may no longer be necessary.

Ideally we actually record the slow tests dynamically and then use that for future runs
(https://github.com/dependabot/dependabot-core/issues/7889) but putting up this to test what happens to runtimes if we simply stop splitting out the slow tests... I imagine things will slow down, but may not be as much as we anticipate?