### PR TITLE
Add `devcontainers` ecosystem

### DIFF
--- a/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
@@ -1,12 +1,82 @@
-# typed: strong
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
+require "dependabot/devcontainers/utils"
 
 module Dependabot
   module Devcontainers
     class FileFetcher < Dependabot::FileFetchers::Base
+      def self.required_files_in?(filenames)
+        # There's several other places a devcontainer.json can be checked into
+        # See: https://containers.dev/implementors/spec/#devcontainerjson
+        filenames.any? { |f| f.end_with?("devcontainer.json") }
+      end
+
+      def self.required_files_message
+        "Repo must contain a dev container configuration file."
+      end
+
+      def fetch_files
+        fetched_files = []
+        fetched_files += root_files
+        fetched_files += scoped_files
+        fetched_files += custom_directory_files
+        return fetched_files if fetched_files.any?
+
+        raise Dependabot::DependencyFileNotFound.new(
+          nil,
+          "Neither .devcontainer.json nor .devcontainer/devcontainer.json nor " \
+          ".devcontainer/<anything>/devcontainer.json found in #{directory}"
+        )
+      end
+
+      private
+
+      def root_files
+        fetch_config_and_lockfile_from(".")
+      end
+
+      def scoped_files
+        return [] unless devcontainer_directory
+
+        fetch_config_and_lockfile_from(".devcontainer")
+      end
+
+      def custom_directory_files
+        return [] unless devcontainer_directory
+
+        custom_directories.flat_map do |directory|
+          fetch_config_and_lockfile_from(directory.path)
+        end
+      end
+
+      def custom_directories
+        repo_contents(dir: ".devcontainer").select { |f| f.type == "dir" && f.name != ".devcontainer" }
+      end
+
+      def devcontainer_directory
+        return @devcontainer_directory if defined?(@devcontainer_directory)
+
+        @devcontainer_directory = repo_contents.find { |f| f.type == "dir" && f.name == ".devcontainer" }
+      end
+
+      def fetch_config_and_lockfile_from(directory)
+        files = []
+
+        config_name = Utils.expected_config_basename(directory)
+        config_file = fetch_file_if_present(File.join(directory, config_name))
+        return files unless config_file
+
+        files << config_file
+
+        lockfile_name = Utils.expected_lockfile_name(File.basename(config_file.name))
+        lockfile = fetch_support_file(File.join(directory, lockfile_name))
+        files << lockfile if lockfile
+
+        files
+      end
     end
   end
 end

--- a/devcontainers/lib/dependabot/devcontainers/file_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser.rb
@@ -3,17 +3,47 @@
 
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
+require "dependabot/devcontainers/version"
+require "dependabot/devcontainers/file_parser/feature_dependency_parser"
 
 module Dependabot
   module Devcontainers
     class FileParser < Dependabot::FileParsers::Base
+      require "dependabot/file_parsers/base/dependency_set"
+
       def parse
-        []
+        dependency_set = DependencySet.new
+
+        config_dependency_files.each do |config_dependency_file|
+          parse_features(config_dependency_file).each do |dep|
+            dependency_set << dep
+          end
+        end
+
+        dependency_set.dependencies
       end
 
       private
 
-      def check_required_files; end
+      def check_required_files
+        return if config_dependency_files.any?
+
+        raise "No dev container configuration!"
+      end
+
+      def parse_features(config_dependency_file)
+        FeatureDependencyParser.new(
+          config_dependency_file: config_dependency_file,
+          repo_contents_path: repo_contents_path,
+          credentials: credentials
+        ).parse
+      end
+
+      def config_dependency_files
+        @config_dependency_files ||= dependency_files.select do |f|
+          f.name.end_with?("devcontainer.json")
+        end
+      end
     end
   end
 end

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -65,6 +65,10 @@ module Dependabot
             # Skip sha pinned tags for now. Ideally the devcontainers CLI would give us updated SHA info
             next if name.end_with?("@sha256")
 
+            # Skip deprecated features until `devcontainer features info tag`
+            # and `devcontainer upgrade` work with them. See https://github.com/devcontainers/cli/issues/712
+            next unless name.include?("/")
+
             current = versions_object["current"]
 
             dep = Dependency.new(

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -1,0 +1,100 @@
+# typed: true
+# frozen_string_literal: true
+
+require "dependabot/devcontainers/requirement"
+require "dependabot/file_parsers/base"
+require "dependabot/shared_helpers"
+require "dependabot/dependency"
+require "json"
+require "uri"
+
+module Dependabot
+  module Devcontainers
+    class FileParser < Dependabot::FileParsers::Base
+      class FeatureDependencyParser
+        def initialize(config_dependency_file:, repo_contents_path:, credentials:)
+          @config_dependency_file = config_dependency_file
+          @repo_contents_path = repo_contents_path
+          @credentials = credentials
+        end
+
+        def parse
+          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              parse_cli_json(evaluate_with_cli)
+            end
+          end
+        end
+
+        private
+
+        def base_dir
+          File.dirname(config_dependency_file.path)
+        end
+
+        def config_name
+          File.basename(config_dependency_file.path)
+        end
+
+        def config_contents
+          config_dependency_file.content
+        end
+
+        # https://github.com/devcontainers/cli/blob/9444540283b236298c28f397dea879e7ec222ca1/src/spec-node/devContainersSpecCLI.ts#L1072
+        def evaluate_with_cli
+          raise "config_name must be a string" unless config_name.is_a?(String) && !config_name.empty?
+
+          cmd = "devcontainer outdated --workspace-folder . --config #{config_name} --output-format json"
+          Dependabot.logger.info("Running command: #{cmd}")
+
+          json = SharedHelpers.run_shell_command(
+            cmd,
+            stderr_to_stdout: false
+          )
+
+          JSON.parse(json)
+        end
+
+        def parse_cli_json(json)
+          dependencies = []
+
+          features = json["features"]
+          features.each do |feature, versions_object|
+            name, requirement = feature.split(":")
+            current = versions_object["current"]
+            wanted = versions_object["wanted"]
+            latest = versions_object["latest"]
+            wanted_major = versions_object["wantedMajor"]
+            latest_major = versions_object["latestMajor"]
+
+            dep = Dependency.new(
+              name: name,
+              version: current,
+              package_manager: "devcontainers",
+              requirements: [
+                {
+                  requirement: requirement,
+                  file: config_dependency_file.name,
+                  groups: ["feature"],
+                  source: nil,
+                  metadata: {
+                    wanted: wanted,
+                    latest: latest,
+                    wanted_major: wanted_major,
+                    latest_major: latest_major
+                  }
+                }
+              ],
+              metadata: {}
+            )
+
+            dependencies << dep
+          end
+          dependencies
+        end
+
+        attr_reader :config_dependency_file, :repo_contents_path, :credentials
+      end
+    end
+  end
+end

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -61,6 +61,10 @@ module Dependabot
           features = json["features"]
           features.each do |feature, versions_object|
             name, requirement = feature.split(":")
+
+            # Skip sha pinned tags for now. Ideally the devcontainers CLI would give us updated SHA info
+            next if name.end_with?("@sha256")
+
             current = versions_object["current"]
             wanted = versions_object["wanted"]
             latest = versions_object["latest"]

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -66,10 +66,6 @@ module Dependabot
             next if name.end_with?("@sha256")
 
             current = versions_object["current"]
-            wanted = versions_object["wanted"]
-            latest = versions_object["latest"]
-            wanted_major = versions_object["wantedMajor"]
-            latest_major = versions_object["latestMajor"]
 
             dep = Dependency.new(
               name: name,
@@ -80,16 +76,9 @@ module Dependabot
                   requirement: requirement,
                   file: config_dependency_file.name,
                   groups: ["feature"],
-                  source: nil,
-                  metadata: {
-                    wanted: wanted,
-                    latest: latest,
-                    wanted_major: wanted_major,
-                    latest_major: latest_major
-                  }
+                  source: nil
                 }
-              ],
-              metadata: {}
+              ]
             )
 
             dependencies << dep

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -71,7 +71,8 @@ module Dependabot
       def update(manifest, requirement)
         ConfigUpdater.new(
           feature: dependency.name,
-          requirement: requirement,
+          requirement: requirement[:requirement],
+          version: dependency.version,
           manifest: manifest,
           repo_contents_path: repo_contents_path,
           credentials: credentials

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -1,12 +1,82 @@
-# typed: strong
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
+require "dependabot/devcontainers/file_updater/config_updater"
 
 module Dependabot
   module Devcontainers
     class FileUpdater < Dependabot::FileUpdaters::Base
+      def self.updated_files_regex
+        [
+          /^\.?devcontainer\.json$/,
+          /^\.?devcontainer-lock\.json$/
+        ]
+      end
+
+      def updated_dependency_files
+        updated_files = []
+
+        manifests.each do |manifest|
+          requirement = dependency.requirements.find { |req| req[:file] == manifest.name }
+          next unless requirement
+
+          config_contents, lockfile_contents = update(manifest, requirement)
+
+          updated_files << updated_file(file: manifest, content: config_contents) if file_changed?(manifest)
+
+          lockfile = lockfile_for(manifest)
+
+          updated_files << updated_file(file: lockfile, content: lockfile_contents) if lockfile && lockfile_contents
+        end
+
+        updated_files
+      end
+
+      private
+
+      def dependency
+        # TODO: Handle one dependency at a time
+        dependencies.first
+      end
+
+      def check_required_files
+        return if dependency_files.any?
+
+        raise "No dev container configuration!"
+      end
+
+      def manifests
+        @manifests ||= dependency_files.select do |f|
+          f.name.end_with?("devcontainer.json")
+        end
+      end
+
+      def lockfile_for(manifest)
+        lockfile_name = lockfile_name_for(manifest)
+
+        dependency_files.find do |f|
+          f.name == lockfile_name
+        end
+      end
+
+      def lockfile_name_for(manifest)
+        basename = File.basename(manifest.name)
+        lockfile_name = Utils.expected_lockfile_name(basename)
+
+        manifest.name.delete_suffix(basename).concat(lockfile_name)
+      end
+
+      def update(manifest, requirement)
+        ConfigUpdater.new(
+          feature: dependency.name,
+          requirement: requirement,
+          manifest: manifest,
+          repo_contents_path: repo_contents_path,
+          credentials: credentials
+        ).update
+      end
     end
   end
 end

--- a/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
@@ -10,9 +10,10 @@ module Dependabot
   module Devcontainers
     class FileUpdater < Dependabot::FileUpdaters::Base
       class ConfigUpdater
-        def initialize(feature:, requirement:, manifest:, repo_contents_path:, credentials:)
+        def initialize(feature:, requirement:, version:, manifest:, repo_contents_path:, credentials:)
           @feature = feature
           @requirement = requirement
+          @version = version
           @manifest = manifest
           @repo_contents_path = repo_contents_path
           @credentials = credentials
@@ -22,8 +23,8 @@ module Dependabot
           SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials) do
               update_manifests(
-                target_requirement: requirement[:requirement],
-                target_version: requirement[:metadata][:latest]
+                target_requirement: requirement,
+                target_version: version
               )
 
               [File.read(manifest_name), File.read(lockfile_name)].compact
@@ -70,7 +71,7 @@ module Dependabot
           SharedHelpers.run_shell_command(cmd, stderr_to_stdout: false)
         end
 
-        attr_reader :feature, :requirement, :manifest, :repo_contents_path, :credentials
+        attr_reader :feature, :requirement, :version, :manifest, :repo_contents_path, :credentials
       end
     end
   end

--- a/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
@@ -1,0 +1,75 @@
+# typed: true
+# frozen_string_literal: true
+
+require "dependabot/file_updaters/base"
+require "dependabot/shared_helpers"
+require "dependabot/logger"
+require "dependabot/devcontainers/utils"
+
+module Dependabot
+  module Devcontainers
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class ConfigUpdater
+        def initialize(feature:, requirement:, manifest:, repo_contents_path:, credentials:)
+          @feature = feature
+          @requirement = requirement
+          @manifest = manifest
+          @repo_contents_path = repo_contents_path
+          @credentials = credentials
+        end
+
+        def update
+          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              update_manifest(
+                target_requirement: requirement[:requirement],
+                target_version: requirement[:metadata][:latest]
+              )
+
+              [File.read(manifest_name), File.read(lockfile_name)].compact
+            end
+          end
+        end
+
+        private
+
+        def base_dir
+          File.dirname(manifest.name)
+        end
+
+        def manifest_name
+          File.basename(manifest.name)
+        end
+
+        def lockfile_name
+          Utils.expected_lockfile_name(manifest_name)
+        end
+
+        def update_manifest(target_requirement:, target_version:)
+          # First force target version to upgrade lockfile. I believe the CLI
+          # shoudl automatically upgrade the lockfile directly, but needs a
+          # explicit version at the moment. If
+          # https://github.com/devcontainers/cli/issues/715 is implement, this
+          # first invocation can be removed
+          run_devcontainer_upgrade(target_version)
+
+          run_devcontainer_upgrade(target_requirement)
+        end
+
+        def run_devcontainer_upgrade(target_version)
+          cmd = "devcontainer upgrade " \
+                "--workspace-folder . " \
+                "--feature #{feature} " \
+                "--config #{manifest_name} " \
+                "--target-version #{target_version}"
+
+          Dependabot.logger.info("Running command: `#{cmd}`")
+
+          SharedHelpers.run_shell_command(cmd, stderr_to_stdout: false)
+        end
+
+        attr_reader :feature, :requirement, :manifest, :repo_contents_path, :credentials
+      end
+    end
+  end
+end

--- a/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
@@ -34,11 +34,11 @@ module Dependabot
         private
 
         def base_dir
-          File.dirname(manifest.name)
+          File.dirname(manifest.path)
         end
 
         def manifest_name
-          File.basename(manifest.name)
+          File.basename(manifest.path)
         end
 
         def lockfile_name

--- a/devcontainers/lib/dependabot/devcontainers/requirement.rb
+++ b/devcontainers/lib/dependabot/devcontainers/requirement.rb
@@ -19,10 +19,6 @@ module Dependabot
         [new(requirement_string)]
       end
 
-      def satisfied_by?(version)
-        super(version.release_part)
-      end
-
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
       def initialize(*requirements)

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -1,12 +1,54 @@
-# typed: strong
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
+require "dependabot/devcontainers/version"
+require "dependabot/update_checkers/version_filters"
+require "dependabot/devcontainers/requirement"
 
 module Dependabot
   module Devcontainers
     class UpdateChecker < Dependabot::UpdateCheckers::Base
+      def latest_version
+        @latest_version ||= dependency.requirements.map do |requirement|
+          Version.new(requirement[:metadata][:latest])
+        end.max
+      end
+
+      def latest_resolvable_version
+        latest_version # TODO
+      end
+
+      def updated_requirements
+        dependency.requirements.map do |requirement|
+          latest_version = requirement[:metadata][:latest]
+          existing_precision = requirement[:requirement].split(".").size
+          updated_requirement = latest_version.split(".")[0...existing_precision].join(".")
+
+          {
+            file: requirement[:file],
+            requirement: updated_requirement,
+            groups: requirement[:groups],
+            source: requirement[:source],
+            metadata: requirement[:metadata]
+          }
+        end
+      end
+
+      def latest_resolvable_version_with_no_unlock
+        raise NotImplementedError
+      end
+
+      private
+
+      def latest_version_resolvable_with_full_unlock?
+        false # TODO
+      end
+
+      def updated_dependencies_after_full_unlock
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -11,9 +11,7 @@ module Dependabot
   module Devcontainers
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       def latest_version
-        @latest_version ||= dependency.requirements.map do |requirement|
-          Version.new(requirement[:metadata][:latest])
-        end.max
+        @latest_version ||= fetch_latest_version
       end
 
       def latest_resolvable_version
@@ -22,16 +20,16 @@ module Dependabot
 
       def updated_requirements
         dependency.requirements.map do |requirement|
-          latest_version = requirement[:metadata][:latest]
-          existing_precision = requirement[:requirement].split(".").size
-          updated_requirement = latest_version.split(".")[0...existing_precision].join(".")
+          required_version = version_class.new(requirement[:requirement])
+          updated_requirement = remove_precision_changes(viable_candidates, required_version).last
+          updated_metadata = requirement[:metadata].update(latest: latest_version)
 
           {
             file: requirement[:file],
             requirement: updated_requirement,
             groups: requirement[:groups],
             source: requirement[:source],
-            metadata: requirement[:metadata]
+            metadata: updated_metadata
           }
         end
       end
@@ -41,6 +39,69 @@ module Dependabot
       end
 
       private
+
+      def viable_candidates
+        @viable_candidates ||= fetch_viable_candidates
+      end
+
+      def fetch_viable_candidates
+        candidates = comparable_versions_from_registry
+        candidates = filter_ignored(candidates)
+        candidates.sort
+      end
+
+      def fetch_latest_version
+        return current_version unless viable_candidates.any?
+
+        viable_candidates.last
+      end
+
+      def remove_precision_changes(versions, required_version)
+        versions.select do |version|
+          version.same_precision?(required_version)
+        end
+      end
+
+      def filter_ignored(versions)
+        filtered =
+          versions.reject do |version|
+            ignore_requirements.any? { |r| version.satisfies?(r) }
+          end
+
+        if @raise_on_ignored &&
+           filter_lower_versions(filtered).empty? &&
+           filter_lower_versions(versions).any?
+          raise AllVersionsIgnored
+        end
+
+        filtered
+      end
+
+      def comparable_versions_from_registry
+        tags_from_registry.filter_map do |tag|
+          version_class.correct?(tag) && version_class.new(tag)
+        end
+      end
+
+      def tags_from_registry
+        @tags_from_registry ||= fetch_tags_from_registry
+      end
+
+      def fetch_tags_from_registry
+        cmd = "devcontainer features info tags #{dependency.name} --output-format json"
+
+        Dependabot.logger.info("Running command: `#{cmd}`")
+
+        output = SharedHelpers.run_shell_command(cmd, stderr_to_stdout: false)
+
+        JSON.parse(output).fetch("publishedTags")
+      end
+
+      def filter_lower_versions(versions)
+        versions.select do |version|
+          version > current_version
+        end
+      end
 
       def latest_version_resolvable_with_full_unlock?
         false # TODO

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -22,14 +22,12 @@ module Dependabot
         dependency.requirements.map do |requirement|
           required_version = version_class.new(requirement[:requirement])
           updated_requirement = remove_precision_changes(viable_candidates, required_version).last
-          updated_metadata = requirement[:metadata].update(latest: latest_version)
 
           {
             file: requirement[:file],
             requirement: updated_requirement,
             groups: requirement[:groups],
-            source: requirement[:source],
-            metadata: updated_metadata
+            source: requirement[:source]
           }
         end
       end

--- a/devcontainers/lib/dependabot/devcontainers/utils.rb
+++ b/devcontainers/lib/dependabot/devcontainers/utils.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Devcontainers
+    module Utils
+      def self.expected_config_basename(directory)
+        root_directory?(directory) ? ".devcontainer.json" : "devcontainer.json"
+      end
+
+      def self.root_directory?(directory)
+        Pathname.new(directory).cleanpath.to_path == Pathname.new(".").cleanpath.to_path
+      end
+
+      def self.expected_lockfile_name(config_file_name)
+        if config_file_name.start_with?(".")
+          ".devcontainer-lock.json"
+        else
+          "devcontainer-lock.json"
+        end
+      end
+    end
+  end
+end

--- a/devcontainers/lib/dependabot/devcontainers/version.rb
+++ b/devcontainers/lib/dependabot/devcontainers/version.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/version"
@@ -7,6 +7,27 @@ require "dependabot/utils"
 module Dependabot
   module Devcontainers
     class Version < Dependabot::Version
+      def same_precision?(other)
+        precision == other.precision
+      end
+
+      def satisfies?(requirement)
+        requirement.satisfied_by?(self)
+      end
+
+      def <=>(other)
+        if self == other
+          precision <=> other.precision
+        else
+          super
+        end
+      end
+
+      protected
+
+      def precision
+        segments.size
+      end
     end
   end
 end

--- a/devcontainers/spec/dependabot/devcontainers/file_fetcher_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_fetcher_spec.rb
@@ -7,4 +7,71 @@ require_common_spec "file_fetchers/shared_examples_for_file_fetchers"
 
 RSpec.describe Dependabot::Devcontainers::FileFetcher do
   it_behaves_like "a dependency file fetcher"
+
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "github",
+      repo: "mona/devcontainers-example",
+      directory: directory
+    )
+  end
+
+  let(:file_fetcher_instance) do
+    described_class.new(source: source, credentials: [], repo_contents_path: repo_contents_path)
+  end
+
+  let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+  context "with a lone .devcontainer.json in repo root" do
+    let(:project_name) { "config_in_root" }
+    let(:directory) { "/" }
+
+    it "fetches the correct files" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to match_array(%w(.devcontainer.json))
+    end
+  end
+
+  context "with a .devcontainer folder" do
+    let(:project_name) { "config_in_dot_devcontainer_folder" }
+    let(:directory) { "/" }
+
+    it "fetches the correct files" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to match_array(%w(.devcontainer/devcontainer.json))
+    end
+  end
+
+  context "with repo that has multiple, valid dev container configs" do
+    let(:project_name) { "multiple_configs" }
+    let(:directory) { "/" }
+    it "fetches the correct files" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to match_array(%w(.devcontainer.json .devcontainer/devcontainer.json))
+    end
+  end
+
+  context "with devcontainer.json files inside custom directories inside .devcontainer folder" do
+    let(:project_name) { "custom_configs" }
+    let(:directory) { "/" }
+
+    it "fetches the correct files" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to match_array(%w(.devcontainer/foo/devcontainer.json .devcontainer/bar/devcontainer.json))
+    end
+  end
+
+  context "with a directory that doesn't exist" do
+    let(:project_name) { "multiple_configs" }
+    let(:directory) { "/.devcontainer/nonexistent" }
+
+    it "raises a helpful error" do
+      expect { file_fetcher_instance.files }
+        .to raise_error(Dependabot::DependencyFileNotFound)
+        .with_message(
+          "Neither .devcontainer.json nor .devcontainer/devcontainer.json nor " \
+          ".devcontainer/<anything>/devcontainer.json found in /.devcontainer/nonexistent"
+        )
+    end
+  end
 end

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -66,13 +66,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.1.0",
-                latest: "2.11.1",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -85,13 +79,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "1.0.0",
-                latest_major: "1",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -116,13 +104,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.1.0",
-                latest: "2.11.1",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -135,13 +117,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "1.0.0",
-                latest_major: "1",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -154,13 +130,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1.0",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "2.0.0",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -185,25 +155,13 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.1.0",
-                latest: "2.11.1",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             },
             {
               requirement: "1",
               file: ".devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.1.0",
-                latest: "2.11.1",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -216,25 +174,13 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "1.0.0",
-                latest_major: "1",
-                wanted_major: "1"
-              }
+              source: nil
             },
             {
               requirement: "1",
               file: ".devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "1.0.0",
-                latest_major: "1",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}
@@ -247,13 +193,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
               requirement: "1.0",
               file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "2.0.0",
-                latest_major: "2",
-                wanted_major: "1"
-              }
+              source: nil
             }
           ],
           metadata: {}

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -212,4 +212,13 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
       expect(dependencies).to be_empty
     end
   end
+
+  context "with deprecated features" do
+    let(:project_name) { "deprecated" }
+    let(:directory) { "/" }
+
+    it "ignores them" do
+      expect(dependencies).to be_empty
+    end
+  end
 end

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -263,4 +263,13 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
 
     it_behaves_like "parse"
   end
+
+  context "with SHA-pinned features" do
+    let(:project_name) { "sha_pinned" }
+    let(:directory) { "/" }
+
+    it "ignores them" do
+      expect(dependencies).to be_empty
+    end
+  end
 end

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -1,0 +1,266 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/source"
+require "dependabot/devcontainers/file_parser"
+require "dependabot/devcontainers/requirement"
+require_common_spec "file_parsers/shared_examples_for_file_parsers"
+
+RSpec.describe Dependabot::Devcontainers::FileParser do
+  it_behaves_like "a dependency file parser"
+
+  let(:parser) do
+    described_class.new(dependency_files: files, source: source, repo_contents_path: repo_contents_path)
+  end
+
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "github",
+      repo: "mona/Example",
+      directory: directory
+    )
+  end
+
+  let(:files) do
+    project_dependency_files(project_name, directory: directory)
+  end
+
+  let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
+
+  let(:dependencies) { parser.parse }
+
+  shared_examples_for "parse" do
+    it "parses dependencies fine" do
+      expect(dependencies.size).to eq(expectations.size)
+
+      expectations.each do |expected|
+        version = expected[:version]
+        name = expected[:name]
+        requirements = expected[:requirements]
+        metadata = expected[:metadata]
+
+        dependency = dependencies.find { |dep| dep.name == name }
+        expect(dependency).to have_attributes(
+          name: name,
+          version: version,
+          requirements: requirements,
+          metadata: metadata
+        )
+      end
+    end
+  end
+
+  context "with a .devcontainer.json in repo root" do
+    let(:project_name) { "config_in_root" }
+    let(:directory) { "/" }
+
+    let(:expectations) do
+      [
+        {
+          name: "ghcr.io/codspace/versioning/foo",
+          version: "1.1.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.1.0",
+                latest: "2.11.1",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/bar",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "1.0.0",
+                latest_major: "1",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        }
+      ].freeze
+    end
+
+    it_behaves_like "parse"
+  end
+
+  context "with a devcontainer.json in a .devcontainer folder" do
+    let(:project_name) { "config_in_dot_devcontainer_folder" }
+    let(:directory) { "/" }
+
+    let(:expectations) do
+      [
+        {
+          name: "ghcr.io/codspace/versioning/foo",
+          version: "1.1.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.1.0",
+                latest: "2.11.1",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/bar",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "1.0.0",
+                latest_major: "1",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/baz",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1.0",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "2.0.0",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        }
+      ].freeze
+    end
+
+    it_behaves_like "parse"
+  end
+
+  context "with multiple, valid devcontainer.json config files in repo" do
+    let(:project_name) { "multiple_configs" }
+    let(:directory) { "/" }
+
+    let(:expectations) do
+      [
+        {
+          name: "ghcr.io/codspace/versioning/foo",
+          version: "1.1.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.1.0",
+                latest: "2.11.1",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            },
+            {
+              requirement: "1",
+              file: ".devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.1.0",
+                latest: "2.11.1",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/bar",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "1.0.0",
+                latest_major: "1",
+                wanted_major: "1"
+              }
+            },
+            {
+              requirement: "1",
+              file: ".devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "1.0.0",
+                latest_major: "1",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/baz",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1.0",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil,
+              metadata: {
+                wanted: "1.0.0",
+                latest: "2.0.0",
+                latest_major: "2",
+                wanted_major: "1"
+              }
+            }
+          ],
+          metadata: {}
+        }
+      ].freeze
+    end
+
+    it_behaves_like "parse"
+  end
+end

--- a/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
@@ -42,25 +42,13 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
             requirement: "2",
             groups: ["feature"],
             file: ".devcontainer.json",
-            source: nil,
-            metadata: {
-              wanted: "1.1.0",
-              latest: "2.11.1",
-              wanted_major: "1",
-              latest_major: "2"
-            }
+            source: nil
           }],
           previous_requirements: [{
             requirement: "1",
             groups: ["feature"],
             file: ".devcontainer.json",
-            source: nil,
-            metadata: {
-              wanted: "1.1.0",
-              latest: "2.11.1",
-              wanted_major: "1",
-              latest_major: "2"
-            }
+            source: nil
           }],
           package_manager: "devcontainers"
         )
@@ -106,25 +94,13 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
               requirement: "2.0",
               groups: ["feature"],
               file: ".devcontainer/devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "2.0.0",
-                latest: "2.0.0",
-                wanted_major: "2",
-                latest_major: "2"
-              }
+              source: nil
             }],
             previous_requirements: [{
               requirement: "1.0",
               groups: ["feature"],
               file: ".devcontainer/devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "1.0.0",
-                latest: "2.0.0",
-                wanted_major: "1",
-                latest_major: "2"
-              }
+              source: nil
             }],
             package_manager: "devcontainers"
           )
@@ -153,25 +129,13 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
               requirement: "2",
               groups: ["feature"],
               file: ".devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "2.11.1",
-                latest: "2.11.1",
-                wanted_major: "2",
-                latest_major: "2"
-              }
+              source: nil
             }],
             previous_requirements: [{
               requirement: "2",
               groups: ["feature"],
               file: ".devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "2.11.1",
-                latest: "2.11.1",
-                wanted_major: "2",
-                latest_major: "2"
-              }
+              source: nil
             }],
             package_manager: "devcontainers"
           )
@@ -195,31 +159,19 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
         [
           Dependabot::Dependency.new(
             name: "ghcr.io/devcontainers/features/common-utils",
-            version: "2.3.2",
-            previous_version: "2.4.0",
+            version: "2.4.0",
+            previous_version: "2.3.2",
             requirements: [{
               requirement: "2",
               groups: ["feature"],
               file: ".devcontainer/devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "2.4.0",
-                latest: "2.4.0",
-                wanted_major: "2",
-                latest_major: "2"
-              }
+              source: nil
             }],
             previous_requirements: [{
               requirement: "2",
               groups: ["feature"],
               file: ".devcontainer/devcontainer.json",
-              source: nil,
-              metadata: {
-                wanted: "2.4.0",
-                latest: "2.4.0",
-                wanted_major: "2",
-                latest_major: "2"
-              }
+              source: nil
             }],
             package_manager: "devcontainers"
           )

--- a/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
@@ -187,5 +187,40 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
         expect(config.content).to include('"version": "2.4.0"')
       end
     end
+
+    context "when target version is not the latest" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "ghcr.io/codspace/versioning/foo",
+            version: "2.10.0",
+            previous_version: "1.1.0",
+            requirements: [{
+              requirement: "2",
+              groups: ["feature"],
+              file: ".devcontainer.json",
+              source: nil
+            }],
+            previous_requirements: [{
+              requirement: "2",
+              groups: ["feature"],
+              file: ".devcontainer.json",
+              source: nil
+            }],
+            package_manager: "devcontainers"
+          )
+        ]
+      end
+
+      let(:project_name) { "updated_manifest_outdated_lockfile" }
+
+      it "does not go past the target version in the lockfile" do
+        expect(subject.size).to eq(1)
+
+        lockfile = subject.first
+        expect(lockfile.name).to eq(".devcontainer-lock.json")
+        expect(lockfile.content).to include('"version": "2.10.0"')
+      end
+    end
   end
 end

--- a/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
@@ -1,0 +1,80 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/devcontainers/file_parser"
+require "dependabot/devcontainers/update_checker"
+require_common_spec "update_checkers/shared_examples_for_update_checkers"
+
+RSpec.describe Dependabot::Devcontainers::UpdateChecker do
+  it_behaves_like "an update checker"
+
+  let(:checker) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      repo_contents_path: repo_contents_path,
+      credentials: github_credentials,
+      security_advisories: security_advisories,
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
+    )
+  end
+
+  let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
+  let(:dependency_files) { project_dependency_files(project_name, directory: directory) }
+  let(:security_advisories) { [] }
+  let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
+
+  let(:dependencies) do
+    file_parser.parse
+  end
+
+  let(:file_parser) do
+    Dependabot::Devcontainers::FileParser.new(
+      dependency_files: dependency_files,
+      repo_contents_path: repo_contents_path,
+      source: nil
+    )
+  end
+
+  let(:dependency) { dependencies.find { |dep| dep.name == name } }
+
+  context "Feature that is out-of-date" do
+    let(:name) { "ghcr.io/codspace/versioning/foo" }
+
+    describe "config in root" do
+      let(:project_name) { "config_in_root" }
+      let(:directory) { "/" }
+      subject { checker.up_to_date? }
+      it { is_expected.to be_falsey }
+    end
+
+    describe "config in .devcontainer folder " do
+      let(:project_name) { "config_in_dot_devcontainer_folder" }
+      let(:directory) { "/.devcontainer" }
+      subject { checker.up_to_date? }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  context "Feature that is already up-to-date" do
+    let(:name) { "ghcr.io/codspace/versioning/bar" }
+
+    describe "config in root" do
+      let(:project_name) { "config_in_root" }
+      let(:directory) { "/" }
+      subject { checker.up_to_date? }
+      it { is_expected.to be_truthy }
+    end
+
+    describe "config in .devcontainer folder " do
+      let(:project_name) { "config_in_dot_devcontainer_folder" }
+      let(:directory) { "/.devcontainer" }
+      subject { checker.up_to_date? }
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/devcontainers/spec/fixtures/projects/config_in_dot_devcontainer_folder/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/config_in_dot_devcontainer_folder/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {},
+        "ghcr.io/codspace/versioning/baz:1.0": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/config_in_folder/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/config_in_folder/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/config_in_folder/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/config_in_folder/.devcontainer/devcontainer.json
@@ -1,7 +1,0 @@
-{
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
-    "features": {
-        "ghcr.io/codspace/versioning/foo:1": {},
-        "ghcr.io/codspace/versioning/bar:1": {}
-    }
-}

--- a/devcontainers/spec/fixtures/projects/config_in_root/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/config_in_root/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/config_in_root/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/config_in_root/.devcontainer.json
@@ -1,6 +1,7 @@
 {
     "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
     "features": {
-        "ghcr.io/codspace/versioning/foo:1": {}
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {}
     }
 }

--- a/devcontainers/spec/fixtures/projects/custom_configs/.devcontainer/bar/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/custom_configs/.devcontainer/bar/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/bar:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/custom_configs/.devcontainer/foo/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/custom_configs/.devcontainer/foo/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/deprecated/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/deprecated/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "docs.github.com",
+    "features": {
+        "sshd": "latest"
+    }
+}

--- a/devcontainers/spec/fixtures/projects/manifest_and_lockfile/.devcontainer-lock.json
+++ b/devcontainers/spec/fixtures/projects/manifest_and_lockfile/.devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/codspace/versioning/bar:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/codspace/versioning/bar@sha256:0eb80a7a45ea6ac6d2057798608be4cacb3d3667d4818118e17acc5037d687d4",
+      "integrity": "sha256:0eb80a7a45ea6ac6d2057798608be4cacb3d3667d4818118e17acc5037d687d4"
+    },
+    "ghcr.io/codspace/versioning/foo:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/codspace/versioning/foo@sha256:80d2d7b58afeaf907451c6f4e24de47b09a327a24a21a2d3323b7abf76d14be5",
+      "integrity": "sha256:80d2d7b58afeaf907451c6f4e24de47b09a327a24a21a2d3323b7abf76d14be5"
+    }
+  }
+}

--- a/devcontainers/spec/fixtures/projects/manifest_and_lockfile/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/manifest_and_lockfile/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/multiple_configs/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/multiple_configs/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/multiple_configs/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/multiple_configs/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:1": {},
+        "ghcr.io/codspace/versioning/bar:1": {},
+        "ghcr.io/codspace/versioning/baz:1.0": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/multiple_roots/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/multiple_roots/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/azure-cli:1": {}
+    }
+}

--- a/devcontainers/spec/fixtures/projects/multiple_roots/src/go/.devcontainer/devcontainer-lock.json
+++ b/devcontainers/spec/fixtures/projects/multiple_roots/src/go/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.4.0",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cd9c4413255c3b71fb716e63ee2df245c81c7262b858cf77406a68c80d09f12e",
+      "integrity": "sha256:cd9c4413255c3b71fb716e63ee2df245c81c7262b858cf77406a68c80d09f12e"
+    }
+  }
+}

--- a/devcontainers/spec/fixtures/projects/multiple_roots/src/go/.devcontainer/devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/multiple_roots/src/go/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "context": "."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        }
+    }
+}

--- a/devcontainers/spec/fixtures/projects/sha_pinned/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/sha_pinned/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "features": {
+        "ghcr.io/devcontainers/features/aws-cli@sha256:4b67518ec3733df53110c3caf7b9d6007363d1b5aaae2f1fa27f18ad0cc9b2b9": {},
+    }
+}

--- a/devcontainers/spec/fixtures/projects/updated_manifest_outdated_lockfile/.devcontainer-lock.json
+++ b/devcontainers/spec/fixtures/projects/updated_manifest_outdated_lockfile/.devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/codspace/versioning/bar:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/codspace/versioning/bar@sha256:0eb80a7a45ea6ac6d2057798608be4cacb3d3667d4818118e17acc5037d687d4",
+      "integrity": "sha256:0eb80a7a45ea6ac6d2057798608be4cacb3d3667d4818118e17acc5037d687d4"
+    },
+    "ghcr.io/codspace/versioning/foo:2": {
+      "version": "2.11.0",
+      "resolved": "ghcr.io/codspace/versioning/foo@sha256:9b5b5f165f7bff54d1b70d7228d63cb8d8a6b9f20fee6db772b520c3391beaa2",
+      "integrity": "sha256:9b5b5f165f7bff54d1b70d7228d63cb8d8a6b9f20fee6db772b520c3391beaa2"
+    }
+  }
+}

--- a/devcontainers/spec/fixtures/projects/updated_manifest_outdated_lockfile/.devcontainer.json
+++ b/devcontainers/spec/fixtures/projects/updated_manifest_outdated_lockfile/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+    "features": {
+        "ghcr.io/codspace/versioning/foo:2": {},
+        "ghcr.io/codspace/versioning/bar:1": {}
+    }
+}


### PR DESCRIPTION
This change provides initial support for a [devcontainers](https://containers.dev) ecosystem, leaning heavily on the [`devcontainers/cli`](https://github.com/devcontainers/cli) for ecosystem-specific implementation.

This updater will look in the provided `--directory` for a `devcontainer.json` (or `.devcontainer.json` if `directory === /`) and update all dev container [Features](https://containers.dev/implementors/features/) that are pinned to an out-of-date major version.  The [lockfile](https://github.com/devcontainers/spec/blob/main/docs/specs/devcontainer-lockfile.md) will also be updated if one is already present in the target directory.

I aim to add future updater granularity/modes in the future.

Requires at least dev container CLI [v0.54.0](https://github.com/devcontainers/cli/pull/689): 

## Demos (with the `dependabot/cli`)

```bash
LOCAL_GITHUB_ACCESS_TOKEN="$LOCAL_GITHUB_ACCESS_TOKEN"  dependabot  \
     --updater-image ghcr.io/dependabot/dependabot-updater-devcontainers  \
      update \
      devcontainers \
      joshspicer/versioning-project-two-configs \
      -o /tmp/updates.yaml \
      --directory /.devcontainer

updater | +-----------------------------------------------------------------------+
updater | |                  Changes to Dependabot Pull Requests                  |
updater | +---------+-------------------------------------------------------------+
updater | | created | ghcr.io/codspace/versioning/foo:1 ( from 1.1.0 to 2.11.1 )  |
updater | | created | ghcr.io/codspace/versioning/baz:1.0 ( from 1.0.0 to 2.0.0 ) |
updater | +---------+-------------------------------------------------------------+
```

```bash
LOCAL_GITHUB_ACCESS_TOKEN="$LOCAL_GITHUB_ACCESS_TOKEN"  dependabot  \
     --updater-image ghcr.io/dependabot/dependabot-updater-devcontainers  \
      update \
      devcontainers \
      joshspicer/versioning-project-two-configs \
      -o /tmp/updates.yaml \
      --directory /

updater | +----------------------------------------------------------------------+
updater | |                 Changes to Dependabot Pull Requests                  |
updater | +---------+------------------------------------------------------------+
updater | | created | ghcr.io/codspace/versioning/foo:1 ( from 1.1.0 to 2.11.1 ) |
updater | +---------+------------------------------------------------------------+
```

Closes https://github.com/dependabot/dependabot-core/issues/7000.
