### PR TITLE
fix semver segments errors due to invalid Versions

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -261,13 +261,6 @@ module Dependabot
         end
       end
 
-      def git_dependency?(dependency)
-        GitCommitChecker.new(
-          dependency: dependency,
-          credentials: job.credentials
-        ).git_dependency?
-      end
-
       def log_requirements_for_update(requirements_to_unlock, checker)
         Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
 

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -221,12 +221,13 @@ module Dependabot
         # There are no group rules defined, so this dependency can be included in the group.
         return true unless group.rules["update-types"]
 
-        # git dependencies are not SemVer compatible so we cannot include them in the group
-        return false if git_dependency?(dependency)
+        version_class = Dependabot::Utils.version_class_for_package_manager(job.package_manager)
+        unless version_class.correct?(dependency.version.to_s) && version_class.correct?(checker.latest_version)
+          return false
+        end
 
-        version = Dependabot::Utils.version_class_for_package_manager(job.package_manager).new(dependency.version.to_s)
-        latest_version = Dependabot::Utils.version_class_for_package_manager(job.package_manager)
-                                          .new(checker.latest_version)
+        version = version_class.new(dependency.version.to_s)
+        latest_version = version_class.new(checker.latest_version)
 
         # Not every version class implements .major, .minor, .patch so we calculate it here from the segments
         latest = semver_segments(latest_version)


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/7978
Fixes https://github.com/dependabot/dependabot-core/issues/7961

Before trying to create a Version, we need to check if it's `correct?` to prevent NilClass errors, and other bad things. This handles the Git dependency case as well, since a Git dependency is not semver. 

I didn't add a new test because this existing test [here](https://github.com/dependabot/dependabot-core/commit/31c4c30c0fb391de4fc226fed5fffce22110dac8#diff-864299df6238a996bac5ef9ae9c06478ce8b06362acfa3193aef0896a6d815f0R265-R293) seems to be doing a pretty good job of testing it using a realistic example of a Git dependency. Now, this extends to other ecosystems now where things like `latest` (Docker) are common, but the Updater tests are always in the context of Bundler so I think this is acceptable.