### PR TITLE
Fix encoding changes when truncating PR descriptions

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -85,7 +85,7 @@ module Dependabot
           msg = (msg[0..trunc_length] + tr_msg)
         end
         # if we used a custom encoding for calculating length, then we need to force back to UTF-8
-        msg.force_encoding(Encoding::UTF_8) unless pr_message_encoding.nil?
+        msg = msg.encode("utf-8", "binary", invalid: :replace, undef: :replace) unless pr_message_encoding.nil?
         msg
       end
 


### PR DESCRIPTION
This is a recreation of #7140 but with changes from #7487 and simpler tests.

When truncating the PR descriptions for Azure, the string is converted from UTF-8 to UTF-16, operated on then changed back to UTF-8. The last step fails resulting in a string with an invalid string that cannot be converted to JSON for the request body and the PR cannot be created.

This PR changes from `force_encoding(...)` to `encode(...)` which seems to solve the problem.
The spec I have added fails when using `force_encoding(..)` but works with `encode(...)` as guided by some [Stack Overflow post](https://stackoverflow.com/a/10466273). The issue shows up when converting to JSON using `to_json` so the spec is modified to test exactly that.

This should fix https://github.com/tinglesoftware/dependabot-azure-devops/issues/730