### PR TITLE
Support updating Package.swift files without a lockfile

### DIFF
--- a/swift/lib/dependabot/swift/update_checker/version_resolver.rb
+++ b/swift/lib/dependabot/swift/update_checker/version_resolver.rb
@@ -31,7 +31,7 @@ module Dependabot
             credentials: credentials
           ).updated_lockfile_content
 
-          return if updated_lockfile_content == lockfile.content
+          return if lockfile && updated_lockfile_content == lockfile.content
 
           updated_lockfile = DependencyFile.new(
             name: "Package.resolved",
@@ -46,7 +46,7 @@ module Dependabot
 
         def dependency_parser(manifest, lockfile)
           FileParser::DependencyParser.new(
-            dependency_files: [manifest, lockfile],
+            dependency_files: [manifest, lockfile].compact,
             repo_contents_path: repo_contents_path,
             credentials: credentials
           )

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     end
   end
 
-  context "with a dependency that needs manifest changes to get updated" do
+  shared_examples_for "a dependency that needs manifest changes to get updated" do
     let(:name) { "github.com/quick/nimble" }
     let(:url) { "https://github.com/Quick/Nimble" }
     let(:upload_pack_fixture) { "nimble" }
@@ -146,6 +146,14 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
         expect(subject.first[:requirement]).to eq("= 12.0.1")
       end
     end
+  end
+
+  it_behaves_like "a dependency that needs manifest changes to get updated"
+
+  context "when there's no lockfile" do
+    let(:project_name) { "ReactiveCocoaNoLockfile" }
+
+    it_behaves_like "a dependency that needs manifest changes to get updated"
   end
 
   context "when dependencies located in a project subfolder" do

--- a/swift/spec/fixtures/projects/ReactiveCocoaNoLockfile/Package.swift
+++ b/swift/spec/fixtures/projects/ReactiveCocoaNoLockfile/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "ReactiveCocoa",
+    platforms: [
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", .exact("9.2.1")),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
I thought we supported this, but there were some issues.

Fixes #8350.