### PR TITLE
Add types to requirement classes

### DIFF
--- a/bundler/lib/dependabot/bundler/requirement.rb
+++ b/bundler/lib/dependabot/bundler/requirement.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
@@ -6,15 +6,19 @@ require "dependabot/utils"
 module Dependabot
   module Bundler
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       # For consistency with other languages, we define a requirements array.
       # Ruby doesn't have an `OR` separator for requirements, so it always
       # contains a single element.
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::Bundler::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)

--- a/common/lib/dependabot/utils.rb
+++ b/common/lib/dependabot/utils.rb
@@ -1,18 +1,24 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "tmpdir"
 require "set"
+require "sorbet-runtime"
+
+require "dependabot/version"
 
 # TODO: in due course, these "registries" should live in a wrapper gem, not
 #       dependabot-core.
 module Dependabot
   module Utils
+    extend T::Sig
+
     BUMP_TMP_FILE_PREFIX = "dependabot_"
-    BUMP_TMP_DIR_PATH = File.expand_path(Dir::Tmpname.create("", "tmp") { nil })
+    BUMP_TMP_DIR_PATH = T.let(File.expand_path(Dir::Tmpname.create("", "tmp") { nil }), String)
 
-    @version_classes = {}
+    @version_classes = T.let({}, T::Hash[String, T.class_of(Dependabot::Version)])
 
+    sig { params(package_manager: String).returns(T.class_of(Dependabot::Version)) }
     def self.version_class_for_package_manager(package_manager)
       version_class = @version_classes[package_manager]
       return version_class if version_class
@@ -20,12 +26,14 @@ module Dependabot
       raise "Unsupported package_manager #{package_manager}"
     end
 
+    sig { params(package_manager: String, version_class: T.class_of(Dependabot::Version)).void }
     def self.register_version_class(package_manager, version_class)
       @version_classes[package_manager] = version_class
     end
 
-    @requirement_classes = {}
+    @requirement_classes = T.let({}, T::Hash[String, T.class_of(Gem::Requirement)])
 
+    sig { params(package_manager: String).returns(T.class_of(Gem::Requirement)) }
     def self.requirement_class_for_package_manager(package_manager)
       requirement_class = @requirement_classes[package_manager]
       return requirement_class if requirement_class
@@ -33,16 +41,19 @@ module Dependabot
       raise "Unsupported package_manager #{package_manager}"
     end
 
+    sig { params(package_manager: String, requirement_class: T.class_of(Gem::Requirement)).void }
     def self.register_requirement_class(package_manager, requirement_class)
       @requirement_classes[package_manager] = requirement_class
     end
 
-    @cloning_package_managers = Set[]
+    @cloning_package_managers = T.let(Set[], T::Set[String])
 
+    sig { params(package_manager: String).returns(T::Boolean) }
     def self.always_clone_for_package_manager?(package_manager)
       @cloning_package_managers.include?(package_manager)
     end
 
+    sig { params(package_manager: String).void }
     def self.register_always_clone(package_manager)
       @cloning_package_managers << package_manager
     end

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,8 +1,11 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot
   class Version < Gem::Version
+    extend T::Sig
+
+    sig { override.params(version: String).void }
     def initialize(version)
       @original_version = version
 
@@ -10,12 +13,14 @@ module Dependabot
     end
 
     # Opt-in to Rubygems 4 behavior
+    sig { override.params(version: Object).returns(T::Boolean) }
     def self.correct?(version)
       return false if version.nil?
 
       version.to_s.match?(ANCHORED_VERSION_PATTERN)
     end
 
+    sig { returns(String) }
     def to_semver
       @original_version
     end

--- a/docker/lib/dependabot/docker/requirement.rb
+++ b/docker/lib/dependabot/docker/requirement.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/utils"
@@ -7,19 +7,23 @@ module Dependabot
   module Docker
     # Lifted from the bundler package manager
     class Requirement < Gem::Requirement
+      extend T::Sig
       # For consistency with other languages, we define a requirements array.
       # Ruby doesn't have an `OR` separator for requirements, so it always
       # contains a single element.
+      sig { params(requirement_string: String).returns([Dependabot::Docker::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
 
+      sig { override.params(version: Dependabot::Docker::Version).returns(T::Boolean) }
       def satisfied_by?(version)
         super(version.release_part)
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)

--- a/git_submodules/lib/dependabot/git_submodules/requirement.rb
+++ b/git_submodules/lib/dependabot/git_submodules/requirement.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
@@ -6,15 +6,19 @@ require "dependabot/utils"
 module Dependabot
   module GitSubmodules
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       # For consistency with other languages, we define a requirements array.
       # Ruby doesn't have an `OR` separator for requirements, so it always
       # contains a single element.
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::GitSubmodules::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)

--- a/github_actions/lib/dependabot/github_actions/requirement.rb
+++ b/github_actions/lib/dependabot/github_actions/requirement.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
@@ -8,15 +8,19 @@ module Dependabot
   module GithubActions
     # Lifted from the bundler package manager
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       # For consistency with other languages, we define a requirements array.
       # Ruby doesn't have an `OR` separator for requirements, so it always
       # contains a single element.
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::GithubActions::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)

--- a/gradle/lib/dependabot/gradle/requirement.rb
+++ b/gradle/lib/dependabot/gradle/requirement.rb
@@ -1,5 +1,7 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
+
+require "sorbet-runtime"
 
 require "dependabot/utils"
 require "dependabot/maven/requirement"
@@ -8,10 +10,13 @@ require "dependabot/gradle/version"
 module Dependabot
   module Gradle
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       quoted = OPS.keys.map { |k| Regexp.quote k }.join("|")
-      PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{Gradle::Version::VERSION_PATTERN})\\s*".freeze
+      PATTERN_RAW = T.let("\\s*(#{quoted})?\\s*(#{Gradle::Version::VERSION_PATTERN})\\s*".freeze, String)
       PATTERN = /\A#{PATTERN_RAW}\z/
 
+      sig { override.params(obj: Object).returns(T::Array[T.any(String, Dependabot::Gradle::Version)]) }
       def self.parse(obj)
         return ["=", Gradle::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
@@ -25,12 +30,14 @@ module Dependabot
         [matches[1] || "=", Gradle::Version.new(matches[2])]
       end
 
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::Gradle::Requirement]) }
       def self.requirements_array(requirement_string)
         split_java_requirement(requirement_string).map do |str|
           new(str)
         end
       end
 
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           convert_java_constraint_to_ruby_constraint(req_string)
@@ -39,6 +46,7 @@ module Dependabot
         super(requirements)
       end
 
+      sig { override.params(version: T.any(String, Dependabot::Gradle::Version)).returns(T::Boolean) }
       def satisfied_by?(version)
         version = Gradle::Version.new(version.to_s)
         super
@@ -46,6 +54,7 @@ module Dependabot
 
       private
 
+      sig { params(req_string: String).returns(T::Array[String]) }
       def self.split_java_requirement(req_string)
         return [req_string] unless req_string.match?(Maven::Requirement::OR_SYNTAX)
 
@@ -53,11 +62,12 @@ module Dependabot
           next str if str.start_with?("(", "[")
 
           exacts, *rest = str.split(/,(?=\[|\()/)
-          [*exacts.split(","), *rest]
+          [*exacts&.split(","), *rest]
         end
       end
       private_class_method :split_java_requirement
 
+      sig { params(req_string: T.nilable(String)).returns(T.nilable(T.any(String, T::Array[T.nilable(String)]))) }
       def convert_java_constraint_to_ruby_constraint(req_string)
         return unless req_string
 
@@ -75,26 +85,28 @@ module Dependabot
         end
       end
 
-      def convert_java_range_to_ruby_range(req_string)
+      sig { params(req_string: String).returns(T.any(T::Array[String], String)) }
+      def convert_java_range_to_ruby_range(req_string) # rubocop:disable Metrics/PerceivedComplexity
         lower_b, upper_b = req_string.split(",").map(&:strip)
 
         lower_b =
           if ["(", "["].include?(lower_b) then nil
-          elsif lower_b.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
+          elsif lower_b&.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
           else
-            ">= #{lower_b.sub(/\[\s*/, '').strip}"
+            ">= #{lower_b&.sub(/\[\s*/, '')&.strip}"
           end
 
         upper_b =
           if [")", "]"].include?(upper_b) then nil
-          elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
+          elsif upper_b&.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
           else
-            "<= #{upper_b.sub(/\s*\]/, '').strip}"
+            "<= #{upper_b&.sub(/\s*\]/, '')&.strip}"
           end
 
         [lower_b, upper_b].compact
       end
 
+      sig { params(req_string: T.nilable(String)).returns(T.nilable(String)) }
       def convert_java_equals_req_to_ruby(req_string)
         return convert_wildcard_req(req_string) if req_string&.include?("+")
 
@@ -104,6 +116,7 @@ module Dependabot
         req_string.gsub(/[\[\]\(\)]/, "")
       end
 
+      sig { params(req_string: String).returns(String) }
       def convert_wildcard_req(req_string)
         version = req_string.split("+").first
         return ">= 0" if version.nil? || version.empty?

--- a/hex/lib/dependabot/hex/requirement.rb
+++ b/hex/lib/dependabot/hex/requirement.rb
@@ -1,34 +1,43 @@
 # typed: true
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/utils"
 require "dependabot/hex/version"
 
 module Dependabot
   module Hex
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       AND_SEPARATOR = /\s+and\s+/
       OR_SEPARATOR = /\s+or\s+/
 
       # Add the double-equality matcher to the list of allowed operations
-      OPS = OPS.merge("==" => ->(v, r) { v == r })
+      OPS = T.let(
+        OPS.merge("==" => ->(v, r) { v == r }),
+        T::Hash[String, T.proc.params(v: Hex::Version, r: Hex::Version).returns(T::Boolean)]
+      )
 
       # Override the version pattern to allow local versions
       quoted = OPS.keys.map { |k| Regexp.quote k }.join "|"
-      PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{Hex::Version::VERSION_PATTERN})\\s*".freeze
+      PATTERN_RAW = T.let("\\s*(#{quoted})?\\s*(#{Hex::Version::VERSION_PATTERN})\\s*".freeze, String)
       PATTERN = /\A#{PATTERN_RAW}\z/
 
       # Returns an array of requirements. At least one requirement from the
       # returned array must be satisfied for a version to be valid.
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::Hex::Requirement]) }
       def self.requirements_array(requirement_string)
         requirement_string.strip.split(OR_SEPARATOR).map do |req_string|
           requirements = req_string.strip.split(AND_SEPARATOR)
-          new(requirements)
+          new(T.unsafe(requirements))
         end
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)
@@ -38,6 +47,7 @@ module Dependabot
       end
 
       # Override the parser to create Hex::Versions
+      sig { override.params(obj: Object).returns([String, Dependabot::Hex::Version]) }
       def self.parse(obj)
         return ["=", Hex::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
@@ -51,10 +61,11 @@ module Dependabot
         [matches[1] || "=", Hex::Version.new(matches[2])]
       end
 
+      sig { override.params(version: T.any(String, Dependabot::Hex::Version)).returns(T::Boolean) }
       def satisfied_by?(version)
         version = Hex::Version.new(version.to_s)
 
-        requirements.all? { |op, rv| (OPS[op] || OPS["="]).call(version, rv) }
+        requirements.all? { |op, rv| T.unsafe(OPS[op] || OPS["="]).call(version, rv) }
       end
     end
   end

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/logger"
 require "dependabot/python/version"
 
@@ -58,7 +60,7 @@ module Dependabot
 
         # Try to match one of our pre-installed Python versions
         requirement = Python::Requirement.requirements_array(requirement_string).first
-        version = PRE_INSTALLED_PYTHON_VERSIONS.find { |v| requirement.satisfied_by?(Python::Version.new(v)) }
+        version = PRE_INSTALLED_PYTHON_VERSIONS.find { |v| T.unsafe(requirement).satisfied_by?(Python::Version.new(v)) }
         return version if version
 
         # Otherwise we have to raise

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -7,6 +7,8 @@ require "dependabot/swift/requirement"
 module Dependabot
   module Swift
     class NativeRequirement
+      extend T::Sig
+
       # TODO: Support pinning to specific revisions
       REGEXP = /(from.*|\.upToNextMajor.*|\.upToNextMinor.*|".*"\s*\.\.[\.<]\s*".*"|exact.*|\.exact.*)/
 
@@ -41,7 +43,7 @@ module Dependabot
 
         @min = min
         @max = max
-        @requirement = Requirement.new(constraint)
+        @requirement = Requirement.new(T.unsafe(constraint))
       end
 
       def to_s
@@ -66,6 +68,7 @@ module Dependabot
 
       private
 
+      sig { params(declaration: String).returns([String, String]) }
       def parse_declaration(declaration)
         if up_to_next_major?
           min = declaration.gsub(/\Afrom\s*:\s*"(\S+)"\s*\z/, '\1')

--- a/swift/lib/dependabot/swift/requirement.rb
+++ b/swift/lib/dependabot/swift/requirement.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
@@ -6,15 +6,19 @@ require "dependabot/utils"
 module Dependabot
   module Swift
     class Requirement < Gem::Requirement
+      extend T::Sig
+
       # For consistency with other languages, we define a requirements array.
       # Swift doesn't have an `OR` separator for requirements, so it
       # always contains a single element.
+      sig { params(requirement_string: String).returns(T::Array[Dependabot::Swift::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      sig { override.params(requirements: String).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
           req_string.split(",").map(&:strip)


### PR DESCRIPTION
Part of #7782 

I stopped adding safe navigation operators (`&.`) and type assertions ([`T.must`][1]) and started using the escape hatch ([`T.unsafe`][2]). Mainly because I am unsure what the expected behaviour is supposed to be in. My main goal with this project is to get as much as possible to as high a type checking level as possible. `T.unsafe` can be dealt with at a later date when attempting to get to [`strong`][3].

[1]: https://sorbet.org/docs/type-assertions#tmust
[2]: https://sorbet.org/docs/troubleshooting#tunsafe
[3]: https://sorbet.org/docs/static#file-level-granularity-strictness-levels