### PR TITLE
Python tar consistency

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -70,7 +70,7 @@ RUN PYENV_VERSION=$PY_3_8 pyenv exec python --version | grep "Python $PY_3_8" ||
 RUN bash /opt/python/helpers/build $PY_3_8
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
-  && tar czf $PY_3_8.tar.gz $PY_3_8
+  && tar --mtime=./$PY_3_8/lib/libpython3.so --sort=name -czf $PY_3_8.tar.gz $PY_3_8
 
 ## 3.9
 # Docker doesn't support parametrizing `COPY --from:python:$PY_1_23-bookworm`, so work around it using an alias.
@@ -88,7 +88,7 @@ RUN PYENV_VERSION=$PY_3_9 pyenv exec python --version | grep "Python $PY_3_9" ||
 RUN bash /opt/python/helpers/build $PY_3_9
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
-  && tar czf $PY_3_9.tar.gz $PY_3_9
+  && tar --mtime=./$PY_3_9/lib/libpython3.so --sort=name -czf $PY_3_9.tar.gz $PY_3_9
 
 ## 3.10
 # Docker doesn't support parametrizing `COPY --from:python:$PY_1_23-bookworm`, so work around it using an alias.
@@ -106,7 +106,7 @@ RUN PYENV_VERSION=$PY_3_10 pyenv exec python --version | grep "Python $PY_3_10" 
 RUN bash /opt/python/helpers/build $PY_3_10
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
-  && tar czf $PY_3_10.tar.gz $PY_3_10
+  && tar --mtime=./$PY_3_10/lib/libpython3.so --sort=name -czf $PY_3_10.tar.gz $PY_3_10
 
 ## 3.11
 # Docker doesn't support parametrizing `COPY --from:python:$PY_1_23-bookworm`, so work around it using an alias.

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -70,6 +70,9 @@ RUN PYENV_VERSION=$PY_3_8 pyenv exec python --version | grep "Python $PY_3_8" ||
 RUN bash /opt/python/helpers/build $PY_3_8
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
+  # Using a consistent mtime and sort order increases the odds this layer will
+  # be pulled from the docker image cache. Using libpython3.so as the reference
+  # instead of a totally random time
   && tar --mtime=./$PY_3_8/lib/libpython3.so --sort=name -czf $PY_3_8.tar.gz $PY_3_8
 
 ## 3.9
@@ -88,6 +91,9 @@ RUN PYENV_VERSION=$PY_3_9 pyenv exec python --version | grep "Python $PY_3_9" ||
 RUN bash /opt/python/helpers/build $PY_3_9
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
+  # Using a consistent mtime and sort order increases the odds this layer will
+  # be pulled from the docker image cache. Using libpython3.so as the reference
+  # instead of a totally random time
   && tar --mtime=./$PY_3_9/lib/libpython3.so --sort=name -czf $PY_3_9.tar.gz $PY_3_9
 
 ## 3.10
@@ -106,6 +112,9 @@ RUN PYENV_VERSION=$PY_3_10 pyenv exec python --version | grep "Python $PY_3_10" 
 RUN bash /opt/python/helpers/build $PY_3_10
 # This python environment occupies ~0.5 GB and gets used for a fraction of jobs, so store it compressed.
 RUN cd $PYENV_ROOT/versions \
+  # Using a consistent mtime and sort order increases the odds this layer will
+  # be pulled from the docker image cache. Using libpython3.so as the reference
+  # instead of a totally random time
   && tar --mtime=./$PY_3_10/lib/libpython3.so --sort=name -czf $PY_3_10.tar.gz $PY_3_10
 
 ## 3.11


### PR DESCRIPTION
When creating tar archives of Python versions:
* sort directory entries by name instead of OS order
* Use the timestamp of libpython3.so as the mtime of all added files.

This should increase the chance that archives created from consistent
sources will be uniform and reproducible, being more likely to match
cached layers.

On one Linux instance:
```
dependabot@492fc87f7481:/usr/local/.pyenv/versions$ md5sum *gz
e4a8931b35ccbd103fb194aa477f0f10  3.10.13.tar.gz
6f9123a5ef7b5f6a8c83d566a840cc6c  3.8.18.tar.gz
2e9d8dc9c22ff8809afd3f26265b0d08  3.9.18.tar.gz
```
On a different server:
```
dependabot@492fc87f7481:/usr/local/.pyenv/versions$ md5sum *gz
e4a8931b35ccbd103fb194aa477f0f10  3.10.13.tar.gz
6f9123a5ef7b5f6a8c83d566a840cc6c  3.8.18.tar.gz
2e9d8dc9c22ff8809afd3f26265b0d08  3.9.18.tar.gz
```