### PR TITLE
Composer: update expected plugin API version

### DIFF
--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG COMPOSER_V1_VERSION=1.10.26
-ARG COMPOSER_V2_VERSION=2.5.8
+ARG COMPOSER_V2_VERSION=2.6.5
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apt-get update \
   && apt-get upgrade -y \

--- a/composer/helpers/v2/composer.lock
+++ b/composer/helpers/v2/composer.lock
@@ -2724,5 +2724,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
       it "raises a helpful error" do
         expect { updated_lockfile_content }.to raise_error do |error|
           expect(error.message).to include("Your requirements could not be resolved to an installable set of packages.")
-          expect(error.message).to include("requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0]")
+          expect(error.message).to include("requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.6.0]")
           expect(error).to be_a Dependabot::DependencyFileNotResolvable
         end
       end
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
       it "raises a helpful error" do
         expect { updated_lockfile_content }.to raise_error do |error|
           expect(error.message).to include("Your requirements could not be resolved to an installable set of packages.")
-          expect(error.message).to include("requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0]")
+          expect(error.message).to include("requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.6.0]")
           expect(error).to be_a Dependabot::DependencyFileNotResolvable
         end
       end

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
       it "updates the dependency version and plugin-api-version (to match instaled composer) in the lockfile" do
         expect(updated_lockfile_entry["version"]).to eq("1.22.1")
         expect(parsed_updated_lockfile_content["prefer-stable"]).to be(false)
-        expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("2.3.0")
+        expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("2.6.0")
       end
     end
 
@@ -147,7 +147,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
 
       it "updates the dependency and does not downgrade the composer version" do
         expect(updated_lockfile_entry["version"]).to eq("1.22.1")
-        expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("2.3.0")
+        expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("2.6.0")
       end
     end
   end

--- a/updater/spec/fixtures/composer/updated/composer.lock
+++ b/updater/spec/fixtures/composer/updated/composer.lock
@@ -70,5 +70,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`plugin-api-version` was changed from "2.3.0" to "2.6.0" in Composer version 2.6.0. https://github.com/composer/composer/commit/16bdfe4dae0d6ef151d71441849e735f3b0a93c8

This pull request fixes tests to allow upgrading Composer to 2.6.0+. I've targeted https://github.com/dependabot/dependabot-core/pull/8159 here, but the base for this can be easily changed to the default branch if that's preferred.