### PR TITLE
Maven: fix classifier being part of the dependency name

### DIFF
--- a/maven/lib/dependabot/maven.rb
+++ b/maven/lib/dependabot/maven.rb
@@ -22,7 +22,7 @@ Dependabot::Dependency.
   register_display_name_builder(
     "maven",
     lambda { |name|
-      _group_id, artifact_id, _classifier = name.split(":")
+      _group_id, artifact_id = name.split(":")
       name.length <= 100 ? name : artifact_id
     }
   )

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -89,9 +89,6 @@ module Dependabot
         return unless (name = dependency_name(dependency_node, pom))
         return if internal_dependency_names.include?(name)
 
-        classifier = dependency_classifier(dependency_node, pom)
-        name = "#{name}:#{classifier}" if classifier
-
         build_dependency(pom, dependency_node, name)
       end
 
@@ -109,7 +106,7 @@ module Dependabot
             property_source: property_source(dependency_node, pom)
           }.compact
 
-        Dependency.new(
+        dependency = Dependency.new(
           name: name,
           version: dependency_version(pom, dependency_node),
           package_manager: "maven",
@@ -119,10 +116,14 @@ module Dependabot
             groups: dependency_groups(pom, dependency_node),
             source: nil,
             metadata: {
-              packaging_type: packaging_type(pom, dependency_node)
+              packaging_type: packaging_type(pom, dependency_node),
             }.merge(property_details)
           }]
         )
+
+        classifier = dependency_classifier(dependency_node, pom)
+        dependency.requirements.first[:metadata][:classifier] = classifier if classifier
+        dependency
       end
 
       def dependency_name(dependency_node, pom)

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -116,7 +116,7 @@ module Dependabot
             groups: dependency_groups(pom, dependency_node),
             source: nil,
             metadata: {
-              packaging_type: packaging_type(pom, dependency_node),
+              packaging_type: packaging_type(pom, dependency_node)
             }.merge(property_details)
           }]
         )

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -106,7 +106,7 @@ module Dependabot
             property_source: property_source(dependency_node, pom)
           }.compact
 
-        dependency = Dependency.new(
+        Dependency.new(
           name: name,
           version: dependency_version(pom, dependency_node),
           package_manager: "maven",
@@ -116,14 +116,11 @@ module Dependabot
             groups: dependency_groups(pom, dependency_node),
             source: nil,
             metadata: {
-              packaging_type: packaging_type(pom, dependency_node)
-            }.merge(property_details)
+              packaging_type: packaging_type(pom, dependency_node),
+              classifier: dependency_classifier(dependency_node, pom)
+            }.merge(property_details).compact
           }]
         )
-
-        classifier = dependency_classifier(dependency_node, pom)
-        dependency.requirements.first[:metadata][:classifier] = classifier if classifier
-        dependency
       end
 
       def dependency_name(dependency_node, pom)

--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -59,7 +59,7 @@ module Dependabot
             ].compact.join(":")
 
             if node.at_xpath("./*/classifier")
-              classifier = evaluated_value(node.at_xpath('./*/classifier').content.strip)
+              classifier = evaluated_value(node.at_xpath("./*/classifier").content.strip)
               dep_classifier = dependency.requirements.first.dig(:metadata, :classifier)
               next false if classifier != dep_classifier
             end

--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -59,8 +59,9 @@ module Dependabot
             ].compact.join(":")
 
             if node.at_xpath("./*/classifier")
-              node_name += ":#{evaluated_value(node.at_xpath('./*/classifier').
-                content.strip)}"
+              classifier = evaluated_value(node.at_xpath('./*/classifier').content.strip)
+              dep_classifier = dependency.requirements.first.dig(:metadata, :classifier)
+              next false if classifier != dep_classifier
             end
 
             next false unless node_name == dependency_name

--- a/maven/lib/dependabot/maven/metadata_finder.rb
+++ b/maven/lib/dependabot/maven/metadata_finder.rb
@@ -117,7 +117,7 @@ module Dependabot
       end
 
       def dependency_artifact_id
-        _group_id, artifact_id, _classifier = dependency.name.split(":")
+        _group_id, artifact_id = dependency.name.split(":")
 
         artifact_id
       end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -251,7 +251,7 @@ module Dependabot
         end
 
         def dependency_metadata_url(repository_url)
-          group_id, artifact_id, _classifier = dependency.name.split(":")
+          group_id, artifact_id = dependency.name.split(":")
 
           "#{repository_url}/" \
             "#{group_id.tr('.', '/')}/" \
@@ -260,9 +260,9 @@ module Dependabot
         end
 
         def dependency_files_url(repository_url, version)
-          group_id, artifact_id, classifier = dependency.name.split(":")
-          type = dependency.requirements.first.
-                 dig(:metadata, :packaging_type)
+          group_id, artifact_id = dependency.name.split(":")
+          type = dependency.requirements.first.dig(:metadata, :packaging_type)
+          classifier = dependency.requirements.first.dig(:metadata, :classifier)
 
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"
           "#{repository_url}/" \

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::Maven::FileParser do
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("io.mockk:mockk:sources")
+          expect(dependency.name).to eq("io.mockk:mockk")
           expect(dependency.version).to eq("1.0.0")
           expect(dependency.requirements).to eq(
             [{
@@ -80,7 +80,10 @@ RSpec.describe Dependabot::Maven::FileParser do
               file: "pom.xml",
               groups: [],
               source: nil,
-              metadata: { packaging_type: "jar" }
+              metadata: {
+                classifier: "sources",
+                packaging_type: "jar"
+              }
             }]
           )
         end

--- a/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
@@ -71,8 +71,9 @@ RSpec.describe Dependabot::Maven::FileUpdater::DeclarationFinder do
     end
 
     context "with a dependency that has a classifier" do
-      let(:dependency_name) { "io.mockk:mockk:sources" }
+      let(:dependency_name) { "io.mockk:mockk" }
       let(:dependency_version) { "1.0.0" }
+      let(:dependency_metadata) { { packaging_type: "jar", classifier: "sources" } }
 
       it "finds the declaration" do
         expect(declaration_nodes.count).to eq(1)

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -50,21 +50,27 @@ RSpec.describe Dependabot::Maven::FileUpdater do
   end
   let(:mockk_dependency) do
     Dependabot::Dependency.new(
-      name: "io.mockk:mockk:sources",
+      name: "io.mockk:mockk",
       version: "1.10.0",
       requirements: [{
         file: "pom.xml",
         requirement: "1.10.0",
         groups: [],
         source: nil,
-        metadata: { packaging_type: "jar" }
+        metadata: {
+          packaging_type: "jar",
+          classifier: "sources"
+        }
       }],
       previous_requirements: [{
         file: "pom.xml",
         requirement: "1.0.0",
         groups: [],
         source: nil,
-        metadata: { packaging_type: "jar" }
+        metadata: {
+          packaging_type: "jar",
+          classifier: "sources"
+        }
       }],
       package_manager: "maven"
     )

--- a/maven/spec/dependabot/maven/metadata_finder_spec.rb
+++ b/maven/spec/dependabot/maven/metadata_finder_spec.rb
@@ -62,13 +62,6 @@ RSpec.describe Dependabot::Maven::MetadataFinder do
       )
     end
 
-    context "when the dependency name has a classifier" do
-      let(:dependency_name) { "io.mockk:mockk:sources" }
-      let(:dependency_version) { "1.10.0" }
-
-      it { is_expected.to eq("https://github.com/mockk/mockk") }
-    end
-
     context "when the github link is buried in the pom" do
       let(:maven_response) { fixture("poms", "guava-23.3-jre.xml") }
 

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -85,8 +85,17 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
   end
 
   describe "#latest_version_details when the dependency has a classifier" do
-    let(:dependency_name) { "io.mockk:mockk:sources" }
+    let(:dependency_name) { "io.mockk:mockk" }
     let(:dependency_version) { "1.0.0" }
+    let(:dependency_requirements) do
+      [{
+        file: "pom.xml",
+        requirement: dependency_version,
+        groups: [],
+        source: nil,
+        metadata: { packaging_type: "jar", classifier: "sources" }
+      }]
+    end
     subject { finder.latest_version_details }
 
     its([:version]) { is_expected.to eq(version_class.new("1.10.0")) }


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/1924 the classifier was added to take account of the different URL pattern needed to pull the dependency, however it was added to the dependency name and this has caused some issues around `allow` and `ignore`. 

I've put up a repro here: https://github.com/dsp-testing/maven-no-make-pr

Since it is appending the classifier to the end of the dependency name, the allow is preventing the update.

To fix this I moved the classifier into the dependency metadata, which didn't exist when #1924 was created, but now is a perfect place for this data to live!