### PR TITLE
Respect style of each action when mixed styles are used

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -24,12 +24,13 @@ module Dependabot
 
     def initialize(dependency:, credentials:,
                    ignored_versions: [], raise_on_ignored: false,
-                   consider_version_branches_pinned: false)
+                   consider_version_branches_pinned: false, dependency_source_details: nil)
       @dependency = dependency
       @credentials = credentials
       @ignored_versions = ignored_versions
       @raise_on_ignored = raise_on_ignored
       @consider_version_branches_pinned = consider_version_branches_pinned
+      @dependency_source_details = dependency_source_details
     end
 
     def git_dependency?
@@ -160,7 +161,7 @@ module Dependabot
     end
 
     def dependency_source_details
-      dependency.source_details(allowed_types: ["git"])
+      @dependency_source_details || dependency.source_details(allowed_types: ["git"])
     end
 
     private

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -40,15 +40,17 @@ module Dependabot
         dependency.requirements.map do |req|
           next req unless updated
 
+          source = req[:source]
+          current = source[:ref]
+
           # Maintain a short git hash only if it matches the latest
           if req[:type] == "git" &&
              updated.match?(/^[0-9a-f]{6,40}$/) &&
-             req[:ref]&.match?(/^[0-9a-f]{6,40}$/) &&
-             updated.start_with?(req[:ref])
+             current.match?(/^[0-9a-f]{6,40}$/) &&
+             updated.start_with?(current)
             next req
           end
 
-          source = req[:source]
           new_source = source.merge(ref: updated)
           req.merge(source: new_source)
         end

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -913,7 +913,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           source: {
             type: "git",
             url: "https://github.com/actions/checkout",
-            ref: "v3.5.2",
+            ref: "master",
             branch: nil
           }
         }]


### PR DESCRIPTION
Fixes #7971.

For example, on https://github.com/getlogbook/logbook:

#### Before

    ± .github/workflows/wheel-builder.yml
    ~~~
    --- /tmp/original20230919-234-sgikwf	2023-09-19 17:36:17.144755893 +0000
    +++ /tmp/updated20230919-234-cdm607	2023-09-19 17:36:17.144755893 +0000
    @@ -25,7 +25,7 @@
         name: Build sdist
         runs-on: ubuntu-latest
         steps:
    -      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
    +      - uses: actions/checkout@v4 # v3.5.3
             with:
               # The tag to build or the tag received by the tag event
               ref: ${{ github.event.inputs.version || github.ref }}
    @@ -50,7 +50,7 @@
             os: [ubuntu-20.04, windows-2019, macos-11]
     
         steps:
    -      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
    +      - uses: actions/checkout@v4 # v3.5.3
             with:
               # The tag to build or the tag received by the tag event
               ref: ${{ github.event.inputs.version || github.ref }}
    ~~~
    3 insertions (+), 3 deletions (-)

#### After

    ± .github/workflows/wheel-builder.yml
    ~~~
    --- /tmp/original20230919-213-acjvhd	2023-09-19 17:35:11.844596815 +0000
    +++ /tmp/updated20230919-213-juz0p3	2023-09-19 17:35:11.844596815 +0000
    @@ -25,7 +25,7 @@
         name: Build sdist
         runs-on: ubuntu-latest
         steps:
    -      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
    +      - uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9 # v4.5.4
             with:
               # The tag to build or the tag received by the tag event
               ref: ${{ github.event.inputs.version || github.ref }}
    @@ -50,7 +50,7 @@
             os: [ubuntu-20.04, windows-2019, macos-11]
     
         steps:
    -      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
    +      - uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9 # v4.5.4
             with:
               # The tag to build or the tag received by the tag event
               ref: ${{ github.event.inputs.version || github.ref }}
    ~~~
    3 insertions (+), 3 deletions (-)