### PR TITLE
Fix poetry regression

### DIFF
--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -244,7 +244,7 @@ module Dependabot
         end
 
         def declaration_regex(dep, old_req)
-          /#{old_req[:groups].first}(?:\.dependencies)?\]\s*\n.*?(?:^\s*|["'])#{escape(dep)}["']?\s*=.*$/mi
+          /#{old_req[:groups].first}(?:\.dependencies)?\]\s*\n.*?(?:^\s*|["'])#{escape(dep)}["']?\s*=[^\n]*$/mi
         end
 
         def table_declaration_regex(dep, old_req)

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -81,10 +81,11 @@ module Dependabot
           old_req = old_r[:requirement]
 
           declaration_regex = declaration_regex(dep, old_r)
-          if content.match?(declaration_regex)
-            content.gsub(declaration_regex) do |match|
-              match.gsub(old_req, new_req)
-            end
+          declaration_match = content.match(declaration_regex)
+          if declaration_match
+            declaration = declaration_match[:declaration]
+            new_declaration = declaration.sub(old_req, new_req)
+            content.sub(declaration, new_declaration)
           else
             content.gsub(table_declaration_regex(dep, new_r)) do |match|
               match.gsub(/(\s*version\s*=\s*["'])#{Regexp.escape(old_req)}/,
@@ -244,7 +245,9 @@ module Dependabot
         end
 
         def declaration_regex(dep, old_req)
-          /#{old_req[:groups].first}(?:\.dependencies)?\]\s*\n.*?(?:^\s*|["'])#{escape(dep)}["']?\s*=[^\n]*$/mi
+          group = old_req[:groups].first
+
+          /#{group}(?:\.dependencies)?\]\s*\n.*?(?<declaration>(?:^\s*|["'])#{escape(dep)}["']?\s*=[^\n]*)$/mi
         end
 
         def table_declaration_regex(dep, old_req)

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
     context "with a pyproject.toml with same dep specified twice in different groups (legacy syntax)" do
       let(:dependency_files) { [pyproject] }
       let(:pyproject_fixture_name) { "different_requirements_legacy.toml" }
-      let(:dependency_name) { "isort" }
+      let(:dependency_name) { "streamlit" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,
@@ -397,7 +397,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
     context "with a pyproject.toml with same dep specified twice in different groups (updated is in main)" do
       let(:dependency_files) { [pyproject] }
       let(:pyproject_fixture_name) { "different_requirements_main.toml" }
-      let(:dependency_name) { "isort" }
+      let(:dependency_name) { "streamlit" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,
@@ -453,7 +453,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
     context "with a pyproject.toml with same dep specified twice in different groups" do
       let(:dependency_files) { [pyproject] }
       let(:pyproject_fixture_name) { "different_requirements.toml" }
-      let(:dependency_name) { "isort" }
+      let(:dependency_name) { "streamlit" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -157,401 +157,396 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
       end
     end
 
-    context "without a lockfile" do
+    context "with a pyproject.toml file" do
       let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "caret_version.toml" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "2.19.1",
-          previous_version: nil,
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^2.19.1",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^1.0.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }]
-        )
+
+      context "without a lockfile" do
+        let(:pyproject_fixture_name) { "caret_version.toml" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "2.19.1",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^2.19.1",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^1.0.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }]
+          )
+        end
+
+        it "updates the pyproject.toml" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+          expect(updated_lockfile.content).to include('requests = "^2.19.1"')
+        end
       end
 
-      it "updates the pyproject.toml" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "that's indented" do
+        let(:pyproject_fixture_name) { "indented.toml" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "2.19.1",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^2.19.1",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^1.0.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
-        expect(updated_lockfile.content).to include('requests = "^2.19.1"')
-      end
-    end
+        it "updates the pyproject.toml" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-    context "without a lockfile and with an indented pyproject.toml" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "indented.toml" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "2.19.1",
-          previous_version: nil,
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^2.19.1",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^1.0.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }]
-        )
-      end
-
-      it "updates the pyproject.toml" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
-
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
-        expect(updated_lockfile.content).to include('  requests = "^2.19.1"')
-      end
-    end
-
-    context "with a pyproject.toml specifying table style dependencies" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "table.toml" }
-      let(:dependency_name) { "isort" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "5.7.0",
-          previous_version: nil,
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^5.7",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^5.4",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }]
-        )
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+          expect(updated_lockfile.content).to include('  requests = "^2.19.1"')
+        end
       end
 
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "specifying table style dependencies" do
+        let(:pyproject_fixture_name) { "table.toml" }
+        let(:dependency_name) { "isort" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "5.7.0",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^5.7",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^5.4",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dev-dependencies.isort]
-          version = "^5.7"
-        TOML
-      end
-    end
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-    context "with a pyproject.toml specifying table style dependencies with version as the last field" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "table_version_last.toml" }
-      let(:dependency_name) { "isort" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "5.7.0",
-          previous_version: nil,
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^5.7",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^5.4",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }]
-        )
-      end
-
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
-
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
-
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dev-dependencies.isort]
-          extras = [ "pyproject",]
-          version = "^5.7"
-        TOML
-      end
-    end
-
-    context "with a pyproject.toml specifying table style dependencies with version conflicting with other deps" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "table_version_conflicts.toml" }
-      let(:dependency_name) { "isort" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "5.7.0",
-          previous_version: nil,
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^5.7",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^5.4",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }]
-        )
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dev-dependencies.isort]
+            version = "^5.7"
+          TOML
+        end
       end
 
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "specifying table style dependencies with version as the last field" do
+        let(:pyproject_fixture_name) { "table_version_last.toml" }
+        let(:dependency_name) { "isort" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "5.7.0",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^5.7",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^5.4",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dev-dependencies.isort]
-          extras = [ "pyproject",]
-          version = "^5.7"
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-          [tool.poetry.dev-dependencies.pytest]
-          extras = [ "pyproject",]
-          version = "^5.4"
-        TOML
-      end
-    end
-
-    context "with a pyproject.toml with same dep specified twice in different groups (legacy syntax)" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "different_requirements_legacy.toml" }
-      let(:dependency_name) { "streamlit" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "1.27.2",
-          previous_version: "1.18.1",
-          package_manager: "pip",
-          requirements: [{
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: "^1.27.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: "^1.12.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }]
-        )
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dev-dependencies.isort]
+            extras = [ "pyproject",]
+            version = "^5.7"
+          TOML
+        end
       end
 
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "specifying table style dependencies with version conflicting with other deps" do
+        let(:pyproject_fixture_name) { "table_version_conflicts.toml" }
+        let(:dependency_name) { "isort" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "5.7.0",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^5.7",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^5.4",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dependencies]
-          streamlit = ">=0.65.0"
-          packaging = ">=20.0"
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-          [tool.poetry.dev-dependencies]
-          black = "^20.8b1"
-          isort = "^5.12.0"
-          flake8 = "^4.0.1"
-          mypy = "^1.6"
-          pytest = "^7.4.2"
-          streamlit = "^1.27.2"
-        TOML
-      end
-    end
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dev-dependencies.isort]
+            extras = [ "pyproject",]
+            version = "^5.7"
 
-    context "with a pyproject.toml with same dep specified twice in different groups (updated is in main)" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "different_requirements_main.toml" }
-      let(:dependency_name) { "streamlit" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "1.27.2",
-          previous_version: "1.18.1",
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^1.27.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^1.12.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev-dependencies"]
-          }]
-        )
+            [tool.poetry.dev-dependencies.pytest]
+            extras = [ "pyproject",]
+            version = "^5.4"
+          TOML
+        end
       end
 
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "with same dep specified twice in different groups (legacy syntax)" do
+        let(:pyproject_fixture_name) { "different_requirements_legacy.toml" }
+        let(:dependency_name) { "streamlit" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "1.27.2",
+            previous_version: "1.18.1",
+            package_manager: "pip",
+            requirements: [{
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: "^1.27.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: "^1.12.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dependencies]
-          packaging = ">=20.0"
-          streamlit = "^1.27.2"
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-          [tool.poetry.dev-dependencies]
-          black = "^20.8b1"
-          isort = "^5.12.0"
-          flake8 = "^4.0.1"
-          mypy = "^1.6"
-          pytest = "^7.4.2"
-          streamlit = ">=0.65.0"
-        TOML
-      end
-    end
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dependencies]
+            streamlit = ">=0.65.0"
+            packaging = ">=20.0"
 
-    context "with a pyproject.toml with same dep specified twice in different groups" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "different_requirements.toml" }
-      let(:dependency_name) { "streamlit" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "1.27.2",
-          previous_version: "1.18.1",
-          package_manager: "pip",
-          requirements: [{
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: "^1.27.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev"]
-          }],
-          previous_requirements: [{
-            requirement: ">=0.65.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }, {
-            requirement: "^1.12.2",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dev"]
-          }]
-        )
-      end
-
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
-
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
-
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry.dependencies]
-          streamlit = ">=0.65.0"
-          packaging = ">=20.0"
-
-          [tool.poetry.group.dev.dependencies]
-          black = "^20.8b1"
-          isort = "^5.12.0"
-          flake8 = "^4.0.1"
-          mypy = "^1.6"
-          pytest = "^7.4.2"
-          streamlit = "^1.27.2"
-        TOML
-      end
-    end
-
-    context "with a pyproject.toml with the same requirement specified in two dependencies" do
-      let(:dependency_files) { [pyproject] }
-      let(:pyproject_fixture_name) { "same_requirements.toml" }
-      let(:dependency_name) { "rq" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: "1.15.0",
-          previous_version: "1.13.0",
-          package_manager: "pip",
-          requirements: [{
-            requirement: "^1.15.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }],
-          previous_requirements: [{
-            requirement: "^1.13.0",
-            file: "pyproject.toml",
-            source: nil,
-            groups: ["dependencies"]
-          }]
-        )
+            [tool.poetry.dev-dependencies]
+            black = "^20.8b1"
+            isort = "^5.12.0"
+            flake8 = "^4.0.1"
+            mypy = "^1.6"
+            pytest = "^7.4.2"
+            streamlit = "^1.27.2"
+          TOML
+        end
       end
 
-      it "updates the pyproject.toml correctly" do
-        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+      context "with same dep specified twice in different groups (updated is in main)" do
+        let(:pyproject_fixture_name) { "different_requirements_main.toml" }
+        let(:dependency_name) { "streamlit" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "1.27.2",
+            previous_version: "1.18.1",
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^1.27.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^1.12.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev-dependencies"]
+            }]
+          )
+        end
 
-        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-        expect(updated_lockfile.content).to include <<~TOML
-          [tool.poetry]
-          name = "dependabot-poetry-bug"
-          version = "0.1.0"
-          description = ""
-          authors = []
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-          [tool.poetry.dependencies]
-          python = "^3.9"
-          rq = "^1.15.0"
-          dramatiq = "^1.13.0"
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dependencies]
+            packaging = ">=20.0"
+            streamlit = "^1.27.2"
 
-          [build-system]
-          requires = ["poetry-core"]
-          build-backend = "poetry.core.masonry.api"
-        TOML
+            [tool.poetry.dev-dependencies]
+            black = "^20.8b1"
+            isort = "^5.12.0"
+            flake8 = "^4.0.1"
+            mypy = "^1.6"
+            pytest = "^7.4.2"
+            streamlit = ">=0.65.0"
+          TOML
+        end
+      end
+
+      context "with same dep specified twice in different groups" do
+        let(:pyproject_fixture_name) { "different_requirements.toml" }
+        let(:dependency_name) { "streamlit" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "1.27.2",
+            previous_version: "1.18.1",
+            package_manager: "pip",
+            requirements: [{
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: "^1.27.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev"]
+            }],
+            previous_requirements: [{
+              requirement: ">=0.65.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }, {
+              requirement: "^1.12.2",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dev"]
+            }]
+          )
+        end
+
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry.dependencies]
+            streamlit = ">=0.65.0"
+            packaging = ">=20.0"
+
+            [tool.poetry.group.dev.dependencies]
+            black = "^20.8b1"
+            isort = "^5.12.0"
+            flake8 = "^4.0.1"
+            mypy = "^1.6"
+            pytest = "^7.4.2"
+            streamlit = "^1.27.2"
+          TOML
+        end
+      end
+
+      context "with the same requirement specified in two dependencies" do
+        let(:pyproject_fixture_name) { "same_requirements.toml" }
+        let(:dependency_name) { "rq" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "1.15.0",
+            previous_version: "1.13.0",
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^1.15.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: "^1.13.0",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }]
+          )
+        end
+
+        it "updates the pyproject.toml correctly" do
+          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+          expect(updated_lockfile.content).to include <<~TOML
+            [tool.poetry]
+            name = "dependabot-poetry-bug"
+            version = "0.1.0"
+            description = ""
+            authors = []
+
+            [tool.poetry.dependencies]
+            python = "^3.9"
+            rq = "^1.15.0"
+            dramatiq = "^1.13.0"
+
+            [build-system]
+            requires = ["poetry-core"]
+            build-backend = "poetry.core.masonry.api"
+          TOML
+        end
       end
     end
 

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -503,7 +503,6 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
 
       context "with the same requirement specified in two dependencies" do
         let(:pyproject_fixture_name) { "same_requirements.toml" }
-        let(:dependency_name) { "rq" }
         let(:dependency) do
           Dependabot::Dependency.new(
             name: dependency_name,
@@ -525,27 +524,58 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
           )
         end
 
-        it "updates the pyproject.toml correctly" do
-          expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+        context "for the first dependency" do
+          let(:dependency_name) { "rq" }
 
-          updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+          it "updates the pyproject.toml correctly" do
+            expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
 
-          expect(updated_lockfile.content).to include <<~TOML
-            [tool.poetry]
-            name = "dependabot-poetry-bug"
-            version = "0.1.0"
-            description = ""
-            authors = []
+            updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
 
-            [tool.poetry.dependencies]
-            python = "^3.9"
-            rq = "^1.15.0"
-            dramatiq = "^1.13.0"
+            expect(updated_lockfile.content).to include <<~TOML
+              [tool.poetry]
+              name = "dependabot-poetry-bug"
+              version = "0.1.0"
+              description = ""
+              authors = []
 
-            [build-system]
-            requires = ["poetry-core"]
-            build-backend = "poetry.core.masonry.api"
-          TOML
+              [tool.poetry.dependencies]
+              python = "^3.9"
+              rq = "^1.15.0"
+              dramatiq = "^1.13.0"
+
+              [build-system]
+              requires = ["poetry-core"]
+              build-backend = "poetry.core.masonry.api"
+            TOML
+          end
+        end
+
+        context "for the second dependency" do
+          let(:dependency_name) { "dramatiq" }
+
+          it "updates the pyproject.toml correctly" do
+            expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+            updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+
+            expect(updated_lockfile.content).to include <<~TOML
+              [tool.poetry]
+              name = "dependabot-poetry-bug"
+              version = "0.1.0"
+              description = ""
+              authors = []
+
+              [tool.poetry.dependencies]
+              python = "^3.9"
+              rq = "^1.13.0"
+              dramatiq = "^1.15.0"
+
+              [build-system]
+              requires = ["poetry-core"]
+              build-backend = "poetry.core.masonry.api"
+            TOML
+          end
         end
       end
     end

--- a/python/spec/fixtures/pyproject_files/same_requirements.toml
+++ b/python/spec/fixtures/pyproject_files/same_requirements.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "dependabot-poetry-bug"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.9"
+rq = "^1.13.0"
+dramatiq = "^1.13.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
If there are multiple dependencies with the same requirement in the same
group in pyproject.toml, sometimes Dependabot could end up incorrectly replacing all of them.

Fixes #8259.
Fixes #8250.