### PR TITLE
Enforce LF line endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text=auto
+* text=auto eof=lf
 Dockerfile.development linguist-language=Dockerfile
 Dockerfile.updater-core linguist-language=Dockerfile


### PR DESCRIPTION
Since #6682 all files in the repository have been normalized to LF. However, when checking out the repository on Windows, and `core.autocrlf` or `core.eol` are unset, line endings are set to CRLF. See [the documentation][^1]:

> If the eol attribute is unspecified for a file, its line endings in the working directory are determined by the `core.autocrlf` or `core.eol` configuration variable (see the definitions of those options in [git-config[1]](https://git-scm.com/docs/git-config)). If `text` is set but neither of those variables is, the default is `eol=crlf` on Windows and `eol=lf` on all other platforms.

We should default to a known good configuration, and not depend on people to have the correct git config to.

[^1]: https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Unspecified-1-1