### PR TITLE
Fix one more `and_call_original`-related flaky spec

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             function: "dependency_source_type",
             options: anything,
             args: anything
-          }).and_call_original
+          }).and_return("private")
 
         allow(Dependabot::Bundler::NativeHelpers)
           .to receive(:run_bundler_subprocess)


### PR DESCRIPTION
### Before

```
$ SUITE_NAME=bundler1 rspec spec/dependabot/bundler/update_checker_spec.rb:181 
Run options: include {:locations=>{"./spec/dependabot/bundler/update_checker_spec.rb"=>[181]}}

Randomized with seed 2658
F

Failures:

  1) Dependabot::Bundler::UpdateChecker#latest_version with a private rubygems source 
     Failure/Error: raise Dependabot::PrivateSourceAuthenticationFailure, source
     
     Dependabot::PrivateSourceAuthenticationFailure:
       The following source could not be reached as it requires authentication (and any provided details were invalid or lacked the required permissions): repo.fury.io
     # ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:135:in `handle_bundler_errors'
     # ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:62:in `rescue in in_a_native_bundler_context'
     # ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:49:in `in_a_native_bundler_context'
     # ./lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb:106:in `private_registry_versions'
     # ./lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb:45:in `versions'
     # ./lib/dependabot/bundler/update_checker/latest_version_finder.rb:48:in `fetch_latest_version_details'
     # ./lib/dependabot/bundler/update_checker/latest_version_finder.rb:32:in `latest_version_details'
     # ./lib/dependabot/bundler/update_checker.rb:198:in `latest_version_details'
     # ./lib/dependabot/bundler/update_checker.rb:22:in `latest_version'
     # ./spec/dependabot/bundler/update_checker_spec.rb:57:in `block (3 levels) in <top (required)>'
     # ./spec/dependabot/bundler/update_checker_spec.rb:181:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:66:in `block (2 levels) in <top (required)>'
     # /home/dependabot/common/spec/spec_helper.rb:47:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Dependabot::SharedHelpers::HelperSubprocessFailed:
     #   Authentication is required for repo.fury.io.
     #   Please supply credentials for this source. You can do this by running:
     #    bundle config repo.fury.io username:password
     #   /home/dependabot/common/lib/dependabot/shared_helpers.rb:188:in `run_helper_subprocess'

Finished in 0.78182 seconds (files took 1.03 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/bundler/update_checker_spec.rb:181 # Dependabot::Bundler::UpdateChecker#latest_version with a private rubygems source 
```

### After

```
$ SUITE_NAME=bundler1 rspec spec/dependabot/bundler/update_checker_spec.rb:181 
Run options: include {:locations=>{"./spec/dependabot/bundler/update_checker_spec.rb"=>[181]}}

Randomized with seed 11508
.

Finished in 0.00987 seconds (files took 1.03 seconds to load)
1 example, 0 failures
```

Follow up to #8361 and #8347.