### PR TITLE
Catch more 404 PNPM fetch errors and raise them as user errors

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -11,6 +11,7 @@ require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/native_helpers"
 require "dependabot/npm_and_yarn/version"
 require "dependabot/npm_and_yarn/requirement"
+require "dependabot/npm_and_yarn/registry_parser"
 require "dependabot/git_metadata_fetcher"
 require "dependabot/git_commit_checker"
 require "dependabot/errors"
@@ -269,7 +270,10 @@ module Dependabot
         return unless resolved_url.start_with?("http")
         return if resolved_url.match?(/(?<!pkg\.)github/)
 
-        registry_source_for(resolved_url, name)
+        RegistryParser.new(
+          resolved_url: resolved_url,
+          credentials: credentials
+        ).registry_source_for(name)
       end
 
       def requirement_for(requirement)
@@ -300,54 +304,6 @@ module Dependabot
           branch: nil,
           ref: details["ref"] || "master"
         }
-      end
-
-      def registry_source_for(resolved_url, name)
-        url =
-          if resolved_url.include?("/~/")
-            # Gemfury format
-            resolved_url.split("/~/").first
-          elsif resolved_url.include?("/#{name}/-/#{name}")
-            # MyGet / Bintray format
-            resolved_url.split("/#{name}/-/#{name}").first
-                        .gsub("dl.bintray.com//", "api.bintray.com/npm/").
-              # GitLab format
-              gsub(%r{\/projects\/\d+}, "")
-          elsif resolved_url.include?("/#{name}/-/#{name.split('/').last}")
-            # Sonatype Nexus / Artifactory JFrog format
-            resolved_url.split("/#{name}/-/#{name.split('/').last}").first
-          elsif (cred_url = url_for_relevant_cred(resolved_url)) then cred_url
-          else
-            resolved_url.split("/")[0..2].join("/")
-          end
-
-        { type: "registry", url: url }
-      end
-
-      def url_for_relevant_cred(resolved_url)
-        resolved_url_host = URI(resolved_url).host
-
-        credential_matching_url =
-          credentials
-          .select { |cred| cred["type"] == "npm_registry" }
-          .sort_by { |cred| cred["registry"].length }
-          .find do |details|
-            next true if resolved_url_host == details["registry"]
-
-            uri = if details["registry"]&.include?("://")
-                    URI(details["registry"])
-                  else
-                    URI("https://#{details['registry']}")
-                  end
-            resolved_url_host == uri.host && resolved_url.include?(details["registry"])
-          end
-
-        return unless credential_matching_url
-
-        # Trim the resolved URL so that it ends at the same point as the
-        # credential registry
-        reg = credential_matching_url["registry"]
-        resolved_url.gsub(/#{Regexp.quote(reg)}.*/, "") + reg
       end
 
       def support_package_files

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -7,7 +7,7 @@ require "dependabot/npm_and_yarn/helpers"
 
 module Dependabot
   module NpmAndYarn
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       class JsonLock
         def initialize(dependency_file)
           @dependency_file = dependency_file

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -7,7 +7,7 @@ require "dependabot/npm_and_yarn/helpers"
 
 module Dependabot
   module NpmAndYarn
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       class LockfileParser
         require "dependabot/npm_and_yarn/file_parser/yarn_lock"
         require "dependabot/npm_and_yarn/file_parser/pnpm_lock"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
@@ -5,7 +5,7 @@ require "dependabot/errors"
 
 module Dependabot
   module NpmAndYarn
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       class PnpmLock
         def initialize(dependency_file)
           @dependency_file = dependency_file

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -7,7 +7,7 @@ require "dependabot/npm_and_yarn/native_helpers"
 
 module Dependabot
   module NpmAndYarn
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       class YarnLock
         def initialize(dependency_file)
           @dependency_file = dependency_file

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -13,7 +13,7 @@ require "dependabot/shared_helpers"
 # rubocop:disable Metrics/ClassLength
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       class NpmLockfileUpdater
         require_relative "npmrc_builder"
         require_relative "package_json_updater"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -5,7 +5,7 @@ require "dependabot/npm_and_yarn/file_updater"
 
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       # Build a .npmrc file from the lockfile content, credentials, and any
       # committed .npmrc
       # We should refactor this to use UpdateChecker::RegistryFinder

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
@@ -6,7 +6,7 @@ require "dependabot/npm_and_yarn/file_parser"
 
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       class PackageJsonPreparer
         def initialize(package_json_content:)
           @package_json_content = package_json_content

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
@@ -5,7 +5,7 @@ require "dependabot/npm_and_yarn/file_updater"
 
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       class PackageJsonUpdater
         def initialize(package_json:, dependencies:)
           @package_json = package_json

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -7,7 +7,7 @@ require "dependabot/shared_helpers"
 
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       class PnpmLockfileUpdater
         require_relative "npmrc_builder"
         require_relative "package_json_updater"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -14,7 +14,7 @@ require "dependabot/errors"
 # rubocop:disable Metrics/ClassLength
 module Dependabot
   module NpmAndYarn
-    class FileUpdater
+    class FileUpdater < Dependabot::FileUpdaters::Base
       class YarnLockfileUpdater
         require_relative "npmrc_builder"
         require_relative "package_json_updater"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -31,6 +31,16 @@ module Dependabot
         { type: "registry", url: url }
       end
 
+      def dependency_name
+        url_base = if resolved_url.include?("/-/")
+                     resolved_url.split("/-/").first
+                   else
+                     resolved_url
+                   end
+
+        url_base.split("/")[3..-1].join("/").gsub("%2F", "/")
+      end
+
       private
 
       attr_reader :resolved_url, :credentials

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -1,0 +1,65 @@
+# typed: false
+# frozen_string_literal: true
+
+module Dependabot
+  module NpmAndYarn
+    class RegistryParser
+      def initialize(resolved_url:, credentials:)
+        @resolved_url = resolved_url
+        @credentials = credentials
+      end
+
+      def registry_source_for(name)
+        url =
+          if resolved_url.include?("/~/")
+            # Gemfury format
+            resolved_url.split("/~/").first
+          elsif resolved_url.include?("/#{name}/-/#{name}")
+            # MyGet / Bintray format
+            resolved_url.split("/#{name}/-/#{name}").first
+                        .gsub("dl.bintray.com//", "api.bintray.com/npm/").
+              # GitLab format
+              gsub(%r{\/projects\/\d+}, "")
+          elsif resolved_url.include?("/#{name}/-/#{name.split('/').last}")
+            # Sonatype Nexus / Artifactory JFrog format
+            resolved_url.split("/#{name}/-/#{name.split('/').last}").first
+          elsif (cred_url = url_for_relevant_cred) then cred_url
+          else
+            resolved_url.split("/")[0..2].join("/")
+          end
+
+        { type: "registry", url: url }
+      end
+
+      private
+
+      attr_reader :resolved_url, :credentials
+
+      def url_for_relevant_cred
+        resolved_url_host = URI(resolved_url).host
+
+        credential_matching_url =
+          credentials
+          .select { |cred| cred["type"] == "npm_registry" }
+          .sort_by { |cred| cred["registry"].length }
+          .find do |details|
+            next true if resolved_url_host == details["registry"]
+
+            uri = if details["registry"]&.include?("://")
+                    URI(details["registry"])
+                  else
+                    URI("https://#{details['registry']}")
+                  end
+            resolved_url_host == uri.host && resolved_url.include?(details["registry"])
+          end
+
+        return unless credential_matching_url
+
+        # Trim the resolved URL so that it ends at the same point as the
+        # credential registry
+        reg = credential_matching_url["registry"]
+        resolved_url.gsub(/#{Regexp.quote(reg)}.*/, "") + reg
+      end
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       dependency_files: files,
       dependencies: dependencies,
       credentials: credentials,
-      repo_contents_path: nil
+      repo_contents_path: repo_contents_path
     )
   end
   let(:dependencies) { [dependency] }
@@ -50,11 +50,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       source: nil
     }]
   end
+
+  let(:files) { project_dependency_files(project_name) }
+
   let(:pnpm_lock) do
     files.find { |f| f.name == "pnpm-lock.yaml" }
   end
 
   let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
+
+  let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
 
   before { FileUtils.mkdir_p(tmp_path)  }
 
@@ -62,7 +67,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
 
   describe "errors" do
     context "with a dependency version that can't be found" do
-      let(:files) { project_dependency_files("pnpm/yanked_version") }
+      let(:project_name) { "pnpm/yanked_version" }
 
       it "raises a helpful error" do
         expect { updated_pnpm_lock_content }
@@ -71,7 +76,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
     end
 
     context "with an invalid requirement in the package.json" do
-      let(:files) { project_dependency_files("pnpm/invalid_requirement") }
+      let(:project_name) { "pnpm/invalid_requirement" }
 
       it "raises a helpful error" do
         expect { updated_pnpm_lock_content }
@@ -80,7 +85,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
     end
 
     context "with a dependency that can't be found" do
-      let(:files) { project_dependency_files("pnpm/nonexistent_dependency_yanked_version") }
+      let(:project_name) { "pnpm/nonexistent_dependency_yanked_version" }
 
       it "raises a helpful error" do
         expect { updated_pnpm_lock_content }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -92,5 +92,34 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           .to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
       end
     end
+
+    context "with a locked dependency that can't be found" do
+      let(:dependency_name) { "@googleapis/youtube" }
+      let(:version) { "13.0.0" }
+      let(:previous_version) { "10.1.0" }
+      let(:requirements) do
+        [{
+          file: "package.json",
+          requirement: "^13.0.0",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+      let(:previous_requirements) do
+        [{
+          file: "package.json",
+          requirement: "^10.1.0",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      let(:project_name) { "pnpm/nonexistent_locked_dependency" }
+
+      it "raises a helpful error" do
+        expect { updated_pnpm_lock_content }
+          .to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+      end
+    end
   end
 end

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "margins",
+	"version": "0.0.1",
+	"type": "module",
+	"dependencies": {
+		"@googleapis/youtube": "^10.1.0",
+                "@tiptap-pro/extension-mathematics": "latest"
+	}
+}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency/pnpm-lock.yaml
@@ -1,0 +1,343 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@googleapis/youtube':
+    specifier: ^10.1.0
+    version: 10.1.0
+
+  '@tiptap-pro/extension-mathematics':
+    specifier: latest
+    version: 2.3.3
+
+packages:
+
+  /@googleapis/youtube@10.1.0:
+    resolution: {integrity: sha512-+80fqeUYINfcYNNse6Qk7O1OTEjTLI0wx8wkxfmMnS3iDMzJVm/WkSMHZtVbGSZmZzD3d8/HDEFKviIastQ5Ng==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      googleapis-common: 6.0.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+    dev: false
+
+  /buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    dev: false
+
+  /call-bind@1.0.5:
+    resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+    dependencies:
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.2
+      set-function-length: 1.1.1
+    dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
+  /define-data-property@1.1.1:
+    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.1
+    dev: false
+
+  /ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
+  /fast-text-encoding@1.0.6:
+    resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
+    dev: false
+
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: false
+
+  /gaxios@5.1.3:
+    resolution: {integrity: sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==}
+    engines: {node: '>=12'}
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 5.0.1
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /gcp-metadata@5.3.0:
+    resolution: {integrity: sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==}
+    engines: {node: '>=12'}
+    dependencies:
+      gaxios: 5.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /get-intrinsic@1.2.2:
+    resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
+    dependencies:
+      function-bind: 1.1.2
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      hasown: 2.0.0
+    dev: false
+
+  /google-auth-library@8.9.0:
+    resolution: {integrity: sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==}
+    engines: {node: '>=12'}
+    dependencies:
+      arrify: 2.0.1
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      fast-text-encoding: 1.0.6
+      gaxios: 5.1.3
+      gcp-metadata: 5.3.0
+      gtoken: 6.1.2
+      jws: 4.0.0
+      lru-cache: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /google-p12-pem@4.0.1:
+    resolution: {integrity: sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      node-forge: 1.3.1
+    dev: false
+
+  /googleapis-common@6.0.4:
+    resolution: {integrity: sha512-m4ErxGE8unR1z0VajT6AYk3s6a9gIMM6EkDZfkPnES8joeOlEtFEJeF8IyZkb0tjPXkktUfYrE4b3Li1DNyOwA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      extend: 3.0.2
+      gaxios: 5.1.3
+      google-auth-library: 8.9.0
+      qs: 6.11.2
+      url-template: 2.0.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.2.2
+    dev: false
+
+  /gtoken@6.1.2:
+    resolution: {integrity: sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      gaxios: 5.1.3
+      google-p12-pem: 4.0.1
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /has-property-descriptors@1.0.1:
+    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
+    dependencies:
+      get-intrinsic: 1.2.2
+    dev: false
+
+  /has-proto@1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /hasown@2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: false
+
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+    dependencies:
+      bignumber.js: 9.1.2
+    dev: false
+
+  /jwa@2.0.0:
+    resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
+  /jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+    dependencies:
+      jwa: 2.0.0
+      safe-buffer: 5.2.1
+    dev: false
+
+  /lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /node-forge@1.3.1:
+    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+    engines: {node: '>= 6.13.0'}
+    dev: false
+
+  /object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+    dev: false
+
+  /qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
+  /safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
+  /set-function-length@1.1.1:
+    resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.1
+    dev: false
+
+  /side-channel@1.0.4:
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      object-inspect: 1.13.1
+    dev: false
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
+  /url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+    dev: false
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
+
+  /yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
+
+  /@tiptap-pro/extension-mathematics@2.3.3:
+    resolution: {integrity: sha512-EV+rf26Z/uXRjXC0Vvm9txlJYFeeDHY/SIolwMg3HrWEpg8/x+zdea1aCAG4b3fOC/BFma8z7lYx8PnAK1swhg==}
+    dev: false


### PR DESCRIPTION
Sometimes errors will have the following shape

```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@tiptap-pro/extension-mathematics/-/extension-mathematics-2.3.3.tgz: Not Found - 404
```

instead of the one we were capturing

```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@dependabot%2Ftotally-fake-dependency-soz: Not Found - 404

This error happened while installing a direct dependency of dependabot_tmp_dir

@dependabot/totally-fake-dependency-soz is not in the npm registry, or you have no permission to fetch it.
```

This PR changes the regex to capture both types of errors.