### PR TITLE
Revert python always clone registration

### DIFF
--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -46,7 +46,7 @@ module Dependabot
 
       private
 
-      PACKAGE_MANAGER_LOOKUP = {
+      PACKAGE_MANAGER_LOOKUP = T.let({
         "bundler" => "bundler",
         "cargo" => "cargo",
         "composer" => "composer",
@@ -64,7 +64,7 @@ module Dependabot
         "pub" => "pub",
         "swift" => "swift",
         "terraform" => "terraform"
-      }.freeze
+      }.freeze, T::Hash[String, String])
 
       sig { params(cfg: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Array[IgnoreCondition]) }
       def ignore_conditions(cfg)

--- a/python/lib/dependabot/python.rb
+++ b/python/lib/dependabot/python.rb
@@ -33,6 +33,3 @@ Dependabot::Dependency.register_name_normaliser(
   "pip",
   ->(name) { Dependabot::Python::NameNormaliser.normalise(name) }
 )
-
-require "dependabot/utils"
-Dependabot::Utils.register_always_clone("python")


### PR DESCRIPTION
The right key was actually "pip", not "python".

Enabling this was silently a noop. Properly enabling it requires more work, so revert for now.

In addition, I added some changes to make sure this doesn't happen again. I guess these changes could potentially get in the middle for people extending dependabot-core to add custom ecosystems, but I don't think anybody is reliably doing this, and if they are, they can probably add one more patch to workaround this. For now, I'd prioritize our own convenience.