### PR TITLE
Gradle: fix comparison of the prefix version range

### DIFF
--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -153,6 +153,10 @@ module Dependabot
       end
 
       def compare_prefixed_token(prefix:, token:, other_prefix:, other_token:)
+        return 1 if token == "+" && other_token != "+"
+        return -1 if other_token == "+" && token != "+"
+        return 0 if token == "+" && other_token == "+"
+
         token_type = token.match?(/^\d+$/) ? :number : :qualifier
         other_token_type = other_token.match?(/^\d+$/) ? :number : :qualifier
 

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -293,6 +293,31 @@ RSpec.describe Dependabot::Gradle::Version do
           let(:other_version) { described_class.new("1-alpha-1") }
           it { is_expected.to eq(0) }
         end
+
+        context "dynamic minor version" do
+          let(:version) { described_class.new("1.+") }
+
+          it "is greater than a non-dynamic version" do
+            expect(version).to be > described_class.new("1.11")
+            expect(version).to be > described_class.new("1.11.1")
+          end
+
+          it "is less than the next major version" do
+            expect(version).to be < described_class.new("2.0")
+          end
+        end
+
+        context "dynamic patch version" do
+          let(:version) { described_class.new("1.1.+") }
+
+          it "is greater than a non-dynamic version" do
+            expect(version).to be > described_class.new("1.1.2")
+          end
+
+          it "is less than the next minor version" do
+            expect(version).to be < described_class.new("1.2")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/3759

This change causes the `+` to always compare higher than any version in the semver position. That means when the dependency specifies `4.+` with no lockfile, it won't attempt to update to version 4.11 because 4.+ already covers that.

The code in `gradle/version.rb` is particularly challenging. If there's a better way to write this let me know.