### PR TITLE
Unlock related Gemfile dependencies, but not everything that changed

### DIFF
--- a/bundler/helpers/v2/lib/functions/force_updater.rb
+++ b/bundler/helpers/v2/lib/functions/force_updater.rb
@@ -21,13 +21,21 @@ module Functions
         definition = build_definition(dependencies_to_unlock: dependencies_to_unlock)
         definition.resolve_remotely!
         specs = definition.resolve
-        updates = ([dependency_name, *dependencies_to_unlock] - subdependencies).uniq.map { |name| { name: name } }
+        updates = ([dependency_name, *dependencies_to_unlock] - subdependencies + extra_top_level_deps(specs)).uniq
+
+        updates = updates.map do |name|
+          {
+            name: name
+          }
+        end
+
         specs = specs.map do |dep|
           {
             name: dep.name,
             version: dep.version
           }
         end
+
         [updates, specs]
       rescue Bundler::SolveFailure => e
         raise unless update_multiple_dependencies?
@@ -52,6 +60,15 @@ module Functions
                 :lockfile_name, :credentials,
                 :update_multiple_dependencies
     alias update_multiple_dependencies? update_multiple_dependencies
+
+    def extra_top_level_deps(specs)
+      top_level_dep_names.reject do |name|
+        original_version = original_specs.find { |s| s.name == name }&.version
+        new_version = specs[name].first&.version
+
+        original_version == new_version
+      end
+    end
 
     def new_dependencies_to_unlock_from(error:, already_unlocked:)
       names = [*already_unlocked, dependency_name]
@@ -118,13 +135,15 @@ module Functions
       # subdependencies
       return [] unless lockfile
 
-      all_deps =  Bundler::LockfileParser.new(lockfile)
-                                         .specs.map(&:name)
-      top_level = Bundler::Definition
-                  .build(gemfile_name, lockfile_name, {})
-                  .dependencies.map(&:name)
+      original_specs.map(&:name) - top_level_dep_names
+    end
 
-      all_deps - top_level
+    def top_level_dep_names
+      @top_level_dep_names ||= Bundler::Definition.build(gemfile_name, lockfile_name, {}).dependencies.map(&:name)
+    end
+
+    def original_specs
+      @original_specs ||= Bundler::LockfileParser.new(lockfile).specs
     end
 
     def unlock_gem(definition:, gem_name:)

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -78,15 +78,6 @@ module Dependabot
             ).parse
         end
 
-        def top_level_dependencies
-          @top_level_dependencies ||=
-            FileParser.new(
-              dependency_files: dependency_files.reject { |file| file.name == lockfile.name },
-              credentials: credentials,
-              source: nil
-            ).parse
-        end
-
         def dependencies_from(updated_deps, specs)
           # You might think we'd want to remove dependencies whose version
           # hadn't changed from this array. We don't. We still need to unlock
@@ -95,17 +86,14 @@ module Dependabot
           #
           # This is kind of a bug in Bundler, and we should try to fix it,
           # but resolving it won't necessarily be easy.
+          updated_deps.filter_map do |dep|
+            original_dep =
+              original_dependencies.find { |d| d.name == dep.fetch("name") }
+            spec = specs.find { |d| d.fetch("name") == dep.fetch("name") }
 
-          # put the lead dependency first
-          index = specs.index { |dep| dep["name"] == updated_deps.first["name"] }
-          specs.unshift(specs.delete_at(index))
-          specs.filter_map do |dep|
-            next unless top_level_dependencies.find { |d| d.name == dep.fetch("name") }
+            next if spec.fetch("version") == original_dep.version
 
-            original_dep = original_dependencies.find { |d| d.name == dep.fetch("name") }
-            next if dep.fetch("version") == original_dep.version
-
-            build_dependency(original_dep, dep)
+            build_dependency(original_dep, spec)
           end
         end
 

--- a/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
@@ -261,5 +261,50 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
         )
       end
     end
+
+    context "when peer dependencies in the Gemfile should update together, but not unlock git gems too" do
+      let(:dependency_files) { bundler_project_dependency_files("top_level_update_with_git_gems") }
+      let(:target_version) { "5.12.0" }
+      let(:dependency_name) { "sentry-rails" }
+      let(:requirements) do
+        [{
+          file: "Gemfile",
+          requirement: "~> 5.10",
+          groups: [:default],
+          source: nil
+        }]
+      end
+      let(:expected_requirements) do
+        [{
+          file: "Gemfile",
+          requirement: "~> 5.12",
+          groups: [:default],
+          source: nil
+        }]
+      end
+
+      it "updates all related dependencies" do
+        expect(updated_dependencies).to eq(
+          [
+            Dependabot::Dependency.new(
+              name: "sentry-rails",
+              version: "5.12.0",
+              previous_version: "5.10.0",
+              requirements: expected_requirements,
+              previous_requirements: requirements,
+              package_manager: "bundler"
+            ),
+            Dependabot::Dependency.new(
+              name: "sentry-ruby",
+              version: "5.12.0",
+              previous_version: "5.10.0",
+              requirements: expected_requirements,
+              previous_requirements: requirements,
+              package_manager: "bundler"
+            )
+          ]
+        )
+      end
+    end
   end
 end

--- a/bundler/spec/fixtures/projects/bundler1/top_level_update_with_git_gems/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/top_level_update_with_git_gems/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# Add sentry gems
+gem 'sentry-rails', '~> 5.10'
+gem 'sentry-ruby', '~> 5.10'
+
+# Add a gem from a git source
+gem 'annotate', github: 'robbevp/annotate_models', branch: 'enhc/support-virtual-columns'

--- a/bundler/spec/fixtures/projects/bundler1/top_level_update_with_git_gems/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/top_level_update_with_git_gems/Gemfile.lock
@@ -1,0 +1,122 @@
+GIT
+  remote: https://github.com/robbevp/annotate_models.git
+  revision: 099acde2ff0c1b7e64f70c996a77f907ee1121be
+  branch: enhc/support-virtual-columns
+  specs:
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (7.1.1)
+      actionview (= 7.1.1)
+      activesupport (= 7.1.1)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actionview (7.1.1)
+      activesupport (= 7.1.1)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activemodel (7.1.1)
+      activesupport (= 7.1.1)
+    activerecord (7.1.1)
+      activemodel (= 7.1.1)
+      activesupport (= 7.1.1)
+      timeout (>= 0.4.0)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    drb (2.1.1)
+      ruby2_keywords
+    erubi (1.12.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.8.3)
+      rdoc
+      reline (>= 0.3.8)
+    loofah (2.21.4)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mini_portile2 (2.8.5)
+    minitest (5.20.0)
+    mutex_m (0.1.2)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    psych (5.1.1)
+      stringio
+    racc (1.7.1)
+    rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.1)
+      actionpack (= 7.1.1)
+      activesupport (= 7.1.1)
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+    rake (13.0.6)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    reline (0.3.9)
+      io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    stringio (3.0.8)
+    thor (1.2.2)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webrick (1.8.1)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  annotate!
+  sentry-rails (~> 5.10)
+  sentry-ruby (~> 5.10)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler2/top_level_update_with_git_gems/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/top_level_update_with_git_gems/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+# Add sentry gems
+gem 'sentry-rails', '~> 5.10'
+gem 'sentry-ruby', '~> 5.10'
+
+# Add a gem from a git source
+gem 'mocha', github: 'freerange/mocha'

--- a/bundler/spec/fixtures/projects/bundler2/top_level_update_with_git_gems/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/top_level_update_with_git_gems/Gemfile.lock
@@ -1,0 +1,112 @@
+GIT
+  remote: https://github.com/freerange/mocha.git
+  revision: f65a74727497d74787aad8cb3ea0212e76a48acc
+  specs:
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (7.1.1)
+      actionview (= 7.1.1)
+      activesupport (= 7.1.1)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actionview (7.1.1)
+      activesupport (= 7.1.1)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
+    builder (3.2.4)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    drb (2.1.1)
+      ruby2_keywords
+    erubi (1.12.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.8.3)
+      rdoc
+      reline (>= 0.3.8)
+    loofah (2.21.4)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    minitest (5.20.0)
+    mutex_m (0.1.2)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    psych (5.1.1)
+      stringio
+    racc (1.7.1)
+    rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.1.1)
+      actionpack (= 7.1.1)
+      activesupport (= 7.1.1)
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+    rake (13.0.6)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    reline (0.3.9)
+      io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
+    sentry-rails (5.10.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.10.0)
+    sentry-ruby (5.10.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    stringio (3.0.8)
+    thor (1.2.2)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webrick (1.8.1)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  arm64-darwin-22
+  arm64-darwin-23
+
+DEPENDENCIES
+  mocha!
+  sentry-rails (~> 5.10)
+  sentry-ruby (~> 5.10)
+
+BUNDLED WITH
+   2.4.21


### PR DESCRIPTION
#7621 fixed an issue where some dependencies were not getting requirement updates in the Gemfile in situations where users would usually expect them.

However, the fix was too aggressive and it caused also unrelated dependencies to the update being unlocked under some situations.

This PR implements a hopefully safer approach.

Fixes #8195.