### PR TITLE
npm: Fall back on configured global registry for scoped packages

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -57,10 +57,12 @@ module Dependabot
         attr_reader :dependency, :credentials, :npmrc_file, :yarnrc_file, :yarnrc_yml_file
 
         def explicit_registry_from_rc(dependency_name)
-          return configured_global_registry unless dependency_name.start_with?("@") && dependency_name.include?("/")
-
-          scope = dependency_name.split("/").first
-          scoped_registry(scope)
+          if dependency_name.start_with?("@") && dependency_name.include?("/")
+            scope = dependency_name.split("/").first
+            scoped_registry(scope) || configured_global_registry
+          else
+            configured_global_registry
+          end
         end
 
         def first_registry_with_dependency_details


### PR DESCRIPTION
If a scoped registry is not configured for a scoped dependency, however a global registry is configured, it should fall back on the configured global registry.

As discussed in https://github.com/dependabot/dependabot-core/issues/8242#issuecomment-1793136986