### PR TITLE
Mark `.rbi` as `linguist-generated`

### DIFF
--- a/sorbet/rbi/gems/.gitattributes
+++ b/sorbet/rbi/gems/.gitattributes
@@ -1,0 +1,1 @@
+**/*.rbi linguist-generated=true


### PR DESCRIPTION
This will collapse diffs in `.rbi` files by default and omit them from the repository language statistics. See [Customizing how changed files appear on GitHub][1] for more details.

This is the `.gitattributes` file that gets generated by the newest version of `tapioca`. `.rbi` files are automatically generated by `tapioca` and should not be manually edited.

[1]: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github