### PR TITLE
Python helper removes bytecode files

### DIFF
--- a/python/helpers/build
+++ b/python/helpers/build
@@ -19,3 +19,17 @@ cp -r \
 
 cd "$install_dir"
 PYENV_VERSION=$1 pyenv exec pip3 --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+
+# Remove the extra objects added during the previous install. Based on
+# https://github.com/docker-library/python/blob/master/Dockerfile-linux.template
+# And the image docker.io/library/python
+find "${PYENV_ROOT:-/usr/local/.pyenv}/versions" -depth \
+    \( \
+    \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+    -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
+    \) -exec rm -rf '{}' +
+
+find -L "${PYENV_ROOT:-/usr/local/.pyenv}/versions" -type f  \
+    -name '*.so' \
+    -exec strip --preserve-dates {} +
+


### PR DESCRIPTION
This removes the pyc files which were added during previous python invocations.

Ensure shared objects are stripped, preserving timestamps.

Before:
```
dependabot@9c1ccba0e418:/usr/local/.pyenv/versions$ du -shc *
51M	3.10.13.tar.gz
185M	3.11.5
51M	3.8.18.tar.gz
49M	3.9.18.tar.gz
335M	total
```

After
```
dependabot@f0f1ba4d48ae:/usr/local/.pyenv/versions$ du -shc *
31M	3.10.13.tar.gz
107M	3.11.5
32M	3.8.18.tar.gz
31M	3.9.18.tar.gz
200M	total
```