### PR TITLE
Bypass review decision for explicitly requested builds

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -65,6 +65,14 @@ jobs:
           DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
           echo "Review decision is: $DECISION"
           echo "DECISION=$DECISION" >> $GITHUB_ENV
+        if: github.event_name != 'workflow_dispatch'
+
+        # sets DECISION to approved if building image was explicitly requested
+      - name: Bypass review decision when workflow was triggered explicitly
+        run: |
+          echo "Review decision bypassed since build was explicitly requested"
+          echo "DECISION=APPROVED:OPEN" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_dispatch'
 
       # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
       - name: Skip forks


### PR DESCRIPTION
I'd like to try #8094 in staging, but currently I'd need someone to "dummy-approve" it for me so that the updater images are uploaded. If I do this, the review loses its point.

Would it make sense to not require an approval if I explicitly trigger the workflow to build updater images?