### PR TITLE
Handle 403 Forbidden errors from PNPM

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -37,6 +37,7 @@ module Dependabot
         IRRESOLVABLE_PACKAGE = "ERR_PNPM_NO_MATCHING_VERSION"
         INVALID_REQUIREMENT = "ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER"
         UNREACHABLE_GIT = %r{ERR_PNPM_FETCH_404[ [^:print:]]+GET (?<url>https://codeload\.github\.com/[^/]+/[^/]+)/}
+        FORBIDDEN_PACKAGE = /ERR_PNPM_FETCH_403[ [^:print:]]+GET (?<dependency_url>.*): Forbidden - 403/
         MISSING_PACKAGE = /ERR_PNPM_FETCH_404[ [^:print:]]+GET (?<dependency_url>.*): Not Found - 404/
 
         def run_pnpm_update(pnpm_lock:)
@@ -89,6 +90,12 @@ module Dependabot
             raise_resolvability_error(error_message, pnpm_lock)
           end
 
+          if error_message.match?(FORBIDDEN_PACKAGE)
+            dependency_url = error_message.match(FORBIDDEN_PACKAGE)
+                                          .named_captures["dependency_url"]
+            raise_missing_package_error(dependency_url, pnpm_lock)
+          end
+
           if error_message.match?(UNREACHABLE_GIT)
             dependency_url = error_message.match(UNREACHABLE_GIT).named_captures.fetch("url")
 
@@ -100,8 +107,7 @@ module Dependabot
           dependency_url = error_message.match(MISSING_PACKAGE)
                                         .named_captures["dependency_url"]
 
-          package_name = RegistryParser.new(resolved_url: dependency_url, credentials: credentials).dependency_name
-          raise_missing_package_error(package_name, pnpm_lock)
+          raise_missing_package_error(dependency_url, pnpm_lock)
         end
 
         def raise_resolvability_error(error_message, pnpm_lock)
@@ -111,7 +117,8 @@ module Dependabot
           raise Dependabot::DependencyFileNotResolvable, msg
         end
 
-        def raise_missing_package_error(package_name, pnpm_lock)
+        def raise_missing_package_error(dependency_url, pnpm_lock)
+          package_name = RegistryParser.new(resolved_url: dependency_url, credentials: credentials).dependency_name
           missing_dep = lockfile_dependencies(pnpm_lock)
                         .find { |dep| dep.name == package_name }
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -101,7 +101,7 @@ module Dependabot
                                         .named_captures["dependency_url"]
 
           package_name = RegistryParser.new(resolved_url: dependency_url, credentials: credentials).dependency_name
-          raise_missing_package_error(package_name, error_message, pnpm_lock)
+          raise_missing_package_error(package_name, pnpm_lock)
         end
 
         def raise_resolvability_error(error_message, pnpm_lock)
@@ -111,7 +111,7 @@ module Dependabot
           raise Dependabot::DependencyFileNotResolvable, msg
         end
 
-        def raise_missing_package_error(package_name, _error_message, pnpm_lock)
+        def raise_missing_package_error(package_name, pnpm_lock)
           missing_dep = lockfile_dependencies(pnpm_lock)
                         .find { |dep| dep.name == package_name }
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -38,7 +38,7 @@ module Dependabot
                      resolved_url
                    end
 
-        url_base.split("/")[3..-1].join("/").gsub("%2F", "/")
+        url_base[/@.*/].gsub("%2F", "/")
       end
 
       private

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -157,5 +157,34 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         end
       end
     end
+
+    context "with a GHPR registry incorrectly configured including the scope" do
+      let(:dependency_name) { "@dsp-testing/inner-source-top-secret-npm-2" }
+      let(:version) { "1.0.9" }
+      let(:previous_version) { "1.0.8" }
+      let(:requirements) do
+        [{
+          file: "package.json",
+          requirement: "1.0.9",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+      let(:previous_requirements) do
+        [{
+          file: "package.json",
+          requirement: "1.0.8",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      let(:project_name) { "pnpm/private_registry_ghpr" }
+
+      it "raises a helpful error" do
+        expect { updated_pnpm_lock_content }
+          .to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+      end
+    end
   end
 end

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/.npmrc
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/.npmrc
@@ -1,0 +1,1 @@
+@dsp-testing:registry=https://npm.pkg.github.com/dsp-testing

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/private_registry_ghpr/pnpm-lock.yaml
@@ -1,0 +1,21 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@dsp-testing/inner-source-top-secret-npm-2':
+    specifier: 1.0.3
+    version: 1.0.3
+
+packages:
+
+  /@dsp-testing/inner-source-top-secret-npm-2@1.0.3:
+    resolution: {integrity: sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg==}
+    dev: false
+
+  /node-forge@0.10.0:
+    resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
+    engines: {node: '>= 6.0.0'}
+    dev: false


### PR DESCRIPTION
One case where they happen is when the user configures incorrectly
`https://npm.pkg.github.com/<org>` as the scope, instead of just
`https://npm.pkg.github.com`.

Another case (I did not test this but I suppose), is when the user
specifies a PAT without the proper read_packages scope.