### PR TITLE
fix completely ignored dependencies querying for updates

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -174,7 +174,7 @@ module Dependabot
     def allowed_update?(dependency)
       # Ignoring all versions is another way to say no updates allowed
       if completely_ignored?(dependency) && !security_updates_only?
-        Dependabot.logger.info("All versions of #{dependency.name} are ignored")
+        Dependabot.logger.info("All versions of #{dependency.name} ignored, no update allowed")
         return false
       end
 

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -171,6 +171,7 @@ module Dependabot
     # separately, if required.
     #
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity
     def allowed_update?(dependency)
       # Ignoring all versions is another way to say no updates allowed
       if completely_ignored?(dependency) && !security_updates_only?
@@ -206,6 +207,7 @@ module Dependabot
       end
     end
     # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def vulnerable?(dependency)
       security_advisories = security_advisories_for(dependency)
@@ -303,9 +305,7 @@ module Dependabot
     private
 
     def completely_ignored?(dependency)
-      ignore_conditions_for(dependency).any? do |ignored_versions|
-        ignored_versions == Dependabot::Config::IgnoreCondition::ALL_VERSIONS
-      end
+      ignore_conditions_for(dependency).any?(Dependabot::Config::IgnoreCondition::ALL_VERSIONS)
     end
 
     def register_experiments

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -174,7 +174,7 @@ module Dependabot
     # rubocop:disable Metrics/CyclomaticComplexity
     def allowed_update?(dependency)
       # Ignoring all versions is another way to say no updates allowed
-      if completely_ignored?(dependency) && !security_updates_only?
+      if completely_ignored?(dependency)
         Dependabot.logger.info("All versions of #{dependency.name} ignored, no update allowed")
         return false
       end


### PR DESCRIPTION
Fixes #7651

If you try to ignore all versions of a dependency that is otherwise allowed to update, Dependabot will still query the registry to get a list of versions.

This becomes a problem if the dependency source is an un-configured private registry because it will fail the HTTP request and cause an error on the job which is completely avoidable if Dependabot had skipped the check.

This PR adds a check for completely ignored dependencies in `allowed_update?` which will fix the issue for individual PRs and grouped updates. 

Future enhancements to this could include checking if the range provided means no update is possible, like if the dependency is at `1.0.0` and the ignored version range is `> 1.0.0`. 