### PR TITLE
Bundler native helpers should not run in a frozen context

### DIFF
--- a/bundler/helpers/v1/lib/functions.rb
+++ b/bundler/helpers/v1/lib/functions.rb
@@ -148,6 +148,9 @@ module Functions
 
     # Use HTTPS for GitHub if lockfile
     Bundler.settings.set_command_option("github.https", "true")
+
+    # Native helpers rely on dependency unlocking, so Bundler should never be frozen
+    Bundler.settings.set_command_option("frozen", "false")
   end
 
   def self.relevant_credentials(credentials)

--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -152,6 +152,9 @@ module Functions
     Bundler.ui = Bundler::UI::Silent.new
 
     Bundler.settings.set_command_option("forget_cli_options", "true")
+
+    # Native helpers rely on dependency unlocking, so Bundler should never be frozen
+    Bundler.settings.set_command_option("frozen", "false")
   end
 
   def self.relevant_credentials(credentials)


### PR DESCRIPTION
While working on #8138, I realized that our Bundler native helpers in production are running with the `frozen` setting set to `true`, because that's what it's set in the updater image as configuration:

https://github.com/dependabot/dependabot-core/blob/7e90f1c86f9da0011397734f28c69637b8c470b8/Dockerfile.updater-core#L118

Our native helper specs don't catch this, because they don't run in the context of the `updater` directory/Gemfile, so the `frozen` setting is not visible, but they do fail when they start running in the context of the `updater` directory/Gemfile. That was surfaced by the changes in #8138.