### PR TITLE
Fix multiple pip compile errors

### DIFF
--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -27,6 +27,8 @@ module Dependabot
         WARNINGS = /\s*# WARNING:.*\Z/m
         UNSAFE_NOTE = /\s*# The following packages are considered to be unsafe.*\Z/m
         RESOLVER_REGEX = /(?<=--resolver=)(\w+)/
+        NATIVE_COMPILATION_ERROR =
+          "pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1"
 
         attr_reader :dependencies, :dependency_files, :credentials
 
@@ -34,6 +36,7 @@ module Dependabot
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
+          @build_isolation = true
         end
 
         def updated_dependency_files
@@ -67,28 +70,7 @@ module Dependabot
             language_version_manager.install_required_python
 
             filenames_to_compile.each do |filename|
-              # Shell out to pip-compile, generate a new set of requirements.
-              # This is slow, as pip-compile needs to do installs.
-              options = pip_compile_options(filename)
-              options_fingerprint = pip_compile_options_fingerprint(options)
-
-              name_part = "pyenv exec pip-compile " \
-                          "#{options} -P " \
-                          "#{dependency.name}"
-              fingerprint_name_part = "pyenv exec pip-compile " \
-                                      "#{options_fingerprint} -P " \
-                                      "<dependency_name>"
-
-              version_part = "#{dependency.version} #{filename}"
-              fingerprint_version_part = "<dependency_version> <filename>"
-
-              # Don't escape pyenv `dep-name==version` syntax
-              run_pip_compile_command(
-                "#{SharedHelpers.escape_command(name_part)}==" \
-                "#{SharedHelpers.escape_command(version_part)}",
-                allow_unsafe_shell_command: true,
-                fingerprint: "#{fingerprint_name_part}==#{fingerprint_version_part}"
-              )
+              compile_file(filename)
             end
 
             # Remove any .python-version file before parsing the reqs
@@ -106,6 +88,44 @@ module Dependabot
               file.dup.tap { |f| f.content = updated_content }
             end
           end
+        end
+
+        def compile_file(filename)
+          # Shell out to pip-compile, generate a new set of requirements.
+          # This is slow, as pip-compile needs to do installs.
+          options = pip_compile_options(filename)
+          options_fingerprint = pip_compile_options_fingerprint(options)
+
+          name_part = "pyenv exec pip-compile " \
+                      "#{options} -P " \
+                      "#{dependency.name}"
+          fingerprint_name_part = "pyenv exec pip-compile " \
+                                  "#{options_fingerprint} -P " \
+                                  "<dependency_name>"
+
+          version_part = "#{dependency.version} #{filename}"
+          fingerprint_version_part = "<dependency_version> <filename>"
+
+          # Don't escape pyenv `dep-name==version` syntax
+          run_pip_compile_command(
+            "#{SharedHelpers.escape_command(name_part)}==" \
+            "#{SharedHelpers.escape_command(version_part)}",
+            allow_unsafe_shell_command: true,
+            fingerprint: "#{fingerprint_name_part}==#{fingerprint_version_part}"
+          )
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          retry_count ||= 0
+          retry_count += 1
+          if compilation_error?(e) && retry_count <= 1
+            @build_isolation = false
+            retry
+          end
+
+          raise
+        end
+
+        def compilation_error?(error)
+          error.message.include?(NATIVE_COMPILATION_ERROR)
         end
 
         def update_manifest_files
@@ -403,7 +423,7 @@ module Dependabot
         end
 
         def pip_compile_options(filename)
-          options = ["--build-isolation"]
+          options = @build_isolation ? ["--build-isolation"] : ["--no-build-isolation"]
           options += pip_compile_index_options
 
           if (requirements_file = compiled_file_for_filename(filename))

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -27,7 +27,7 @@ module Dependabot
         GIT_DEPENDENCY_UNREACHABLE_REGEX = /git clone --filter=blob:none --quiet (?<url>[^\s]+).* /
         GIT_REFERENCE_NOT_FOUND_REGEX = /Did not find branch or tag '(?<tag>[^\n"]+)'/m
         NATIVE_COMPILATION_ERROR =
-          "pip._internal.exceptions.InstallationSubprocessError: Command errored out with exit status 1:"
+          "pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1"
         # See https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata
         PYTHON_PACKAGE_NAME_REGEX = /[A-Za-z0-9_\-]+/
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -393,7 +393,9 @@ RSpec.describe namespace::PipCompileVersionResolver do
       context "because it ran out of disk space" do
         before do
           allow(Dependabot::SharedHelpers)
-            .to receive(:run_shell_command)
+            .to receive(:run_shell_command).and_call_original
+          allow(Dependabot::SharedHelpers)
+            .to receive(:run_shell_command).with(a_string_matching(/pyenv exec pip-compile/), *any_args)
             .and_raise(
               Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                 message: "OSError: [Errno 28] No space left on device",
@@ -411,7 +413,9 @@ RSpec.describe namespace::PipCompileVersionResolver do
       context "because it ran out of memory" do
         before do
           allow(Dependabot::SharedHelpers)
-            .to receive(:run_shell_command)
+            .to receive(:run_shell_command).and_call_original
+          allow(Dependabot::SharedHelpers)
+            .to receive(:run_shell_command).with(a_string_matching(/pyenv exec pip-compile/), *any_args)
             .and_raise(
               Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                 message: "MemoryError",


### PR DESCRIPTION
This PR contains a few different bug fixes and refactorings.

I decided to propose them together, because the failing cases I was working with did not get fixed by applying only a subset of the fixes, but they need all of them to start creating sane PRs.

Break up of the different fixes is:

* Fix regex match of pip-compile errors as a way to retry `pip-compile` with `--no-build-isolation`. This error was caused by Pip itself changing the error message, and just catches up with the change. 500455f9a1c91dc937b7c1e38d9cb93ebbc47cb9
* Copy `--no-build-isolation` retry code into the file updater. Normally error detection only needs to happen in the update checker, since we fail early when detecting these errors and we don't need to check again in the file updater. We don't reach that far. However, in the case of these retries, if we succeed when retying, we keep going and need the same fallback when updating files. This could be improved by passing around whether `--no-build-isolation` needs to be used or not from the update checker to the file updater, but for now I just copied the code to detect it. f4fa838fe5dd70aa2ed5eb5097a8f3990a80f9b2
* Workaround a very common compilation error. `PyYAML < 6` is incompatible with `Cython 3`, which we use since [last July](https://github.com/dependabot/dependabot-core/pull/7586). In that PR, this problem was actually surfaced by our specs, but we failed to notice that it was not a specs-only problem where we could upgrade ourselves to PyYAML 6, but a real world user issue. Generally we don't introduce this kind of workaround but in this case I believe it's very wide spread so it's worth introducing it and paying the cost of maintaining this extra code. bb3398a64624f29af16072c48385b8f7f4964496

This is a reproducible example being fixed by this PR:

```
$ bin/dry-run.rb pip "raiden-network/raiden" --dir="/requirements" --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=90cd5a6cc27e31088a39fd35c0dccf89871dfa88 --cache=files --dep aiortc
```