### PR TITLE
Teach Docker::Version about SHA and String versions

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -83,6 +83,7 @@ module Dependabot
 
       def correct_version_for(dependency)
         version = dependency.version
+        version = version.to_s if version.is_a?(Gem::Version)
         return if version.nil? || version.empty?
 
         version_class = version_class_for(dependency.package_manager)

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -51,14 +51,13 @@ module Dependabot
 
             dependency_set << Dependency.new(
               name: parsed_from_line.fetch("image"),
-              version: Dependabot::Docker::Version.new(version).to_semver,
+              version: Dependabot::Docker::Version.new(version),
               package_manager: "docker",
               requirements: [
                 requirement: nil,
                 groups: [],
                 file: dockerfile.name,
-                source: source_from(parsed_from_line),
-                metadata: { :version => version }
+                source: source_from(parsed_from_line)
               ]
             )
           end
@@ -129,14 +128,13 @@ module Dependabot
       def build_image_dependency(file, details, version)
         Dependency.new(
           name: details.fetch("image"),
-          version: Dependabot::Docker::Version.new(version).to_semver,
+          version: Dependabot::Docker::Version.new(version),
           package_manager: "docker",
           requirements: [
             requirement: nil,
             groups: [],
             file: file.name,
-            source: source_from(details),
-            metadata: { :version => version }
+            source: source_from(details)
           ]
         )
       end

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -6,6 +6,7 @@ require "docker_registry2"
 require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
+require "dependabot/docker/version"
 require "dependabot/errors"
 
 module Dependabot
@@ -50,13 +51,14 @@ module Dependabot
 
             dependency_set << Dependency.new(
               name: parsed_from_line.fetch("image"),
-              version: version,
+              version: Dependabot::Docker::Version.new(version).to_semver,
               package_manager: "docker",
               requirements: [
                 requirement: nil,
                 groups: [],
                 file: dockerfile.name,
-                source: source_from(parsed_from_line)
+                source: source_from(parsed_from_line),
+                metadata: { :version => version }
               ]
             )
           end
@@ -127,13 +129,14 @@ module Dependabot
       def build_image_dependency(file, details, version)
         Dependency.new(
           name: details.fetch("image"),
-          version: version,
+          version: Dependabot::Docker::Version.new(version).to_semver,
           package_manager: "docker",
           requirements: [
             requirement: nil,
             groups: [],
             file: file.name,
-            source: source_from(details)
+            source: source_from(details),
+            metadata: { :version => version }
           ]
         )
       end

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -21,7 +21,10 @@ module Dependabot
       attr_reader :name
 
       def initialize(name)
-        @name = name
+        @name = begin
+          name = name.to_s if name.is_a?(Gem::Version)
+          name
+        end
       end
 
       def to_s

--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -12,6 +12,9 @@ module Dependabot
     # for a description of Java versions.
     #
     class Version < Dependabot::Version
+      VERSION_PATTERN = %r{[0-9A-z]*}
+      ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/
+
       def initialize(version)
         release_part, update_part = version.split("_", 2)
 

--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -12,14 +12,19 @@ module Dependabot
     # for a description of Java versions.
     #
     class Version < Dependabot::Version
-      VERSION_PATTERN = %r{[0-9A-z]*}
-      ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/
+      SHA_REGEX = /[0-9a-f]{64}/.freeze
+      STRING_REGEX = /^[a-zA-Z]+$/.freeze
 
       def initialize(version)
+        if version.to_s.match?(SHA_REGEX) || version.to_s.match?(STRING_REGEX)
+          @release_part = version
+          @update_part = 0
+          return @release_part
+        end
+
         release_part, update_part = version.split("_", 2)
 
         @release_part = Dependabot::Version.new(release_part.sub("v", "").tr("-", "."))
-
         @update_part = Dependabot::Version.new(update_part&.start_with?(/[0-9]/) ? update_part : 0)
 
         super(@release_part)
@@ -27,6 +32,8 @@ module Dependabot
 
       def self.correct?(version)
         return true if version.is_a?(Gem::Version)
+        return true if version.to_s.match?(SHA_REGEX)
+        return true if version.to_s.match?(STRING_REGEX)
 
         # We can't call new here because Gem::Version calls self.correct? in its initialize method
         # causing an infinite loop, so instead we check if the release_part of the version is correct
@@ -39,10 +46,14 @@ module Dependabot
       end
 
       def to_semver
+        return @release_part if @release_part.to_s.match?(SHA_REGEX)
+        return @release_part if @release_part.to_s.match?(STRING_REGEX)
         @release_part.to_semver
       end
 
       def segments
+        return [@release_part] if @release_part.to_s.match?(SHA_REGEX)
+        return [@release_part] if @release_part.to_s.match?(STRING_REGEX)
         @release_part.segments
       end
 

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "has the right details" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("17.04")
+        expect(dependency.version.to_semver).to eq("17.04")
         expect(dependency.requirements).to eq(expected_requirements)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -96,7 +96,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+          expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -190,7 +190,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("artful")
+          expect(dependency.version.to_semver).to eq("artful")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -319,7 +319,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("ubuntu")
-                expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                                                  "fc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
@@ -355,7 +355,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version.to_semver).to eq("12.04.5")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
@@ -387,7 +387,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -406,7 +406,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("python")
-          expect(dependency.version).to eq("3.6.3")
+          expect(dependency.version.to_semver).to eq("3.6.3")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -430,7 +430,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("node")
-            expect(dependency.version).to eq("10-alpine")
+            expect(dependency.version.to_semver).to eq("10.alpine")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -456,7 +456,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("myreg/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -484,7 +484,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("myreg/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -510,7 +510,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("myreg/ubuntu")
-            expect(dependency.version).to eq("17.04")
+            expect(dependency.version.to_semver).to eq("17.04")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -568,7 +568,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -587,7 +587,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -610,7 +610,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("artful")
+          expect(dependency.version.to_semver).to eq("artful")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -646,7 +646,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "has the right details" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("nginx")
-        expect(dependency.version).to eq("1.14.2")
+        expect(dependency.version.to_semver).to eq("1.14.2")
         expect(dependency.requirements).to eq(expected_requirements)
       end
     end
@@ -673,7 +673,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-repo/nginx")
-          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.version.to_semver).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -696,7 +696,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("nginx")
-          expect(dependency.version).to eq("fancy")
+          expect(dependency.version.to_semver).to eq("fancy")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -766,7 +766,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -799,7 +799,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version.to_semver).to eq("12.04.5")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
@@ -831,7 +831,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -850,7 +850,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("nginx")
-          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.version.to_semver).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -874,7 +874,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("nginx")
-            expect(dependency.version).to eq("1.14.2")
+            expect(dependency.version.to_semver).to eq("1.14.2")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -900,7 +900,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("myreg/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -928,7 +928,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("myreg/ubuntu")
-          expect(dependency.version).to eq("17.04")
+          expect(dependency.version.to_semver).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -954,7 +954,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("myreg/ubuntu")
-            expect(dependency.version).to eq("17.04")
+            expect(dependency.version.to_semver).to eq("17.04")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -981,7 +981,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("nginx")
-          expect(dependency.version).to eq("1.2.34")
+          expect(dependency.version.to_semver).to eq("1.2.34")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1000,7 +1000,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("ubuntu")
-          expect(dependency.version).to eq("20.04.2")
+          expect(dependency.version.to_semver).to eq("20.04.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1032,7 +1032,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("nginx")
-          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.version.to_semver).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1051,7 +1051,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-repo/nginx")
-          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.version.to_semver).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1087,7 +1087,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "has the right details" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("nginx")
-        expect(dependency.version).to eq("1.14.2")
+        expect(dependency.version.to_semver).to eq("1.14.2")
         expect(dependency.requirements).to eq(expected_requirements)
       end
     end
@@ -1115,7 +1115,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("sql/sql")
-          expect(dependency.version).to eq("v1.2.3")
+          expect(dependency.version.to_semver).to eq("1.2.3")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1139,7 +1139,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("nginx")
-          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.version.to_semver).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -1158,7 +1158,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("canonical/ubuntu")
-          expect(dependency.version).to eq("18.04")
+          expect(dependency.version.to_semver).to eq("18.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -260,7 +260,8 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version.to_semver)
+              .to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -320,7 +321,7 @@ RSpec.describe Dependabot::Docker::FileParser do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("ubuntu")
                 expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
-                                                 "fc38288cf73aa07485005")
+                                                           "fc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
             end
@@ -766,7 +767,8 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version.to_semver).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version.to_semver)
+              .to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end

--- a/docker/spec/dependabot/docker/version_spec.rb
+++ b/docker/spec/dependabot/docker/version_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dependabot::Docker::Version do
     end
 
     it "returns false for non-versions" do
-      expect(described_class.correct?("python")).to be false
+      expect(described_class.correct?("not_a_version")).to be false
     end
   end
 


### PR DESCRIPTION
Previous `Docker::Version#new` would always return a String. Then it was modified to try and return a `Gem::Version`, but Docker versions can also be a SHA or a String (like with `alpine:edge`).

This PR teaches Docker versions to handle SHA and String versions internally, and just treats them as Strings.