### PR TITLE
Improve running specs

### DIFF
--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,7 +3,7 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose
 
 # NOTE: Don't use `if` branches without `else` part, since the code in some of
 # then seems to not abort the script regardless of `set -e`

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,7 +3,7 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose
 
 # NOTE: Don't use `if` branches without `else` part, since the code in some of
 # then seems to not abort the script regardless of `set -e`

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,7 +3,7 @@
 set -e
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose
 
 # NOTE: Don't use `if` branches without `else` part, since the code in some of
 # then seems to not abort the script regardless of `set -e`

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "debug", "~> 1.8.0"
   spec.add_development_dependency "gpgme", "~> 2.0"
-  spec.add_development_dependency "parallel_tests", "~> 4.2.0"
   spec.add_development_dependency "rake", "~> 13"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "rspec-its", "~> 1.3"
@@ -52,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.19.0"
   spec.add_development_dependency "rubocop-sorbet", "~> 0.7.3"
   spec.add_development_dependency "stackprof", "~> 0.2.16"
+  spec.add_development_dependency "turbo_tests", "~> 2.2.0"
   spec.add_development_dependency "vcr", "~> 6.1"
   spec.add_development_dependency "webmock", "~> 3.18"
 

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -4,7 +4,7 @@ set -e
 
 bundle install
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose
 
 # Should we only run these on one of the CI_NODE_INDEX's?
 cd /opt/npm_and_yarn && npm run lint && cd -

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -4,7 +4,7 @@ set -e
 
 bundle install
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose
 
 # Should we only run these on one of the CI_NODE_INDEX's?
 cd /opt/npm_and_yarn && npm run lint && cd -

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -4,7 +4,7 @@ set -e
 
 bundle install
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose
 
 # Should we only run these on one of the CI_NODE_INDEX's?
 cd /opt/npm_and_yarn && npm run lint && cd -

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -5,4 +5,4 @@ set -e
 pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -5,4 +5,4 @@ set -e
 pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -5,4 +5,4 @@ set -e
 pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose

--- a/swift/script/ci-test
+++ b/swift/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose

--- a/swift/script/ci-test
+++ b/swift/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_rspec spec/ --verbose
+bundle exec turbo_tests --verbose

--- a/swift/script/ci-test
+++ b/swift/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --group-by filesize --type rspec --verbose
+bundle exec parallel_test spec/ --type rspec --verbose

--- a/swift/script/ci-test
+++ b/swift/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec parallel_test spec/ --type rspec --verbose
+bundle exec parallel_rspec spec/ --verbose


### PR DESCRIPTION
[Turbo Tests](https://github.com/serpapi/turbo_tests) is a parallel_tests drop-in replacement that changes the default output to look exactly the same as plain RSpec.

It makes it easier to inspect failures at the end of the output instead of being interleaved.