### PR TITLE
Respect poetry explicit source

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -137,12 +137,21 @@ module Dependabot
 
             check_requirements(requirement)
 
-            {
-              requirement: requirement.is_a?(String) ? requirement : requirement["version"],
-              file: pyproject.name,
-              source: nil,
-              groups: [type]
-            }
+            if requirement.is_a?(String)
+              {
+                requirement: requirement,
+                file: pyproject.name,
+                source: nil,
+                groups: [type]
+              }
+            else
+              {
+                requirement: requirement["version"],
+                file: pyproject.name,
+                source: requirement.fetch("source", nil),
+                groups: [type]
+              }
+            end
           end
         end
 

--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -12,9 +12,10 @@ module Dependabot
         PYPI_BASE_URL = "https://pypi.org/simple/"
         ENVIRONMENT_VARIABLE_REGEX = /\$\{.+\}/
 
-        def initialize(dependency_files:, credentials:)
+        def initialize(dependency_files:, credentials:, dependency:)
           @dependency_files = dependency_files
           @credentials      = credentials
+          @dependency       = dependency
         end
 
         def index_urls
@@ -124,7 +125,11 @@ module Dependabot
 
             if source["default"]
               urls[:main] = source["url"]
-            else
+            elsif source["priority"] != "explicit"
+              # if source is not explicit, add it to extra
+              urls[:extra] << source["url"]
+            elsif @dependency.all_sources.include?(source["name"])
+              # if source is explicit, and dependency has specified it as a source, add it to extra
               urls[:extra] << source["url"]
             end
           end

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -213,7 +213,8 @@ module Dependabot
           @index_urls ||=
             IndexFinder.new(
               dependency_files: dependency_files,
-              credentials: credentials
+              credentials: credentials,
+              dependency: dependency
             ).index_urls
         end
 

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -251,6 +251,15 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         expect(dependency_names).to include("sphinx")
       end
     end
+
+    context "with package specify source" do
+      let(:pyproject_fixture_name) { "package_specify_source.toml" }
+      subject(:dependency) { dependencies.find { |f| f.name == "black" } }
+
+      it "specifies a package source" do
+        expect(dependency.requirements[0][:source]).to eq("custom")
+      end
+    end
   end
 
   describe "parse standard python files" do

--- a/python/spec/dependabot/python/update_checker/index_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/index_finder_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
   let(:finder) do
     described_class.new(
       dependency_files: dependency_files,
-      credentials: credentials
+      credentials: credentials,
+      dependency: dependency
     )
   end
   let(:credentials) do
@@ -21,6 +22,19 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
     }]
   end
   let(:dependency_files) { [requirements_file] }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "requests",
+      version: "2.4.1",
+      requirements: [{
+        requirement: "==2.4.1",
+        file: "requirements.txt",
+        groups: ["dependencies"],
+        source: nil
+      }],
+      package_manager: "pip"
+    )
+  end
 
   before do
     stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
@@ -302,6 +316,43 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
               "https://pypi.org/simple/",
               "https://some.internal.registry.com/pypi/"
             ]
+          )
+        end
+      end
+
+      context "when set in a pyproject.toml file and marked as explicit" do
+        let(:pyproject_fixture_name) { "extra_source_explicit.toml" }
+        let(:dependency_files) { [pyproject] }
+
+        it "gets the right index URLs" do
+          expect(index_urls).to match_array(
+            [
+              "https://pypi.org/simple/"
+            ]
+          )
+        end
+      end
+
+      context "when set in a pyproject.toml file and marked as explicit and specify with source" do
+        let(:pyproject_fixture_name) { "extra_source_explicit_and_package_specify_source.toml" }
+        let(:dependency_files) { [pyproject] }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "requests",
+            version: "2.4.1",
+            requirements: [{
+              requirement: "==2.4.1",
+              file: "requirements.txt",
+              groups: ["dependencies"],
+              source: "custom"
+            }],
+            package_manager: "pip"
+          )
+        end
+
+        it "gets the right index URLs" do
+          expect(index_urls).to match_array(
+            ["https://pypi.org/simple/", "https://some.internal.registry.com/pypi/"]
           )
         end
       end

--- a/python/spec/fixtures/pyproject_files/extra_source_explicit.toml
+++ b/python/spec/fixtures/pyproject_files/extra_source_explicit.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "2.18.0"
+
+[[tool.poetry.source]]
+name = "custom"
+url = "https://some.internal.registry.com/pypi/"
+priority = "explicit"

--- a/python/spec/fixtures/pyproject_files/extra_source_explicit_and_package_specify_source.toml
+++ b/python/spec/fixtures/pyproject_files/extra_source_explicit_and_package_specify_source.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = { version = "2.18.0", source = "custom" }
+
+[[tool.poetry.source]]
+name = "custom"
+url = "https://some.internal.registry.com/pypi/"
+priority = "explicit"

--- a/python/spec/fixtures/pyproject_files/package_specify_source.toml
+++ b/python/spec/fixtures/pyproject_files/package_specify_source.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "PoetryGroups"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = ">=3.10"
+black = {version="^22.12.0", source="custom"}


### PR DESCRIPTION
## Context

- The issue #7918 is being addressed to incorporate support for Poetry's explicit package source.
- Following this update, the explicit package source will only be utilized if a package explicitly specifies it as the source.

Poetry 1.5.0 introduced the concept of an explicit package source, which can be found here: [Explicit Package Sources](https://python-poetry.org/docs/repositories/#explicit-package-sources).

> If package sources are configured as explicit, these sources are only searched when a package configuration [explicitly indicates](https://python-poetry.org/docs/repositories/#package-source-constraint) that it should be found on this package source.

## Summary of Modifications
- An update has been made to the pyproject_files_parser, which previously ignored package source configuration in pyproject.toml but will now correctly read the value.
- The index_finder has also been updated to ignore any source marked as explicit unless it is specified as the source of the package.

## Testing
- test with `./bin/dry-run.rb` and check explicit package source won't be consider unless it is defined as the source of a package

## User facing changes
- a source marked as explicitly, won't be check for package that not specified it as source
- other behavior should be the same

## To-Do:
- based on the document [package-source-constraint](https://python-poetry.org/docs/repositories/#package-source-constraint), If a package specifies a source, it should not check other sources. Currently all sources (except explicitly) will still be considered

> A repository that is configured to be the only source for retrieving a certain package can itself have any priority. In particular, it does not need to have priority "explicit". If a repository is configured to be the source of a package, it will be the only source that is considered for that package and the repository priority will have no effect on the resolution.

Fixes #7918.