### PR TITLE
Raise user errors on invalid poetry manifest

### DIFF
--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
 
     subject(:dependencies) { parser.dependency_set.dependencies }
 
+    context "incorrectly defined" do
+      let(:pyproject_fixture_name) { "incorrect_poetry_setup.toml" }
+
+      it "raises a DependencyFileNotParseable error" do
+        expect { parser.dependency_set }
+          .to raise_error do |error|
+            expect(error.class)
+              .to eq(Dependabot::DependencyFileNotParseable)
+            expect(error.message)
+              .to eq <<~ERROR.strip
+                /pyproject.toml is missing the following sections:
+                  * tool.poetry.name
+                  * tool.poetry.version
+                  * tool.poetry.description
+                  * tool.poetry.authors
+              ERROR
+          end
+      end
+    end
+
     context "without a lockfile" do
       its(:length) { is_expected.to eq(15) }
 

--- a/python/spec/fixtures/pyproject_files/incorrect_poetry_setup.toml
+++ b/python/spec/fixtures/pyproject_files/incorrect_poetry_setup.toml
@@ -1,0 +1,28 @@
+[project]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6 || ^3.7"
+geopy = "^1.13"
+Pillow = "^5.1"
+requests = "^2.18"
+
+[tool.poetry.dev-dependencies]
+black = "^18.5"
+flake8 = "^3.5"
+flake8-comprehensions = "^1.4"
+httmock = "^1.2"
+hypothesis = "^3.56"
+mypy = "^0.600"
+pytest = "^3.5"
+pytest-cov = "^2.5"
+pytest-mock = "^1.9"
+pytest-sugar = "^0.9"
+pytest-random-order = "^0.7"
+tox = "^3.0"


### PR DESCRIPTION
If a user defines an incorrect `pyproject.toml` file for Poetry, for example, because it's missing some required keys like `tool.poetry.name`, well end up crashing because Poetry can't handle with that under the hood.

For example,

```
$ bin/dry-run.rb pip "obervinov/vault-package" --dir="/." --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=9782e76cbd40d26b64049e4f1389af4a273b62b3 
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/obervinov/vault-package/.
=> parsing dependency files
=> updating 4 dependencies: hvac, keyring, python-dateutil, logger

=== hvac (1.1.0)
 => checking for updates 1/4
🌍 --> GET https://pypi.org/simple/hvac/
🌍 <-- 200 https://pypi.org/simple/hvac/
 => latest available version is 1.2.1
/home/dependabot/common/lib/dependabot/shared_helpers.rb:344:in `run_shell_command': 'name' (Dependabot::SharedHelpers::HelperSubprocessFailed)
	from /home/dependabot/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:311:in `run_poetry_command'
	from /home/dependabot/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:86:in `block (2 levels) in fetch_latest_resolvable_version_string'
	from /home/dependabot/common/lib/dependabot/shared_helpers.rb:195:in `with_git_configured'
	from /home/dependabot/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:79:in `block in fetch_latest_resolvable_version_string'
	from /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `block in in_a_temporary_directory'
	from /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `chdir'
	from /home/dependabot/common/lib/dependabot/shared_helpers.rb:56:in `in_a_temporary_directory'
	from /home/dependabot/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:78:in `fetch_latest_resolvable_version_string'
	from /home/dependabot/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:51:in `latest_resolvable_version'
	from /home/dependabot/python/lib/dependabot/python/update_checker.rb:43:in `latest_resolvable_version'
	from bin/dry-run.rb:705:in `block in <main>'
	from bin/dry-run.rb:667:in `each'
```

This PR adds some raw validation to `pyproject.toml` and raises a user error if not valid.

