### PR TITLE
Added record update job error api back to capture unknown errors 

### DIFF
--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -217,17 +217,19 @@ module Dependabot
     end
 
     def record_error(error_details)
-      if error_details[:"error-type"] == "file_fetcher_error"
-        service.record_update_job_unknown_error(
-          error_type: error_details.fetch(:"error-type"),
-          error_details: error_details[:"error-detail"]
-        )
-      else
-        service.record_update_job_error(
-          error_type: error_details.fetch(:"error-type"),
-          error_details: error_details[:"error-detail"]
-        )
-      end
+      service.record_update_job_error(
+        error_type: error_details.fetch(:"error-type"),
+        error_details: error_details[:"error-detail"]
+      )
+
+      # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
+      return unless Experiments.enabled?(:record_update_job_unknown_error)
+      return unless error_details.fetch(:"error-type") == "file_fetcher_error"
+
+      service.record_update_job_unknown_error(
+        error_type: error_details.fetch(:"error-type"),
+        error_details: error_details[:"error-detail"]
+      )
     end
 
     # Perform a debug check of connectivity to GitHub/GHES. This also ensures

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -49,8 +49,7 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
-    def record_update_job_unknown_error(error_type:, error_details:, dependency: nil)
-      @errors << [error_type.to_s, dependency]
+    def record_update_job_unknown_error(error_type:, error_details:)
       client.record_update_job_unknown_error(error_type: error_type, error_details: error_details)
     end
 

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -44,14 +44,15 @@ module Dependabot
         raise error if RUN_HALTING_ERRORS.keys.any? { |err| error.is_a?(err) }
 
         error_details = error_details_for(error, dependency: dependency, dependency_group: dependency_group)
-        if error_details.fetch(:"error-type") == "unknown_error"
+        service.record_update_job_error(
+          error_type: error_details.fetch(:"error-type"),
+          error_details: error_details[:"error-detail"],
+          dependency: dependency
+        )
+        # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
+        if Experiments.enabled?(:record_update_job_unknown_error) &&
+           error_details.fetch(:"error-type") == "unknown_error"
           log_unknown_error_with_backtrace(error, dependency)
-        else
-          service.record_update_job_error(
-            error_type: error_details.fetch(:"error-type"),
-            error_details: error_details[:"error-detail"],
-            dependency: dependency
-          )
         end
 
         log_dependency_error(
@@ -66,6 +67,8 @@ module Dependabot
       def log_dependency_error(dependency:, error:, error_type:, error_detail: nil)
         if error_type == "unknown_error"
           Dependabot.logger.error "Error processing #{dependency.name} (#{error.class.name})"
+          Dependabot.logger.error error.message
+          error.backtrace.each { |line| Dependabot.logger.error line }
         else
           Dependabot.logger.info(
             "Handled error whilst updating #{dependency.name}: #{error_type} #{error_detail}"
@@ -81,13 +84,14 @@ module Dependabot
         raise error if RUN_HALTING_ERRORS.keys.any? { |err| error.is_a?(err) }
 
         error_details = error_details_for(error, dependency_group: dependency_group)
-        if error_details.fetch(:"error-type") == "unknown_error"
+        service.record_update_job_error(
+          error_type: error_details.fetch(:"error-type"),
+          error_details: error_details[:"error-detail"]
+        )
+        # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
+        if Experiments.enabled?(:record_update_job_unknown_error) &&
+           error_details.fetch(:"error-type") == "unknown_error"
           log_unknown_error_with_backtrace(error, dependency_group)
-        else
-          service.record_update_job_error(
-            error_type: error_details.fetch(:"error-type"),
-            error_details: error_details[:"error-detail"]
-          )
         end
 
         log_job_error(
@@ -101,6 +105,8 @@ module Dependabot
       def log_job_error(error:, error_type:, error_detail: nil)
         if error_type == "unknown_error"
           Dependabot.logger.error "Error processing job (#{error.class.name})"
+          Dependabot.logger.error error.message
+          error.backtrace.each { |line| Dependabot.logger.error line }
         else
           Dependabot.logger.info(
             "Handled error whilst processing job: #{error_type} #{error_detail}"
@@ -210,9 +216,6 @@ module Dependabot
       end
 
       def log_unknown_error_with_backtrace(error, dependency = nil, _dependency_group = nil)
-        Dependabot.logger.error error.message
-        error.backtrace.each { |line| Dependabot.logger.error line }
-
         error_details = {
           "error-class" => error.class.to_s,
           "error-message" => error.message,
@@ -227,8 +230,7 @@ module Dependabot
           package_manager: job.package_manager,
           class_name: error.class.name
         })
-        service.record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details,
-                                                dependency: dependency)
+        service.record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
       end
     end
   end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -52,7 +52,7 @@ module Dependabot
         # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
         if Experiments.enabled?(:record_update_job_unknown_error) &&
            error_details.fetch(:"error-type") == "unknown_error"
-          log_unknown_error_with_backtrace(error, dependency)
+          log_unknown_error_with_backtrace(error)
         end
 
         log_dependency_error(
@@ -91,7 +91,7 @@ module Dependabot
         # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
         if Experiments.enabled?(:record_update_job_unknown_error) &&
            error_details.fetch(:"error-type") == "unknown_error"
-          log_unknown_error_with_backtrace(error, dependency_group)
+          log_unknown_error_with_backtrace(error)
         end
 
         log_job_error(
@@ -215,7 +215,7 @@ module Dependabot
         end
       end
 
-      def log_unknown_error_with_backtrace(error, dependency = nil, _dependency_group = nil)
+      def log_unknown_error_with_backtrace(error)
         error_details = {
           "error-class" => error.class.to_s,
           "error-message" => error.message,


### PR DESCRIPTION
## Context

- This PR adds the new feature flag named `record_update_job_unknown_error`. It has been created to be always enabled when running on our cloud infrastructure but remains inactive for GHES. The reason behind this differentiation is that older versions of GHES do not support the functionality of reporting unknown errors. This change ensures smooth operation across various environments without compromising on functionality where supported.

- This feature flag will be used to skip any `api_client.record_update_job_unknown_error` call to capture the unknown error when running in GHES environment.

- This new feature flag `record_update_job_unknown_error` is already created in Dependabot-api and deployed to production.

- The [PR](https://github.com/github/dependabot-updates/issues/3650#:~:text=EE-,Track%20unknown%20errors%20dependabot/dependabot%2Dcore%237534,-EE) which introduced the new api `record_update_job_unknown_error` for reference.