### PR TITLE
yarn:update add a handled error for missing tags

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -295,7 +295,8 @@ module Dependabot
           handle_timeout(error_message, yarn_lock) if error_message.match?(TIMEOUT_FETCHING_PACKAGE)
 
           if error_message.start_with?("Couldn't find any versions") ||
-             error_message.include?(": Not found")
+             error_message.include?(": Not found") ||
+             error_message.include?("Couldn't find match for")
 
             raise_resolvability_error(error_message, yarn_lock) unless resolvable_before_update?(yarn_lock)
 


### PR DESCRIPTION
In the case of git dependencies, if the version is not tagged correctly the error is not caught as a resolvability error. This adds handling for the error message if a release is not tagged as expected.