### PR TITLE
Add back the Docker::Version.correct? method

### DIFF
--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -22,6 +22,18 @@ module Dependabot
         super(@release_part)
       end
 
+      def self.correct?(version)
+        return true if version.is_a?(Gem::Version)
+        # We can't call new here because Gem::Version calls self.correct? in its initialize method
+        # causing an infinite loop, so instead we check if the release_part of the version is correct
+        release_part, _ = version.split("_", 2)
+        release_part = release_part.sub("v", "").tr("-", ".")
+        super(release_part)
+      rescue ArgumentError
+        # if we can't instantiate a version, it can't be correct
+        false
+      end
+
       def to_semver
         @release_part.to_semver
       end

--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -24,9 +24,10 @@ module Dependabot
 
       def self.correct?(version)
         return true if version.is_a?(Gem::Version)
+
         # We can't call new here because Gem::Version calls self.correct? in its initialize method
         # causing an infinite loop, so instead we check if the release_part of the version is correct
-        release_part, _ = version.split("_", 2)
+        release_part, = version.split("_", 2)
         release_part = release_part.sub("v", "").tr("-", ".")
         super(release_part)
       rescue ArgumentError


### PR DESCRIPTION
The `#correct?` method mimics creating a new `Docker::Version` without actually instantiating one. It checks that the semver part of the `Docker::Version` is actually valid semver.

The [previous version](https://github.com/dependabot/dependabot-core/blob/e1967ef907e681817f596a99e5eb741c1de48d8a/docker/lib/dependabot/docker/version.rb#L23) of this method called `#new` and `Docker::Version#new` would call `Gem::Version#new` which would call `#correct?`, and it would get stuck in an infinite loop, so it was removed.

This PR adds in a working version of the method and there are already existing test cases for it like https://github.com/dependabot/dependabot-core/blob/7cf009180799b2c1d58f710d45b521d18853a25a/docker/spec/dependabot/docker/version_spec.rb#L30-L45