### PR TITLE
build(deps): bump pNPM to 8.11.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=8.10.5
+ARG PNPM_VERSION=8.11.0
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
 ARG YARN_VERSION=3.7.0


### PR DESCRIPTION
Release notes

https://github.com/pnpm/pnpm/releases/tag/v8.11.0

Note to reviewers/users : 

This might lead to some confusion with _larger-than expected diffs_ in the rare situations described in https://github.com/pnpm/pnpm/pull/7318 but it is a necessary change 