### PR TITLE
grouped security updates

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -190,7 +190,7 @@ module Dependabot
           repo_contents_path: job.repo_contents_path,
           credentials: job.credentials,
           ignored_versions: job.ignore_conditions_for(dependency),
-          security_advisories: [], # FIXME: Version updates do not use advisory data for now
+          security_advisories: job.security_advisories_for(dependency),
           raise_on_ignored: raise_on_ignored,
           requirements_update_strategy: job.requirements_update_strategy,
           dependency_group: dependency_group,

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -1,6 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/create_group_security_update_pull_request"
 require "dependabot/updater/operations/create_security_update_pull_request"
 require "dependabot/updater/operations/group_update_all_versions"
 require "dependabot/updater/operations/refresh_group_update_pull_request"
@@ -30,6 +31,7 @@ module Dependabot
       # that does, so these Operations should be ordered so that those with most
       # specific preconditions go before those with more permissive checks.
       OPERATIONS = [
+        CreateGroupSecurityUpdatePullRequest,
         CreateSecurityUpdatePullRequest,
         RefreshSecurityUpdatePullRequest,
         RefreshGroupUpdatePullRequest,

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/updater/security_update_helpers"
+require "dependabot/updater/group_update_creation"
 
 # This class implements our strategy for updating multiple, insecure dependencies
 # to a secure version. We attempt to make the smallest version update possible,
@@ -11,6 +12,7 @@ module Dependabot
     module Operations
       class CreateGroupSecurityUpdatePullRequest
         include SecurityUpdateHelpers
+        include GroupUpdateCreation
 
         def self.applies_to?(job:)
           return false if job.updating_a_pull_request?
@@ -44,8 +46,31 @@ module Dependabot
           if target_dependencies.empty?
             record_security_update_dependency_not_found
           else
-            # TODO make a grouped PR for all dependencies
-            # target_dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+            # make a temporary fake group to use the existing logic
+            group = Dependabot::DependencyGroup.new(
+              name: "security-update",
+              rules: {
+                "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
+              }
+            )
+            target_dependencies.each do |dep|
+              group.dependencies << dep
+            end
+
+            dependency_change = compile_all_dependency_changes_for(group)
+
+            if dependency_change.updated_dependencies.any?
+              Dependabot.logger.info("Creating a pull request for '#{group.name}'")
+              begin
+                service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
+              rescue StandardError => e
+                error_handler.handle_job_error(error: e, dependency_group: group)
+              end
+            else
+              Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")
+            end
+
+            dependency_change
           end
         end
 
@@ -57,212 +82,7 @@ module Dependabot
                     :error_handler,
                     :created_pull_requests
 
-        def check_and_create_pr_with_error_handling(dependency)
-          check_and_create_pull_request(dependency)
-        rescue Dependabot::InconsistentRegistryResponse => e
-          error_handler.log_dependency_error(
-            dependency: dependency,
-            error: e,
-            error_type: "inconsistent_registry_response",
-            error_detail: e.message
-          )
-        rescue StandardError => e
-          error_handler.handle_dependency_error(error: e, dependency: dependency)
         end
-
-        # rubocop:disable Metrics/AbcSize
-        # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/MethodLength
-        def check_and_create_pull_request(dependency)
-          checker = update_checker_for(dependency)
-
-          log_checking_for_update(dependency)
-
-          Dependabot.logger.info("Latest version is #{checker.latest_version}")
-
-          unless checker.vulnerable?
-            # The current dependency isn't vulnerable if the version is correct and
-            # can be matched against the advisories affected versions
-            if checker.version_class.correct?(checker.dependency.version)
-              return record_security_update_not_needed_error(checker)
-            end
-
-            return record_dependency_file_not_supported_error(checker)
-          end
-
-          return record_security_update_ignored(checker) unless job.allowed_update?(dependency)
-
-          # The current version is still vulnerable and  Dependabot can't find a
-          # published or compatible non-vulnerable version, this can happen if the
-          # fixed version hasn't been published yet or the published version isn't
-          # compatible with the current environment (e.g. python version) or
-          # version (uses a different version suffix for gradle/maven)
-          return record_security_update_not_found(checker) if checker.up_to_date?
-
-          if pr_exists_for_latest_version?(checker)
-            Dependabot.logger.info(
-              "Pull request already exists for #{checker.dependency.name} " \
-              "with latest version #{checker.latest_version}"
-            )
-            return record_pull_request_exists_for_latest_version(checker)
-          end
-
-          requirements_to_unlock = requirements_to_unlock(checker)
-          log_requirements_for_update(requirements_to_unlock, checker)
-          return record_security_update_not_possible_error(checker) if requirements_to_unlock == :update_not_possible
-
-          updated_deps = checker.updated_dependencies(
-            requirements_to_unlock: requirements_to_unlock
-          )
-
-          # Prevent updates that don't end up fixing any security advisories,
-          # blocking any updates where dependabot-core updates to a vulnerable
-          # version. This happens for npm/yarn subdendencies where Dependabot has no
-          # control over the target version. Related issue:
-          #   https://github.com/github/dependabot-api/issues/905
-          return record_security_update_not_possible_error(checker) if updated_deps.none? { |d| job.security_fix?(d) }
-
-          if (existing_pr = existing_pull_request(updated_deps))
-            # Create a update job error to prevent dependabot-api from creating a
-            # update_not_possible error, this is likely caused by a update job retry
-            # so should be invisible to users (as the first job completed with a pull
-            # request)
-            record_pull_request_exists_for_security_update(existing_pr)
-
-            deps = existing_pr.map do |dep|
-              if dep.fetch("dependency-removed", false)
-                "#{dep.fetch('dependency-name')}@removed"
-              else
-                "#{dep.fetch('dependency-name')}@#{dep.fetch('dependency-version')}"
-              end
-            end
-
-            return Dependabot.logger.info(
-              "Pull request already exists for #{deps.join(', ')}"
-            )
-          end
-
-          dependency_change = Dependabot::DependencyChangeBuilder.create_from(
-            job: job,
-            dependency_files: dependency_snapshot.dependency_files,
-            updated_dependencies: updated_deps,
-            change_source: checker.dependency
-          )
-          create_pull_request(dependency_change)
-        rescue Dependabot::AllVersionsIgnored
-          Dependabot.logger.info("All updates for #{dependency.name} were ignored")
-          # Report this error to the backend to create an update job error
-          raise
-        end
-        # rubocop:enable Metrics/MethodLength
-        # rubocop:enable Metrics/AbcSize
-        # rubocop:enable Metrics/PerceivedComplexity
-
-        def update_checker_for(dependency)
-          Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
-            dependency: dependency,
-            dependency_files: dependency_snapshot.dependency_files,
-            repo_contents_path: job.repo_contents_path,
-            credentials: job.credentials,
-            ignored_versions: job.ignore_conditions_for(dependency),
-            security_advisories: job.security_advisories_for(dependency),
-            raise_on_ignored: true, # always true for security updates
-            requirements_update_strategy: job.requirements_update_strategy,
-            options: job.experiments
-          )
-        end
-
-        def log_checking_for_update(dependency)
-          Dependabot.logger.info(
-            "Checking if #{dependency.name} #{dependency.version} needs updating"
-          )
-          job.log_ignore_conditions_for(dependency)
-        end
-
-        def log_up_to_date(dependency)
-          Dependabot.logger.info(
-            "No update needed for #{dependency.name} #{dependency.version}"
-          )
-        end
-
-        def log_requirements_for_update(requirements_to_unlock, checker)
-          Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
-
-          return unless checker.respond_to?(:requirements_update_strategy)
-
-          Dependabot.logger.info(
-            "Requirements update strategy #{checker.requirements_update_strategy}"
-          )
-        end
-
-        def pr_exists_for_latest_version?(checker)
-          latest_version = checker.latest_version&.to_s
-          return false if latest_version.nil?
-
-          job.existing_pull_requests
-             .select { |pr| pr.count == 1 }
-             .map(&:first)
-             .select { |pr| pr.fetch("dependency-name") == checker.dependency.name }
-             .any? { |pr| pr.fetch("dependency-version", nil) == latest_version }
-        end
-
-        def existing_pull_request(updated_dependencies)
-          new_pr_set = Set.new(
-            updated_dependencies.map do |dep|
-              {
-                "dependency-name" => dep.name,
-                "dependency-version" => dep.version,
-                "dependency-removed" => dep.removed? ? true : nil
-              }.compact
-            end
-          )
-
-          job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set } ||
-            created_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
-        end
-
-        def requirements_to_unlock(checker)
-          if !checker.requirements_unlocked_or_can_be?
-            if checker.can_update?(requirements_to_unlock: :none) then :none
-            else
-              :update_not_possible
-            end
-          elsif checker.can_update?(requirements_to_unlock: :own) then :own
-          elsif checker.can_update?(requirements_to_unlock: :all) then :all
-          else
-            :update_not_possible
-          end
-        end
-
-        def create_pull_request(dependency_change)
-          Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
-                                 "pull request for creation")
-
-          service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
-
-          created_pull_requests << dependency_change.updated_dependencies.map do |dep|
-            {
-              "dependency-name" => dep.name,
-              "dependency-version" => dep.version,
-              "dependency-removed" => dep.removed? ? true : nil
-            }.compact
-          end
-        end
-
-        def update_pull_request(dependency_change)
-          Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
-                                 "pull request for update")
-
-          service.update_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
-        end
-
-        def close_pull_request(reason:)
-          reason_string = reason.to_s.tr("_", " ")
-          Dependabot.logger.info("Telling backend to close pull request for " \
-                                 "#{job.dependencies.join(', ')} - #{reason_string}")
-          service.close_pull_request(job.dependencies, reason)
-        end
-      end
     end
   end
 end

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -1,0 +1,268 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/updater/security_update_helpers"
+
+# This class implements our strategy for updating multiple, insecure dependencies
+# to a secure version. We attempt to make the smallest version update possible,
+# i.e. semver patch-level increase is preferred over minor-level increase.
+module Dependabot
+  class Updater
+    module Operations
+      class CreateGroupSecurityUpdatePullRequest
+        include SecurityUpdateHelpers
+
+        def self.applies_to?(job:)
+          return false if job.updating_a_pull_request?
+          # If we haven't been given data for the vulnerable dependency,
+          # this strategy cannot act.
+          return false unless job.dependencies&.any?
+
+          return false unless job.security_updates_only?
+
+          return true if job.dependencies.count > 1
+        end
+
+        def self.tag_name
+          :create_security_pr
+        end
+
+        def initialize(service:, job:, dependency_snapshot:, error_handler:)
+          @service = service
+          @job = job
+          @dependency_snapshot = dependency_snapshot
+          @error_handler = error_handler
+          # TODO: Collect @created_pull_requests on the Job object?
+          @created_pull_requests = []
+        end
+
+        def perform
+          Dependabot.logger.info("Starting security update job for #{job.source.repo}")
+
+          target_dependencies = dependency_snapshot.job_dependencies
+
+          if target_dependencies.empty?
+            record_security_update_dependency_not_found
+          else
+            # TODO make a grouped PR for all dependencies
+            # target_dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+          end
+        end
+
+        private
+
+        attr_reader :job,
+                    :service,
+                    :dependency_snapshot,
+                    :error_handler,
+                    :created_pull_requests
+
+        def check_and_create_pr_with_error_handling(dependency)
+          check_and_create_pull_request(dependency)
+        rescue Dependabot::InconsistentRegistryResponse => e
+          error_handler.log_dependency_error(
+            dependency: dependency,
+            error: e,
+            error_type: "inconsistent_registry_response",
+            error_detail: e.message
+          )
+        rescue StandardError => e
+          error_handler.handle_dependency_error(error: e, dependency: dependency)
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/MethodLength
+        def check_and_create_pull_request(dependency)
+          checker = update_checker_for(dependency)
+
+          log_checking_for_update(dependency)
+
+          Dependabot.logger.info("Latest version is #{checker.latest_version}")
+
+          unless checker.vulnerable?
+            # The current dependency isn't vulnerable if the version is correct and
+            # can be matched against the advisories affected versions
+            if checker.version_class.correct?(checker.dependency.version)
+              return record_security_update_not_needed_error(checker)
+            end
+
+            return record_dependency_file_not_supported_error(checker)
+          end
+
+          return record_security_update_ignored(checker) unless job.allowed_update?(dependency)
+
+          # The current version is still vulnerable and  Dependabot can't find a
+          # published or compatible non-vulnerable version, this can happen if the
+          # fixed version hasn't been published yet or the published version isn't
+          # compatible with the current environment (e.g. python version) or
+          # version (uses a different version suffix for gradle/maven)
+          return record_security_update_not_found(checker) if checker.up_to_date?
+
+          if pr_exists_for_latest_version?(checker)
+            Dependabot.logger.info(
+              "Pull request already exists for #{checker.dependency.name} " \
+              "with latest version #{checker.latest_version}"
+            )
+            return record_pull_request_exists_for_latest_version(checker)
+          end
+
+          requirements_to_unlock = requirements_to_unlock(checker)
+          log_requirements_for_update(requirements_to_unlock, checker)
+          return record_security_update_not_possible_error(checker) if requirements_to_unlock == :update_not_possible
+
+          updated_deps = checker.updated_dependencies(
+            requirements_to_unlock: requirements_to_unlock
+          )
+
+          # Prevent updates that don't end up fixing any security advisories,
+          # blocking any updates where dependabot-core updates to a vulnerable
+          # version. This happens for npm/yarn subdendencies where Dependabot has no
+          # control over the target version. Related issue:
+          #   https://github.com/github/dependabot-api/issues/905
+          return record_security_update_not_possible_error(checker) if updated_deps.none? { |d| job.security_fix?(d) }
+
+          if (existing_pr = existing_pull_request(updated_deps))
+            # Create a update job error to prevent dependabot-api from creating a
+            # update_not_possible error, this is likely caused by a update job retry
+            # so should be invisible to users (as the first job completed with a pull
+            # request)
+            record_pull_request_exists_for_security_update(existing_pr)
+
+            deps = existing_pr.map do |dep|
+              if dep.fetch("dependency-removed", false)
+                "#{dep.fetch('dependency-name')}@removed"
+              else
+                "#{dep.fetch('dependency-name')}@#{dep.fetch('dependency-version')}"
+              end
+            end
+
+            return Dependabot.logger.info(
+              "Pull request already exists for #{deps.join(', ')}"
+            )
+          end
+
+          dependency_change = Dependabot::DependencyChangeBuilder.create_from(
+            job: job,
+            dependency_files: dependency_snapshot.dependency_files,
+            updated_dependencies: updated_deps,
+            change_source: checker.dependency
+          )
+          create_pull_request(dependency_change)
+        rescue Dependabot::AllVersionsIgnored
+          Dependabot.logger.info("All updates for #{dependency.name} were ignored")
+          # Report this error to the backend to create an update job error
+          raise
+        end
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def update_checker_for(dependency)
+          Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
+            dependency: dependency,
+            dependency_files: dependency_snapshot.dependency_files,
+            repo_contents_path: job.repo_contents_path,
+            credentials: job.credentials,
+            ignored_versions: job.ignore_conditions_for(dependency),
+            security_advisories: job.security_advisories_for(dependency),
+            raise_on_ignored: true, # always true for security updates
+            requirements_update_strategy: job.requirements_update_strategy,
+            options: job.experiments
+          )
+        end
+
+        def log_checking_for_update(dependency)
+          Dependabot.logger.info(
+            "Checking if #{dependency.name} #{dependency.version} needs updating"
+          )
+          job.log_ignore_conditions_for(dependency)
+        end
+
+        def log_up_to_date(dependency)
+          Dependabot.logger.info(
+            "No update needed for #{dependency.name} #{dependency.version}"
+          )
+        end
+
+        def log_requirements_for_update(requirements_to_unlock, checker)
+          Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
+
+          return unless checker.respond_to?(:requirements_update_strategy)
+
+          Dependabot.logger.info(
+            "Requirements update strategy #{checker.requirements_update_strategy}"
+          )
+        end
+
+        def pr_exists_for_latest_version?(checker)
+          latest_version = checker.latest_version&.to_s
+          return false if latest_version.nil?
+
+          job.existing_pull_requests
+             .select { |pr| pr.count == 1 }
+             .map(&:first)
+             .select { |pr| pr.fetch("dependency-name") == checker.dependency.name }
+             .any? { |pr| pr.fetch("dependency-version", nil) == latest_version }
+        end
+
+        def existing_pull_request(updated_dependencies)
+          new_pr_set = Set.new(
+            updated_dependencies.map do |dep|
+              {
+                "dependency-name" => dep.name,
+                "dependency-version" => dep.version,
+                "dependency-removed" => dep.removed? ? true : nil
+              }.compact
+            end
+          )
+
+          job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set } ||
+            created_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
+        end
+
+        def requirements_to_unlock(checker)
+          if !checker.requirements_unlocked_or_can_be?
+            if checker.can_update?(requirements_to_unlock: :none) then :none
+            else
+              :update_not_possible
+            end
+          elsif checker.can_update?(requirements_to_unlock: :own) then :own
+          elsif checker.can_update?(requirements_to_unlock: :all) then :all
+          else
+            :update_not_possible
+          end
+        end
+
+        def create_pull_request(dependency_change)
+          Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
+                                 "pull request for creation")
+
+          service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
+
+          created_pull_requests << dependency_change.updated_dependencies.map do |dep|
+            {
+              "dependency-name" => dep.name,
+              "dependency-version" => dep.version,
+              "dependency-removed" => dep.removed? ? true : nil
+            }.compact
+          end
+        end
+
+        def update_pull_request(dependency_change)
+          Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
+                                 "pull request for update")
+
+          service.update_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
+        end
+
+        def close_pull_request(reason:)
+          reason_string = reason.to_s.tr("_", " ")
+          Dependabot.logger.info("Telling backend to close pull request for " \
+                                 "#{job.dependencies.join(', ')} - #{reason_string}")
+          service.close_pull_request(job.dependencies, reason)
+        end
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -22,7 +22,7 @@ module Dependabot
 
           return false unless job.security_updates_only?
 
-          return true if job.dependencies.count > 1
+          true if job.dependencies.count > 1
         end
 
         def self.tag_name
@@ -81,8 +81,7 @@ module Dependabot
                     :dependency_snapshot,
                     :error_handler,
                     :created_pull_requests
-
-        end
+      end
     end
   end
 end

--- a/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     racc (1.7.1)
     rack (2.1.3)
     rainbow (3.1.1)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     rexml (3.2.6)
     rubocop (1.56.0)
       base64 (~> 0.1.1)


### PR DESCRIPTION
This is a grouped security updates prototype.

It detects a group by seeing multiple dependencies are passed into a security update job. Then it creates a grouping on-the-fly to generate a single PR instead of the usual multiple PRs. 

This is a feature in development, so there's no way to exercise it without flags set in the service. 