### PR TITLE
fix: duplicate response body before mutating it

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb
@@ -42,7 +42,7 @@ module Dependabot
           @project_npm_response ||= Dependabot::RegistryClient.get(url: url)
           return false unless @project_npm_response.status == 200
 
-          @project_npm_response.body.force_encoding("UTF-8").encode.
+          @project_npm_response.body.dup.force_encoding("UTF-8").encode.
             include?(project_description)
         rescue Excon::Error::Socket, Excon::Error::Timeout, URI::InvalidURIError
           false


### PR DESCRIPTION
Addresses the following error that is happening in `main` npm tests : 

> 
> Failure/Error:
> @project_npm_response.body.force_encoding("UTF-8").encode.
> include?(project_description)
> 
>  FrozenError:
>    can't modify frozen String: ""

Example failure : https://github.com/dependabot/dependabot-core/actions/runs/6019388208/job/16329143018?pr=7811