### PR TITLE
raise if the reference already exists

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -247,7 +247,6 @@ module Dependabot
           @branch_name = ref.gsub(%r{^refs/heads/}, "")
           branch
         rescue Octokit::UnprocessableEntity => e
-          # Return quietly in the case of a race
           raise if e.message.match?(/Reference already exists/i)
 
           retrying_branch_creation ||= false

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -248,7 +248,7 @@ module Dependabot
           branch
         rescue Octokit::UnprocessableEntity => e
           # Return quietly in the case of a race
-          return nil if e.message.match?(/Reference already exists/i)
+          raise if e.message.match?(/Reference already exists/i)
 
           retrying_branch_creation ||= false
           raise if retrying_branch_creation


### PR DESCRIPTION
This was missed in #8013.

Currently it returns `nil` but then raises an UnexpectedError.