### PR TITLE
fix #8414 follow poetry source constraint

### DIFF
--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -123,13 +123,13 @@ module Dependabot
             # If source is PyPI, skip it, and let it pick the default URI
             next if source["name"].casecmp?("PyPI")
 
-            if source["default"]
+            if @dependency.all_sources.include?(source["name"])
+              # If dependency has specified this source, use it
+              return { main: source["url"], extra: [] }
+            elsif source["default"]
               urls[:main] = source["url"]
             elsif source["priority"] != "explicit"
               # if source is not explicit, add it to extra
-              urls[:extra] << source["url"]
-            elsif @dependency.all_sources.include?(source["name"])
-              # if source is explicit, and dependency has specified it as a source, add it to extra
               urls[:extra] << source["url"]
             end
           end

--- a/python/spec/dependabot/python/update_checker/index_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/index_finder_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
 
         it "gets the right index URLs" do
           expect(index_urls).to match_array(
-            ["https://pypi.org/simple/", "https://some.internal.registry.com/pypi/"]
+            ["https://some.internal.registry.com/pypi/"]
           )
         end
       end


### PR DESCRIPTION
## Context
- fix #8414

> Package source constraints are strongly suggested for all packages that are expected to be provided only by one specific source to avoid dependency confusion attacks.

https://python-poetry.org/docs/repositories/#package-source-constraint

## Summary
- Update the `index_finder.rb` script to ensure that if a dependency has a package source configuration in `pyproject.toml`, it won't utilize any other sources as its `:main` source.
- Please note that the behavior may not completely align with Poetry's behavior. 
  - For example, if a package points to a source that is not defined in `pyproject.toml`, Poetry will raise an exception, but Dependabot will continue to check the default source. 
  - **Should we consider aligning dependabot behavior with Poetry's in this regard?**

## User-facing changes
- dependabot bot won't check default source if a package defined its source correctly.


## Testing Instructions
`[dependabot-core-dev] ~ $ ./bin/dry-run.rb pip lucemia/dependabot-source-constraint --cache=files`


### Before modification
- dependabot will check `https://pypi.org/simple/requests/`

```
=> reading cloned repo from /home/dependabot/tmp/lucemia/dependabot-source-constraint
=> parsing dependency files
=> updating 1 dependencies: requests

=== requests ()
 => checking for updates 1/1
🌍 --> GET https://pypi.org/simple/requests/
🌍 <-- 200 https://pypi.org/simple/requests/
🌍 --> GET https://some.internal.registry.com/pypi/requests/
 => handled error whilst updating requests: private_source_timed_out {:source=>"https://some.internal.registry.com/pypi/"}
🌍 Total requests made: '2'
🎈 Ecosystem Versions log: {:languages=>{:python=>{"raw"=>"^3.7", "max"=>"3.11"}}}
```

### After modification
- dependabot won't check `https://pypi.org/simple/requests/`

```
=> reading cloned repo from /home/dependabot/tmp/lucemia/dependabot-source-constraint
=> parsing dependency files
=> updating 1 dependencies: requests

=== requests ()
 => checking for updates 1/1
🌍 --> GET https://some.internal.registry.com/pypi/requests/
 => handled error whilst updating requests: private_source_timed_out {:source=>"https://some.internal.registry.com/pypi/"}
🌍 Total requests made: '1'
🎈 Ecosystem Versions log: {:languages=>{:python=>{"raw"=>"^3.7", "max"=>"3.11"}}}
```