### PR TITLE
Bump type strictness

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "pathname"

--- a/common/lib/dependabot/workspace/base.rb
+++ b/common/lib/dependabot/workspace/base.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Dependabot

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "excon"


### PR DESCRIPTION
This is splitting out the `spoom bump` from #8469 while I figure out why `bundle exec spoom bump --from=true --to=strict` _really_ wants to bump `bundler/helpers/v1/run.rb` when it doesn't meet the requirements to be `strict.`