### PR TITLE
Explicitly add `# typed: false` for bin files

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 
 unless %w(minor patch).include?(ARGV[0])

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# typed: false
 # frozen_string_literal: true
 
 # This script executes a full update run for a given repo (optionally for a


### PR DESCRIPTION
These files are included in the spoom report, but didn't have a type sigil. These were found with `grep --recursive --files-without-match --include "*.rb" "# typed: " .`. Now the only `.rb` files without sigils are bundler spec fixtures.