### PR TITLE
Add types to clients

### DIFF
--- a/common/lib/dependabot.rb
+++ b/common/lib/dependabot.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"

--- a/common/lib/dependabot/clients/bitbucket_with_retries.rb
+++ b/common/lib/dependabot/clients/bitbucket_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require_relative "bitbucket"
@@ -30,7 +30,7 @@ module Dependabot
 
       def initialize(max_retries: 3, **args)
         @max_retries = max_retries || 3
-        @client = Bitbucket.new(**args)
+        @client = Bitbucket.new(**T.unsafe(args))
       end
 
       def method_missing(method_name, *args, &block)

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -6,6 +6,8 @@ require "dependabot/shared_helpers"
 module Dependabot
   module Clients
     class CodeCommit
+      extend T::Sig
+
       class NotFound < StandardError; end
 
       #######################

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "octokit"
@@ -67,7 +67,7 @@ module Dependabot
       #################
 
       def fetch_commit(repo, branch)
-        response = ref(repo, "heads/#{branch}")
+        response = T.unsafe(self).ref(repo, "heads/#{branch}")
 
         raise Octokit::NotFound if response.is_a?(Array)
 
@@ -75,7 +75,7 @@ module Dependabot
       end
 
       def fetch_default_branch(repo)
-        repository(repo).default_branch
+        T.unsafe(self).repository(repo).default_branch
       end
 
       ############

--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "gitlab"
@@ -50,11 +50,11 @@ module Dependabot
       #################
 
       def fetch_commit(repo, branch)
-        branch(repo, branch).commit.id
+        T.unsafe(self).branch(repo, branch).commit.id
       end
 
       def fetch_default_branch(repo)
-        project(repo).default_branch
+        T.unsafe(self).project(repo).default_branch
       end
 
       ############

--- a/common/lib/wildcard_matcher.rb
+++ b/common/lib/wildcard_matcher.rb
@@ -1,7 +1,10 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 class WildcardMatcher
+  extend T::Sig
+
+  sig { params(wildcard_string: T.nilable(String), candidate_string: T.nilable(String)).returns(T::Boolean) }
   def self.match?(wildcard_string, candidate_string)
     return false unless wildcard_string && candidate_string
 

--- a/sorbet/rbi/shims/array.rbi
+++ b/sorbet/rbi/shims/array.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Array
+  sig { returns(String) }
+  def to_json; end
+end

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -1,0 +1,18 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Aws
+  module CodeCommit
+    class Client
+      class << self
+        def new(*_arg0); end
+      end
+    end
+
+    module Errors
+      class BranchDoesNotExistException < Aws::Errors::ServiceError; end
+
+      class FileDoesNotExistException < Aws::Errors::ServiceError; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/aws-sdk-ecr.rbi
+++ b/sorbet/rbi/shims/aws-sdk-ecr.rbi
@@ -1,0 +1,11 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Aws
+  module ECR
+    module Errors
+      class InvalidSignatureException < Aws::Errors::ServiceError; end
+      class UnrecognizedClientException < Aws::Errors::ServiceError; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/hash.rbi
+++ b/sorbet/rbi/shims/hash.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Hash
+  sig { returns(String) }
+  def to_json; end
+end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -5,11 +5,6 @@
 # typed: false
 
 module ::Azure::Error::NotFound; end
-module Aws::CodeCommit::Client; end
-module Aws::CodeCommit::Errors::BranchDoesNotExistException; end
-module Aws::CodeCommit::Errors::FileDoesNotExistException; end
-module Aws::ECR::Errors::InvalidSignatureException; end
-module Aws::ECR::Errors::UnrecognizedClientException; end
 module Bundler::CompactIndexClient::Updater; end
 module Bundler::SolveFailure; end
 module Dependabot::NpmAndYarn::FileFetcher::Pysch::SyntaxError; end


### PR DESCRIPTION
Mainly adding `typed: true` to clients, but also includes:

- Making `dependabot.rb` and `wildcard_matcher.rb` `typed: strong` mostly as a learning experience to see what is required at that type enforcement level
- Define stubs of `to_json` for `Array` and `Hash`
- Define stubs for `AWS` errors which Sorbet is unable to determine (See [The TODO RBI file][1] for more details)
- Wrap `*_with_retries` clients with `T.unsafe` as they explicitly rely on `method_missing` which Sorbet can't deal with

Related to #7782. Supersedes #8028 (as I created that from the `main` branch of my fork 🤦)

[1]: https://sorbet.org/docs/rbi#the-todo-rbi-file