### PR TITLE
Fix windows servercore Docker updates

### DIFF
--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -33,7 +33,7 @@ module Dependabot
       end
 
       def looks_like_prerelease?
-        numeric_version.gsub(/kb/i, "").match?(/[a-zA-Z]/)
+        numeric_version.match?(/[a-zA-Z]/)
       end
 
       def comparable_to?(other)
@@ -110,7 +110,7 @@ module Dependabot
       def numeric_version
         return unless comparable?
 
-        version.gsub(/-[a-z]+/, "").downcase
+        version.gsub(/kb/i, "").gsub(/-[a-z]+/, "").downcase
       end
 
       def precision


### PR DESCRIPTION
We currently special case `mcr.microsoft.com/windows/servercore`. This is because normally suffixes including non numeric characters signal prereleases, but in the case of these images, they have the `KB-` suffix which actually means cumulative updates over the base version, not prereleases.

This is really not great, and we should figure out a better way to give people what they want rather than adding special cases all over the place.

However, we have been special casing `KB` for a long time, so for now this PR fixes an issue that I found with it. It's the following:

```
$ bin/dry-run.rb docker dotnet/dotnet-docker  --dir /src/aspnet/6.0/nanoserver-1809/amd64/ --cache files
=> reading dependency files from cache manifest: ./dry-run/dotnet/dotnet-docker/src/aspnet/6.0/nanoserver-1809/amd64/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: windows/servercore

=== windows/servercore (1809-KB4493509-amd64)
 => checking for updates 1/1
 => latest available version is 2009-amd64
 => latest allowed version is 2009-amd64
 => requirements to unlock: own
 => requirements update strategy: 
 => bump windows/servercore from 1809-kb4493509-amd64 to 2009-amd64 in /src/aspnet/6.0/nanoserver-1809/amd64

    ± src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
    ~~~
    --- /tmp/original20231120-1142-dm58mc	2023-11-20 16:15:51.254491013 +0000
    +++ /tmp/updated20231120-1142-lznwpg	2023-11-20 16:15:51.254491013 +0000
    @@ -3,7 +3,7 @@
     ARG REPO=mcr.microsoft.com/dotnet/runtime
     
     # Installer image
    -FROM mcr.microsoft.com/windows/servercore:1809-KB4493509-amd64 AS installer
    +FROM mcr.microsoft.com/windows/servercore:2009-amd64 AS installer
     
     # Install ASP.NET Core Runtime
     RUN powershell -Command `
    ~~~
    2 insertions (+), 2 deletions (-)
```

Dependabot will avoid proposing update to KB versions, even if they are available. After this PR:

```
$ bin/dry-run.rb docker dotnet/dotnet-docker  --dir /src/aspnet/6.0/nanoserver-1809/amd64/ --cache files
=> reading dependency files from cache manifest: ./dry-run/dotnet/dotnet-docker/src/aspnet/6.0/nanoserver-1809/amd64/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: windows/servercore

=== windows/servercore (1809-KB4493509-amd64)
 => checking for updates 1/1
 => latest available version is 2009-KB4579311-amd64
 => latest allowed version is 2009-KB4579311-amd64
 => requirements to unlock: own
 => requirements update strategy: 
 => bump windows/servercore from 1809-kb4493509-amd64 to 2009-kb4579311-amd64 in /src/aspnet/6.0/nanoserver-1809/amd64

    ± src/aspnet/6.0/nanoserver-1809/amd64/Dockerfile
    ~~~
    --- /tmp/original20231120-1158-ql9d48	2023-11-20 16:16:07.266495006 +0000
    +++ /tmp/updated20231120-1158-hkc2rv	2023-11-20 16:16:07.266495006 +0000
    @@ -3,7 +3,7 @@
     ARG REPO=mcr.microsoft.com/dotnet/runtime
     
     # Installer image
    -FROM mcr.microsoft.com/windows/servercore:1809-KB4493509-amd64 AS installer
    +FROM mcr.microsoft.com/windows/servercore:2009-KB4579311-amd64 AS installer
     
     # Install ASP.NET Core Runtime
     RUN powershell -Command `
    ~~~
    2 insertions (+), 2 deletions (-)
🌍 Total requests made: '0'
```

With this PR, I expect these specs to no longer get in the middle of #8432.