### PR TITLE
Remove the leading v from Docker versions

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -50,7 +50,7 @@ module Dependabot
 
             dependency_set << Dependency.new(
               name: parsed_from_line.fetch("image"),
-              version: version,
+              version: version.sub(/^v/, ""),
               package_manager: "docker",
               requirements: [
                 requirement: nil,
@@ -127,7 +127,7 @@ module Dependabot
       def build_image_dependency(file, details, version)
         Dependency.new(
           name: details.fetch("image"),
-          version: version,
+          version: version.sub(/^v/, ""),
           package_manager: "docker",
           requirements: [
             requirement: nil,

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -1115,7 +1115,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("sql/sql")
-          expect(dependency.version).to eq("v1.2.3")
+          expect(dependency.version).to eq("1.2.3")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end


### PR DESCRIPTION
Docker versions currently include the leading `v` which is not valid semver. This PR strips the leading `v` when we parse and create docker dependencies.