### PR TITLE
Improve detection of unsupported cargo toolchains

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -146,7 +146,7 @@ module Dependabot
           # returns a non-zero status
           return if process.success?
 
-          if stdout.include?("usage of sparse registries requires `-Z sparse-registry`")
+          if using_old_toolchain?(stdout)
             raise Dependabot::DependencyFileNotEvaluatable, "Dependabot only supports toolchain 1.68 and up."
           end
 
@@ -168,6 +168,15 @@ module Dependabot
               process_exit_value: process.to_s
             }
           )
+        end
+
+        def using_old_toolchain?(message)
+          return true if message.include?("usage of sparse registries requires `-Z sparse-registry`")
+
+          version_log = /rust version (?<version>\d.\d+)/.match(message)
+          return false unless version_log
+
+          version_class.new(version_log[:version]) < version_class.new("1.68")
         end
 
         def write_temporary_dependency_files
@@ -385,6 +394,10 @@ module Dependabot
 
         def virtual_manifest?(file)
           !file.content.include?("[package]")
+        end
+
+        def version_class
+          dependency.version_class
         end
       end
     end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -244,7 +244,7 @@ module Dependabot
 
           raise Dependabot::DependencyFileNotResolvable, error.message if resolvability_error?(error.message)
 
-          raise error
+          raise
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -238,7 +238,7 @@ module Dependabot
             return nil
           end
 
-          if error.message.include?("usage of sparse registries requires `-Z sparse-registry`")
+          if using_old_toolchain?(error.message)
             raise Dependabot::DependencyFileNotEvaluatable, "Dependabot only supports toolchain 1.68 and up."
           end
 
@@ -248,6 +248,15 @@ module Dependabot
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
+
+        def using_old_toolchain?(message)
+          return true if message.include?("usage of sparse registries requires `-Z sparse-registry`")
+
+          version_log = /rust version (?<version>\d.\d+)/.match(message)
+          return false unless version_log
+
+          version_class.new(version_log[:version]) < version_class.new("1.68")
+        end
 
         def unreachable_git_urls
           return @unreachable_git_urls if defined?(@unreachable_git_urls)

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -295,7 +295,11 @@ module Dependabot
           return true if message.match?(/feature `[^\`]+` is required/)
           return true if message.include?("unexpected end of input while parsing major version number")
 
-          !original_requirements_resolvable?
+          original_requirements_resolvable = original_requirements_resolvable?
+
+          return false if original_requirements_resolvable == :unknown
+
+          !original_requirements_resolvable
         end
 
         def original_requirements_resolvable?
@@ -310,13 +314,15 @@ module Dependabot
 
           true
         rescue SharedHelpers::HelperSubprocessFailed => e
-          raise unless e.message.include?("no matching version") ||
-                       e.message.include?("failed to select a version") ||
-                       e.message.include?("no matching package named") ||
-                       e.message.include?("failed to parse manifest") ||
-                       e.message.include?("failed to update submodule")
-
-          false
+          if e.message.include?("no matching version") ||
+             e.message.include?("failed to select a version") ||
+             e.message.include?("no matching package named") ||
+             e.message.include?("failed to parse manifest") ||
+             e.message.include?("failed to update submodule")
+            false
+          else
+            :unknown
+          end
         end
 
         def workspace_native_library_update_error?(message)


### PR DESCRIPTION
We're getting the following flaky in cargo:

https://github.com/dependabot/dependabot-core/actions/runs/6493735738/job/17635263354

```
Failures:

  1) Dependabot::Cargo::UpdateChecker::VersionResolver latest_resolvable_version when using a toolchain that is too old raises a helpful error
     Failure/Error:
       expect { subject }
         .to raise_error(Dependabot::DependencyFileNotEvaluatable)

       expected Dependabot::DependencyFileNotEvaluatable, got #<Dependabot::SharedHelpers::HelperSubprocessFailed: Blocking waiting for file lock on package cache
       error: Unable to update registry `crates-io`

       Caused by:
         usage of sparse registries requires `-Z sparse-registry`> with backtrace:
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:153:in `run_cargo_command'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:137:in `run_cargo_update_command'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:307:in `block (2 levels) in original_requirements_resolvable?'
         # /home/dependabot/common/lib/dependabot/shared_helpers.rb:195:in `with_git_configured'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:306:in `block in original_requirements_resolvable?'
         # /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `block in in_a_temporary_directory'
         # /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `chdir'
         # /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `in_a_temporary_directory'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:303:in `original_requirements_resolvable?'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:298:in `resolvability_error?'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:245:in `handle_cargo_errors'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:59:in `rescue in fetch_latest_resolvable_version'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:41:in `fetch_latest_resolvable_version'
         # ./lib/dependabot/cargo/update_checker/version_resolver.rb:33:in `latest_resolvable_version'
         # ./spec/dependabot/cargo/update_checker/version_resolver_spec.rb:71:in `block (3 levels) in <top (required)>'
         # ./spec/dependabot/cargo/update_checker/version_resolver_spec.rb:177:in `block (5 levels) in <top (required)>'
         # ./spec/dependabot/cargo/update_checker/version_resolver_spec.rb:177:in `block (4 levels) in <top (required)>'
         # /home/dependabot/common/spec/spec_helper.rb:46:in `block (2 levels) in <top (required)>'
     # ./spec/dependabot/cargo/update_checker/version_resolver_spec.rb:177:in `block (4 levels) in <top (required)>'
     # /home/dependabot/common/spec/spec_helper.rb:46:in `block (2 levels) in <top (required)>'

Finished in 33.38 seconds (files took 1.24 seconds to load)
360 examples, 1 failure

Failed examples:

rspec ./spec/dependabot/cargo/update_checker/version_resolver_spec.rb:176 # Dependabot::Cargo::UpdateChecker::VersionResolver latest_resolvable_version when using a toolchain that is too old raises a helpful error
```

It seems confusing to me because we fail to categorize the error as matching ``usage of sparse registries requires `-Z sparse-registry` `` which is what determines that the cargo version is too old. But still, the command being raised is including that.

The problem is that we fail to match the string in the original error, but then when later trying to figure out whether the error was a resolvability issue, we end up running another cargo command to see if the original requirements were resolvable, and in that case, the ``usage of sparse registries requires `-Z sparse-registry` `` string is in the output.

So I'm wondering why the original error did not include the string.

To be able to verify this, we could return "nil" from `original_requirements_resolvable` if this happens, and let the original error be raised in that case.