### PR TITLE
Ensure Docker versions are valid Dependabot::Versions

### DIFF
--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -14,16 +14,11 @@ module Dependabot
       def initialize(version)
         release_part, update_part = version.split("_", 2)
 
-        @release_part = Dependabot::Version.new(release_part.tr("-", "."))
+        @release_part = Dependabot::Version.new(release_part.sub("v", "").tr("-", "."))
 
         @update_part = Dependabot::Version.new(update_part&.start_with?(/[0-9]/) ? update_part : 0)
-      end
 
-      def self.correct?(version)
-        super(new(version).to_semver)
-      rescue ArgumentError
-        # if we can't instantiate a version, it can't be correct
-        false
+        super(@release_part)
       end
 
       def to_semver

--- a/docker/spec/dependabot/docker/version_spec.rb
+++ b/docker/spec/dependabot/docker/version_spec.rb
@@ -27,13 +27,19 @@ RSpec.describe Dependabot::Docker::Version do
   end
 
   describe ".correct?" do
+    def check_version_for_correctness?(version)
+      docker_version = described_class.new(version)
+      described_class.correct?(docker_version)
+    end
+
     it "classifies standard versions as correct" do
-      expect(described_class.correct?("2.4.2")).to be true
+      expect(check_version_for_correctness?("2.4.2")).to be true
     end
 
     it "classifies java versions as correct" do
-      expect(described_class.correct?("11.0.16_8")).to be true
-      expect(described_class.correct?("11.0.16.1")).to be true
+      expect(check_version_for_correctness?("11.0.16_8")).to be true
+      expect(check_version_for_correctness?("v11.0.16_8")).to be true
+      expect(check_version_for_correctness?("11.0.16.1")).to be true
     end
   end
 

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -218,7 +218,7 @@ module Dependabot
 
         version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).new(dependency.version.to_s)
         latest_version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).
-          new(checker.latest_version)
+                         new(checker.latest_version)
 
         # Not every version class implements .major, .minor, .patch so we calculate it here from the segments
         latest = semver_segments(latest_version)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -217,8 +217,11 @@ module Dependabot
         return false if git_dependency?(dependency)
 
         version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).new(dependency.version.to_s)
+        latest_version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).
+          new(checker.latest_version)
+
         # Not every version class implements .major, .minor, .patch so we calculate it here from the segments
-        latest = semver_segments(checker.latest_version)
+        latest = semver_segments(latest_version)
         current = semver_segments(version)
         return group.rules["update-types"].include?("major") if latest[:major] > current[:major]
         return group.rules["update-types"].include?("minor") if latest[:minor] > current[:minor]

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -535,6 +535,13 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         expect(dependency_change.updated_dependency_files_hash.length).to eql(2)
         expect(dependency_change.updated_dependency_files.map(&:name)).
           to eql(%w(Dockerfile.bundler Dockerfile.cargo))
+
+        # We are able to handle the irregular semver version strings like "v2.0.20230509134123"
+        expect(
+          dependency_change.updated_dependencies.
+          map  { |dependency| Dependabot::Docker::Version.new(dependency.version) }.
+          all? { |dependency| Dependabot::Docker::Version.correct?(dependency) }
+        ).to be_truthy
       end
 
       group_update_all.perform


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/7938

WIP

`Dependabot::Docker::Version#new` would normally return an instance of a `Gem::Version` with an actual value, but `Docker::Version#initialize` failed to call `#super` and so it returned `Gem::Version.new(nil)` instead.

This PR fixes that issue in the `Dependabot::Docker::Version` class by actually calling `#super` and it also removes the overloaded `#self.correct?(version)` method that was present since the base method should now work correctly.

Finally, in `Updater::GroupUpdateCreation` we make sure to cast the version returned by the latest version finder to an actual `Dependabot::Version` so we can use the `Dependabot::Version#segments` method.