### PR TITLE
Ignore file dependencies when parsing requirement files

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -99,6 +99,10 @@ def parse_requirements(directory):
                 if install_req.req is None:
                     continue
 
+                # Ignore file: requirements
+                if install_req.link is not None and install_req.link.is_file:
+                    continue
+
                 pattern = r"-[cr] (.*) \(line \d+\)"
                 abs_path = re.search(pattern, install_req.comes_from).group(1)
                 rel_path = os.path.relpath(abs_path, directory)

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -320,6 +320,11 @@ RSpec.describe Dependabot::Python::FileParser do
       its(:length) { is_expected.to eq(2) }
     end
 
+    context "with a file dependency" do
+      let(:requirements_fixture_name) { "with_path_dependency.txt" }
+      its(:length) { is_expected.to eq(1) }
+    end
+
     context "with a constraints file" do
       let(:files) { [requirements, constraints] }
       let(:requirements_fixture_name) { "with_constraints.txt" }

--- a/python/spec/fixtures/requirements/with_path_dependency.txt
+++ b/python/spec/fixtures/requirements/with_path_dependency.txt
@@ -1,0 +1,2 @@
+psycopg2==2.6.1
+file:.#egg=bowtie-json-schema


### PR DESCRIPTION
These can't be updated.

If we try to update them, we end up running into errors later. Sample repro:

```
$ bin/dry-run.rb pip "bowtie-json-schema/bowtie" --dir="/." --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=a8fd4b1828d5a71f8bda669e8dc84daf19caa1c9 --cache=files --dep bowtie-json-schema
```