### PR TITLE
fix: call 'split' on string-type object, not on version-type object

### DIFF
--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -29,7 +29,7 @@ module Dependabot
 
       def initialize(version)
         @version_string = version.to_s
-        version, @local_version = version.split("+")
+        version, @local_version = @version_string.split("+")
         version ||= ""
         version = version.gsub(/^v/, "")
         if version.include?("!")


### PR DESCRIPTION
This hopefully fixes #8003 which exhibits the following error:

```
updater | 2023/09/14 09:33:53 ERROR <job_721897648> Error processing pytz (NoMethodError)
updater | 2023/09/14 09:33:53 ERROR <job_721897648> undefined method `split' for #<Dependabot::Python::Version 2023.3.post1>
updater | 
updater |         version, @local_version = version.split("+")
updater |                                          ^^^^^^
```

The error message is indicating that the `split` method is being called on an instance of `Dependabot::Python::Version`, not a string. The `split` method is a string method, so it cannot be called on an object of a different type unless it implements its own "split" method, which this "Version" type doesn't seem to do.

cc @carogalvin 👋 😅 sorry for pinging you here but this seems to be a showstopper for grouped dependabot PRs with Python at the moment. I started seeing this error as I added grouped dependencies like so:

```diff
version: 2

updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    registries: "*"
    schedule:
      interval: "weekly"
      day: "tuesday"
  - package-ecosystem: "pip"
+     groups:
+       production-dependencies:
+         dependency-type: "production"
+         update-types:
+           - minor
+           - patch
+       development-dependencies:
+         dependency-type: "development"
+         update-types:
+           - minor
+           - patch
    insecure-external-code-execution: allow
    directory: "/"
    registries: "*"
    schedule:
      interval: "weekly"
      day: "tuesday"
    ignore:
      - dependency-name: "dr"
    open-pull-requests-limit: 50
    allow:
      - dependency-name: "*"
        dependency-type: all
    commit-message:
      prefix: "chore"
      include: "scope"
    versioning-strategy: increase-if-necessary

registries:
  github:
    type: git
    url: https://github.com/
    username: x-access-token
    password: ${{secrets.REDACTED_TOKEN}}

  cloudsmith:
    type: python-index
    url: https://dl.cloudsmith.io/<REDACTED>/<ORG>/<REPO>/python/simple/
    replaces-base: true
```

I'm no expert in ruby, so take this PR as just an indication as to what might be wrong 😅 