### PR TITLE
Remove another git warning during specs

### DIFF
--- a/updater/spec/support/dummy_pkg_helpers.rb
+++ b/updater/spec/support/dummy_pkg_helpers.rb
@@ -50,7 +50,7 @@ module DummyPkgHelpers
 
     # The content directory needs to a repo
     Dir.chdir(tmp_dir) do
-      system("git init . && git add . && git commit --allow-empty -m 'Init'", out: File::NULL)
+      system("git init --initial-branch main . && git add . && git commit --allow-empty -m 'Init'", out: File::NULL)
     end
 
     tmp_dir


### PR DESCRIPTION
Same as #8100, but for updater specs.