### PR TITLE
Teach Dependabot how to present multi-directory PRs

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -164,7 +164,7 @@ module Dependabot
         updates = dependencies.map(&:name).uniq.count
 
         if source&.directories
-          "bump the #{dependency_group.name} with #{updates} update#{'s' if updates > 1}" 
+          "bump the #{dependency_group.name} with #{updates} update#{'s' if updates > 1}"
         else
           "bump the #{dependency_group.name} group#{pr_name_directory} with #{updates} update#{'s' if updates > 1}"
         end
@@ -363,7 +363,7 @@ module Dependabot
           update_count = dependencies_in_directory.map(&:name).uniq.count
 
           msg += "Bumps the #{dependency_group.name} " \
-                "with #{update_count} update#{update_count > 1 ? 's' : ''}:"
+                 "with #{update_count} update#{update_count > 1 ? 's' : ''}:"
 
           msg += if update_count >= 5
                    header = %w(Package From To)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -162,7 +162,12 @@ module Dependabot
 
       def group_pr_name
         updates = dependencies.map(&:name).uniq.count
-        "bump the #{dependency_group.name} group#{pr_name_directory} with #{updates} update#{'s' if updates > 1}"
+
+        if source&.directories
+          "bump the #{dependency_group.name} with #{updates} update#{'s' if updates > 1}" 
+        else
+          "bump the #{dependency_group.name} group#{pr_name_directory} with #{updates} update#{'s' if updates > 1}"
+        end
       end
 
       def pr_name_prefix
@@ -260,7 +265,7 @@ module Dependabot
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/AbcSize
       def version_commit_message_intro
-        return multi_directory_group_intro if dependency_group && job.source&.directories.count > 1
+        return multi_directory_group_intro if dependency_group && source&.directories
 
         return group_intro if dependency_group
 
@@ -351,7 +356,7 @@ module Dependabot
       def multi_directory_group_intro
         msg = ""
 
-        job.source.directories.each do |directory|
+        source.directories.each do |directory|
           dependencies_in_directory = dependencies.select { |dep| dep.directory == directory }
 
           update_count = dependencies_in_directory.map(&:name).uniq.count

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2452,6 +2452,101 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
       end
+
+      context "for a multi-directory dependency group", :vcr do
+        let(:source) do
+          Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directories: ["/foo", "/bar"])
+        end
+        let(:dependency_group) do
+          Dependabot::DependencyGroup.new(name: "go_modules group across 2 directories", rules: { patterns: ["*"] })
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.5.0",
+            previous_version: "1.4.0",
+            package_manager: "dummy",
+            requirements: [],
+            previous_requirements: [],
+            metadata: { directory: "/foo" }
+          )
+        end
+
+        it "has the correct message" do
+          expect(pr_message).to start_with(
+            "Bumps the go_modules group across 2 directories with 1 update: " \
+            "[business](https://github.com/gocardless/business)."
+          )
+        end
+
+        it "includes the version from -> to" do
+          expect(pr_message).to include(
+            "from 1.4.0 to 1.5.0"
+          )
+        end
+
+        context "with two dependencies" do
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: [],
+            metadata: { directory: "/foo" }
+            )
+          end
+          let(:dependencies) { [dependency, dependency2] }
+
+          before do
+            business2_repo_url =
+              "https://api.github.com/repos/gocardless/business2"
+            stub_request(:get, business2_repo_url)
+              .to_return(status: 200,
+                         body: fixture("github", "business_repo.json"),
+                         headers: json_header)
+            stub_request(:get, "#{business2_repo_url}/contents/")
+              .to_return(status: 200,
+                         body: fixture("github", "business_files.json"),
+                         headers: json_header)
+            stub_request(:get, "#{business2_repo_url}/releases?per_page=100")
+              .to_return(status: 200,
+                         body: fixture("github", "business_releases.json"),
+                         headers: json_header)
+            stub_request(:get, "https://api.github.com/repos/gocardless/" \
+                               "business2/contents/CHANGELOG.md?ref=master")
+              .to_return(status: 200,
+                         body: fixture("github", "changelog_contents.json"),
+                         headers: json_header)
+            stub_request(:get, "https://rubygems.org/api/v1/gems/business2.json")
+              .to_return(
+                status: 200,
+                body: fixture("ruby", "rubygems_response_statesman.json")
+              )
+
+            business2_service_pack_url =
+              "https://github.com/gocardless/business2.git/info/refs" \
+              "?service=git-upload-pack"
+            stub_request(:get, business2_service_pack_url)
+              .to_return(
+                status: 200,
+                body: fixture("git", "upload_packs", "no_tags"),
+                headers: {
+                  "content-type" => "application/x-git-upload-pack-advertisement"
+                }
+              )
+          end
+
+          it "has the correct message" do
+            expect(pr_message).to start_with(
+              "Bumps the go_modules group across 2 directories with 2 updates: " \
+              "[business](https://github.com/gocardless/business) and " \
+              "[business2](https://github.com/gocardless/business2)."
+            )
+          end
+        end
+      end
     end
 
     context "for a library" do

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2494,7 +2494,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               package_manager: "dummy",
               requirements: [],
               previous_requirements: [],
-            metadata: { directory: "/foo" }
+              metadata: { directory: "/foo" }
             )
           end
           let(:dependencies) { [dependency, dependency2] }
@@ -2556,7 +2556,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               package_manager: "dummy",
               requirements: [],
               previous_requirements: [],
-            metadata: { directory: "/bar" }
+              metadata: { directory: "/bar" }
             )
           end
           let(:dependencies) { [dependency, dependency2] }

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -45,7 +45,7 @@ module Dependabot
         d.version == d.previous_version
       end
 
-      updated_deps.each { |d| d.metadata[:directory] = job.source.directory }
+      updated_deps.each { |d| d.metadata[:directory] = job.source.directory } if job.source&.directory
 
       Dependabot::DependencyChange.new(
         job: job,

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -45,6 +45,8 @@ module Dependabot
         d.version == d.previous_version
       end
 
+      updated_deps.each { |d| d.metadata[:directory] = job.source.directory }
+
       Dependabot::DependencyChange.new(
         job: job,
         updated_dependencies: updated_deps,

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -69,7 +69,7 @@ module Dependabot
 
           # make a temporary fake group to use the existing logic
           @group = Dependabot::DependencyGroup.new(
-            name: "#{job.package_manager} group across #{job&.directories.count || 1} directories with #{job.dependencies.count} updates",
+            name: "#{job.package_manager} group across #{job&.directories.count || 1} directories",
             rules: {
               "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
             }

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -68,12 +68,7 @@ module Dependabot
           return @group if defined?(@group)
 
           # make a temporary fake group to use the existing logic
-          @group = Dependabot::DependencyGroup.new(
-            name: "#{job.package_manager} group across #{job&.directories.count || 1} directories",
-            rules: {
-              "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
-            }
-          )
+          @group = grouped_security_update_group(job) 
           dependency_snapshot.job_dependencies.each do |dep|
             @group.dependencies << dep
           end

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -69,7 +69,7 @@ module Dependabot
 
           # make a temporary fake group to use the existing logic
           @group = Dependabot::DependencyGroup.new(
-            name: "#{job.package_manager} at #{job.source.directory || '/'} security update",
+            name: "#{job.package_manager} group across #{job&.directories.count || 1} directories with #{job.dependencies.count} updates",
             rules: {
               "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
             }

--- a/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_security_update_pull_request.rb
@@ -68,7 +68,7 @@ module Dependabot
           return @group if defined?(@group)
 
           # make a temporary fake group to use the existing logic
-          @group = grouped_security_update_group(job) 
+          @group = grouped_security_update_group(job)
           dependency_snapshot.job_dependencies.each do |dep|
             @group.dependencies << dep
           end

--- a/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
@@ -67,7 +67,7 @@ module Dependabot
           return @group if defined?(@group)
 
           # make a temporary fake group to use the existing logic
-          @group = grouped_security_update_group(job) 
+          @group = grouped_security_update_group(job)
           dependency_snapshot.job_dependencies.each do |dep|
             @group.dependencies << dep
           end

--- a/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_security_update_pull_request.rb
@@ -67,12 +67,7 @@ module Dependabot
           return @group if defined?(@group)
 
           # make a temporary fake group to use the existing logic
-          @group = Dependabot::DependencyGroup.new(
-            name: "#{job.package_manager} at #{job.source.directory || '/'} security update",
-            rules: {
-              "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
-            }
-          )
+          @group = grouped_security_update_group(job) 
           dependency_snapshot.job_dependencies.each do |dep|
             @group.dependencies << dep
           end

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -9,7 +9,7 @@ module Dependabot
     module SecurityUpdateHelpers
       def grouped_security_update_group(job)
         Dependabot::DependencyGroup.new(
-          name: "#{job.package_manager} group across #{job&.directories.count || 1} directories",
+          name: "#{job.package_manager} group across #{job.source&.directories.count || 1} directories",
           rules: {
             "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
           }

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -9,7 +9,7 @@ module Dependabot
     module SecurityUpdateHelpers
       def grouped_security_update_group(job)
         Dependabot::DependencyGroup.new(
-          name: "#{job.package_manager} group across #{job.source&.directories.count || 1} directories",
+          name: "#{job.package_manager} group across #{job.source&.directories&.count || 1} directories",
           rules: {
             "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
           }

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -7,6 +7,15 @@
 module Dependabot
   class Updater
     module SecurityUpdateHelpers
+      def grouped_security_update_group(job)
+        Dependabot::DependencyGroup.new(
+          name: "#{job.package_manager} group across #{job&.directories.count || 1} directories",
+          rules: {
+            "patterns" => "*" # The grouping is more dictated by the dependencies passed in.
+          }
+        )
+      end
+
       def record_security_update_not_needed_error(checker)
         Dependabot.logger.info(
           "no security update needed as #{checker.dependency.name} " \

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -18,8 +18,11 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
                         "password" => "github-token"
                       }
                     ],
-                    experiments: {})
+                    experiments: {},
+                    source: source)
   end
+
+  let(:source) { Dependabot::Source.new(provider: "github", repo: "gocardless/bump") }
 
   let(:dependency_files) do
     [


### PR DESCRIPTION
Fix up the title and PR body for mutli-directory PRs so they split the dependency updates by directory.

So https://github.com/dsp-testing/gsu-7/pull/1 would look like

![Screenshot 2023-11-30 at 4 19 27 PM](https://github.com/dependabot/dependabot-core/assets/12107187/5f552f47-fc65-4937-a409-55c61fc0c3d4)
