### PR TITLE
Fix more Sorbet + `and_call_original` issues

### DIFF
--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -394,7 +394,9 @@ RSpec.describe namespace::PipCompileVersionResolver do
       context "because it ran out of disk space" do
         before do
           allow(Dependabot::SharedHelpers)
-            .to receive(:run_shell_command).and_call_original
+            .to receive(:run_shell_command)
+          allow(Dependabot::SharedHelpers)
+            .to receive(:run_shell_command).with("pyenv versions").and_return("3.11.5")
           allow(Dependabot::SharedHelpers)
             .to receive(:run_shell_command).with(a_string_matching(/pyenv exec pip-compile/), *any_args)
             .and_raise(
@@ -414,7 +416,9 @@ RSpec.describe namespace::PipCompileVersionResolver do
       context "because it ran out of memory" do
         before do
           allow(Dependabot::SharedHelpers)
-            .to receive(:run_shell_command).and_call_original
+            .to receive(:run_shell_command)
+          allow(Dependabot::SharedHelpers)
+            .to receive(:run_shell_command).with("pyenv versions").and_return("3.11.5")
           allow(Dependabot::SharedHelpers)
             .to receive(:run_shell_command).with(a_string_matching(/pyenv exec pip-compile/), *any_args)
             .and_raise(


### PR DESCRIPTION
### Before

```
$ rspec spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:408
Run options: include {:locations=>{"./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb"=>[408]}}

Randomized with seed 64626
F

Failures:

  1) Dependabot::Python::UpdateChecker::PipCompileVersionResolver#resolvable? that fails to resolve due to resource limits because it ran out of disk space raises a helpful error
     Failure/Error:
       expect { subject }
         .to raise_error(Dependabot::OutOfDisk)
     
       expected Dependabot::OutOfDisk but nothing was raised
     # ./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:409:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:25:in `block (2 levels) in <top (required)>'
     # /home/dependabot/common/spec/spec_helper.rb:47:in `block (2 levels) in <top (required)>'

Top 1 slowest examples (3.32 seconds, 100.0% of total time):
  Dependabot::Python::UpdateChecker::PipCompileVersionResolver#resolvable? that fails to resolve due to resource limits because it ran out of disk space raises a helpful error
    3.32 seconds ./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:408

Finished in 3.32 seconds (files took 1.02 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:408 # Dependabot::Python::UpdateChecker::PipCompileVersionResolver#resolvable? that fails to resolve due to resource limits because it ran out of disk space raises a helpful error
```

### After

```
$ rspec spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:408
Run options: include {:locations=>{"./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb"=>[408]}}

Randomized with seed 28103
.

Top 1 slowest examples (0.00828 seconds, 86.8% of total time):
  Dependabot::Python::UpdateChecker::PipCompileVersionResolver#resolvable? that fails to resolve due to resource limits because it ran out of disk space raises a helpful error
    0.00828 seconds ./spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb:410

Finished in 0.00954 seconds (files took 0.97773 seconds to load)
1 example, 0 failures
```

Follow up to #8392, #8361 and #8347.