### PR TITLE
Generate and upload spoom coverage report on main

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -26,19 +26,19 @@ jobs:
 
       - run: bundle exec spoom coverage timeline --save
 
-      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      - uses: actions/upload-artifact@v3
+      - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v3
         with:
           name: spoom_data
           path: ./spoom_data/
 
-      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      - run: ./script/generate-coverage-report
+      - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: ./script/generate-coverage-report
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      - uses: actions/upload-artifact@v3
+      - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v3
         with:
           name: spoom_report
           path: ./spoom_report.html

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -26,7 +26,19 @@ jobs:
 
       - run: bundle exec spoom coverage timeline --save
 
+      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       - uses: actions/upload-artifact@v3
         with:
           name: spoom_data
           path: ./spoom_data/
+
+      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      - run: ./script/generate-coverage-report
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: spoom_report
+          path: ./spoom_report.html

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage/
 .rdbg_history
 # Ignore Jetbrains IntelliJ project-config directory
 .idea/
+# Ignore spoom coverage report
+spoom_data/
+spoom_report.html

--- a/script/generate-coverage-report
+++ b/script/generate-coverage-report
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+total_snapshots=$(gh api -X GET /repos/dependabot/dependabot-core/actions/artifacts -f name=spoom_data -f per_page=100)
+echo "$(jq -r '.total_count' <<< "$total_snapshots")" snapshots found in total
+
+main_snapshots=$(jq -r '.artifacts[] | select(.name == "spoom_data" and .workflow_run.head_branch == "main") | .id' <<< "$total_snapshots")
+echo "$(wc -w <<< "$main_snapshots")" snapshots found on main branch
+
+for id in $main_snapshots; do
+  gh api /repos/dependabot/dependabot-core/actions/artifacts/"$id" | \
+    jq -r '.archive_download_url' | \
+    xargs gh api -X GET > spoom_data.zip && \
+    unzip -qq -o spoom_data.zip -d spoom_data && \
+    rm spoom_data.zip
+done
+
+echo Download complete
+
+echo Generating coverage report
+bundle exec spoom coverage report


### PR DESCRIPTION
Two changes:

- Only upload spoom snapshot data on `main` branch
  - We don't ultimately care about snapshots taken on PRs until they are merged
- Generate the HTML report when running on `main` branch
  - Allows us to easily see progress

[Successful run][1]

[1]: https://github.com/dependabot/dependabot-core/actions/runs/6202656407?pr=8047