### PR TITLE
Add Sorbet VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,7 +10,8 @@
 		"hoovercj.ruby-linter",
 		"miguel-savignano.ruby-symbols",
 		"ms-vscode-remote.remote-containers",
-		"koichisasada.vscode-rdbg"
+		"koichisasada.vscode-rdbg",
+		"sorbet.sorbet-vscode-extension"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "Dockerfile.*": "dockerfile"
   },
   "jest.pathToJest": "${workspaceFolder}/npm_and_yarn/helpers/node_modules/.bin/jest",
-  "jest.pathToConfig": "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js"
+  "jest.pathToConfig": "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js",
+  "sorbet.enabled": true
 }

--- a/sorbet/config
+++ b/sorbet/config
@@ -3,3 +3,4 @@
 --ignore=tmp/
 --ignore=vendor/
 --ignore=updater/
+--disable-watchman


### PR DESCRIPTION
This adds and enables the [Sorbet VSCode extension][1] as outlined in [the Sorbet documetation][2].

This PR also disables Sorbet's [watchman][3] integration. That does limit Sorbet to only type-checking files that are edited in VSCode. But this would require editing the setup scripts and/or Dockerfiles. As Sorbet is still an optional part of the codebase, I think this is an acceptable trade-off for now.

Part of #7782

[1]: https://marketplace.visualstudio.com/items?itemName=sorbet.sorbet-vscode-extension
[2]: https://sorbet.org/docs/vscode
[3]: https://github.com/facebook/watchman