### PR TITLE
Removed logging of commands from Subprocess failure

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -82,7 +82,6 @@ module Dependabot
     end
 
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def self.run_helper_subprocess(command:, function:, args:, env: nil,
                                    stderr_to_stdout: false,
                                    allow_unsafe_shell_command: false)
@@ -131,21 +130,20 @@ module Dependabot
       return response["result"] if process.success?
 
       raise HelperSubprocessFailed.new(
-        message: "#{response['error']} failed with command (#{error_context[:command]})",
+        message: response["error"],
         error_class: response["error_class"],
         error_context: error_context,
         trace: response["trace"]
       )
     rescue JSON::ParserError
       raise HelperSubprocessFailed.new(
-        message: stdout.empty? ? "No output from command (#{error_context[:command]})" : stdout,
+        message: stdout || "No output from command",
         error_class: "JSON::ParserError",
         error_context: error_context
       )
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
+    # rubocop:enable Metrics/MethodLength
     def self.check_out_of_memory_error(stderr, error_context)
       return unless stderr&.include?("JavaScript heap out of memory")
 


### PR DESCRIPTION
Removing logging of the command during Subprocess failure. This might contain PII info and since this data is displayed during Dependabot job logs (during failure/exception) so removing it. 