### PR TITLE
Add types to clients

### DIFF
--- a/common/lib/dependabot.rb
+++ b/common/lib/dependabot.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/shared_helpers"
 require "excon"
+require "sorbet-runtime"
 
 module Dependabot
   module Clients

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -7,6 +7,8 @@ require "excon"
 module Dependabot
   module Clients
     class Azure
+      extend T::Sig
+
       class NotFound < StandardError; end
 
       class InternalServerError < StandardError; end
@@ -253,8 +255,9 @@ module Dependabot
         JSON.parse(response.body).fetch("value")
       end
 
+      sig { params(url: String).returns(Excon::Response) }
       def get(url)
-        response = nil
+        response = T.let(nil, T.nilable(Excon::Response))
 
         retry_connection_failures do
           response = Excon.get(
@@ -267,20 +270,21 @@ module Dependabot
             )
           )
 
-          raise InternalServerError if response.status == 500
-          raise BadGateway if response.status == 502
-          raise ServiceNotAvailable if response.status == 503
+          raise InternalServerError if response&.status == 500
+          raise BadGateway if response&.status == 502
+          raise ServiceNotAvailable if response&.status == 503
         end
 
-        raise Unauthorized if response.status == 401
-        raise Forbidden if response.status == 403
-        raise NotFound if response.status == 404
+        raise Unauthorized if response&.status == 401
+        raise Forbidden if response&.status == 403
+        raise NotFound if response&.status == 404
 
-        response
+        T.must(response)
       end
 
-      def post(url, json)
-        response = nil
+      sig { params(url: String, json: String).returns(Excon::Response) }
+      def post(url, json) # rubocop:disable Metrics/PerceivedComplexity
+        response = T.let(nil, T.nilable(Excon::Response))
 
         retry_connection_failures do
           response = Excon.post(
@@ -298,25 +302,26 @@ module Dependabot
             )
           )
 
-          raise InternalServerError if response.status == 500
-          raise BadGateway if response.status == 502
-          raise ServiceNotAvailable if response.status == 503
+          raise InternalServerError if response&.status == 500
+          raise BadGateway if response&.status == 502
+          raise ServiceNotAvailable if response&.status == 503
         end
 
-        raise Unauthorized if response.status == 401
+        raise Unauthorized if response&.status == 401
 
-        if response.status == 403
+        if response&.status == 403
           raise TagsCreationForbidden if tags_creation_forbidden?(response)
 
           raise Forbidden
         end
-        raise NotFound if response.status == 404
+        raise NotFound if response&.status == 404
 
-        response
+        T.must(response)
       end
 
+      sig { params(url: String, json: String).returns(Excon::Response) }
       def patch(url, json)
-        response = nil
+        response = T.let(nil, T.nilable(Excon::Response))
 
         retry_connection_failures do
           response = Excon.patch(
@@ -334,16 +339,16 @@ module Dependabot
             )
           )
 
-          raise InternalServerError if response.status == 500
-          raise BadGateway if response.status == 502
-          raise ServiceNotAvailable if response.status == 503
+          raise InternalServerError if response&.status == 500
+          raise BadGateway if response&.status == 502
+          raise ServiceNotAvailable if response&.status == 503
         end
 
-        raise Unauthorized if response.status == 401
-        raise Forbidden if response.status == 403
-        raise NotFound if response.status == 404
+        raise Unauthorized if response&.status == 401
+        raise Forbidden if response&.status == 403
+        raise NotFound if response&.status == 404
 
-        response
+        T.must(response)
       end
 
       private

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"

--- a/common/lib/dependabot/clients/bitbucket_with_retries.rb
+++ b/common/lib/dependabot/clients/bitbucket_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "bitbucket"
@@ -30,7 +30,7 @@ module Dependabot
 
       def initialize(max_retries: 3, **args)
         @max_retries = max_retries || 3
-        @client = Bitbucket.new(**args)
+        @client = Bitbucket.new(**T.unsafe(args))
       end
 
       def method_missing(method_name, *args, &block)

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -6,6 +6,8 @@ require "dependabot/shared_helpers"
 module Dependabot
   module Clients
     class CodeCommit
+      extend T::Sig
+
       class NotFound < StandardError; end
 
       #######################

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "octokit"
@@ -67,7 +67,7 @@ module Dependabot
       #################
 
       def fetch_commit(repo, branch)
-        response = ref(repo, "heads/#{branch}")
+        response = T.unsafe(self).ref(repo, "heads/#{branch}")
 
         raise Octokit::NotFound if response.is_a?(Array)
 
@@ -75,7 +75,7 @@ module Dependabot
       end
 
       def fetch_default_branch(repo)
-        repository(repo).default_branch
+        T.unsafe(self).repository(repo).default_branch
       end
 
       ############

--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "gitlab"
@@ -50,11 +50,11 @@ module Dependabot
       #################
 
       def fetch_commit(repo, branch)
-        branch(repo, branch).commit.id
+        T.unsafe(self).branch(repo, branch).commit.id
       end
 
       def fetch_default_branch(repo)
-        project(repo).default_branch
+        T.unsafe(self).project(repo).default_branch
       end
 
       ############

--- a/common/lib/wildcard_matcher.rb
+++ b/common/lib/wildcard_matcher.rb
@@ -1,7 +1,10 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 class WildcardMatcher
+  extend T::Sig
+
+  sig { params(wildcard_string: T.nilable(String), candidate_string: T.nilable(String)).returns(T::Boolean) }
   def self.match?(wildcard_string, candidate_string)
     return false unless wildcard_string && candidate_string
 

--- a/sorbet/rbi/shims/array.rbi
+++ b/sorbet/rbi/shims/array.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Array
+  sig { returns(String) }
+  def to_json; end
+end

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -1,0 +1,18 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Aws
+  module CodeCommit
+    class Client
+      class << self
+        def new(*_arg0); end
+      end
+    end
+
+    module Errors
+      class BranchDoesNotExistException < Aws::Errors::ServiceError; end
+
+      class FileDoesNotExistException < Aws::Errors::ServiceError; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/aws-sdk-ecr.rbi
+++ b/sorbet/rbi/shims/aws-sdk-ecr.rbi
@@ -1,0 +1,11 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Aws
+  module ECR
+    module Errors
+      class InvalidSignatureException < Aws::Errors::ServiceError; end
+      class UnrecognizedClientException < Aws::Errors::ServiceError; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/hash.rbi
+++ b/sorbet/rbi/shims/hash.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Hash
+  sig { returns(String) }
+  def to_json; end
+end


### PR DESCRIPTION
Mainly adding `typed: true` to clients, but also includes:

- Making `dependabot.rb` and `wildcard_matcher.rb` `typed: strong` mostly as a learning experience to see what is required at that type enforcement level
- Define stubs of `to_json` for `Array` and `Hash`
- Define stubs for `AWS` errors which Sorbet is unable to determine (See [The TODO RBI file][1] for more details)
- Wrap `*_with_retries` clients with `T.unsafe` as they explicitly rely on `method_missing` which Sorbet can't deal with

#7782

[1]: https://sorbet.org/docs/rbi#the-todo-rbi-file