### PR TITLE
Fix warnings when running tests in common

### DIFF
--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1368,7 +1368,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
       let(:fill_repo) { nil }
       before do
         Dir.chdir(repo_path) do
-          `git init .`
+          `git init --initial-branch main .`
           fill_repo
           `git add .`
           `git commit --allow-empty -m'fake clone source'`


### PR DESCRIPTION
A lot of warnings like this get printed:

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
```