### PR TITLE
Fix version comments after quoted strings

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -78,7 +78,7 @@ module Dependabot
           updated_content =
             updated_content
             .gsub(
-              /(?<=\W|"|')#{Regexp.escape(old_declaration)}(?<comment>\s+#.*)?(?=\s|"|'|$)/
+              /(?<=\W|"|')#{Regexp.escape(old_declaration)}["']?(?<comment>\s+#.*)?(?=\s|$)/
             ) do |match|
               comment = Regexp.last_match(:comment)
               match.gsub!(old_declaration, new_declaration)

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -374,11 +374,11 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         it "updates SHA version" do
           old_sha = dependency.previous_requirements.first.dig(:source, :ref)
           expect(subject.content).to include "#{dependency.name}@#{dependency.requirements.first.dig(:source, :ref)}"
-          expect(subject.content).not_to match(/#{old_sha}\s+#.*#{dependency.previous_version}/)
+          expect(subject.content).not_to match(/#{old_sha}['"]?\s+#.*#{dependency.previous_version}/)
         end
         it "updates version comment" do
           new_sha = dependency.requirements.first.dig(:source, :ref)
-          expect(subject.content).not_to match(/@#{new_sha}\s+#.*#{dependency.previous_version}\s*$/)
+          expect(subject.content).not_to match(/@#{new_sha}['"]?\s+#.*#{dependency.previous_version}\s*$/)
 
           expect(subject.content).to include "# v#{dependency.version}"
           expect(subject.content).to include "# #{dependency.version}"

--- a/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
+++ b/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
     # The comment on the next line has a trailing tab. The version should still be updated.
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0 
+    - uses: "actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81" # v2.1.0
+    - uses: 'actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81' # v2.1.0
   integration:
     - uses: actions/checkout@v2.1.0 # comments that include the version (v2.1.0) shouldn't be updated for non-SHA refs
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81#v2.1.0 # this shouldn't be updated, because the version is part of the ref, not a comment.

--- a/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
+++ b/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
@@ -13,10 +13,9 @@ jobs:
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
     # The comment on the next line has a trailing tab. The version should still be updated.
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0 
-    - uses: actions/checkout@01aecc # v2.1.0
   integration:
     - uses: actions/checkout@v2.1.0 # comments that include the version (v2.1.0) shouldn't be updated for non-SHA refs
-    - uses: actions/checkout@01aecc#v2.1.0 # this shouldn't be updated, because the version is part of the ref, not a comment.
+    - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81#v2.1.0 # this shouldn't be updated, because the version is part of the ref, not a comment.
 
     # The version in the comment for the next action shouldn't be updated
     # because it refers to past behavior.


### PR DESCRIPTION
When YAML strings are quoted, Dependabot fails to update trailing version comments. For example, Dependabot will update the SHA but not the "v2.1.0" comment below:

```yaml
- uses: "actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81" # v2.1.0
```

This PR fixes the bug in the associated regex.

In addition, this PR removes a test case using a short SHA (`"01aecc"`) that is no longer updated (a problem that the test suite doesn't notice) and isn't supported by GitHub Actions anymore.

It also updates a short-SHA-based test case (`"01aecc#v2.1.0"`) to use a full-length SHA so that it is more likely to catch bugs that might be introduced.

Fixes #8125