### PR TITLE
Refactor composer error handling and better handle potential errors

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -171,17 +171,8 @@ module Dependabot
             raise PrivateSourceAuthenticationFailure, "nova.laravel.com"
           end
 
-          if error.message.match?(UpdateChecker::VersionResolver::FAILED_GIT_CLONE_WITH_MIRROR)
-            dependency_url = error.message.match(UpdateChecker::VersionResolver::FAILED_GIT_CLONE_WITH_MIRROR)
-                                  .named_captures.fetch("url")
-            raise Dependabot::GitDependenciesNotReachable, dependency_url
-          end
-
-          if error.message.match?(UpdateChecker::VersionResolver::FAILED_GIT_CLONE)
-            dependency_url = error.message.match(UpdateChecker::VersionResolver::FAILED_GIT_CLONE)
-                                  .named_captures.fetch("url")
-            raise Dependabot::GitDependenciesNotReachable, dependency_url
-          end
+          dependency_url = Helpers.dependency_url_from_git_clone_error(error.message)
+          raise Dependabot::GitDependenciesNotReachable, dependency_url if dependency_url
 
           # NOTE: This matches an error message from composer plugins used to install ACF PRO
           # https://github.com/PhilippBaschke/acf-pro-installer/blob/772cec99c6ef8bc67ba6768419014cc60d141b27/src/ACFProInstaller/Exceptions/MissingKeyException.php#L14

--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -32,9 +32,13 @@ module Dependabot
       def self.dependency_url_from_git_clone_error(message)
         if message.match?(FAILED_GIT_CLONE_WITH_MIRROR)
           dependency_url = message.match(FAILED_GIT_CLONE_WITH_MIRROR).named_captures.fetch("url")
+          raise "Could not parse dependency_url from git clone error: #{message}" if dependency_url.empty?
+
           clean_dependency_url(dependency_url)
         elsif message.match?(FAILED_GIT_CLONE)
           dependency_url = message.match(FAILED_GIT_CLONE).named_captures.fetch("url")
+          raise "Could not parse dependency_url from git clone error: #{message}" if dependency_url.empty?
+
           clean_dependency_url(dependency_url)
         end
       end

--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -14,8 +14,8 @@ module Dependabot
         |composer-(?:plugin|runtime)-api)$
       /x
 
-      FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --(mirror|checkout)[^']*'(?<url>.*?)'/
-      FAILED_GIT_CLONE = /Failed to clone (?<url>.*?)/
+      FAILED_GIT_CLONE_WITH_MIRROR = /^Failed to execute git clone --(mirror|checkout)[^']*'(?<url>[^']*?)'/
+      FAILED_GIT_CLONE = /^Failed to clone (?<url>.*?)/
 
       def self.composer_version(composer_json, parsed_lockfile = nil)
         if parsed_lockfile && parsed_lockfile["plugin-api-version"]

--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -14,6 +14,9 @@ module Dependabot
         |composer-(?:plugin|runtime)-api)$
       /x
 
+      FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --(mirror|checkout)[^']*'(?<url>.*?)'/
+      FAILED_GIT_CLONE = /Failed to clone (?<url>.*?)/
+
       def self.composer_version(composer_json, parsed_lockfile = nil)
         if parsed_lockfile && parsed_lockfile["plugin-api-version"]
           version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
@@ -26,6 +29,16 @@ module Dependabot
         "2"
       end
 
+      def self.dependency_url_from_git_clone_error(message)
+        if message.match?(FAILED_GIT_CLONE_WITH_MIRROR)
+          dependency_url = message.match(FAILED_GIT_CLONE_WITH_MIRROR).named_captures.fetch("url")
+          clean_dependency_url(dependency_url)
+        elsif message.match?(FAILED_GIT_CLONE)
+          dependency_url = message.match(FAILED_GIT_CLONE).named_captures.fetch("url")
+          clean_dependency_url(dependency_url)
+        end
+      end
+
       def self.invalid_v2_requirement?(composer_json)
         return false unless composer_json.key?("require")
 
@@ -34,6 +47,16 @@ module Dependabot
         end
       end
       private_class_method :invalid_v2_requirement?
+
+      def self.clean_dependency_url(dependency_url)
+        return dependency_url unless URI::DEFAULT_PARSER.regexp[:ABS_URI].match?(dependency_url)
+
+        url = URI.parse(dependency_url)
+        url.user = nil
+        url.password = nil
+        url.to_s
+      end
+      private_class_method :clean_dependency_url
     end
   end
 end


### PR DESCRIPTION
Sometimes we're getting failures like these:

```
  1) Dependabot::Composer::FileUpdater::LockfileUpdater the updated lockfile when another dependency has an unreachable git source raises a helpful errors
     Failure/Error:
       expect { updated_lockfile_content }.to raise_error do |error|
         expect(error).to be_a Dependabot::GitDependenciesNotReachable
         expect(error.dependency_urls)
           .to eq(["https://github.com/no-exist-sorry/monolog.git"])
       end

       expected: ["https://github.com/no-exist-sorry/monolog.git"]
            got: [""]

       (compared using ==)
     # ./spec/dependabot/composer/file_updater/lockfile_updater_spec.rb:652:in `block (4 levels) in <top (required)>'
     # /home/dependabot/common/spec/spec_helper.rb:46:in `block (2 levels) in <top (required)>'
```

This PR raises a runtime error when this happens to help finding out the culprit.