### PR TITLE
Add Manual Trigger for Gem Release

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
     # It's fine to trigger on every release because if we tag a release w/o
     # bumping the Gem version, RubyGems will reject it with an error that the
     # version is already live.
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     # bumping the Gem version, RubyGems will reject it with an error that the
     # version is already live.
     types: [published]
+  workflow_dispatch:
 
 jobs:
   release-gems:


### PR DESCRIPTION
- Add Manual Trigger for Gem Release. The gem release action workflow is failing with error missing tag. The tag is already present. I do not have any other way to cleanly trigger this workflow so adding this PR to manually trigger the gem release.
- Add `edited` to Release event, which means when the release tag in Dependabot Core is edited this action workflow will be triggered as well.