### PR TITLE
Update Sorbet from `0.5.11011` to `0.5.11026`

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", ">= 4.6", "< 7.0"
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "psych", "~> 5.0"
-  spec.add_dependency "sorbet-runtime", "~> 0.5"
+  spec.add_dependency "sorbet-runtime", "~> 0.5.11026"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
   spec.add_development_dependency "debug", "~> 1.8.0"

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -25,6 +25,9 @@ gemspec path: "../terraform"
 gem "reek", group: :development
 gem "solargraph", group: :development
 
+# Sorbet
+# This conditional is necessary because Sorbet does not support aarch64-linux (Docker on Apple Silicon) yet.
+# See https://github.com/sorbet/sorbet/issues/4119
 if RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("x86_64")
   gem "sorbet", group: :development
   gem "tapioca", require: false, group: :development

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
       octokit (>= 4.6, < 7.0)
       parser (>= 2.5, < 4.0)
       psych (~> 5.0)
-      sorbet-runtime (~> 0.5)
+      sorbet-runtime (~> 0.5.11026)
       toml-rb (>= 1.1.2, < 3.0)
 
 PATH
@@ -283,7 +283,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
-    sorbet-runtime (0.5.11011)
+    sorbet-runtime (0.5.11026)
     stringio (3.0.6)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)


### PR DESCRIPTION
This changes the version range of `sorbet-runtime` from `~> 0.5` (AKA `>= 0.5, < 0.6`) to `~> 0.5.11026` (AKA `>= 0.5.11026`). This supersedes #8048.

I also added a comment about why `sorbet` and `tapioca` are currently guarded by a conditional. Hopefully we can remove it in the near future.