### PR TITLE
Fix false positive auth redaction

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -5,7 +5,7 @@ require "dependabot/utils"
 
 module Dependabot
   class DependabotError < StandardError
-    BASIC_AUTH_REGEX = %r{://(?<auth>[^:]*:[^@%\s]+(@|%40))}
+    BASIC_AUTH_REGEX = %r{://(?<auth>[^:@]*:[^@%\s]+(@|%40))}
     # Remove any path segment from fury.io sources
     FURY_IO_PATH_REGEX = %r{fury\.io/(?<path>.+)}
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -5,7 +5,7 @@ require "dependabot/utils"
 
 module Dependabot
   class DependabotError < StandardError
-    BASIC_AUTH_REGEX = %r{://(?<auth>[^:@]*:[^@%\s]+(@|%40))}
+    BASIC_AUTH_REGEX = %r{://(?<auth>[^:@]*:[^@%\s/]+(@|%40))}
     # Remove any path segment from fury.io sources
     FURY_IO_PATH_REGEX = %r{fury\.io/(?<path>.+)}
 

--- a/common/spec/dependabot/errors_spec.rb
+++ b/common/spec/dependabot/errors_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Dependabot::DependabotError do
 
       it { is_expected.to eq("git://github.com error") }
     end
+
+    context "with multiple uri's include @ in their fragment, but no auth" do
+      let(:message) do
+        <<~MESSAGE.strip
+          https://github.com/EspressoSystems/tide-disco.git#tide-disco@0.4.1
+          https://github.com/EspressoSystems/tide-disco.git#tide-disco@0.4.1
+        MESSAGE
+      end
+
+      it { is_expected.to eq(message) }
+    end
   end
 end
 


### PR DESCRIPTION
If error includes multiple urls with @ in their fragments, we would redact it incorrectly.