### PR TITLE
Add `.git-blame-ignore-revs-file` and ignore style change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# These commits will be ignored by the GitHub blame view.
+# The git blame CLI can ignore them as well by doing:
+#   git blame --ignore-revs-file .git-blame-ignore-revs <filepath>
+# or via global config:
+#   git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Changed Layout/DotPosition from leading to trailing
+3fc49229761517cf3dc6979018a9a2d84f733ece


### PR DESCRIPTION
This ignores the _large_ style change commit https://github.com/dependabot/dependabot-core/commit/3fc49229761517cf3dc6979018a9a2d84f733ece.

See [Ignore commits in the blame view (Beta)][1] for more information.

[1]: https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/