### PR TITLE
build(deps): bump go from 1.21.0 to 1.21.1

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -4,11 +4,15 @@ ARG TARGETARCH
 USER root
 
 # Install Go. See https://go.dev/dl/ for updates
-ARG GOLANG_VERSION=1.21.0
+ARG GOLANG_VERSION=1.21.1
 
 # You can find the SHA's here: https://go.dev/dl/
-ARG GOLANG_AMD64_CHECKSUM=d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742
-ARG GOLANG_ARM64_CHECKSUM=f3d4548edf9b22f26bbd49720350bbfe59d75b7090a1a2bff1afad8214febaf3
+
+# curl -s https://go.dev/dl/?mode=json | jq -r --arg GOLANG_VERSION "$GOLANG_VERSION" '.[] | .files[] | select(.filename == ("go" + $GOLANG_VERSION + ".linux-amd64.tar.gz")) | .sha256'
+ARG GOLANG_AMD64_CHECKSUM=b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae
+
+# curl -s https://go.dev/dl/?mode=json | jq -r --arg GOLANG_VERSION "$GOLANG_VERSION" '.[] | .files[] | select(.filename == ("go" + $GOLANG_VERSION + ".linux-arm64.tar.gz")) | .sha256'
+ARG GOLANG_ARM64_CHECKSUM=7da1a3936a928fd0b2602ed4f3ef535b8cd1990f1503b8d3e1acc0fa0759c967
 
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \


### PR DESCRIPTION
From: https://go.dev/doc/devel/release#go1.21.1

> go1.21.1 (released 2023-09-06) includes four security fixes to the cmd/go, crypto/tls, and html/template packages, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the context, crypto/tls, encoding/gob, encoding/xml, go/types, net/http, os, and path/filepath packages. See the [Go 1.21.1 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.1+label%3ACherryPickApproved) on our issue tracker for details.