### PR TITLE
Actions: skip unsupported uses strings

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -46,6 +46,7 @@ module Dependabot
 
         uses_strings.each do |string|
           # TODO: Support Docker references and path references
+          next if string.start_with?(".") || string.start_with?("docker://")
           next unless string.match?(GITHUB_REPO_REFERENCE)
 
           dep = build_github_dependency(file, string)

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -215,6 +215,14 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    describe "with a local reusable workflow that has an @ in the file name" do
+      let(:workflow_file_fixture_name) { "local_workflow_with_at.yml" }
+
+      it "does not treat the path like a dependency" do
+        expect(dependencies).to eq([])
+      end
+    end
+
     describe "with composite actions" do
       let(:workflow_file_fixture_name) { "composite_action.yml" }
       let(:workflow_files) do

--- a/github_actions/spec/fixtures/workflow_files/local_workflow_with_at.yml
+++ b/github_actions/spec/fixtures/workflow_files/local_workflow_with_at.yml
@@ -1,0 +1,6 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml@v2.1.0


### PR DESCRIPTION
This fixes a bug where if you name the local reusable workflow with an `@` then the path is parsed wrong.

For example with `./.github/workflows/test.yml@v2.1.0`. The code expects either `<owner>/<repo>@<version>` or `./.github/<path>`, but this parsed as `./.github/<path>@<version>` which is wrong since the `@v2.1.0` is just a part of the path. Thus we ended up with a dependency of `owner: '.github'` which broke the update when fetching the remote file.

Since we currently don't support updating the dependencies of local paths in this way, and also we don't support updating `docker://` workflows either, I'm explicitly skipping them for now to avoid any other latent issues. 

Conveniently there was a TODO that I could put this skip right after 😄.