### PR TITLE
Use `python3`/`pip3` so we don't have to have `python`/`pip` symlinks

### DIFF
--- a/python/helpers/build
+++ b/python/helpers/build
@@ -18,4 +18,4 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=$1 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+PYENV_VERSION=$1 pyenv exec pip3 --disable-pip-version-check install --use-pep517 -r "requirements.txt"

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -133,7 +133,7 @@ module Dependabot
           write_temporary_dependency_files
 
           requirements = SharedHelpers.run_helper_subprocess(
-            command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+            command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
             function: "parse_requirements",
             args: [Dir.pwd]
           )

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -247,7 +247,7 @@ module Dependabot
             write_temporary_pyproject
 
             SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
               function: "parse_pep621_dependencies",
               args: [pyproject.name]
             )

--- a/python/lib/dependabot/python/file_parser/setup_file_parser.rb
+++ b/python/lib/dependabot/python/file_parser/setup_file_parser.rb
@@ -60,7 +60,7 @@ module Dependabot
             write_temporary_dependency_files
 
             requirements = SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
               function: "parse_setup",
               args: [Dir.pwd]
             )
@@ -81,7 +81,7 @@ module Dependabot
             write_sanitized_setup_file
 
             requirements = SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
               function: "parse_setup",
               args: [Dir.pwd]
             )

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -376,7 +376,7 @@ module Dependabot
 
         def package_hashes_for(name:, version:, algorithm:)
           SharedHelpers.run_helper_subprocess(
-            command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+            command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
             function: "get_dependency_hash",
             args: [name, version, algorithm]
           ).map { |h| "--hash=#{algorithm}:#{h['hash']}" }

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -326,7 +326,7 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do |dir|
             File.write(File.join(dir, "Pipfile"), pipfile_content)
             SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
               function: "get_pipfile_hash",
               args: [dir]
             )

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -232,7 +232,7 @@ module Dependabot
               write_temporary_dependency_files(pyproject_content)
 
               SharedHelpers.run_helper_subprocess(
-                command: "pyenv exec python #{python_helper_path}",
+                command: "pyenv exec python3 #{python_helper_path}",
                 function: "get_pyproject_hash",
                 args: [dir]
               )

--- a/python/lib/dependabot/python/file_updater/requirement_replacer.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_replacer.rb
@@ -134,7 +134,7 @@ module Dependabot
 
         def package_hashes_for(name:, version:, algorithm:)
           SharedHelpers.run_helper_subprocess(
-            command: "pyenv exec python #{NativeHelpers.python_helper_path}",
+            command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
             function: "get_dependency_hash",
             args: [name, version, algorithm]
           ).map { |h| "--hash=#{algorithm}:#{h['hash']}" }


### PR DESCRIPTION
To reduce ambiguity, by default the compiled output from python 3 results in the commands `python3` / `pip3`. Often wrapper tooling will create additional symlinks of `python`/`pip` pointing at these, but they aren't the out-of-the-box default when compiling Python straight from source.

In our case, `pyenv` _does_ add these symlinks. However, if we move away from using `pyenv install` to another method (:wink:), then life will be simpler if we directly call `python3` / `pip3` because we won't need to create symlinks.