### PR TITLE
Expose a new directory_not_found user error

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -427,6 +427,11 @@ def handle_dependabot_error(error:)
       "error-type": "branch_not_found",
       "error-detail": { "branch-name": error.branch_name }
     }
+  when Dependabot::DirectoryNotFound
+    {
+      "error-type": "directory_not_found",
+      "error-detail": { "directory-name": error.directory_name }
+    }
   when Dependabot::DependencyFileNotParseable
     {
       "error-type": "dependency_file_not_parseable",

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
           )
       end
 
-      it "raises a DependencyFileNotFound error" do
+      it "raises a DirectoryNotFound error" do
         expect { file_fetcher_instance.files }
-          .to raise_error(Dependabot::DependencyFileNotFound)
+          .to raise_error(Dependabot::DirectoryNotFound)
       end
     end
 
@@ -95,9 +95,9 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
           )
       end
 
-      it "raises a DependencyFileNotFound error" do
+      it "raises a DirectoryNotFound error" do
         expect { file_fetcher_instance.files }
-          .to raise_error(Dependabot::DependencyFileNotFound)
+          .to raise_error(Dependabot::DirectoryNotFound)
       end
     end
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -54,6 +54,15 @@ module Dependabot
   # Repo level errors #
   #####################
 
+  class DirectoryNotFound < DependabotError
+    attr_reader :directory_name
+
+    def initialize(directory_name, msg = nil)
+      @directory_name = directory_name
+      super(msg)
+    end
+  end
+
   class BranchNotFound < DependabotError
     attr_reader :branch_name
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -309,6 +309,8 @@ module Dependabot
 
         _fetch_repo_contents_fully_specified(provider, repo, tmp_path, commit)
       rescue *CLIENT_NOT_FOUND_ERRORS
+        raise Dependabot::DirectoryNotFound, directory if path == directory.gsub(%r{^/*}, "")
+
         result = raise_errors ? -> { raise } : -> { [] }
         retrying ||= false
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -194,7 +194,7 @@ module Dependabot
       def repo_contents(dir: ".", ignore_base_directory: false,
                         raise_errors: true, fetch_submodules: false)
         dir = File.join(directory, dir) unless ignore_base_directory
-        path = Pathname.new(File.join(dir)).cleanpath.to_path.gsub(%r{^/*}, "")
+        path = Pathname.new(dir).cleanpath.to_path.gsub(%r{^/*}, "")
 
         @repo_contents ||= {}
         @repo_contents[dir] ||= if repo_contents_path

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -916,10 +916,10 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
         .to_return(status: 404)
     end
 
-    it "raises a Dependabot::DependencyFileNotFound error" do
+    it "raises a Dependabot::DirectoryNotFound error" do
       expect { file_fetcher_instance.files }
-        .to raise_error(Dependabot::DependencyFileNotFound) do |error|
-          expect(error.file_path).to eq("dir/<anything>.(cs|vb|fs)proj")
+        .to raise_error(Dependabot::DirectoryNotFound) do |error|
+          expect(error.directory_name).to eq("dir")
         end
     end
   end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -134,6 +134,11 @@ module Dependabot
             "error-type": "branch_not_found",
             "error-detail": { "branch-name": error.branch_name }
           }
+        when Dependabot::DirectoryNotFound
+          {
+            "error-type": "directory_not_found",
+            "error-detail": { "directory-name": error.directory_name }
+          }
         when Dependabot::RepoNotFound
           # This happens if the repo gets removed after a job gets kicked off.
           # This also happens when a configured personal access token is not authz'd to fetch files from the job repo.


### PR DESCRIPTION
If the user is configuring a directory for dependabot that no longer exists, and the ecosystem does not clone full repositories, we'll end up with unknown `Octokit::NotFound` errors when trying to fetch dependency files.

This PR creates a new error that will be displayed to the user so that she can fix her configuration.