### PR TITLE
Handle null dependencies in package.json

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
@@ -72,14 +72,12 @@ module Dependabot
 
           @git_ssh_requirements_to_swap = []
 
-          NpmAndYarn::FileParser::DEPENDENCY_TYPES.each do |t|
-            JSON.parse(package_json_content).fetch(t, {}).each do |_, req|
-              next unless req.is_a?(String)
-              next unless req.start_with?("git+ssh:")
+          NpmAndYarn::FileParser.each_dependency(JSON.parse(package_json_content)) do |_, req, _t|
+            next unless req.is_a?(String)
+            next unless req.start_with?("git+ssh:")
 
-              req = req.split("#").first
-              @git_ssh_requirements_to_swap << req
-            end
+            req = req.split("#").first
+            @git_ssh_requirements_to_swap << req
           end
 
           @git_ssh_requirements_to_swap

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_preparer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_preparer_spec.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/file_updater/package_json_preparer"
+
+RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonPreparer do
+  describe "#prepared_content" do
+    it "does not craash when finding null dependencies" do
+      original_content = fixture("projects", "generic", "null_deps", "package.json")
+
+      preparer = described_class.new(package_json_content: original_content)
+
+      expect(preparer.prepared_content).to eq(original_content)
+    end
+  end
+end

--- a/npm_and_yarn/spec/fixtures/projects/generic/null_deps/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/generic/null_deps/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@unction/isnil",
+  "version": "6.6.3",
+  "description": "Determines if a value is not a value",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/unctionjs/isNil#readme",
+  "repository": "github:unctionjs/isNil",
+  "dependencies": null
+}


### PR DESCRIPTION
Our dependency parsing class was parsing these just fine, but not other classes.

Fixes errors like 

```
SECURITY_ADVISORIES='[{"dependency-name":"@babel/traverse","patched-versions":[],"unaffected-versions":[],"affected-versions":[">= 8.0.0-alpha.0 < 8.0.0-alpha.4","< 7.23.2"]}]'  bin/dry-run.rb npm_and_yarn "unctionjs/isNil" --dir="/." --dep="@babel/traverse" --security-updates-only --updater-options=grouped_updates_experimental_rules,npm_transitive_dependency_removal,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=967b0de4a2ccadf63e3e14745bb8a95a2a1e1347
```