### PR TITLE
Ignore dependencies from remote constraint files

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -105,6 +105,11 @@ def parse_requirements(directory):
 
                 pattern = r"-[cr] (.*) \(line \d+\)"
                 abs_path = re.search(pattern, install_req.comes_from).group(1)
+
+                # Ignore dependencies from remote constraint files
+                if not os.path.isfile(abs_path):
+                    continue
+
                 rel_path = os.path.relpath(abs_path, directory)
 
                 requirement_packages.append({

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -266,6 +266,11 @@ RSpec.describe Dependabot::Python::FileParser do
       end
     end
 
+    context "with remote constraints" do
+      let(:requirements_fixture_name) { "remote_constraints.txt" }
+      its(:length) { is_expected.to eq(0) }
+    end
+
     context "with no version specified" do
       let(:requirements_fixture_name) { "version_not_specified.txt" }
       its(:length) { is_expected.to eq(2) }

--- a/python/spec/fixtures/requirements/remote_constraints.txt
+++ b/python/spec/fixtures/requirements/remote_constraints.txt
@@ -1,0 +1,1 @@
+-c "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.11.txt"


### PR DESCRIPTION
These are remote dependencies, so we can't update them.

If we parse them, we'll end up crashing somewhere else.