### PR TITLE
Pass user info to Sentry

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -142,6 +142,10 @@ module Dependabot
       @repo_private
     end
 
+    def repo_owner
+      source&.organization
+    end
+
     def updating_a_pull_request?
       @updating_a_pull_request
     end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -109,7 +109,10 @@ module Dependabot
           extra: extra.merge({
             dependency_name: dependency&.name,
             dependency_group: dependency_group&.name
-          }.compact)
+          }.compact),
+          user: {
+            id: job&.repo_owner
+          }
         }
       )
     end


### PR DESCRIPTION
It could be useful to be able to prioritize errors by the number of repos affected.