### PR TITLE
Dependencies only match with one group

### DIFF
--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -9,12 +9,6 @@ require "dependabot/dependency_group"
 # any groups from the job's configuration before assigning the dependency list to
 # the groups.
 #
-# We permit dependencies to be in more than one group and also track those which
-# have zero matches so they may be updated individuall.
-#
-# **Note:** This is currently an experimental feature which is not supported
-#           in the service or as an integration point.
-#
 module Dependabot
   class DependencyGroupEngine
     class ConfigurationError < StandardError; end
@@ -43,6 +37,8 @@ module Dependabot
 
             group.dependencies.push(dependency)
             matches << group
+            # We only want to add a dependency to one group, so break after the first match
+            break matches
           end
 
           # If we had no matches, collect the dependency as ungrouped

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -129,12 +129,12 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           dependency_group_engine.assign_to_groups!(dependencies: dependencies)
         end
 
-        it "adds dependencies to every group they match" do
+        it "adds dependencies to the first group they match" do
           group_a = dependency_group_engine.find_group(name: "group-a")
           expect(group_a.dependencies).to eql([dummy_pkg_a, dummy_pkg_c])
 
           group_b = dependency_group_engine.find_group(name: "group-b")
-          expect(group_b.dependencies).to eql([dummy_pkg_b, dummy_pkg_c])
+          expect(group_b.dependencies).to eql([dummy_pkg_b])
         end
 
         it "keeps a list of any dependencies that do not match any groups" do

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -198,13 +198,8 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         "Found 2 group(s)."
       )
 
-      expect(mock_service).to receive(:create_pull_request) do |dependency_change|
+      expect(mock_service).to receive(:create_pull_request).exactly(1).times do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("my-group")
-        expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
-      end
-
-      expect(mock_service).to receive(:create_pull_request) do |dependency_change|
-        expect(dependency_change.dependency_group.name).to eql("my-overlapping-group")
         expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
       end
 


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/7915

Right now, dependencies will show up in every group they match with. This PR changes that so dependencies will only match one group.

Dependencies will try to match against each group in the same order, which is the order that they are listed in the `dependabot.yml` file.