### PR TITLE
Clone submodules in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: dorny/paths-filter@v2
         id: changes
@@ -212,6 +214,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       # using bundler as the test updater
       - name: Build ecosystem image
         run: script/build bundler

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL (ruby)

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set PR
         run: echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Build the dependabot-updater-<ecosystem> image
         # despite the script input being $NAME, the resulting image is dependabot-updater-${ECOSYSTEM}

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Build dependabot-updater-core image
         run: script/build common
       - name: Log in to GHCR

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,6 +58,8 @@ jobs:
           - { path: terraform, name: terraform, ecosystem: terraform }
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: dorny/paths-filter@v2
         if: github.event_name != 'workflow_dispatch'
         id: changes


### PR DESCRIPTION
We don't yet have any submodules, but we will be adding one with Nuget updater overhaul. In other to deploy those changes, I need to run the branch-images workflow manually, but that will always use the version of workflows in main (or optionally in a branch of our own repo), so I cannot build an image for that PR without introducing this first.