### PR TITLE
💅 Use defaults instead of comments for documentation

### DIFF
--- a/sorbet/tapioca/config.yml
+++ b/sorbet/tapioca/config.yml
@@ -1,13 +1,6 @@
 gem:
-  # Add your `gem` command parameters here:
-  #
-  # exclude:
-  # - gem_name
-  # doc: true
-  # workers: 5
+  doc: true
+  exclude: []
 dsl:
-  # Add your `dsl` command parameters here:
-  #
-  # exclude:
-  # - SomeGeneratorName
-  # workers: 5
+  exclude: []
+  workers: 2


### PR DESCRIPTION
The documentation that was generated when this was installed has been causing warnings to be added to PR diffs. These values are defaults, which seem to be just as helpful as the comments which were added.

[Source for defaults](https://github.com/Shopify/tapioca/blob/fa61b834119d4a9dc0643862d4ad4804225b0ab9/README.md?plain=1#L879-L935)

This is meant to address 👇 warnings 
<img width="638" alt="image" src="https://github.com/dependabot/dependabot-core/assets/5278382/e30a20a8-da29-4e49-8c32-3811d75e1e0d">
