### PR TITLE
Fix some flaky test failures

### DIFF
--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Dependabot::FileFetcherCommand do
       JSON.parse(fixture("jobs/job_with_credentials.json"))
     end
 
+    after do
+      # The job definition in this context loads an experiment, so reset it
+      Dependabot::Experiments.reset!
+    end
+
     it "fetches the files and writes the fetched files to output.json", vcr: true do
       expect(api_client).not_to receive(:mark_job_as_processed)
 

--- a/updater/spec/fixtures/bundler_vendored/original/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_vendored/original/Gemfile.lock
@@ -13,7 +13,9 @@ GEM
       dummy-pkg-a (~> 2.0)
 
 PLATFORMS
-  x86_64-darwin-22
+  aarch64-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   dummy-git-dependency!

--- a/updater/spec/fixtures/bundler_vendored/updated/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_vendored/updated/Gemfile.lock
@@ -13,7 +13,8 @@ GEM
       dummy-pkg-a (~> 2.0)
 
 PLATFORMS
-  x86_64-darwin-22
+  aarch64-linux
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
First commit makes updater specs pass on `aarch64-linux`.
Second commit fixes some random dependent test failures introduced by #8104.