### PR TITLE
bump(deps): bump regclient from 0.5.1 to 0.5.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # Install regctl. See https://github.com/regclient/regclient/releases for updates
-ARG REGCTL_VERSION=0.5.5
+ARG REGCTL_VERSION=0.5.6
 
 # These are manually calculated as they are not provided by the maintainer
 # curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64 | sha256sum
-ARG REGCTL_AMD64_CHECKSUM=1ee329753045ccc74a2daf7f64c056390908d66a94ec5f1843f5967e80f66cff
+ARG REGCTL_AMD64_CHECKSUM=ed352bc9991e3f12819b27fe516c58c4dab1fc0ee66c2f24d54c922a4f6fd582
 # curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-arm64 | sha256sum
-ARG REGCTL_ARM64_CHECKSUM=d734279b5955e2a2ab22ccf6080efaef03e2ca2edf3c8db7ad11a21f958c967f
+ARG REGCTL_ARM64_CHECKSUM=5e6ab7a5c48017f3213078ba726714010c608a7761f3f18e55d44be36ca5d95b
 
 ENV PATH=/opt/bin:$PATH
 RUN cd /tmp \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # Install regctl. See https://github.com/regclient/regclient/releases for updates
-ARG REGCTL_VERSION=0.5.1
+ARG REGCTL_VERSION=0.5.3
 
 # These are manually calculated as they are not provided by the maintainer
-ARG REGCTL_AMD64_CHECKSUM=484f98e99c90341336b1be99b2b333e7129fde3535b54ef97b4673e8fb2b1d6c
-ARG REGCTL_ARM64_CHECKSUM=17312dadc43ed24886076b0669bc36a9d790c26140fbacb66b0b89f5f96ece52
+# curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64 | sha256sum
+ARG REGCTL_AMD64_CHECKSUM=5141569cd0ef6e52a9dc67391c432f1bdd0cfd2d3b82d3f22d56f94feab7203e
+# curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-arm64 | sha256sum
+ARG REGCTL_ARM64_CHECKSUM=380105c05c6c69ea3d35a8efeec0ccfa1bdfc38a876bf7d473be06d7267bae99
 
 ENV PATH=/opt/bin:$PATH
 RUN cd /tmp \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # Install regctl. See https://github.com/regclient/regclient/releases for updates
-ARG REGCTL_VERSION=0.5.3
+ARG REGCTL_VERSION=0.5.5
 
 # These are manually calculated as they are not provided by the maintainer
 # curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64 | sha256sum
-ARG REGCTL_AMD64_CHECKSUM=5141569cd0ef6e52a9dc67391c432f1bdd0cfd2d3b82d3f22d56f94feab7203e
+ARG REGCTL_AMD64_CHECKSUM=1ee329753045ccc74a2daf7f64c056390908d66a94ec5f1843f5967e80f66cff
 # curl -sL https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-arm64 | sha256sum
-ARG REGCTL_ARM64_CHECKSUM=380105c05c6c69ea3d35a8efeec0ccfa1bdfc38a876bf7d473be06d7267bae99
+ARG REGCTL_ARM64_CHECKSUM=d734279b5955e2a2ab22ccf6080efaef03e2ca2edf3c8db7ad11a21f958c967f
 
 ENV PATH=/opt/bin:$PATH
 RUN cd /tmp \


### PR DESCRIPTION
Release notes : 

https://github.com/regclient/regclient/releases/tag/v0.5.2
https://github.com/regclient/regclient/releases/tag/v0.5.3
https://github.com/regclient/regclient/releases/tag/v0.5.4
https://github.com/regclient/regclient/releases/tag/v0.5.5
https://github.com/regclient/regclient/releases/tag/v0.5.6