### PR TITLE
Avoid trying to parse poetry.lock if pyproject.toml is invalid for Poetry

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -27,7 +27,7 @@ module Dependabot
           dependency_set = Dependabot::FileParsers::Base::DependencySet.new
 
           dependency_set += pyproject_dependencies if using_poetry? || using_pep621?
-          dependency_set += lockfile_dependencies if lockfile
+          dependency_set += lockfile_dependencies if using_poetry? && lockfile
 
           dependency_set
         end

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -311,6 +311,23 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
       subject(:dependencies) { parser.dependency_set.dependencies }
 
       its(:length) { is_expected.to eq(0) }
+
+      context "and a leftover poetry.lock" do
+        let(:poetry_lock) do
+          Dependabot::DependencyFile.new(
+            name: "poetry.lock",
+            content: poetry_lock_body
+          )
+        end
+        let(:poetry_lock_body) do
+          fixture("poetry_locks", poetry_lock_fixture_name)
+        end
+        let(:poetry_lock_fixture_name) { "poetry.lock" }
+
+        let(:files) { [pyproject, pdm_lock, poetry_lock] }
+
+        its(:length) { is_expected.to eq(0) }
+      end
     end
 
     context "with optional dependencies" do


### PR DESCRIPTION
Otherwise we'll end up with an error, like here:

```
$ bin/dry-run.rb pip "The-Dark-Limit/watchdog-node" --dir="/." --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=79b38eac0d4ac6e6e737f077fb0988af8edee9d4 --cache=files
```