### PR TITLE
Fix broken composer CI

### DIFF
--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
 
-      before { ENV["DEPENDABOT_TEST_MEMORY_ALLOCATION"] = "16G" }
+      before { ENV["DEPENDABOT_TEST_MEMORY_ALLOCATION"] = "32G" }
       after { ENV.delete("DEPENDABOT_TEST_MEMORY_ALLOCATION") }
 
       it "raises a Dependabot::OutOfMemory error" do


### PR DESCRIPTION
Apparently Actions can now deal with 16G, so our test no longer causes an OutOfMemory error.