### PR TITLE
Bump RUBY_VERSIONS to include 3.1.4 and 3.2.2

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -12,7 +12,7 @@ module Dependabot
         class RubyVersionNotFound < StandardError; end
 
         RUBY_VERSIONS = %w(
-          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.3 3.2.0
+          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.4 3.2.2
         ).freeze
 
         attr_reader :gemspec

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content
         end
-        it { is_expected.to include("ruby '3.1.3'\n") }
+        it { is_expected.to include("ruby '3.1.4'\n") }
         it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
       end
 
@@ -122,7 +122,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content
         end
-        it { is_expected.to include("ruby '3.2.0'\n") }
+        it { is_expected.to include("ruby '3.2.2'\n") }
         it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
       end
 


### PR DESCRIPTION
Closes: https://github.com/dependabot/dependabot-core/issues/8040

I am getting an error Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound for a project that has a ruby version requirement for 3.2.2 This PR bumps the expected RUBY_VERSIONS to include the latest for [Ruby 3.1](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/) and [Ruby 3.2.2](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/)

Ran tests locally and passed
<img width="775" alt="image" src="https://github.com/dependabot/dependabot-core/assets/19719/1da985c5-048f-4e04-b05c-6eda4909edc2">
