### PR TITLE
Fix some github actions version comments not getting updated

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -164,6 +164,14 @@ module Dependabot
       @dependency_source_details || dependency.source_details(allowed_types: ["git"])
     end
 
+    def most_specific_version_tag_for_sha(commit_sha)
+      tags = local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
+                       .sort_by { |t| version_class.new(t.name) }
+      return if tags.empty?
+
+      tags[-1].name
+    end
+
     private
 
     attr_reader :dependency, :credentials, :ignored_versions
@@ -187,14 +195,6 @@ module Dependabot
 
     def precision(version)
       version.split(".").length
-    end
-
-    def most_specific_version_tag_for_sha(commit_sha)
-      tags = local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
-                       .sort_by { |t| version_class.new(t.name) }
-      return if tags.empty?
-
-      tags[-1].name
     end
 
     def allowed_versions(local_tags)

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -66,7 +66,11 @@ module Dependabot
     end
 
     def pinned_ref_looks_like_commit_sha?
-      ref_looks_like_commit_sha?(ref)
+      return false unless ref && ref_looks_like_commit_sha?(ref)
+
+      return false unless pinned?
+
+      local_repo_git_metadata_fetcher.head_commit_for_ref(ref).nil?
     end
 
     def head_commit_for_pinned_ref
@@ -74,11 +78,7 @@ module Dependabot
     end
 
     def ref_looks_like_commit_sha?(ref)
-      return false unless ref&.match?(/^[0-9a-f]{6,40}$/)
-
-      return false unless pinned?
-
-      local_repo_git_metadata_fetcher.head_commit_for_ref(ref).nil?
+      ref.match?(/^[0-9a-f]{6,40}$/)
     end
 
     def branch_or_ref_in_release?(version)

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -60,6 +60,7 @@ module Dependabot
           # TODO: Support updating Docker sources
           next unless new_req.fetch(:source).fetch(:type) == "git"
 
+          old_ref = old_req.fetch(:source).fetch(:ref)
           new_ref = new_req.fetch(:source).fetch(:ref)
 
           old_declaration = old_req.fetch(:metadata).fetch(:declaration_string)
@@ -81,7 +82,7 @@ module Dependabot
             ) do |match|
               comment = Regexp.last_match(:comment)
               match.gsub!(old_declaration, new_declaration)
-              if comment && (updated_comment = updated_version_comment(comment, new_ref))
+              if comment && (updated_comment = updated_version_comment(comment, old_ref, new_ref))
                 match.gsub!(comment, updated_comment)
               end
               match
@@ -91,17 +92,24 @@ module Dependabot
         updated_content
       end
 
-      def updated_version_comment(comment, new_ref)
+      def updated_version_comment(comment, old_ref, new_ref)
         raise "No comment!" unless comment
 
         comment = comment.rstrip
-        return unless dependency.previous_version && dependency.version
-        return unless comment.end_with? dependency.previous_version
-
         git_checker = Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials)
-        return unless git_checker.ref_looks_like_commit_sha?(new_ref)
+        return unless git_checker.ref_looks_like_commit_sha?(old_ref)
 
-        comment.gsub(dependency.previous_version, dependency.version)
+        previous_version_tag = git_checker.most_specific_version_tag_for_sha(old_ref)
+        previous_version = version_class.new(previous_version_tag).to_s
+        return unless comment.end_with? previous_version
+
+        new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
+        new_version = version_class.new(new_version_tag).to_s
+        comment.gsub(previous_version, new_version)
+      end
+
+      def version_class
+        GithubActions::Version
       end
     end
   end

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -60,10 +60,12 @@ module Dependabot
           # TODO: Support updating Docker sources
           next unless new_req.fetch(:source).fetch(:type) == "git"
 
+          new_ref = new_req.fetch(:source).fetch(:ref)
+
           old_declaration = old_req.fetch(:metadata).fetch(:declaration_string)
           new_declaration =
             old_declaration
-            .gsub(/@.*+/, "@#{new_req.fetch(:source).fetch(:ref)}")
+            .gsub(/@.*+/, "@#{new_ref}")
 
           # Replace the old declaration that's preceded by a non-word character
           # and followed by a whitespace character (comments) or EOL.
@@ -79,7 +81,7 @@ module Dependabot
             ) do |match|
               comment = Regexp.last_match(:comment)
               match.gsub!(old_declaration, new_declaration)
-              if comment && (updated_comment = updated_version_comment(comment, new_req))
+              if comment && (updated_comment = updated_version_comment(comment, new_ref))
                 match.gsub!(comment, updated_comment)
               end
               match
@@ -89,7 +91,7 @@ module Dependabot
         updated_content
       end
 
-      def updated_version_comment(comment, new_req)
+      def updated_version_comment(comment, new_ref)
         raise "No comment!" unless comment
 
         comment = comment.rstrip
@@ -97,7 +99,7 @@ module Dependabot
         return unless comment.end_with? dependency.previous_version
 
         git_checker = Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials)
-        return unless git_checker.ref_looks_like_commit_sha?(new_req.fetch(:source).fetch(:ref))
+        return unless git_checker.ref_looks_like_commit_sha?(new_ref)
 
         comment.gsub(dependency.previous_version, dependency.version)
       end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -44,8 +44,8 @@ module Dependabot
 
           # Maintain a short git hash only if it matches the latest
           if req[:type] == "git" &&
-             updated.match?(/^[0-9a-f]{6,40}$/) &&
-             current.match?(/^[0-9a-f]{6,40}$/) &&
+             git_commit_checker.ref_looks_like_commit_sha?(updated) &&
+             git_commit_checker.ref_looks_like_commit_sha?(current) &&
              updated.start_with?(current)
             next req
           end

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -6,6 +6,7 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/source"
 require "dependabot/github_actions/file_updater"
+require "dependabot/github_actions/version"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::GithubActions::FileUpdater do

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -315,12 +315,13 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         let(:workflow_file_body) do
           fixture("workflow_files", "pinned_sources_version_comments.yml")
         end
+        let(:previous_version) { "2.1.0" }
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "actions/checkout",
             version: "2.2.0",
             package_manager: "github_actions",
-            previous_version: "2.1.0",
+            previous_version: previous_version,
             previous_requirements: [{
               requirement: nil,
               groups: [],
@@ -339,10 +340,10 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
               source: {
                 type: "git",
                 url: "https://github.com/actions/checkout",
-                ref: "v2.1.0",
+                ref: "v#{previous_version}",
                 branch: nil
               },
-              metadata: { declaration_string: "actions/checkout@v2.1.0" }
+              metadata: { declaration_string: "actions/checkout@v#{previous_version}" }
             }],
             requirements: [{
               requirement: nil,
@@ -384,6 +385,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           expect(subject.content).to include "# @v#{dependency.version}"
           expect(subject.content).to include "# pin @v#{dependency.version}"
           expect(subject.content).to include "# tag=v#{dependency.version}"
+        end
+        context "when previous version is older than comment" do
+          let(:previous_version) { "2.0.0" }
+
+          it "updates version comment" do
+            expect(subject.content).to include "# v#{dependency.version}"
+            expect(subject.content).to include "# #{dependency.version}"
+            expect(subject.content).to include "# @v#{dependency.version}"
+            expect(subject.content).to include "# pin @v#{dependency.version}"
+            expect(subject.content).to include "# tag=v#{dependency.version}"
+          end
         end
         it "doesn't update version comments when @ref is not a SHA" do
           old_version = dependency.previous_requirements[1].dig(:source, :ref)


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/pull/6995 for an example.

Since there is an old action pinned to `actions/checkout@v3.6.0`, that's the version the dependency takes, and the one that tries to be replaced. However, all comments are using `# v4.0.0`, since that's what the other actions are using, so the comment replace fails.

Instead, respect the version each action is pinned to when performing the replace, keeping the spirit of #8068.