### PR TITLE
Add sorbet dependencies

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", ">= 4.6", "< 7.0"
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "psych", "~> 5.0"
+  spec.add_dependency "sorbet-runtime", "~> 0.5"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
   spec.add_development_dependency "debug", "~> 1.8.0"
@@ -49,7 +50,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.3"
   spec.add_development_dependency "rubocop", "~> 1.56.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.19.0"
+  spec.add_development_dependency "sorbet", "~> 0.5"
   spec.add_development_dependency "stackprof", "~> 0.2.16"
+  spec.add_development_dependency "tapioca", "~> 0.11"
   spec.add_development_dependency "vcr", "~> 6.1"
   spec.add_development_dependency "webmock", "~> 3.18"
 

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -25,4 +25,9 @@ gemspec path: "../terraform"
 gem "reek", group: :development
 gem "solargraph", group: :development
 
+# Sorbet
+gem "sorbet", group: :development
+gem "sorbet-runtime"
+gem "tapioca", require: false, group: :development
+
 gemspec

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -25,9 +25,4 @@ gemspec path: "../terraform"
 gem "reek", group: :development
 gem "solargraph", group: :development
 
-# Sorbet
-gem "sorbet", group: :development
-gem "sorbet-runtime"
-gem "tapioca", require: false, group: :development
-
 gemspec

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -27,6 +27,7 @@ PATH
       octokit (>= 4.6, < 7.0)
       parser (>= 2.5, < 4.0)
       psych (~> 5.0)
+      sorbet-runtime (~> 0.5)
       toml-rb (>= 1.1.2, < 3.0)
 
 PATH
@@ -282,6 +283,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
+    sorbet-runtime (0.5.11011)
     stringio (3.0.6)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)


### PR DESCRIPTION
Part of #7782 and step 1 of the [adopting Sorbet in an existing codebase][1] guide.

This will be followed with step 2 [initializing sorbet][2]

[1]: https://sorbet.org/docs/adopting#step-1-install-dependencies
[2]: https://sorbet.org/docs/adopting#step-2-initialize-sorbet-in-our-project