### PR TITLE
Use `rstrip` to trim trailing newlines

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -176,7 +176,7 @@ module Dependabot
 
           return unless @file_text[file.download_url].valid_encoding?
 
-          @file_text[file.download_url].sub(/\n*\z/, "")
+          @file_text[file.download_url].rstrip
         end
 
         def fetch_github_file(file_source, file)

--- a/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
@@ -48,7 +48,7 @@ module Dependabot
               Range.new(0, -1)
             end
 
-          changelog_lines.slice(slice_range).join("\n").sub(/\n*\z/, "")
+          changelog_lines.slice(slice_range).join("\n").rstrip
         end
 
         private


### PR DESCRIPTION
See
- https://github.com/dependabot/dependabot-core/security/code-scanning/55
- https://github.com/dependabot/dependabot-core/security/code-scanning/108

https://ruby-doc.org/3.2.2/String.html#method-i-rstrip