### PR TITLE
Bump `nuget` files type strictness

### DIFF
--- a/nuget/lib/dependabot/nuget/cache_manager.rb
+++ b/nuget/lib/dependabot/nuget/cache_manager.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/file_fetchers"

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Dependabot

--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/nuget/update_checker"

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "nokogiri"

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "dependabot/nuget/version"

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "excon"


### PR DESCRIPTION
This change bumps the type strictness for the files added in #8179. That PR was started before Sorbet was added to the codebase, so it's expected that they started as `#typed: false`.

The bump was performed automatically with `bundle exec spoom bump --from=false --to=true nuget`.