### PR TITLE
Correct handling of `updater` directory in sorbet

### DIFF
--- a/bundler/lib/dependabot/bundler.rb
+++ b/bundler/lib/dependabot/bundler.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/bundler/lib/dependabot/bundler/version.rb
+++ b/bundler/lib/dependabot/bundler/version.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/version"

--- a/bundler/lib/dependabot/bundler/version.rb
+++ b/bundler/lib/dependabot/bundler/version.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/version"

--- a/cargo/lib/dependabot/cargo.rb
+++ b/cargo/lib/dependabot/cargo.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/cargo/lib/dependabot/cargo.rb
+++ b/cargo/lib/dependabot/cargo.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/common/lib/dependabot/config.rb
+++ b/common/lib/dependabot/config.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot

--- a/common/lib/dependabot/config.rb
+++ b/common/lib/dependabot/config.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Dependabot

--- a/composer/lib/dependabot/composer.rb
+++ b/composer/lib/dependabot/composer.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/docker/lib/dependabot/docker.rb
+++ b/docker/lib/dependabot/docker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/docker/lib/dependabot/docker.rb
+++ b/docker/lib/dependabot/docker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/elm/lib/dependabot/elm.rb
+++ b/elm/lib/dependabot/elm.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/elm/lib/dependabot/elm.rb
+++ b/elm/lib/dependabot/elm.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/git_submodules/lib/dependabot/git_submodules.rb
+++ b/git_submodules/lib/dependabot/git_submodules.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/git_submodules/lib/dependabot/git_submodules.rb
+++ b/git_submodules/lib/dependabot/git_submodules.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/git_submodules/lib/dependabot/git_submodules/version.rb
+++ b/git_submodules/lib/dependabot/git_submodules/version.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/version"

--- a/git_submodules/lib/dependabot/git_submodules/version.rb
+++ b/git_submodules/lib/dependabot/git_submodules/version.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/version"

--- a/github_actions/lib/dependabot/github_actions.rb
+++ b/github_actions/lib/dependabot/github_actions.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/github_actions/lib/dependabot/github_actions.rb
+++ b/github_actions/lib/dependabot/github_actions.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/go_modules/lib/dependabot/go_modules.rb
+++ b/go_modules/lib/dependabot/go_modules.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/go_modules/lib/dependabot/go_modules.rb
+++ b/go_modules/lib/dependabot/go_modules.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/gradle/lib/dependabot/gradle.rb
+++ b/gradle/lib/dependabot/gradle.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/hex/lib/dependabot/hex.rb
+++ b/hex/lib/dependabot/hex.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/maven/lib/dependabot/maven.rb
+++ b/maven/lib/dependabot/maven.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/nuget/lib/dependabot/nuget.rb
+++ b/nuget/lib/dependabot/nuget.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/omnibus/lib/dependabot/omnibus.rb
+++ b/omnibus/lib/dependabot/omnibus.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/python"

--- a/omnibus/lib/dependabot/omnibus.rb
+++ b/omnibus/lib/dependabot/omnibus.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/python"

--- a/pub/lib/dependabot/pub.rb
+++ b/pub/lib/dependabot/pub.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/pub/lib/dependabot/pub.rb
+++ b/pub/lib/dependabot/pub.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/python/lib/dependabot/python.rb
+++ b/python/lib/dependabot/python.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot

--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Dependabot

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,10 +1,6 @@
---dir
-.
---dir
-updater
+--dir=.
 --ignore=tmp/
 --ignore=vendor/
---ignore=updater/
 --disable-watchman
 
 # Sorbet doesn't currently support RSpec very well, so we ignore all of our specs.

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -13,11 +13,7 @@ module Dependabot::NpmAndYarn::FileFetcher::Pysch::SyntaxError; end
 module Dependabot::NpmAndYarn::FileParser::DependencySet; end
 module Dependabot::Service::Raven; end
 module Dependabot::Service::Terminal::Table; end
-module Dependabot::Updater::ErrorHandler; end
-module Dependabot::Updater::ErrorHandler::RUN_HALTING_ERRORS; end
 module Dependabot::Updater::Operations; end
-module Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest; end
-module Dependabot::Updater::SubprocessFailed; end
 module HTTP::ConnectionError; end
 class HTTP::Client
   def auth(value); end

--- a/sorbet/tapioca/require.rb
+++ b/sorbet/tapioca/require.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # Add your extra requires here (`bin/tapioca require` can be used to bootstrap this list)

--- a/sorbet/tapioca/require.rb
+++ b/sorbet/tapioca/require.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # Add your extra requires here (`bin/tapioca require` can be used to bootstrap this list)

--- a/swift/lib/dependabot/swift.rb
+++ b/swift/lib/dependabot/swift.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/swift/lib/dependabot/swift.rb
+++ b/swift/lib/dependabot/swift.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/terraform/lib/dependabot/terraform.rb
+++ b/terraform/lib/dependabot/terraform.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "raven"

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # This class describes a change to the project's Dependencies which has been

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/dependency_group"

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "base64"

--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Dependabot

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "base64"

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/config/ignore_condition"

--- a/updater/lib/dependabot/logger/formats.rb
+++ b/updater/lib/dependabot/logger/formats.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "logger"

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "base64"

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # Dependabot components

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # This class is responsible for aggregating individual DependencyChange objects

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/errors"

--- a/updater/lib/dependabot/updater/errors.rb
+++ b/updater/lib/dependabot/updater/errors.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Dependabot

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/operations/create_group_security_update_pull_request"

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/security_update_helpers"

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/group_update_creation"

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/security_update_helpers"

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/operations/create_group_update_pull_request"

--- a/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/security_update_helpers"

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/updater/group_update_creation"

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # This class implements our strategy for 'refreshing' an existing Pull Request

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # This class implements our strategy for iterating over all of the dependencies


### PR DESCRIPTION
The current configuration had 2 directories listed, `.` and `updater`. However, Sorbet only allows for a single directory. Additionally, we also had `--ignore=updater`. This configuration appeared to be accepted but hid some errors.

Also, a couple of points about `todo.rbi`:
- Things should only ever be removed from `todo.rbi`, never added. Either:
	- They should be migrated to a hand-written `.rbi` in `sorbet/rbi/shims`
	- A `spoom` generated `.rbi` should be added in `sorbet/rbi/gems`
- None of the `Dependabot::` classes or modules should appear in `todo.rbi`
	- This is an indication that those files should be migrated to `# typed: true`