### PR TITLE
Add types to `FileUpdaters::Base`

### DIFF
--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -12,12 +12,16 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::Dependency]) }
       attr_reader :dependencies
+
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       attr_reader :dependency_files
+
       sig { returns(T.nilable(String)) }
       attr_reader :repo_contents_path
+
       sig { returns(T::Array[T::Hash[String, String]]) }
       attr_reader :credentials
+
       sig { returns(T::Hash[Symbol, T.untyped]) }
       attr_reader :options
 

--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -1,18 +1,39 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Dependabot
   module FileUpdaters
     class Base
-      attr_reader :dependencies, :dependency_files, :repo_contents_path,
-                  :credentials, :options
+      extend T::Sig
+      extend T::Helpers
+      abstract!
 
+      sig { returns(T::Array[Dependabot::Dependency]) }
+      attr_reader :dependencies
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      attr_reader :dependency_files
+      sig { returns(T.nilable(String)) }
+      attr_reader :repo_contents_path
+      sig { returns(T::Array[T::Hash[String, String]]) }
+      attr_reader :credentials
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      attr_reader :options
+
+      sig { overridable.returns(String) }
       def self.updated_files_regex
         raise NotImplementedError
       end
 
-      def initialize(dependencies:, dependency_files:, repo_contents_path: nil,
-                     credentials:, options: {})
+      sig do
+        params(
+          dependencies: T::Array[Dependabot::Dependency],
+          dependency_files: T::Array[Dependabot::DependencyFile],
+          credentials: T::Array[T::Hash[String, String]],
+          repo_contents_path: T.nilable(String),
+          options: T::Hash[Symbol, T.untyped]
+        ).void
+      end
+      def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path: nil, options: {})
         @dependencies = dependencies
         @dependency_files = dependency_files
         @repo_contents_path = repo_contents_path
@@ -22,31 +43,36 @@ module Dependabot
         check_required_files
       end
 
+      sig { overridable.returns(T::Array[::Dependabot::DependencyFile]) }
       def updated_dependency_files
         raise NotImplementedError
       end
 
       private
 
+      sig { overridable.void }
       def check_required_files
         raise NotImplementedError
       end
 
+      sig { params(filename: String).returns(T.nilable(Dependabot::DependencyFile)) }
       def get_original_file(filename)
         dependency_files.find { |f| f.name == filename }
       end
 
+      sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
       def file_changed?(file)
         dependencies.any? { |dep| requirement_changed?(file, dep) }
       end
 
+      sig { params(file: Dependabot::DependencyFile, dependency: Dependabot::Dependency).returns(T::Boolean) }
       def requirement_changed?(file, dependency)
-        changed_requirements =
-          dependency.requirements - dependency.previous_requirements
+        changed_requirements = dependency.requirements - dependency.previous_requirements
 
         changed_requirements.any? { |f| f[:file] == file.name }
       end
 
+      sig { params(file: Dependabot::DependencyFile, content: String).returns(Dependabot::DependencyFile) }
       def updated_file(file:, content:)
         updated_file = file.dup
         updated_file.content = content

--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 module Dependabot
   module FileUpdaters
     class Base

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -100,7 +100,7 @@ module Dependabot
       end
 
       def directory
-        dependency_files.first.directory
+        dependency_files.first&.directory
       end
 
       def vendor_dir

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -20,7 +20,7 @@ module Dependabot
       end
 
       def updated_dependency_files
-        updated_files = dependency_files.dup
+        updated_files = T.let(dependency_files.dup, T.untyped)
 
         # Loop through each of the changed requirements, applying changes to
         # all pom and extensions files for that change. Note that the logic

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -24,7 +24,7 @@ module Dependabot
       end
 
       def updated_dependency_files
-        updated_files = dependency_files.dup
+        updated_files = T.let(dependency_files.dup, T.untyped)
 
         # Loop through each of the changed requirements, applying changes to
         # all files for that change. Note that the logic is different here


### PR DESCRIPTION
A couple of notable things I'd like to highlight about this PR:

- Reordered the parameters of `initialize` to fix [`Sorbet/KeywordArgumentOrdering`: Optional keyword arguments must be at the end of the parameter list][1]
- It's a little unclear what the types of `credentials` and `options` should be
	- I was more confident in `credentials` being `T::Hash[String, String]`
	- I was less confident in `options` so it's `T::Hash[String, T.untyped]`
- Methods marked with [`overridable`][2] should likely be marked as `abstract`, but `abstract` methods are required to have no body, and I am not sure if anything is depending on them raising a `NotImplementedError`
- Changes to other files are type system 'escape hatches' as they haven't been properly typed yet and I wanted to keep this PR small

Part of #7782

[1]: https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetkeywordargumentordering
[2]: https://sorbet.org/docs/override-checking