### PR TITLE
handle updating manifests across multiple directories

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -30,35 +30,35 @@ module Dependabot
       def fetch_files
         # Ensure we always check out the full repo contents for go_module
         # updates.
-        unless go_mod
-          raise(
-            Dependabot::DependencyFileNotFound,
-            Pathname.new(File.join(directory, "go.mod"))
-            .cleanpath.to_path
-          )
+        SharedHelpers.in_a_temporary_repo_directory(
+          directory,
+          clone_repo_contents
+        ) do
+          unless go_mod
+            raise(
+              Dependabot::DependencyFileNotFound,
+              Pathname.new(File.join(directory, "go.mod"))
+                      .cleanpath.to_path
+            )
+          end
+
+          fetched_files = [go_mod]
+          # Fetch the (optional) go.sum
+          fetched_files << go_sum if go_sum
+          fetched_files
         end
-
-        fetched_files = [go_mod]
-        # Fetch the (optional) go.sum
-        fetched_files << go_sum if go_sum
-
-        fetched_files
       end
 
       def go_mod
         return @go_mod if defined?(@go_mod)
 
-        SharedHelpers.in_a_temporary_repo_directory(directory, clone_repo_contents) do
-          @go_mod = fetch_file_if_present("go.mod")
-        end
+        @go_mod = fetch_file_if_present("go.mod")
       end
 
       def go_sum
         return @go_sum if defined?(@go_sum)
 
-        SharedHelpers.in_a_temporary_repo_directory(directory, clone_repo_contents) do
-          @go_sum = fetch_file_if_present("go.sum")
-        end
+        @go_sum = fetch_file_if_present("go.sum")
       end
 
       def recurse_submodules_when_cloning?

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -30,35 +30,35 @@ module Dependabot
       def fetch_files
         # Ensure we always check out the full repo contents for go_module
         # updates.
-        SharedHelpers.in_a_temporary_repo_directory(
-          directory,
-          clone_repo_contents
-        ) do
-          unless go_mod
-            raise(
-              Dependabot::DependencyFileNotFound,
-              Pathname.new(File.join(directory, "go.mod"))
-              .cleanpath.to_path
-            )
-          end
-
-          fetched_files = [go_mod]
-          # Fetch the (optional) go.sum
-          fetched_files << go_sum if go_sum
-          fetched_files
+        unless go_mod
+          raise(
+            Dependabot::DependencyFileNotFound,
+            Pathname.new(File.join(directory, "go.mod"))
+            .cleanpath.to_path
+          )
         end
+
+        fetched_files = [go_mod]
+        # Fetch the (optional) go.sum
+        fetched_files << go_sum if go_sum
+
+        fetched_files
       end
 
       def go_mod
         return @go_mod if defined?(@go_mod)
 
-        @go_mod = fetch_file_if_present("go.mod")
+        SharedHelpers.in_a_temporary_repo_directory(directory, clone_repo_contents) do
+          @go_mod = fetch_file_if_present("go.mod")
+        end
       end
 
       def go_sum
         return @go_sum if defined?(@go_sum)
 
-        @go_sum = fetch_file_if_present("go.sum")
+        SharedHelpers.in_a_temporary_repo_directory(directory, clone_repo_contents) do
+          @go_sum = fetch_file_if_present("go.sum")
+        end
       end
 
       def recurse_submodules_when_cloning?

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -85,6 +85,15 @@ module Dependabot
       !!existing_pull_request
     end
 
+    def merge_changes!(dependency_changes)
+      dependency_changes.each do |dependency_change|
+        updated_dependencies.concat(dependency_change.updated_dependencies)
+        updated_dependency_files.concat(dependency_change.updated_dependency_files)
+      end
+      updated_dependencies.compact!
+      updated_dependency_files.compact!
+    end
+
     private
 
     def existing_pull_request

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "pathname"
+
 # This class is responsible for aggregating individual DependencyChange objects
 # by tracking changes to individual files and the overall dependency list.
 module Dependabot
@@ -22,9 +24,9 @@ module Dependabot
       end
 
       # Returns an array of DependencyFile objects for the current state
-      def current_dependency_files
-        @dependency_file_batch.map do |_path, data|
-          data[:file]
+      def current_dependency_files(directory)
+        @dependency_file_batch.filter_map do |path, data|
+          data[:file] if Pathname.new(path).dirname.to_s == directory
         end
       end
 

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -25,6 +25,7 @@ module Dependabot
 
       # Returns an array of DependencyFile objects for the current state
       def current_dependency_files(directory)
+        directory = Pathname.new(directory).cleanpath.to_s
         @dependency_file_batch.filter_map do |path, data|
           data[:file] if Pathname.new(path).dirname.to_s == directory
         end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -24,8 +24,12 @@ module Dependabot
       end
 
       # Returns an array of DependencyFile objects for the current state
-      def current_dependency_files(directory)
-        directory = Pathname.new(directory).cleanpath.to_s
+      def current_dependency_files(job)
+        directory = Pathname.new(job.source.directory).cleanpath.to_s
+
+        # GitHub Actions adds a special case where root directory scans the .github/workflows folder
+        directory = "/.github/workflows" if job.package_manager == "github_actions" && directory == "/"
+
         @dependency_file_batch.filter_map do |path, data|
           data[:file] if Pathname.new(path).dirname.to_s == directory
         end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -34,8 +34,8 @@ module Dependabot
             next
           end
 
-          # Get the current state of the dependency files for use in this iteration
-          dependency_files = group_changes.current_dependency_files
+          # Get the current state of the dependency files for use in this iteration, filter by directory
+          dependency_files = group_changes.current_dependency_files(job.source.directory)
 
           # Reparse the current files
           reparsed_dependencies = dependency_file_parser(dependency_files).parse

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -35,7 +35,7 @@ module Dependabot
           end
 
           # Get the current state of the dependency files for use in this iteration, filter by directory
-          dependency_files = group_changes.current_dependency_files(job.source.directory)
+          dependency_files = group_changes.current_dependency_files(job)
 
           # Reparse the current files
           reparsed_dependencies = dependency_file_parser(dependency_files).parse

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -22,7 +22,7 @@ module Dependabot
 
           return false unless job.security_updates_only?
 
-          true if job.dependencies.count > 1
+          true if job.dependencies.count > 1 || (job.source.directories && job.source.directories.count > 1)
         end
 
         def self.tag_name
@@ -40,38 +40,20 @@ module Dependabot
 
         def perform
           Dependabot.logger.info("Starting security update job for #{job.source.repo}")
+          return record_security_update_dependency_not_found if dependency_snapshot.job_dependencies.empty?
 
-          target_dependencies = dependency_snapshot.job_dependencies
-
-          if target_dependencies.empty?
-            record_security_update_dependency_not_found
+          if dependency_change.updated_dependencies.any?
+            Dependabot.logger.info("Creating a pull request for '#{group.name}'")
+            begin
+              service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
+            rescue StandardError => e
+              error_handler.handle_job_error(error: e, dependency_group: group)
+            end
           else
-            # make a temporary fake group to use the existing logic
-            group = Dependabot::DependencyGroup.new(
-              name: "#{job.package_manager} at #{job.source.directory || '/'} security update",
-              rules: {
-                "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
-              }
-            )
-            target_dependencies.each do |dep|
-              group.dependencies << dep
-            end
-
-            dependency_change = compile_all_dependency_changes_for(group)
-
-            if dependency_change.updated_dependencies.any?
-              Dependabot.logger.info("Creating a pull request for '#{group.name}'")
-              begin
-                service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
-              rescue StandardError => e
-                error_handler.handle_job_error(error: e, dependency_group: group)
-              end
-            else
-              Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")
-            end
-
-            dependency_change
+            Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")
           end
+
+          dependency_change
         end
 
         private
@@ -81,6 +63,42 @@ module Dependabot
                     :dependency_snapshot,
                     :error_handler,
                     :created_pull_requests
+
+        def group
+          return @group if defined?(@group)
+
+          # make a temporary fake group to use the existing logic
+          @group = Dependabot::DependencyGroup.new(
+            name: "#{job.package_manager} at #{job.source.directory || '/'} security update",
+            rules: {
+              "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
+            }
+          )
+          dependency_snapshot.job_dependencies.each do |dep|
+            @group.dependencies << dep
+          end
+          @group
+        end
+
+        def dependency_change
+          return @dependency_change if defined?(@dependency_change)
+
+          if job.source.directories.nil?
+            @dependency_change = compile_all_dependency_changes_for(group)
+          else
+            dependency_changes = job.source.directories.map do |directory|
+              job.source.directory = directory
+              # Fixes not updating because it already updated in a previous group
+              dependency_snapshot.handled_dependencies.clear
+              compile_all_dependency_changes_for(group)
+            end
+
+            # merge the changes together into one
+            @dependency_change = dependency_changes.first
+            @dependency_change.merge_changes!(dependency_changes[1..-1]) if dependency_changes.count > 1
+            @dependency_change
+          end
+        end
       end
     end
   end

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -14,22 +14,21 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
         Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-gemfile-lock", directory: "/hello/.."),
         Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "/elsewhere"),
         Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown"),
-        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob"),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob")
       ]
     end
 
     it "returns the current dependency files filtered by directory" do
-      expect(described_class.new(initial_dependency_files: files).
-        current_dependency_files('/').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+      expect(described_class.new(initial_dependency_files: files)
+        .current_dependency_files("/").map(&:name)).to eq(%w(Gemfile Gemfile.lock))
     end
 
     it "normalizes the directory" do
-      expect(described_class.new(initial_dependency_files: files).
-        current_dependency_files('/.').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+      expect(described_class.new(initial_dependency_files: files)
+        .current_dependency_files("/.").map(&:name)).to eq(%w(Gemfile Gemfile.lock))
 
-      expect(described_class.new(initial_dependency_files: files).
-        current_dependency_files('/hello/..').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+      expect(described_class.new(initial_dependency_files: files)
+        .current_dependency_files("/hello/..").map(&:name)).to eq(%w(Gemfile Gemfile.lock))
     end
-
   end
 end

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/job"
+require "dependabot/updater/operations"
+
+require "spec_helper"
+
+RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
+  describe "current_dependency_files" do
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-gemfile", directory: "/"),
+        Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-gemfile-lock", directory: "/hello/.."),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "/elsewhere"),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown"),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob"),
+      ]
+    end
+
+    it "returns the current dependency files filtered by directory" do
+      expect(described_class.new(initial_dependency_files: files).
+        current_dependency_files('/').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+    end
+
+    it "normalizes the directory" do
+      expect(described_class.new(initial_dependency_files: files).
+        current_dependency_files('/.').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+
+      expect(described_class.new(initial_dependency_files: files).
+        current_dependency_files('/hello/..').map { |f| f.name }).to eq(%w[Gemfile Gemfile.lock])
+    end
+
+  end
+end

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             updating_a_pull_request?: false,
                             dependencies: [anything],
                             dependency_groups: [anything],
+                            source: Dependabot::Source.new(provider: "github", repo: "gocardless/bump"),
                             is_a?: true)
 
       expect(described_class.class_for(job: job))

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_by_dependency_type.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_by_dependency_type.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_overlapping_groups.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_overlapping_groups.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping_with_global_ignores.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_semver_grouping_with_global_ignores.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_ungrouped.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_ungrouped.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_dependencies_changed.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_dependencies_changed.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_similar_pr.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_similar_pr.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_versions_changed.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_versions_changed.yaml
@@ -3,7 +3,7 @@ job:
   source:
     provider: github
     repo: dependabot/smoke-tests
-    directory: "/bundler"
+    directory: "/"
     branch:
     api-endpoint: https://api.github.com/
     hostname: github.com


### PR DESCRIPTION
follow-on to #8309

This makes the Updater run multiple updates across multiple directories, then smashes all the changes together and creates a PR. Confirmed with some of the smoke tests: https://github.com/dependabot/smoke-tests/pull/135 
