### PR TITLE
strictly type `Updater` mixins

### DIFF
--- a/sorbet/config
+++ b/sorbet/config
@@ -3,6 +3,7 @@
 --ignore=vendor/
 --ignore=.bundle/
 --disable-watchman
+--enable-experimental-requires-ancestor
 
 # Sorbet doesn't currently support RSpec very well, so we ignore all of our specs.
 # See https://stackoverflow.com/a/76548429

--- a/updater/lib/dependabot/updater/operations/base.rb
+++ b/updater/lib/dependabot/updater/operations/base.rb
@@ -1,0 +1,45 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Updater
+    module Operations
+      class Base
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        sig { returns(Dependabot::Service) }
+        attr_reader :service
+
+        sig { returns(Dependabot::DependencySnapshot) }
+        attr_reader :dependency_snapshot
+
+        sig { returns(Dependabot::Job) }
+        attr_reader :job
+
+        sig { returns(Dependabot::Updater::ErrorHandler) }
+        attr_reader :error_handler
+
+        sig do
+          params(
+            service: Dependabot::Service,
+            job: Dependabot::Job,
+            dependency_snapshot: Dependabot::DependencySnapshot,
+            error_handler: Dependabot::Updater::ErrorHandler
+          )
+            .void
+        end
+        def initialize(service, job, dependency_snapshot, error_handler)
+          @service = service
+          @dependency_snapshot = dependency_snapshot
+          @job = job
+          @error_handler = error_handler
+        end
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/security_update_helpers"
 require "dependabot/updater/group_update_creation"
 
@@ -10,7 +11,7 @@ require "dependabot/updater/group_update_creation"
 module Dependabot
   class Updater
     module Operations
-      class CreateGroupSecurityUpdatePullRequest
+      class CreateGroupSecurityUpdatePullRequest < Dependabot::Updater::Operations::Base
         include SecurityUpdateHelpers
         include GroupUpdateCreation
 
@@ -31,10 +32,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = []
         end

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/group_update_creation"
 
 # This class implements our strategy for creating a single Pull Request which
@@ -13,7 +14,7 @@ require "dependabot/updater/group_update_creation"
 module Dependabot
   class Updater
     module Operations
-      class CreateGroupUpdatePullRequest
+      class CreateGroupUpdatePullRequest < Dependabot::Updater::Operations::Base
         include GroupUpdateCreation
 
         # We do not invoke this class directly for any jobs, so let's return false in the event this
@@ -29,10 +30,7 @@ module Dependabot
         # Since this class is not invoked generically based on the job definition, this class accepts a `group` argument
         # which is expected to be a prepopulated DependencyGroup object.
         def initialize(service:, job:, dependency_snapshot:, error_handler:, group:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
           @group = group
         end
 
@@ -57,11 +55,7 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :group
+        attr_reader :group
 
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/security_update_helpers"
 
 # This class implements our strategy for updating a single, insecure dependency
@@ -9,7 +10,7 @@ require "dependabot/updater/security_update_helpers"
 module Dependabot
   class Updater
     module Operations
-      class CreateSecurityUpdatePullRequest
+      class CreateSecurityUpdatePullRequest < Dependabot::Updater::Operations::Base
         include SecurityUpdateHelpers
 
         def self.applies_to?(job:)
@@ -26,10 +27,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = []
         end
@@ -54,11 +52,7 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :created_pull_requests
+        attr_reader :created_pull_requests
 
         def check_and_create_pr_with_error_handling(dependency)
           check_and_create_pull_request(dependency)

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/operations/create_group_update_pull_request"
 require "dependabot/updater/operations/update_all_versions"
 
@@ -17,7 +18,7 @@ require "dependabot/updater/operations/update_all_versions"
 module Dependabot
   class Updater
     module Operations
-      class GroupUpdateAllVersions
+      class GroupUpdateAllVersions < Dependabot::Updater::Operations::Base
         include GroupUpdateCreation
 
         def self.applies_to?(job:)
@@ -33,10 +34,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
           @dependencies_handled = Set.new
         end
 
@@ -64,11 +62,6 @@ module Dependabot
         end
 
         private
-
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
 
         def run_grouped_dependency_updates # rubocop:disable Metrics/AbcSize
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")

--- a/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/security_update_helpers"
 require "dependabot/updater/group_update_creation"
 require "dependabot/updater/group_update_refreshing"
@@ -11,7 +12,7 @@ require "dependabot/updater/group_update_refreshing"
 module Dependabot
   class Updater
     module Operations
-      class RefreshGroupSecurityUpdatePullRequest
+      class RefreshGroupSecurityUpdatePullRequest < Dependabot::Updater::Operations::Base
         include SecurityUpdateHelpers
         include GroupUpdateCreation
         include GroupUpdateRefreshing
@@ -32,10 +33,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
         end
 
         def perform

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
 require "dependabot/updater/group_update_creation"
 require "dependabot/updater/group_update_refreshing"
 
@@ -22,7 +23,7 @@ require "dependabot/updater/group_update_refreshing"
 module Dependabot
   class Updater
     module Operations
-      class RefreshGroupUpdatePullRequest
+      class RefreshGroupUpdatePullRequest < Dependabot::Updater::Operations::Base
         include GroupUpdateCreation
         include GroupUpdateRefreshing
 
@@ -42,10 +43,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
         end
 
         def perform # rubocop:disable Metrics/AbcSize
@@ -94,11 +92,6 @@ module Dependabot
         end
 
         private
-
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
 
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
+
 # This class implements our strategy for 'refreshing' an existing Pull Request
 # that updates an insecure dependency.
 #
@@ -13,7 +15,7 @@
 module Dependabot
   class Updater
     module Operations
-      class RefreshSecurityUpdatePullRequest
+      class RefreshSecurityUpdatePullRequest < Dependabot::Updater::Operations::Base
         include SecurityUpdateHelpers
 
         def self.applies_to?(job:)
@@ -30,10 +32,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
         end
 
         def perform
@@ -44,11 +43,6 @@ module Dependabot
         end
 
         private
-
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
 
         def dependencies
           dependency_snapshot.job_dependencies

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
+
 # This class implements our strategy for 'refreshing' an existing Pull Request
 # that updates a dependnency to the latest permitted version.
 #
@@ -11,7 +13,7 @@
 module Dependabot
   class Updater
     module Operations
-      class RefreshVersionUpdatePullRequest
+      class RefreshVersionUpdatePullRequest < Dependabot::Updater::Operations::Base
         def self.applies_to?(job:)
           return false if job.security_updates_only?
           # If we haven't been given metadata about the dependencies present
@@ -26,10 +28,7 @@ module Dependabot
         end
 
         def initialize(service:, job:, dependency_snapshot:, error_handler:)
-          @service = service
-          @job = job
-          @dependency_snapshot = dependency_snapshot
-          @error_handler = error_handler
+          super(service, job, dependency_snapshot, error_handler)
         end
 
         def perform
@@ -42,11 +41,7 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :created_pull_requests
+        attr_reader :created_pull_requests
 
         def dependencies
           dependency_snapshot.job_dependencies

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -1,13 +1,15 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/base"
+
 # This class implements our strategy for iterating over all of the dependencies
 # for a specific project folder to find those that are out of date and create
 # a single PR per Dependency.
 module Dependabot
   class Updater
     module Operations
-      class UpdateAllVersions
+      class UpdateAllVersions < Dependabot::Updater::Operations::Base
         def self.applies_to?(job:)
           return false if job.security_updates_only?
           return false if job.updating_a_pull_request?

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
+
+require "sorbet-runtime"
 
 # This module extracts all helpers required to perform additional update job
 # error recording and logging for Security Updates since they are shared
@@ -7,6 +9,12 @@
 module Dependabot
   class Updater
     module SecurityUpdateHelpers
+      extend T::Sig
+      extend T::Helpers
+
+      requires_ancestor { Dependabot::Updater::Operations::Base }
+
+      sig { params(job: Dependabot::Job).returns(Dependabot::DependencyGroup) }
       def grouped_security_update_group(job)
         Dependabot::DependencyGroup.new(
           name: "#{job.package_manager} group",
@@ -16,6 +24,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_security_update_not_needed_error(checker)
         Dependabot.logger.info(
           "no security update needed as #{checker.dependency.name} " \
@@ -30,6 +39,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_security_update_ignored(checker)
         Dependabot.logger.info(
           "Dependabot cannot update to the required version as all versions " \
@@ -44,6 +54,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_dependency_file_not_supported_error(checker)
         Dependabot.logger.info(
           "Dependabot can't update vulnerable dependencies for projects " \
@@ -59,6 +70,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_security_update_not_possible_error(checker)
         latest_allowed_version =
           (checker.lowest_resolvable_security_fix_version ||
@@ -85,6 +97,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_security_update_not_found(checker)
         Dependabot.logger.info(
           "Dependabot can't find a published or compatible non-vulnerable " \
@@ -102,6 +115,7 @@ module Dependabot
         )
       end
 
+      sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_pull_request_exists_for_latest_version(checker)
         service.record_update_job_error(
           error_type: "pull_request_exists_for_latest_version",
@@ -113,6 +127,7 @@ module Dependabot
         )
       end
 
+      sig { params(existing_pull_request: T::Array[T::Hash[String, T.untyped]]).void }
       def record_pull_request_exists_for_security_update(existing_pull_request)
         updated_dependencies = existing_pull_request.map do |dep|
           {
@@ -130,6 +145,7 @@ module Dependabot
         )
       end
 
+      sig { void }
       def record_security_update_dependency_not_found
         service.record_update_job_error(
           error_type: "security_update_dependency_not_found",
@@ -137,6 +153,7 @@ module Dependabot
         )
       end
 
+      sig { params(lowest_non_vulnerable_version: T.nilable(String)).void }
       def earliest_fixed_version_message(lowest_non_vulnerable_version)
         if lowest_non_vulnerable_version
           "The earliest fixed version is #{lowest_non_vulnerable_version}."
@@ -145,6 +162,14 @@ module Dependabot
         end
       end
 
+      sig do
+        params(
+          checker: Dependabot::UpdateCheckers::Base,
+          latest_allowed_version: T.nilable(String),
+          conflicting_dependencies: T::Array[T::Hash[String, String]]
+        )
+          .returns(String)
+      end
       def security_update_not_possible_message(checker, latest_allowed_version,
                                                conflicting_dependencies)
         if conflicting_dependencies.any?


### PR DESCRIPTION
Because the mixins use properties available in the `Operation` classes, Sorbet needs to know that they exist. I created a common base class that contains the properties required by the mixins, and used Sorbet's [`require_ancestor`][1] to ensure that the properties are available.

[1]: https://sorbet.org/docs/requires-ancestor