### PR TITLE
Clone submodules when building images manually

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -82,6 +82,7 @@ jobs:
           gh pr checkout ${{ inputs.pr }}
           git fetch origin main
           git merge origin/main --ff-only || exit 1
+          git submodule update --init --recursive
           echo "TAG=$(git rev-parse HEAD)" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch'
 


### PR DESCRIPTION
This is a follow up to #8429. When building images manually, we need to manually checkout PRs, so we also need to manually clone submodules.