### PR TITLE
port Docker updater improvements from Azure DevOps

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -158,7 +158,7 @@ module Dependabot
         old_tags.each do |old_tag|
           old_tag_regex = /^\s+(?:-\s)?(?:tag|version):\s+["']?#{old_tag}["']?(?=\s|$)/
           modified_content = modified_content.gsub(old_tag_regex) do |old_img_tag|
-            old_img_tag.gsub(old_tag.to_s, new_yaml_tag(file).to_s)
+            old_img_tag.gsub(old_tag.to_s, new_helm_tag(file).to_s)
           end
         end
         modified_content
@@ -187,11 +187,6 @@ module Dependabot
         "#{prefix}#{dependency.name}#{tag}#{digest}"
       end
 
-      def new_yaml_tag(file)
-        element = dependency.requirements.find { |r| r[:file] == file.name }
-        element.fetch(:source)[:tag] || ""
-      end
-
       def old_yaml_images(file)
         previous_requirements(file).map do |r|
           prefix = r.fetch(:source)[:registry] ? "#{r.fetch(:source)[:registry]}/" : ""
@@ -203,8 +198,17 @@ module Dependabot
 
       def old_helm_tags(file)
         previous_requirements(file).map do |r|
-          r.fetch(:source)[:tag] || ""
+          tag = r.fetch(:source)[:tag] || ""
+          digest = r.fetch(:source)[:digest] ? "@sha256:#{r.fetch(:source)[:digest]}" : ""
+          "#{tag}#{digest}"
         end
+      end
+
+      def new_helm_tag(file)
+        element = dependency.requirements.find { |r| r[:file] == file.name }
+        tag = element.fetch(:source)[:tag] || ""
+        digest = element.fetch(:source)[:digest] ? "@sha256:#{element.fetch(:source)[:digest]}" : ""
+        "#{tag}#{digest}"
       end
 
       def requirements(file)

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -9,8 +9,8 @@ module Dependabot
       WORDS_WITH_BUILD = /(?:(?:-[a-z]+)+-[0-9]+)+/
       VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[0-9]+)*(?:_[0-9]+|\.[a-z0-9]+|#{WORDS_WITH_BUILD}|-(?:kb)?[0-9]+)*)/i
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
-      VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-]*-)?#{VERSION_REGEX}$/i
-      VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
+      VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-_]*-)?#{VERSION_REGEX}$/i
+      VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-_]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
       NAME_WITH_VERSION =
         /
           #{VERSION_WITH_PFX}|

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -462,6 +462,34 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
+    context "with a _ in the tag" do
+      let(:dockerfile_fixture_name) { "underscore" }
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: {
+              registry: "registry-host.io:5000",
+              tag: "someRepo_19700101.4"
+            }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("myreg/ubuntu")
+          expect(dependency.version).to eq("someRepo_19700101.4")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
     context "with a private registry and a tag" do
       let(:dockerfile_fixture_name) { "private_tag" }
 

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1194,6 +1194,48 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       its(:content) { is_expected.to include "image:\n  repository: 'nginx'\n  tag: 1.14.3\n" }
     end
 
+    context "when a digest is used" do
+      let(:helmfile) do
+        Dependabot::DependencyFile.new(
+          content: helmfile_body,
+          name: "values.yaml"
+        )
+      end
+      let(:helmfile_body) { fixture("helm", "yaml", "digest.yaml") }
+      let(:helm_dependency) do
+        Dependabot::Dependency.new(
+          name: "ubuntu",
+          version: "sha256:c9cf959fd83770dfdefd8fb42cfef0761432af36a764c077aed54bbc5bb25368",
+          previous_version: "sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "sha256:c9cf959fd83770dfdefd8fb42cfef0761432af36a764c077aed54bbc5bb25368" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the updated helmfile" do
+        subject(:updated_helmfile) do
+          updated_files.find { |f| f.name == "values.yaml" }
+        end
+
+        its(:content) do
+          is_expected.to include "version: 'sha256:c9cf959fd83770dfdefd8fb42cfef0761432af36a7"
+        end
+      end
+    end
+
     context "when there are multiple images" do
       let(:helmfile) do
         Dependabot::DependencyFile.new(
@@ -1313,6 +1355,46 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         end
 
         its(:content) { is_expected.to include "image:\n  repository: \"nginx\"\n  tag: \"1.14.3\"\n" }
+      end
+    end
+
+    context "with version number" do
+      let(:helmfile) do
+        Dependabot::DependencyFile.new(
+          content: helmfile_body,
+          name: "values.yaml"
+        )
+      end
+      let(:helmfile_body) { fixture("helm", "yaml", "values.yaml") }
+      let(:helm_dependency) do
+        Dependabot::Dependency.new(
+          name: "nginx",
+          version: "1.14.3",
+          previous_version: "1.14.2",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.14.3" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.14.2" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the updated helmfile" do
+        subject(:updated_helmfile) do
+          updated_files.find { |f| f.name == "values.yaml" }
+        end
+
+        its(:content) { is_expected.to include "image:\n  repository: 'nginx'\n  tag: 1.14.3\n" }
       end
     end
 

--- a/docker/spec/fixtures/docker/dockerfiles/underscore
+++ b/docker/spec/fixtures/docker/dockerfiles/underscore
@@ -1,0 +1,18 @@
+FROM registry-host.io:5000/myreg/ubuntu:someRepo_19700101.4
+
+### SYSTEM DEPENDENCIES
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      dirmngr \
+      git \
+
+### RUBY
+
+# Install Ruby 2.4
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
+    && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu zesty main" > /etc/apt/sources.list.d/brightbox.list \
+    && apt-get update
+RUN apt-get install -y ruby2.4 ruby2.4-dev

--- a/docker/spec/fixtures/helm/yaml/digest.yaml
+++ b/docker/spec/fixtures/helm/yaml/digest.yaml
@@ -1,0 +1,7 @@
+foo:
+  image: nginx:1.14.2
+
+bar:
+  image:
+    repository: 'canonical/ubuntu'
+    version: 'sha256:295c7be079025306c4f1d65997fcf7adb411c88f139ad1d34b537164aa060369'


### PR DESCRIPTION
As part of the work inside Azure DevOps to improve dependabot (see #8179) there were some updates to the Docker updater that needed to be split out into their own PR, specifically:

- Allow docker version prefixes to contain underscores
- Add support for digests when updating helm charts

(cc @brbayes-msft)