### PR TITLE
go: fix ambiguous import when using a module without a dot

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -28,9 +28,9 @@ COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # See https://tip.golang.org/doc/toolchain#select
-# By specifying go1.20, we use 1.20 for any go.mod with go directive <=1.20.
+# By specifying go1.20.8, we use 1.20.8 for any go.mod with go directive <=1.20.
 # By specifying auto, it automatically downloads the correct version if the go.mod is > 1.20,
 # unless it's already downloaded, like Go 1.21.0 above.
-ENV GOTOOLCHAIN="go1.20+auto"
-# This pre-installs go 1.20 so that each job doesn't have to do it.
+ENV GOTOOLCHAIN="go1.20.8+auto"
+# This pre-installs go 1.20.8 so that each job doesn't have to do it.
 RUN go version


### PR DESCRIPTION
Due to a bug in Go 1.20 (see https://github.com/golang/go/issues/61873), when importing a module without a dot in it, we get:

```
 18:13 ❱ GOTOOLCHAIN="go1.20+auto" go get
akvorado: ambiguous import: found package akvorado in multiple modules:
        akvorado (/home/bernat/code/free/akvorado)
         (/home/bernat/src/gocode/pkg/mod/golang.org/toolchain@v0.0.1-go1.20.linux-amd64/src/akvorado)
```

This issue was fixed in Go 1.20.8 which was just released. By using `go1.20.8` as a toolchain for anything <= 1.20, we still cover the use case introduced in #7884, but we also avoid this bug. `go1.20.8` is a valid toolchain. For Go 1.20, only `go1.20` is a valid version for `go` directive in `go.mod`.