### PR TITLE
fix grouped update PRs are missing current -> updated version message

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -483,8 +483,8 @@ module Dependabot
         "| #{row.join(' | ')} |"
       end
 
-      def metadata_cascades
-        return metadata_cascades_for_dep(dependencies.first) if dependencies.one?
+      def metadata_cascades # rubocop:disable Metrics/PerceivedComplexity
+        return metadata_cascades_for_dep(dependencies.first) if dependencies.one? && !dependency_group
 
         dependencies.map do |dep|
           msg = if dep.removed?

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1927,6 +1927,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           )
         end
 
+        it "includes the version from -> to" do
+          expect(pr_message).to include(
+            "from 1.4.0 to 1.5.0"
+          )
+        end
+
         context "with two dependencies" do
           let(:dependency2) do
             Dependabot::Dependency.new(


### PR DESCRIPTION
fixes #7662

Group PRs that only have 1 dependency are missing the version from -> to line. 

There are examples in this very repo: https://github.com/dependabot/dependabot-core/pull/8459

The reason this happened is in the past, for PRs with one dependency the version update was included in the title. For grouped updates, the group info is included in the title, so the version info needs to be in the body. We just missed one place where we needed to check for a group. 