### PR TITLE
Enable always clone for Python (take 2)

### DIFF
--- a/python/lib/dependabot/python.rb
+++ b/python/lib/dependabot/python.rb
@@ -33,3 +33,6 @@ Dependabot::Dependency.register_name_normaliser(
   "pip",
   ->(name) { Dependabot::Python::NameNormaliser.normalise(name) }
 )
+
+require "dependabot/utils"
+Dependabot::Utils.register_always_clone("pip")

--- a/python/lib/dependabot/python/file_updater.rb
+++ b/python/lib/dependabot/python/file_updater.rb
@@ -88,7 +88,8 @@ module Dependabot
         PipfileFileUpdater.new(
           dependencies: dependencies,
           dependency_files: dependency_files,
-          credentials: credentials
+          credentials: credentials,
+          repo_contents_path: repo_contents_path
         ).updated_dependency_files
       end
 

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -193,7 +193,7 @@ module Dependabot
 
         def updated_generated_files
           @updated_generated_files ||=
-            SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.in_a_temporary_repo_directory(dependency_files.first.directory, repo_contents_path) do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(prepared_pipfile_content)
                 install_required_python

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -22,12 +22,13 @@ module Dependabot
 
         DEPENDENCY_TYPES = %w(packages dev-packages).freeze
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies, :dependency_files, :credentials, :repo_contents_path
 
-        def initialize(dependencies:, dependency_files:, credentials:)
+        def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path:)
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
+          @repo_contents_path = repo_contents_path
         end
 
         def updated_dependency_files

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -191,7 +191,8 @@ module Dependabot
         {
           dependency: dependency,
           dependency_files: dependency_files,
-          credentials: credentials
+          credentials: credentials,
+          repo_contents_path: repo_contents_path
         }
       end
 

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -33,12 +33,13 @@ module Dependabot
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"
         ERROR_REGEX = /(?<=ERROR\:\W).*$/
 
-        attr_reader :dependency, :dependency_files, :credentials
+        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
 
-        def initialize(dependency:, dependency_files:, credentials:)
+        def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency
           @dependency_files         = dependency_files
           @credentials              = credentials
+          @repo_contents_path       = repo_contents_path
           @build_isolation = true
         end
 

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -39,12 +39,13 @@ module Dependabot
 
         DEPENDENCY_TYPES = %w(packages dev-packages).freeze
 
-        attr_reader :dependency, :dependency_files, :credentials
+        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
 
-        def initialize(dependency:, dependency_files:, credentials:)
+        def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency
           @dependency_files         = dependency_files
           @credentials              = credentials
+          @repo_contents_path       = repo_contents_path
         end
 
         def latest_resolvable_version(requirement: nil)

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -69,7 +69,7 @@ module Dependabot
           return @latest_resolvable_version_string[requirement] if @latest_resolvable_version_string.key?(requirement)
 
           @latest_resolvable_version_string[requirement] ||=
-            SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.in_a_temporary_repo_directory(base_directory, repo_contents_path) do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(updated_req: requirement)
                 install_required_python
@@ -191,7 +191,7 @@ module Dependabot
         # boolean, so that all deps for this repo will raise identical
         # errors when failing to update
         def check_original_requirements_resolvable
-          SharedHelpers.in_a_temporary_directory do
+          SharedHelpers.in_a_temporary_repo_directory(base_directory, repo_contents_path) do
             write_temporary_dependency_files(update_pipfile: false)
 
             run_pipenv_command("pyenv exec pipenv lock")
@@ -200,6 +200,10 @@ module Dependabot
           rescue SharedHelpers::HelperSubprocessFailed => e
             handle_pipenv_errors_resolving_original_reqs(e)
           end
+        end
+
+        def base_directory
+          dependency_files.first.directory
         end
 
         def handle_pipenv_errors_resolving_original_reqs(error)

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -38,12 +38,13 @@ module Dependabot
           \s+check\syour\sgit\sconfiguration
         /mx
 
-        attr_reader :dependency, :dependency_files, :credentials
+        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
 
-        def initialize(dependency:, dependency_files:, credentials:)
+        def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency
           @dependency_files         = dependency_files
           @credentials              = credentials
+          @repo_contents_path       = repo_contents_path
         end
 
         def latest_resolvable_version(requirement: nil)

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
     described_class.new(
       dependency_files: dependency_files,
       dependencies: [dependency],
-      credentials: credentials
+      credentials: credentials,
+      repo_contents_path: nil
     )
   end
   let(:dependency_files) { [pipfile, lockfile] }

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
         end
       end
 
-      context "with a path dependency", :slow do
+      context "with a path dependency" do
         let(:dependency_files) { [pipfile, lockfile, setupfile] }
         let(:setupfile) do
           Dependabot::DependencyFile.new(

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
       dependency_files: dependency_files,
       dependencies: [dependency],
       credentials: credentials,
-      repo_contents_path: nil
+      repo_contents_path: repo_contents_path
     )
   end
   let(:dependency_files) { [pipfile, lockfile] }
@@ -60,6 +60,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
       "password" => "token"
     }]
   end
+  let(:repo_contents_path) { nil }
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
@@ -429,6 +430,44 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
               .to eq("==2.18.4")
             expect(json_lockfile["default"]["pbr"]).to_not be_nil
           end
+        end
+      end
+
+      context "with a python library setup as an editable dependency that needs extra files" do
+        let(:project_name) { "pipenv/editable-package" }
+        let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
+        let(:dependency_files) do
+          %w(Pipfile Pipfile.lock pyproject.toml).map do |name|
+            Dependabot::DependencyFile.new(
+              name: name,
+              content: fixture("projects", project_name, name)
+            )
+          end
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "cryptography",
+            version: "41.0.5",
+            previous_version: "40.0.1",
+            package_manager: "pip",
+            requirements: [{
+              requirement: "==41.0.5",
+              file: "Pipfile",
+              source: nil,
+              groups: ["develop"]
+            }],
+            previous_requirements: [{
+              requirement: "==40.0.1",
+              file: "Pipfile",
+              source: nil,
+              groups: ["develop"]
+            }]
+          )
+        end
+
+        it "updates the dependency" do
+          expect(json_lockfile["develop"]["cryptography"]["version"])
+            .to eq("==41.0.5")
         end
       end
     end

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe namespace::PipCompileVersionResolver do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: credentials
+      credentials: credentials,
+      repo_contents_path: nil
     )
   end
   let(:credentials) do

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: credentials
+      credentials: credentials,
+      repo_contents_path: nil
     )
   end
   let(:credentials) do

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
       dependency: dependency,
       dependency_files: dependency_files,
       credentials: credentials,
-      repo_contents_path: nil
+      repo_contents_path: repo_contents_path
     )
   end
   let(:credentials) do
@@ -56,6 +56,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
       source: nil
     }]
   end
+  let(:repo_contents_path) { nil }
 
   describe "#latest_resolvable_version" do
     subject do
@@ -384,6 +385,33 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
             )
           end
       end
+    end
+
+    context "with a python library setup as an editable dependency that needs extra files" do
+      let(:project_name) { "pipenv/editable-package" }
+      let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
+      let(:dependency_name) { "cryptography" }
+      let(:dependency_version) { "40.0.1" }
+      let(:dependency_requirements) do
+        [{
+          file: "Pipfile",
+          requirement: "==40.0.1",
+          groups: ["develop"],
+          source: nil
+        }]
+      end
+      let(:updated_requirement) { ">= 40.0.1, <= 41.0.5" }
+
+      let(:dependency_files) do
+        %w(Pipfile Pipfile.lock pyproject.toml).map do |name|
+          Dependabot::DependencyFile.new(
+            name: name,
+            content: fixture("projects", project_name, name)
+          )
+        end
+      end
+
+      it { is_expected.to eq(Gem::Version.new("41.0.5")) }
     end
   end
 

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe namespace::PoetryVersionResolver do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: credentials
+      credentials: credentials,
+      repo_contents_path: nil
     )
   end
   let(:credentials) do

--- a/python/spec/fixtures/projects/pipenv/editable-package/Pipfile
+++ b/python/spec/fixtures/projects/pipenv/editable-package/Pipfile
@@ -1,0 +1,16 @@
+[dev-packages]
+cryptography = "==40.0.1"
+[dev-packages.ballcone]
+editable = true
+extras = ["dev"]
+path = "."
+[packages.ballcone]
+editable = true
+path = "."
+[requires]
+[scripts]
+test = "python3 -m unittest discover"
+[[source]]
+name = "pypi"
+url = "https://pypi.python.org/simple"
+verify_ssl = true

--- a/python/spec/fixtures/projects/pipenv/editable-package/Pipfile.lock
+++ b/python/spec/fixtures/projects/pipenv/editable-package/Pipfile.lock
@@ -1,0 +1,119 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "786a4e40a998579a379e7ef7976fd68bf8862c4a03cda000933ffbf515517046"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "ballcone": {
+            "editable": true,
+            "path": "."
+        }
+    },
+    "develop": {
+        "ballcone": {
+            "editable": true,
+            "path": "."
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc",
+                "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a",
+                "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417",
+                "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab",
+                "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520",
+                "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36",
+                "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743",
+                "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8",
+                "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed",
+                "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684",
+                "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56",
+                "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324",
+                "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d",
+                "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235",
+                "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e",
+                "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088",
+                "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000",
+                "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7",
+                "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e",
+                "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673",
+                "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c",
+                "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe",
+                "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2",
+                "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098",
+                "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8",
+                "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a",
+                "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0",
+                "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b",
+                "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896",
+                "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e",
+                "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9",
+                "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2",
+                "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b",
+                "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6",
+                "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404",
+                "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f",
+                "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0",
+                "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4",
+                "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc",
+                "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936",
+                "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba",
+                "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872",
+                "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb",
+                "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614",
+                "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1",
+                "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d",
+                "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969",
+                "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b",
+                "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4",
+                "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627",
+                "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956",
+                "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.16.0"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405",
+                "sha256:1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356",
+                "sha256:2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472",
+                "sha256:28d63d75bf7ae4045b10de5413fb1d6338616e79015999ad9cf6fc538f772d41",
+                "sha256:32057d3d0ab7d4453778367ca43e99ddb711770477c4f072a51b3ca69602780a",
+                "sha256:3a4805a4ca729d65570a1b7cac84eac1e431085d40387b7d3bbaa47e39890b88",
+                "sha256:63dac2d25c47f12a7b8aa60e528bfb3c51c5a6c5a9f7c86987909c6c79765554",
+                "sha256:650883cc064297ef3676b1db1b7b1df6081794c4ada96fa457253c4cc40f97db",
+                "sha256:6f2bbd72f717ce33100e6467572abaedc61f1acb87b8d546001328d7f466b778",
+                "sha256:7c872413353c70e0263a9368c4993710070e70ab3e5318d85510cc91cce77e7c",
+                "sha256:918cb89086c7d98b1b86b9fdb70c712e5a9325ba6f7d7cfb509e784e0cfc6917",
+                "sha256:9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797",
+                "sha256:a805a7bce4a77d51696410005b3e85ae2839bad9aa38894afc0aa99d8e0c3160",
+                "sha256:cc3a621076d824d75ab1e1e530e66e7e8564e357dd723f2533225d40fe35c60c",
+                "sha256:cd033d74067d8928ef00a6b1327c8ea0452523967ca4463666eeba65ca350d4c",
+                "sha256:cf91e428c51ef692b82ce786583e214f58392399cf65c341bc7301d096fa3ba2",
+                "sha256:d36bbeb99704aabefdca5aee4eba04455d7a27ceabd16f3b3ba9bdcc31da86c4",
+                "sha256:d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122",
+                "sha256:f5d7b79fa56bc29580faafc2ff736ce05ba31feaa9d4735048b0de7d9ceb2b94"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==40.0.1"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+            ],
+            "version": "==2.21"
+        }
+    }
+}

--- a/python/spec/fixtures/projects/pipenv/editable-package/ballcone/__init__.py
+++ b/python/spec/fixtures/projects/pipenv/editable-package/ballcone/__init__.py
@@ -1,0 +1,3 @@
+__version__ = '0'
+__author__ = 'Dmitry Ustalov'
+__license__ = 'MIT'

--- a/python/spec/fixtures/projects/pipenv/editable-package/pyproject.toml
+++ b/python/spec/fixtures/projects/pipenv/editable-package/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ballcone"
+authors = [{name = "Dmitry Ustalov"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Database",
+    "Topic :: Internet :: Log Analysis",
+    "Topic :: Internet :: WWW/HTTP",
+    "Typing :: Typed",
+]
+license = {text = "MIT"}
+description = "Ballcone is a fast and lightweight server-side Web analytics solution."
+keywords = ["Web analytics", "log analysis", "columnar storage", "syslog", "nginx"]
+urls = {Homepage = "https://github.com/dustalov/ballcone"}
+requires-python = "~=3.9"
+dependencies = []
+dynamic = ["version"]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.scripts]
+ballcone = "ballcone.__main__:main"
+
+[tool.setuptools]
+zip-safe = true
+
+[tool.setuptools.packages.find]
+include = ["ballcone*"]
+
+[tool.setuptools.package-data]
+"*" = ["*.html", "*.js"]
+
+[tool.setuptools.dynamic]
+version = {attr = "ballcone.__version__"}
+
+[tool.mypy]
+ignore_missing_imports = true
+allow_untyped_calls = true
+allow_untyped_decorators = true
+warn_unused_ignores = false
+strict = true


### PR DESCRIPTION
This PR retries #8266, but:

* With a correct ecosystem key (`pip`, instead of `python`).
* Making sure the cloned repo is passed around, although still used only for Pipenv. We should make sure the clone is also used for Poetry and Pip compile in the future but for now I decided to limit this PR to fix the pipenv issue I was dealing with initially.