### PR TITLE
Ignore repo access issues while parsing actions dependencies

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -153,6 +153,12 @@ module Dependabot
       @local_tag_for_pinned_sha = most_specific_version_tag_for_sha(ref) if pinned_ref_looks_like_commit_sha?
     end
 
+    def version_for_pinned_sha
+      return unless local_tag_for_pinned_sha && version_class.correct?(local_tag_for_pinned_sha)
+
+      version_class.new(local_tag_for_pinned_sha)
+    end
+
     def git_repo_reachable?
       local_upload_pack
       true

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -55,19 +55,21 @@ module Dependabot
             credentials: credentials,
             consider_version_branches_pinned: true
           )
-          next unless git_checker.pinned?
+          if git_checker.git_repo_reachable?
+            next unless git_checker.pinned?
 
-          # If dep does not have an assigned (semver) version, look for a commit that references a semver tag
-          unless dep.version
-            resolved = git_checker.version_for_pinned_sha
+            # If dep does not have an assigned (semver) version, look for a commit that references a semver tag
+            unless dep.version
+              resolved = git_checker.version_for_pinned_sha
 
-            if resolved
-              dep = Dependency.new(
-                name: dep.name,
-                version: resolved.to_s,
-                requirements: dep.requirements,
-                package_manager: dep.package_manager
-              )
+              if resolved
+                dep = Dependency.new(
+                  name: dep.name,
+                  version: resolved.to_s,
+                  requirements: dep.requirements,
+                  package_manager: dep.package_manager
+                )
+              end
             end
           end
 

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -59,12 +59,12 @@ module Dependabot
 
           # If dep does not have an assigned (semver) version, look for a commit that references a semver tag
           unless dep.version
-            resolved = git_checker.local_tag_for_pinned_sha
+            resolved = git_checker.version_for_pinned_sha
 
-            if resolved && version_class.correct?(resolved)
+            if resolved
               dep = Dependency.new(
                 name: dep.name,
-                version: version_class.new(resolved).to_s,
+                version: resolved.to_s,
                 requirements: dep.requirements,
                 package_manager: dep.package_manager
               )

--- a/github_actions/spec/fixtures/workflow_files/inaccessible_source.yml
+++ b/github_actions/spec/fixtures/workflow_files/inaccessible_source.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Integration
+jobs:
+  chore:
+    steps:
+    - uses: inaccessible/source@v1


### PR DESCRIPTION
The functionality that needs accessing the dependency source is not critical, so skip it if the repo is not accessible. The end result of this should be that we still parse the dependency, and it will be properly ignored before checking updates for it. If it's a non ignored dependency, we should be getting another `git_dependencies_not_reachable` error when checking for updates.