### PR TITLE
Remove feature flag gating dependency removal

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -142,8 +142,7 @@ module Dependabot
         @vulnerability_audit ||=
           VulnerabilityAuditor.new(
             dependency_files: dependency_files,
-            credentials: credentials,
-            allow_removal: @options.key?(:npm_transitive_dependency_removal)
+            credentials: credentials
           ).audit(
             dependency: dependency,
             security_advisories: security_advisories

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -16,10 +16,9 @@ module Dependabot
   module NpmAndYarn
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class VulnerabilityAuditor
-        def initialize(dependency_files:, credentials:, allow_removal: false)
+        def initialize(dependency_files:, credentials:)
           @dependency_files = dependency_files
           @credentials = credentials
-          @allow_removal = allow_removal
         end
 
         # rubocop:disable Metrics/MethodLength
@@ -109,24 +108,16 @@ module Dependabot
             "No patched version available for #{dependency.name}"
           when :fix_incomplete
             "The lockfile might be out of sync?"
-          when :vulnerable_dependency_removed
-            "#{dependency.name} was removed in the update. Dependabot is not able to " \
-            "deal with this yet, but you can still upgrade manually."
           end
         end
 
         def validate_audit_result(audit_result, security_advisories)
           return :fix_unavailable unless audit_result["fix_available"]
-          return :vulnerable_dependency_removed if !@allow_removal && vulnerable_dependency_removed?(audit_result)
           return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
           return :downgrades_dependencies if downgrades_dependencies?(audit_result)
           return :fix_incomplete if fix_incomplete?(audit_result)
 
           :viable
-        end
-
-        def vulnerable_dependency_removed?(audit_result)
-          !audit_result["target_version"]
         end
 
         def dependency_still_vulnerable?(audit_result, security_advisories)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
       "password" => "token"
     }]
   end
-  let(:allow_removal) { true }
 
   subject do
-    described_class.new(dependency_files: dependency_files, credentials: credentials, allow_removal: allow_removal)
+    described_class.new(dependency_files: dependency_files, credentials: credentials)
   end
 
   before do
@@ -139,29 +138,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             }],
             "top_level_ancestors" => ["@dependabot-fixtures/npm-remove-dependency"]
           )
-      end
-
-      context "when removal is disabled" do
-        let(:allow_removal) { false }
-
-        it "logs vulnerable_dependency_removed and returns fix_available => false" do
-          security_advisories = [
-            Dependabot::SecurityAdvisory.new(
-              dependency_name: dependency.name,
-              package_manager: "npm_and_yarn",
-              vulnerable_versions: ["<1.0.1"],
-              safe_versions: ["1.0.1"]
-            )
-          ]
-
-          expect(Dependabot.logger).to receive(:info).with(/audit result not viable: vulnerable_dependency_removed/i)
-          expect(subject.audit(dependency: dependency, security_advisories: security_advisories))
-            .to include(
-              "fix_available" => false,
-              "explanation" => "#{dependency.name} was removed in the update. " \
-                               "Dependabot is not able to deal with this yet, but you can still upgrade manually."
-            )
-        end
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -277,15 +277,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         it "allows full unlocking" do
           expect(checker.can_update?(requirements_to_unlock: :all)).to eq(true)
         end
-
-        context "when the vulnerable transitive dependency is removed as a result of updating its parent" do
-          let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency_removed") }
-          let(:registry_listing_url) { "https://registry.npmjs.org/locked_transitive_dependency_removed" }
-
-          it "doesn't allow an update because removal has not been enabled" do
-            expect(checker.can_update?(requirements_to_unlock: :all)).to eq(false)
-          end
-        end
       end
 
       context "when a transitive dependency is able to update without unlocking its parent but is still vulnerable",
@@ -1505,11 +1496,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       context "when the vulnerable transitive dependency is removed as a result of updating its parent" do
         let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency_removed") }
         let(:registry_listing_url) { "https://registry.npmjs.org/locked-transitive-dependency-removed" }
-        let(:options) do
-          {
-            npm_transitive_dependency_removal: true
-          }
-        end
 
         it "correctly updates the parent dependency and removes the transitive because removal is enabled" do
           expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_including_metadata(
@@ -1688,8 +1674,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           .to receive(:new)
           .with(
             dependency_files: dependency_files,
-            credentials: credentials,
-            allow_removal: false
+            credentials: credentials
           ).and_call_original
 
         checker.send(:vulnerability_audit)
@@ -1744,8 +1729,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           .to receive(:new)
           .with(
             dependency_files: dependency_files,
-            credentials: credentials,
-            allow_removal: false
+            credentials: credentials
           ).and_call_original
 
         checker.send(:vulnerability_audit)


### PR DESCRIPTION
We needed to gate this feature because older versions of GHES didn't have support for PRs that remove dependencies. All currently supported versions of GHES now support this so we can remove the flag.