### PR TITLE
Parallelize tests on all ecosystems, except for Pub

### DIFF
--- a/cargo/script/ci-test
+++ b/cargo/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/common/script/ci-test
+++ b/common/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/docker/script/ci-test
+++ b/docker/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/elm/script/ci-test
+++ b/elm/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/git_submodules/script/ci-test
+++ b/git_submodules/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/github_actions/script/ci-test
+++ b/github_actions/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/gradle/script/ci-test
+++ b/gradle/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/maven/script/ci-test
+++ b/maven/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose

--- a/terraform/script/ci-test
+++ b/terraform/script/ci-test
@@ -3,4 +3,4 @@
 set -e
 
 bundle install
-bundle exec rspec spec
+bundle exec turbo_tests --verbose


### PR DESCRIPTION
When I worked on #6590, I apparently forgot to enable parallel tests for all ecosystems. All of them seem to be running fine in parallel, except for Pub.

For now I'm enabling parallel tests for the others.