### PR TITLE
Fix type issues detected in GitHub Actions ecosystem

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -153,8 +153,7 @@ module Dependabot
 
               Dir.chdir(repo_contents_path) do
                 ref_branch = find_container_branch(git_commit_checker.dependency_source_details[:ref])
-
-                git_commit_checker.head_commit_for_local_branch(ref_branch)
+                git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
               end
             end
           end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -254,6 +254,7 @@ module Dependabot
           "git branch --remotes --contains #{sha}",
           fingerprint: "git branch --remotes --contains <sha>"
         ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
+        return if branches_including_ref.empty?
 
         current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }
 


### PR DESCRIPTION
After deploying #8441, I saw this new error:

```
Parameter 'ref': Expected type String, got type NilClass
Caller: /home/dependabot/common/lib/dependabot/git_commit_checker.rb:98
Definition: /home/dependabot/common/lib/dependabot/git_metadata_fetcher.rb:71
```

I think this should fix the culprit.