### PR TITLE
fix docker-dev-shell on ARM

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -25,7 +25,7 @@ gemspec path: "../terraform"
 gem "reek", group: :development
 gem "solargraph", group: :development
 
-install_if -> { RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("x86_64") } do
+if RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("x86_64")
   gem "sorbet", group: :development
   gem "tapioca", require: false, group: :development
 end


### PR DESCRIPTION
Fixes the freeze on `bundle install` when running `bin/docker-dev-shell common --rebuild ` on ARM. 

Not sure why `install_if` worked in common but doesn't work in omnibus. Plain ole `if` seems ok though!