### PR TITLE
Catch up test lockfile with parser 3.2.2.4 release

### DIFF
--- a/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_grouped_by_types/updated_development_deps/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     racc (1.7.1)


### PR DESCRIPTION
The new parser 3.2.2.4 release has caused a new test failure.