### PR TITLE
Make sorbet and tapioca optional

### DIFF
--- a/common/Gemfile
+++ b/common/Gemfile
@@ -3,3 +3,8 @@
 source "https://rubygems.org"
 
 gemspec
+
+install_if -> { RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("x86_64") } do
+  gem "sorbet", group: :development
+  gem "tapioca", require: false, group: :development
+end

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -50,9 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.3"
   spec.add_development_dependency "rubocop", "~> 1.56.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.19.0"
-  spec.add_development_dependency "sorbet", "~> 0.5"
   spec.add_development_dependency "stackprof", "~> 0.2.16"
-  spec.add_development_dependency "tapioca", "~> 0.11"
   spec.add_development_dependency "vcr", "~> 6.1"
   spec.add_development_dependency "webmock", "~> 3.18"
 


### PR DESCRIPTION
Sorbet currently doesn't support `aarch64-linux`. Unfortunately, this means that it doesn't work on Docker on macOS, unless you force `--platform=linux/amd64` or `DOCKER_DEFAULT_PLATFORM=linux/amd64`.

This change makes `sorbet` and `tapioca` only install on supported platforms for now. This means that typechecking with `srb tc` will not work on Docker on macOS. However, while it's an optional, non-enforced, part of the project this is an acceptable trade-off.

Thankfully, it looks like official support for `aarch64-linux` is extremely close to being completed. So I anticipate this workaround will be shortlived.

References:
- https://github.com/sorbet/sorbet/issues/4119
- https://github.com/sorbet/sorbet-build-image/pull/8