### PR TITLE
Properly capture and re-raise PublicSourceTimedOut errors in Bundler

### DIFF
--- a/bundler/helpers/v2/spec/functions/dependency_source_spec.rb
+++ b/bundler/helpers/v2/spec/functions/dependency_source_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Functions::DependencySource do
           .to raise_error do |error|
             expect(error).to be_a(Bundler::HTTPError)
             expect(error.message)
-              .to include("Could not fetch specs from")
+              .to include("Could not fetch specs from #{registry_url} due to underlying error")
           end
       end
     end

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -26,7 +26,7 @@ module Dependabot
           BAD_AUTH_REGEX = /Bad username or password for (?<source>.*)\.$/
           FORBIDDEN_AUTH_REGEX = /Access token could not be authenticated for (?<source>.*)\.$/
           BAD_CERT_REGEX = /verify the SSL certificate for (?<source>.*)\.$/
-          HTTP_ERR_REGEX = /Could not fetch specs from (?<source>.*)$/
+          HTTP_ERR_REGEX = /Could not fetch specs from (?<source>\S+)/
         end
 
         RETRYABLE_ERRORS = %w(

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "that bad-requested, but was a private repo" do
         let(:error_message) do
           <<~ERR
-            Could not fetch specs from https://repo.fury.io/greysteil/
+            Could not fetch specs from https://repo.fury.io/greysteil/ due to underlying error
           ERR
         end
 


### PR DESCRIPTION
Bundler error message changed in Bundler 2.2.0.