### PR TITLE
Fix poetry multiple requirement replacement in pyproject.toml

### DIFF
--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -63,7 +63,7 @@ module Dependabot
           dependencies
             .select { |dep| requirement_changed?(pyproject, dep) }
             .reduce(pyproject.content.dup) do |content, dep|
-              updated_requirement =
+              new_req =
                 dep.requirements.find { |r| r[:file] == pyproject.name }
                    .fetch(:requirement)
 
@@ -75,12 +75,12 @@ module Dependabot
               declaration_regex = declaration_regex(dep)
               updated_content = if content.match?(declaration_regex)
                                   content.gsub(declaration_regex) do |match|
-                                    match.gsub(old_req, updated_requirement)
+                                    match.gsub(old_req, new_req)
                                   end
                                 else
                                   content.gsub(table_declaration_regex(dep)) do |match|
                                     match.gsub(/(\s*version\s*=\s*["'])#{Regexp.escape(old_req)}/,
-                                               '\1' + updated_requirement)
+                                               '\1' + new_req)
                                   end
                                 end
 

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -60,24 +60,23 @@ module Dependabot
         end
 
         def updated_pyproject_content
-          dependencies
-            .select { |dep| requirement_changed?(pyproject, dep) }
-            .reduce(pyproject.content.dup) do |content, dep|
-              new_req =
-                dep.requirements.find { |r| r[:file] == pyproject.name }
-                   .fetch(:requirement)
+          content = pyproject.content
+          return content unless requirement_changed?(pyproject, dependency)
 
-              old_req =
-                dep.previous_requirements
-                   .find { |r| r[:file] == pyproject.name }
-                   .fetch(:requirement)
+          new_req =
+            dependency.requirements.find { |r| r[:file] == pyproject.name }
+                      .fetch(:requirement)
 
-              updated_content = replace_dep(dep, content, old_req, new_req)
+          old_req =
+            dependency.previous_requirements
+                      .find { |r| r[:file] == pyproject.name }
+                      .fetch(:requirement)
 
-              raise "Content did not change!" if content == updated_content
+          updated_content = replace_dep(dependency, content, old_req, new_req)
 
-              updated_content
-            end
+          raise "Content did not change!" if content == updated_content
+
+          updated_content
         end
 
         def replace_dep(dep, content, old_req, new_req)

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -72,22 +72,26 @@ module Dependabot
                    .find { |r| r[:file] == pyproject.name }
                    .fetch(:requirement)
 
-              declaration_regex = declaration_regex(dep)
-              updated_content = if content.match?(declaration_regex)
-                                  content.gsub(declaration_regex) do |match|
-                                    match.gsub(old_req, new_req)
-                                  end
-                                else
-                                  content.gsub(table_declaration_regex(dep)) do |match|
-                                    match.gsub(/(\s*version\s*=\s*["'])#{Regexp.escape(old_req)}/,
-                                               '\1' + new_req)
-                                  end
-                                end
+              updated_content = replace_dep(dep, content, old_req, new_req)
 
               raise "Content did not change!" if content == updated_content
 
               updated_content
             end
+        end
+
+        def replace_dep(dep, content, old_req, new_req)
+          declaration_regex = declaration_regex(dep)
+          if content.match?(declaration_regex)
+            content.gsub(declaration_regex) do |match|
+              match.gsub(old_req, new_req)
+            end
+          else
+            content.gsub(table_declaration_regex(dep)) do |match|
+              match.gsub(/(\s*version\s*=\s*["'])#{Regexp.escape(old_req)}/,
+                         '\1' + new_req)
+            end
+          end
         end
 
         def updated_lockfile_content

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -74,7 +74,7 @@ module Dependabot
 
               declaration_regex = declaration_regex(dep)
               updated_content = if content.match?(declaration_regex)
-                                  content.gsub(declaration_regex(dep)) do |match|
+                                  content.gsub(declaration_regex) do |match|
                                     match.gsub(old_req, updated_requirement)
                                   end
                                 else

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -338,6 +338,174 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
       end
     end
 
+    context "with a pyproject.toml with same dep specified twice in different groups (legacy syntax)" do
+      let(:dependency_files) { [pyproject] }
+      let(:pyproject_fixture_name) { "different_requirements_legacy.toml" }
+      let(:dependency_name) { "isort" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.27.2",
+          previous_version: "1.18.1",
+          package_manager: "pip",
+          requirements: [{
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: "^1.27.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev-dependencies"]
+          }],
+          previous_requirements: [{
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: "^1.12.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev-dependencies"]
+          }]
+        )
+      end
+
+      it "updates the pyproject.toml correctly" do
+        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+        expect(updated_lockfile.content).to include <<~TOML
+          [tool.poetry.dependencies]
+          streamlit = ">=0.65.0"
+          packaging = ">=20.0"
+
+          [tool.poetry.dev-dependencies]
+          black = "^20.8b1"
+          isort = "^5.12.0"
+          flake8 = "^4.0.1"
+          mypy = "^1.6"
+          pytest = "^7.4.2"
+          streamlit = "^1.27.2"
+        TOML
+      end
+    end
+
+    context "with a pyproject.toml with same dep specified twice in different groups (updated is in main)" do
+      let(:dependency_files) { [pyproject] }
+      let(:pyproject_fixture_name) { "different_requirements_main.toml" }
+      let(:dependency_name) { "isort" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.27.2",
+          previous_version: "1.18.1",
+          package_manager: "pip",
+          requirements: [{
+            requirement: "^1.27.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev-dependencies"]
+          }],
+          previous_requirements: [{
+            requirement: "^1.12.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev-dependencies"]
+          }]
+        )
+      end
+
+      it "updates the pyproject.toml correctly" do
+        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+        expect(updated_lockfile.content).to include <<~TOML
+          [tool.poetry.dependencies]
+          packaging = ">=20.0"
+          streamlit = "^1.27.2"
+
+          [tool.poetry.dev-dependencies]
+          black = "^20.8b1"
+          isort = "^5.12.0"
+          flake8 = "^4.0.1"
+          mypy = "^1.6"
+          pytest = "^7.4.2"
+          streamlit = ">=0.65.0"
+        TOML
+      end
+    end
+
+    context "with a pyproject.toml with same dep specified twice in different groups" do
+      let(:dependency_files) { [pyproject] }
+      let(:pyproject_fixture_name) { "different_requirements.toml" }
+      let(:dependency_name) { "isort" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.27.2",
+          previous_version: "1.18.1",
+          package_manager: "pip",
+          requirements: [{
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: "^1.27.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev"]
+          }],
+          previous_requirements: [{
+            requirement: ">=0.65.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }, {
+            requirement: "^1.12.2",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dev"]
+          }]
+        )
+      end
+
+      it "updates the pyproject.toml correctly" do
+        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+        expect(updated_lockfile.content).to include <<~TOML
+          [tool.poetry.dependencies]
+          streamlit = ">=0.65.0"
+          packaging = ">=20.0"
+
+          [tool.poetry.group.dev.dependencies]
+          black = "^20.8b1"
+          isort = "^5.12.0"
+          flake8 = "^4.0.1"
+          mypy = "^1.6"
+          pytest = "^7.4.2"
+          streamlit = "^1.27.2"
+        TOML
+      end
+    end
+
     context "with a poetry.lock" do
       let(:lockfile) do
         Dependabot::DependencyFile.new(

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
       end
     end
 
-    context "with the oldest python version currently supported by Dependabot", :slow do
+    context "with the oldest python version currently supported by Dependabot" do
       let(:python_version) { "3.8.17" }
       let(:pyproject_fixture_name) { "python_38.toml" }
       let(:lockfile_fixture_name) { "python_38.lock" }

--- a/python/spec/fixtures/pyproject_files/different_requirements.toml
+++ b/python/spec/fixtures/pyproject_files/different_requirements.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "streamlit-server-state"
+version = "0.17.1"
+description = ""
+authors = ["Yuichiro Tachibana (Tsuchiya) <t.yic.yt@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/whitphx/streamlit-server-state"
+
+[tool.poetry.dependencies]
+streamlit = ">=0.65.0"
+packaging = ">=20.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^20.8b1"
+isort = "^5.12.0"
+flake8 = "^4.0.1"
+mypy = "^1.6"
+pytest = "^7.4.2"
+streamlit = "^1.12.2"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/python/spec/fixtures/pyproject_files/different_requirements_legacy.toml
+++ b/python/spec/fixtures/pyproject_files/different_requirements_legacy.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "streamlit-server-state"
+version = "0.17.1"
+description = ""
+authors = ["Yuichiro Tachibana (Tsuchiya) <t.yic.yt@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/whitphx/streamlit-server-state"
+
+[tool.poetry.dependencies]
+streamlit = ">=0.65.0"
+packaging = ">=20.0"
+
+[tool.poetry.dev-dependencies]
+black = "^20.8b1"
+isort = "^5.12.0"
+flake8 = "^4.0.1"
+mypy = "^1.6"
+pytest = "^7.4.2"
+streamlit = "^1.12.2"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/python/spec/fixtures/pyproject_files/different_requirements_main.toml
+++ b/python/spec/fixtures/pyproject_files/different_requirements_main.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "streamlit-server-state"
+version = "0.17.1"
+description = ""
+authors = ["Yuichiro Tachibana (Tsuchiya) <t.yic.yt@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/whitphx/streamlit-server-state"
+
+[tool.poetry.dependencies]
+packaging = ">=20.0"
+streamlit = "^1.12.2"
+
+[tool.poetry.dev-dependencies]
+black = "^20.8b1"
+isort = "^5.12.0"
+flake8 = "^4.0.1"
+mypy = "^1.6"
+pytest = "^7.4.2"
+streamlit = ">=0.65.0"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
If a `pyproject` specifies the same dependency in the development and main groups, that will cause Dependabot to crash.

This PR fixes the problem.

It can be reproduced with

```
bin/dry-run.rb pip "whitphx/streamlit-server-state" --dir="/." --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=0ccf9bd713ae97042a40705f8f29555bcd8003c8 --cache=files --dep streamline
```