### PR TITLE
Make building the default python concurrent rather than sequential

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -90,7 +90,7 @@ RUN cd $PYENV_ROOT/versions \
 # Docker doesn't support parametrizing `COPY --from:python:$PY_1_23-bookworm`, so work around it using an alias.
 # TODO: If upstream adds support for Ubuntu, use that instead of Debian as the base suffix: https://github.com/docker-library/python/pull/791
 FROM python:$PY_3_11-bookworm as upstream-python-3.11
-FROM python-core
+FROM python-core as python-3.11
 ARG PYTHON_INSTALL_LOCATION="$PYENV_ROOT/versions/$PY_3_11"
 COPY --from=upstream-python-3.11 --chown=dependabot:dependabot /usr/local/bin $PYTHON_INSTALL_LOCATION/bin
 COPY --from=upstream-python-3.11 --chown=dependabot:dependabot /usr/local/include $PYTHON_INSTALL_LOCATION/include
@@ -100,9 +100,9 @@ RUN find $PYTHON_INSTALL_LOCATION/bin -type f -exec sed -i "1s|^#!/usr/local/bin
 # Ensure pyenv works and it's the python version we expect
 RUN PYENV_VERSION=$PY_3_11 pyenv exec python --version | grep "Python $PY_3_11" || exit 1
 RUN bash /opt/python/helpers/build $PY_3_11
+# This is the default Python, so no need to tar it
 
-RUN pyenv global $PY_3_11
-
+FROM python-core
 # Install C-libs needed to build users' Python packages. Please document why each package is needed.
 USER root
 RUN apt-get update \
@@ -130,3 +130,9 @@ COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 COPY --from=python-3.8 $PYENV_ROOT/versions/$PY_3_8.tar.gz $PYENV_ROOT/versions/$PY_3_8.tar.gz
 COPY --from=python-3.9 $PYENV_ROOT/versions/$PY_3_9.tar.gz $PYENV_ROOT/versions/$PY_3_9.tar.gz
 COPY --from=python-3.10 $PYENV_ROOT/versions/$PY_3_10.tar.gz $PYENV_ROOT/versions/$PY_3_10.tar.gz
+COPY --from=python-3.11 $PYENV_ROOT/versions/ $PYENV_ROOT/versions/
+
+# Copy the output of the build script, it should be identical across Python versions
+COPY --from=python-3.11 /opt/python/ /opt/python/
+
+RUN pyenv global $PY_3_11


### PR DESCRIPTION
Previously we'd build all the non-default pythons concurrently with building the default python, and then sequence installing the `apt` packages behind building the default Python.

However, these `apt` packages can take a little while to fetch/install, and they don't require the default Python, so instead parallelize building the default python at the same time as installing the apt packages.

This also makes the flow consistent across all pythons of building in a separate stage and then copying to the final image.