### PR TITLE
Fix PNPM issues with private registries

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -493,7 +493,7 @@ def handle_dependabot_error(error:)
       }
     }
   else
-    raise error
+    raise
   end
 end
 # rubocop:enable Metrics/MethodLength

--- a/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.js
+++ b/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.js
@@ -68,6 +68,7 @@ function nameVerDevFromPkgSnapshot(depPath, pkgSnapshot, projectSnapshots) {
   return {
     name: name,
     version: version,
+    resolved: pkgSnapshot.resolution.tarball,
     dev: pkgSnapshot.dev,
     specifiers: specifiers,
     aliased: aliased

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -140,7 +140,10 @@ module Dependabot
             @dependency_urls = dependencies.map do |dependency|
               UpdateChecker::RegistryFinder.new(
                 dependency: dependency,
-                credentials: credentials
+                credentials: credentials,
+                npmrc_file: npmrc_file,
+                yarnrc_file: yarnrc_file,
+                yarnrc_yml_file: yarnrc_yml_file
               ).dependency_url
             end
             return @dependency_urls
@@ -307,6 +310,11 @@ module Dependabot
         def yarnrc_file
           @yarnrc_file ||= dependency_files
                            .find { |f| f.name.end_with?(".yarnrc") }
+        end
+
+        def yarnrc_yml_file
+          @yarnrc_yml_file ||= dependency_files
+                               .find { |f| f.name.end_with?(".yarnrc.yml") }
         end
 
         def yarn_lock

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -31,7 +31,7 @@ module Dependabot
         end
 
         def registry
-          @registry ||= locked_registry || first_registry_with_dependency_details
+          @registry ||= locked_registry || configured_registry || first_registry_with_dependency_details
         end
 
         def auth_headers
@@ -49,15 +49,19 @@ module Dependabot
         end
 
         def registry_from_rc(dependency_name)
-          return global_registry unless dependency_name.start_with?("@") && dependency_name.include?("/")
-
-          scope = dependency_name.split("/").first
-          scoped_registry(scope)
+          explicit_registry_from_rc(dependency_name) || global_registry
         end
 
         private
 
         attr_reader :dependency, :credentials, :npmrc_file, :yarnrc_file, :yarnrc_yml_file
+
+        def explicit_registry_from_rc(dependency_name)
+          return configured_global_registry unless dependency_name.start_with?("@") && dependency_name.include?("/")
+
+          scope = dependency_name.split("/").first
+          scoped_registry(scope)
+        end
 
         def first_registry_with_dependency_details
           @first_registry_with_dependency_details ||=
@@ -126,6 +130,13 @@ module Dependabot
           detailed_registry || lockfile_registry
         end
 
+        def configured_registry
+          configured_registry_url = explicit_registry_from_rc(dependency.name)
+          return unless configured_registry_url
+
+          normalize_configured_registry(configured_registry_url)
+        end
+
         def known_registries
           @known_registries ||=
             begin
@@ -160,10 +171,7 @@ module Dependabot
           npmrc_file.content.scan(NPM_GLOBAL_REGISTRY_REGEX) do
             next if Regexp.last_match[:registry].include?("${")
 
-            registry = Regexp.last_match[:registry].strip
-                             .sub(%r{/+$}, "")
-                             .sub(%r{^.*?//}, "")
-                             .gsub(/\s+/, "%20")
+            registry = normalize_configured_registry(Regexp.last_match[:registry].strip)
             next if registries.map { |r| r["registry"] }.include?(registry)
 
             registries << {
@@ -183,10 +191,7 @@ module Dependabot
           yarnrc_file.content.scan(YARN_GLOBAL_REGISTRY_REGEX) do
             next if Regexp.last_match[:registry].include?("${")
 
-            registry = Regexp.last_match[:registry].strip
-                             .sub(%r{/+$}, "")
-                             .sub(%r{^.*?//}, "")
-                             .gsub(/\s+/, "%20")
+            registry = normalize_configured_registry(Regexp.last_match[:registry].strip)
             registries << {
               "type" => "npm_registry",
               "registry" => registry,
@@ -208,34 +213,40 @@ module Dependabot
           end
         end
 
-        # rubocop:disable Metrics/PerceivedComplexity
         def global_registry
           return @global_registry if defined? @global_registry
+
+          @global_registry ||= configured_global_registry || "https://registry.npmjs.org"
+        end
+
+        # rubocop:disable Metrics/PerceivedComplexity
+        def configured_global_registry
+          return @configured_global_registry if defined? @configured_global_registry
 
           npmrc_file&.content.to_s.scan(NPM_GLOBAL_REGISTRY_REGEX) do
             next if Regexp.last_match[:registry].include?("${")
 
-            return @global_registry = Regexp.last_match[:registry].strip
+            return @configured_global_registry = Regexp.last_match[:registry].strip
           end
 
           yarnrc_file&.content.to_s.scan(YARN_GLOBAL_REGISTRY_REGEX) do
             next if Regexp.last_match[:registry].include?("${")
 
-            return @global_registry = Regexp.last_match[:registry].strip
+            return @configured_global_registry = Regexp.last_match[:registry].strip
           end
 
           if parsed_yarnrc_yml&.key?("npmRegistryServer")
-            return @global_registry = parsed_yarnrc_yml["npmRegistryServer"]
+            return @configured_global_registry = parsed_yarnrc_yml["npmRegistryServer"]
           end
 
           replaces_base = credentials.find { |cred| cred["type"] == "npm_registry" && cred["replaces-base"] == true }
           if replaces_base
             registry = replaces_base["registry"]
             registry = "https://#{registry}" unless registry.start_with?("http")
-            return @global_registry = registry
+            return @configured_global_registry = registry
           end
 
-          "https://registry.npmjs.org"
+          @configured_global_registry = nil
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
@@ -257,7 +268,7 @@ module Dependabot
             return yarn_berry_registry if yarn_berry_registry
           end
 
-          global_registry
+          nil
         end
 
         # npm registries expect slashes to be escaped
@@ -278,6 +289,12 @@ module Dependabot
           return @parsed_yarnrc_yml if defined? @parsed_yarnrc_yml
 
           @parsed_yarnrc_yml = YAML.safe_load(yarnrc_yml_file.content)
+        end
+
+        def normalize_configured_registry(url)
+          url.sub(%r{/+$}, "")
+             .sub(%r{^.*?//}, "")
+             .gsub(/\s+/, "%20")
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -57,10 +57,12 @@ module Dependabot
         attr_reader :dependency, :credentials, :npmrc_file, :yarnrc_file, :yarnrc_yml_file
 
         def explicit_registry_from_rc(dependency_name)
-          return configured_global_registry unless dependency_name.start_with?("@") && dependency_name.include?("/")
-
-          scope = dependency_name.split("/").first
-          scoped_registry(scope)
+          if dependency_name.start_with?("@") && dependency_name.include?("/")
+            scope = dependency_name.split("/").first
+            scoped_registry(scope) || configured_global_registry
+          else
+            configured_global_registry
+          end
         end
 
         def first_registry_with_dependency_details

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -31,7 +31,7 @@ module Dependabot
         end
 
         def registry
-          locked_registry || first_registry_with_dependency_details
+          @registry ||= locked_registry || first_registry_with_dependency_details
         end
 
         def auth_headers

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -397,6 +397,23 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           )
         end
       end
+
+      context "when tarball urls included" do
+        let(:dependency_files) { project_dependency_files("pnpm/tarball_urls") }
+        let(:dependency_name) { "babel-core" }
+        let(:requirement) { "^6.26.0" }
+
+        it "includes the URL in the details" do
+          expect(lockfile_details).to eq(
+            "aliased" => false,
+            "dev" => true,
+            "name" => "babel-core",
+            "resolved" => "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            "specifiers" => ["^6.26.0"],
+            "version" => "6.26.3"
+          )
+        end
+      end
     end
 
     context "for npm lockfiles" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
@@ -160,6 +160,24 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
 
     it { is_expected.to eq("registry.npmjs.org") }
 
+    context "with both a scoped npm registry and a global one" do
+      let(:dependency_name) { "@dependabot/some_dep" }
+      let(:npmrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".npmrc",
+          content: "registry=https://example.com\n@dependabot:registry=https://scoped.example.com"
+        )
+      end
+
+      it { is_expected.to eq("scoped.example.com") }
+
+      context "and a dependency under a different scope" do
+        let(:dependency_name) { "@foo/bar" }
+
+        it { is_expected.to eq("example.com") }
+      end
+    end
+
     context "with credentials for a private registry" do
       let(:credentials) do
         [{

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
@@ -25,16 +25,20 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
       "password" => "token"
     }]
   end
+  let(:dependency_name) { "etag" }
+  let(:requirements) do
+    [{
+      file: "package.json",
+      requirement: "^1.0.0",
+      groups: [],
+      source: source
+    }]
+  end
   let(:dependency) do
     Dependabot::Dependency.new(
-      name: "etag",
+      name: dependency_name,
       version: "1.0.0",
-      requirements: [{
-        file: "package.json",
-        requirement: "^1.0.0",
-        groups: [],
-        source: source
-      }],
+      requirements: requirements,
       package_manager: "npm_and_yarn"
     )
   end
@@ -434,15 +438,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
     end
 
     context "when multiple js sources are provided" do
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: "example",
-          version: "1.0.0",
-          requirements: requirements,
-          package_manager: "npm_and_yarn"
-        )
-      end
-
+      let(:dependency_name) { "example" }
       let(:requirements) do
         [
           {
@@ -466,15 +462,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
     end
 
     context "when a public registry and a private registry is detected" do
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: "example",
-          version: "1.0.0",
-          requirements: requirements,
-          package_manager: "npm_and_yarn"
-        )
-      end
-
+      let(:dependency_name) { "example" }
       let(:requirements) do
         [
           {

--- a/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_only_global_registry/.npmrc
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_only_global_registry/.npmrc
@@ -1,0 +1,1 @@
+registry=https://global.example.org

--- a/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_other_scoped_registry/.npmrc
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_other_scoped_registry/.npmrc
@@ -1,0 +1,1 @@
+@other:registry=https://registry.example.org

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/tarball_urls/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/tarball_urls/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "devDependencies": {
+    "babel-core": "^6.26.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/tarball_urls/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/tarball_urls/pnpm-lock.yaml
@@ -1,0 +1,361 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+devDependencies:
+  babel-core:
+    specifier: ^6.26.0
+    version: 6.26.3
+
+packages:
+
+  /ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==, tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /ansi-styles@2.2.1:
+    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /babel-code-frame@6.26.0:
+    resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==, tarball: https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz}
+    dependencies:
+      chalk: 1.1.3
+      esutils: 2.0.3
+      js-tokens: 3.0.2
+    dev: true
+
+  /babel-core@6.26.3:
+    resolution: {integrity: sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==, tarball: https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz}
+    dependencies:
+      babel-code-frame: 6.26.0
+      babel-generator: 6.26.1
+      babel-helpers: 6.24.1
+      babel-messages: 6.23.0
+      babel-register: 6.26.0
+      babel-runtime: 6.26.0
+      babel-template: 6.26.0
+      babel-traverse: 6.26.0
+      babel-types: 6.26.0
+      babylon: 6.18.0
+      convert-source-map: 1.9.0
+      debug: 2.6.9
+      json5: 0.5.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      path-is-absolute: 1.0.1
+      private: 0.1.8
+      slash: 1.0.0
+      source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-generator@6.26.1:
+    resolution: {integrity: sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==, tarball: https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz}
+    dependencies:
+      babel-messages: 6.23.0
+      babel-runtime: 6.26.0
+      babel-types: 6.26.0
+      detect-indent: 4.0.0
+      jsesc: 1.3.0
+      lodash: 4.17.21
+      source-map: 0.5.7
+      trim-right: 1.0.1
+    dev: true
+
+  /babel-helpers@6.24.1:
+    resolution: {integrity: sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==, tarball: https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz}
+    dependencies:
+      babel-runtime: 6.26.0
+      babel-template: 6.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-messages@6.23.0:
+    resolution: {integrity: sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==, tarball: https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz}
+    dependencies:
+      babel-runtime: 6.26.0
+    dev: true
+
+  /babel-register@6.26.0:
+    resolution: {integrity: sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==, tarball: https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz}
+    dependencies:
+      babel-core: 6.26.3
+      babel-runtime: 6.26.0
+      core-js: 2.6.12
+      home-or-tmp: 2.0.0
+      lodash: 4.17.21
+      mkdirp: 0.5.6
+      source-map-support: 0.4.18
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-runtime@6.26.0:
+    resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==, tarball: https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz}
+    dependencies:
+      core-js: 2.6.12
+      regenerator-runtime: 0.11.1
+    dev: true
+
+  /babel-template@6.26.0:
+    resolution: {integrity: sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==, tarball: https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz}
+    dependencies:
+      babel-runtime: 6.26.0
+      babel-traverse: 6.26.0
+      babel-types: 6.26.0
+      babylon: 6.18.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-traverse@6.26.0:
+    resolution: {integrity: sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==, tarball: https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz}
+    dependencies:
+      babel-code-frame: 6.26.0
+      babel-messages: 6.23.0
+      babel-runtime: 6.26.0
+      babel-types: 6.26.0
+      babylon: 6.18.0
+      debug: 2.6.9
+      globals: 9.18.0
+      invariant: 2.2.4
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-types@6.26.0:
+    resolution: {integrity: sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==, tarball: https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz}
+    dependencies:
+      babel-runtime: 6.26.0
+      esutils: 2.0.3
+      lodash: 4.17.21
+      to-fast-properties: 1.0.3
+    dev: true
+
+  /babylon@6.18.0:
+    resolution: {integrity: sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==, tarball: https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz}
+    hasBin: true
+    dev: true
+
+  /balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
+    dev: true
+
+  /brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
+  /chalk@1.1.3:
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==, tarball: https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: 2.0.0
+      strip-ansi: 3.0.1
+      supports-color: 2.0.0
+    dev: true
+
+  /concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==, tarball: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz}
+    dev: true
+
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==, tarball: https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz}
+    dev: true
+
+  /core-js@2.6.12:
+    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==, tarball: https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz}
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
+    requiresBuild: true
+    dev: true
+
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, tarball: https://registry.npmjs.org/debug/-/debug-2.6.9.tgz}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: true
+
+  /detect-indent@4.0.0:
+    resolution: {integrity: sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==, tarball: https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      repeating: 2.0.1
+    dev: true
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==, tarball: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==, tarball: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /globals@9.18.0:
+    resolution: {integrity: sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==, tarball: https://registry.npmjs.org/globals/-/globals-9.18.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /has-ansi@2.0.0:
+    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==, tarball: https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-regex: 2.1.1
+    dev: true
+
+  /home-or-tmp@2.0.0:
+    resolution: {integrity: sha512-ycURW7oUxE2sNiPVw1HVEFsW+ecOpJ5zaj7eC0RlwhibhRBod20muUN8qu/gzx956YrLolVvs1MTXwKgC2rVEg==, tarball: https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      os-homedir: 1.0.2
+      os-tmpdir: 1.0.2
+    dev: true
+
+  /invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==, tarball: https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
+  /is-finite@1.1.0:
+    resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==, tarball: https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /js-tokens@3.0.2:
+    resolution: {integrity: sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz}
+    dev: true
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}
+    dev: true
+
+  /jsesc@1.3.0:
+    resolution: {integrity: sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==, tarball: https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz}
+    hasBin: true
+    dev: true
+
+  /json5@0.5.1:
+    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==, tarball: https://registry.npmjs.org/json5/-/json5-0.5.1.tgz}
+    hasBin: true
+    dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz}
+    dev: true
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, tarball: https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
+  /minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==, tarball: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==, tarball: https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz}
+    dev: true
+
+  /mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==, tarball: https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+    dev: true
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==, tarball: https://registry.npmjs.org/ms/-/ms-2.0.0.tgz}
+    dev: true
+
+  /os-homedir@1.0.2:
+    resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==, tarball: https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==, tarball: https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==, tarball: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /private@0.1.8:
+    resolution: {integrity: sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==, tarball: https://registry.npmjs.org/private/-/private-0.1.8.tgz}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /regenerator-runtime@0.11.1:
+    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz}
+    dev: true
+
+  /repeating@2.0.1:
+    resolution: {integrity: sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==, tarball: https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-finite: 1.1.0
+    dev: true
+
+  /slash@1.0.0:
+    resolution: {integrity: sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==, tarball: https://registry.npmjs.org/slash/-/slash-1.0.0.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map-support@0.4.18:
+    resolution: {integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==, tarball: https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz}
+    dependencies:
+      source-map: 0.5.7
+    dev: true
+
+  /source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==, tarball: https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /strip-ansi@3.0.1:
+    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-regex: 2.1.1
+    dev: true
+
+  /supports-color@2.0.0:
+    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==, tarball: https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /to-fast-properties@1.0.3:
+    resolution: {integrity: sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==, tarball: https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /trim-right@1.0.1:
+    resolution: {integrity: sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==, tarball: https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz}
+    engines: {node: '>=0.10.0'}
+    dev: true


### PR DESCRIPTION
This PR fixes two issues:

* Dependabot can't infer the proper registry for each dependency by looking at registry urls in pnpm-lock.yaml.

This is handy because developers don't need to commit a `.npmrc` file and matches what we already support for NPM and Yarn.

* Dependabot incorrectly tries to infer the proper registry for each dependency by looking at presence in the registry, even when registries & scopes are explicitly configured in `.npmrc`.

This is a good last resort fallback, but it should not be used if registries & scopes have been explicitly configured.

Fixes https://github.com/dependabot/dependabot-core/issues/8242.
Fixes performance issues introduced by https://github.com/dependabot/dependabot-core/pull/8094.
Likely to fix https://github.com/dependabot/dependabot-core/issues/8008.