### PR TITLE
Bump RUBY_VERSIONS to include 3.0.6

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -11,7 +11,7 @@ module Dependabot
         class RubyVersionNotFound < StandardError; end
 
         RUBY_VERSIONS = %w(
-          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.5 3.1.3 3.2.0
+          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.3 3.2.0
         ).freeze
 
         attr_reader :gemspec

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content
         end
-        it { is_expected.to include("ruby '3.0.5'\n") }
+        it { is_expected.to include("ruby '3.0.6'\n") }
         it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
       end
 


### PR DESCRIPTION
Closes: https://github.com/dependabot/dependabot-core/issues/7942

I am getting an error `Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound` for a project that has a ruby version requirement for `3.0.6`. This PR bumps the expected RUBY_VERSIONS to include the latest for [ruby 3.0](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/)

Ran tests locally and passed
<img width="766" alt="Screen Shot 2023-08-31 at 2 35 12 PM" src="https://github.com/dependabot/dependabot-core/assets/62567263/f1122393-797a-4372-9360-c431b84824e8">
