### PR TITLE
Support Python requirements with preceding "v"

### DIFF
--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -9,7 +9,7 @@ module Dependabot
       COMPARISON = /===|==|>=|<=|<|>|~=|!=/
       VERSION = /([1-9][0-9]*!)?[0-9]+[a-zA-Z0-9\-_.*]*(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?/
 
-      REQUIREMENT = /(?<comparison>#{COMPARISON})\s*\\?\s*(?<version>#{VERSION})/
+      REQUIREMENT = /(?<comparison>#{COMPARISON})\s*\\?\s*v?(?<version>#{VERSION})/
       HASH = /--hash=(?<algorithm>.*?):(?<hash>.*?)(?=\s|\\|$)/
       REQUIREMENTS = /#{REQUIREMENT}(\s*,\s*\\?\s*#{REQUIREMENT})*/
       HASHES = /#{HASH}(\s*\\?\s*#{HASH})*/

--- a/python/spec/dependabot/python/requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/requirement_parser_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe Dependabot::Python::RequirementParser do
         end
       end
 
+      context "with preceeding v" do
+        let(:line) { "luigi==v0.1.0" }
+        its([:name]) { is_expected.to eq "luigi" }
+        its([:requirements]) do
+          is_expected.to eq [{ comparison: "==", version: "0.1.0" }]
+        end
+      end
+
       context "with a comment" do
         let(:line) { "luigi==0.1.0 # some comment" }
         its([:name]) { is_expected.to eq "luigi" }


### PR DESCRIPTION
We currently raise an error when trying to update requirements like this, for example:

```
mypy==v1.5.1
```

Such an error can be reproduced with:

```
bin/dry-run.rb pip "Rahul2044/cve-bin-tool" --dir="/." --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error,unignore_commands --commit=abaa7571b4aac36489b59137f0ef827c0f4c7ded --cache=files --dep mypy
```