### PR TITLE
Fix more test failures

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             function: "dependency_source_type",
             options: anything,
             args: anything
-          }).and_call_original
+          }).and_return("private")
 
         allow(Dependabot::Bundler::NativeHelpers)
           .to receive(:run_bundler_subprocess)
@@ -579,7 +579,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             function: "dependency_source_type",
             options: anything,
             args: anything
-          }).and_call_original
+          }).and_return("private")
 
         allow(Dependabot::Bundler::NativeHelpers)
           .to receive(:run_bundler_subprocess)


### PR DESCRIPTION
Probably due to sorbet and rspec's `and_call_original` not playing nice with each other.

See for example latest run in main branch's CI: https://github.com/dependabot/dependabot-core/actions/runs/6787005329/job/18448834031.