### PR TITLE
Fix missing codecommit require

### DIFF
--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "aws-sdk-codecommit"
 require "dependabot/shared_helpers"
 
 module Dependabot

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "aws-sdk-codecommit"
 require "spec_helper"
 require "dependabot/clients/codecommit"
 


### PR DESCRIPTION
While looking into https://github.com/dependabot/dependabot-core/pull/8460, I grepped for codecommit requires and I wonder whether we were actually using this dependency.

Then I found this error in our error tracker:

```
uninitialized constant Dependabot::Clients::CodeCommit::Aws

            Aws::CodeCommit::Client.new
```

Sounds like we are missing a require?