### PR TITLE
Honor NuGet.config sources and search all build files for properties

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -13,17 +13,10 @@ module Dependabot
         require_relative "repository_finder"
 
         def self.fetch_nupkg_buffer(dependency_urls, package_id, package_version)
-          # nupkg should be the same regardless of the repository, so try nuget.org first
-          default_repository_details = RepositoryFinder.get_default_repository_details(package_id)
-          nupkg_buffer = fetch_nupkg_buffer_from_repository(default_repository_details, package_id, package_version)
-
-          dependency_urls.each do |repository_details|
-            next if repository_details[:repository_url] == RepositoryFinder::DEFAULT_REPOSITORY_URL
-
-            nupkg_buffer ||= fetch_nupkg_buffer_from_repository(repository_details, package_id, package_version)
+          # check all repositories for the first one that has the nupkg
+          dependency_urls.reduce(nil) do |nupkg_buffer, repository_details|
+            nupkg_buffer || fetch_nupkg_buffer_from_repository(repository_details, package_id, package_version)
           end
-
-          nupkg_buffer
         end
 
         def self.fetch_nupkg_buffer_from_repository(repository_details, package_id, package_version)

--- a/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
@@ -14,17 +14,10 @@ module Dependabot
         require_relative "repository_finder"
 
         def self.fetch_nuspec(dependency_urls, package_id, package_version)
-          # nuspec should be the same regardless of the repository, so try nuget.org first
-          default_repository_details = RepositoryFinder.get_default_repository_details(package_id)
-          nuspec_xml = fetch_nuspec_from_repository(default_repository_details, package_id, package_version)
-
-          dependency_urls.each do |repository_details|
-            next if repository_details[:repository_url] == RepositoryFinder::DEFAULT_REPOSITORY_URL
-
-            nuspec_xml ||= fetch_nuspec_from_repository(repository_details, package_id, package_version)
+          # check all repositories for the first one that has the nuspec
+          dependency_urls.reduce(nil) do |nuspec_xml, repository_details|
+            nuspec_xml || fetch_nuspec_from_repository(repository_details, package_id, package_version)
           end
-
-          nuspec_xml
         end
 
         def self.fetch_nuspec_from_repository(repository_details, package_id, package_version)

--- a/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
@@ -50,4 +50,37 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
 
     its(:length) { is_expected.to eq(34) }
   end
+
+  context "api.nuget.org is not hit if it's not in the NuGet.Config" do
+    let(:dependency_version) { "42.42.42" }
+    let(:nuget_config_body) { fixture("configs", "example.com_nuget.config") }
+    let(:nuget_config) { Dependabot::DependencyFile.new(name: "NuGet.Config", content: nuget_config_body) }
+    let(:dependency_files) { [csproj, nuget_config] }
+    subject(:transitive_dependencies) { finder.transitive_dependencies }
+
+    before(:context) do
+      disallowed_urls = %w(
+        https://api.nuget.org/v3/index.json
+        https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.nuspec
+        https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.nuspec
+      )
+
+      disallowed_urls.each do |url|
+        stub_request(:get, url)
+          .to_raise(StandardError.new("Not allowed to query `#{url}`"))
+      end
+
+      stub_request(:get, "https://nuget.example.com/v3/index.json")
+        .to_return(status: 200, body: fixture("nuget_responses", "example_index.json"))
+      stub_request(:get, "https://nuget.example.com/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.nuspec")
+        .to_return(status: 200, body: fixture("nuspecs", "Microsoft.Extensions.DependencyModel_42.42.42_faked.nuspec"))
+      stub_request(:get, "https://nuget.example.com/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.nuspec")
+        .to_return(status: 200, body: fixture("nuspecs", "Microsoft.NETCore.Platforms_43.43.43_faked.nuspec"))
+    end
+
+    # this test doesn't really care about the dependency count, we just need to ensure that `api.nuget.org` wasn't hit
+    its(:length) do
+      is_expected.to eq(1)
+    end
+  end
 end

--- a/nuget/spec/fixtures/configs/example.com_nuget.config
+++ b/nuget/spec/fixtures/configs/example.com_nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="packages" value="https://nuget.example.com/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget/spec/fixtures/csproj/directory_build_props_that_pulls_in_from_parent.props
+++ b/nuget/spec/fixtures/csproj/directory_build_props_that_pulls_in_from_parent.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/nuget/spec/fixtures/csproj/directory_build_props_with_package_update_variable.props
+++ b/nuget/spec/fixtures/csproj/directory_build_props_with_package_update_variable.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>

--- a/nuget/spec/fixtures/csproj/directory_build_props_with_property_version.props
+++ b/nuget/spec/fixtures/csproj/directory_build_props_with_property_version.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+  </PropertyGroup>
+</Project>

--- a/nuget/spec/fixtures/csproj/property_version_not_in_file.csproj
+++ b/nuget/spec/fixtures/csproj/property_version_not_in_file.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ProeprtyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/nuget/spec/fixtures/nuget_responses/example_index.json
+++ b/nuget/spec/fixtures/nuget_responses/example_index.json
@@ -1,0 +1,197 @@
+{
+  "version": "3.0.0",
+  "resources": [
+    {
+      "@id": "https://azuresearch-usnc.example.com/query",
+      "@type": "SearchQueryService",
+      "comment": "Query endpoint of NuGet Search service (primary)"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/query",
+      "@type": "SearchQueryService",
+      "comment": "Query endpoint of NuGet Search service (secondary)"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService",
+      "comment": "Autocomplete endpoint of NuGet Search service (primary)"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService",
+      "comment": "Autocomplete endpoint of NuGet Search service (secondary)"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/",
+      "@type": "SearchGalleryQueryService/3.0.0-rc",
+      "comment": "Azure Website based Search Service used by Gallery (primary)"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/",
+      "@type": "SearchGalleryQueryService/3.0.0-rc",
+      "comment": "Azure Website based Search Service used by Gallery (secondary)"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-semver1/",
+      "@type": "RegistrationsBaseUrl",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored"
+    },
+    {
+      "@id": "https://api.example.com/v3-flatcontainer/",
+      "@type": "PackageBaseAddress/3.0.0",
+      "comment": "Base URL of where NuGet packages are stored, in the format https://api.example.com/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg"
+    },
+    {
+      "@id": "https://www.example.com/api/v2",
+      "@type": "LegacyGallery"
+    },
+    {
+      "@id": "https://www.example.com/api/v2",
+      "@type": "LegacyGallery/2.0.0"
+    },
+    {
+      "@id": "https://www.example.com/api/v2/package",
+      "@type": "PackagePublish/2.0.0"
+    },
+    {
+      "@id": "https://www.example.com/api/v2/symbolpackage",
+      "@type": "SymbolPackagePublish/4.9.0",
+      "comment": "The gallery symbol publish endpoint."
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/query",
+      "@type": "SearchQueryService/3.0.0-rc",
+      "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/query",
+      "@type": "SearchQueryService/3.0.0-rc",
+      "comment": "Query endpoint of NuGet Search service (secondary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/query",
+      "@type": "SearchQueryService/3.5.0",
+      "comment": "Query endpoint of NuGet Search service (primary) that supports package type filtering"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/query",
+      "@type": "SearchQueryService/3.5.0",
+      "comment": "Query endpoint of NuGet Search service (secondary) that supports package type filtering"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.0.0-rc",
+      "comment": "Autocomplete endpoint of NuGet Search service (primary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.0.0-rc",
+      "comment": "Autocomplete endpoint of NuGet Search service (secondary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.5.0",
+      "comment": "Autocomplete endpoint of NuGet Search service (primary) that supports package type filtering"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.5.0",
+      "comment": "Autocomplete endpoint of NuGet Search service (secondary) that supports package type filtering"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-semver1/",
+      "@type": "RegistrationsBaseUrl/3.0.0-rc",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://www.example.com/packages/{id}/{version}/ReportAbuse",
+      "@type": "ReportAbuseUriTemplate/3.0.0-rc",
+      "comment": "URI template used by NuGet Client to construct Report Abuse URL for packages used by RC clients"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-semver1/{id-lower}/index.json",
+      "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+      "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-semver1/{id-lower}/{version-lower}.json",
+      "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+      "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/query",
+      "@type": "SearchQueryService/3.0.0-beta",
+      "comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/query",
+      "@type": "SearchQueryService/3.0.0-beta",
+      "comment": "Query endpoint of NuGet Search service (secondary) used by beta clients"
+    },
+    {
+      "@id": "https://azuresearch-usnc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.0.0-beta",
+      "comment": "Autocomplete endpoint of NuGet Search service (primary) used by beta clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.example.com/autocomplete",
+      "@type": "SearchAutocompleteService/3.0.0-beta",
+      "comment": "Autocomplete endpoint of NuGet Search service (secondary) used by beta clients"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-semver1/",
+      "@type": "RegistrationsBaseUrl/3.0.0-beta",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://www.example.com/packages/{id}/{version}/ReportAbuse",
+      "@type": "ReportAbuseUriTemplate/3.0.0-beta",
+      "comment": "URI template used by NuGet Client to construct Report Abuse URL for packages"
+    },
+    {
+      "@id": "https://www.example.com/packages/{id}/{version}?_src=template",
+      "@type": "PackageDetailsUriTemplate/5.1.0",
+      "comment": "URI template used by NuGet Client to construct details URL for packages"
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-gz-semver1/",
+      "@type": "RegistrationsBaseUrl/3.4.0",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-gz-semver2/",
+      "@type": "RegistrationsBaseUrl/3.6.0",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://api.example.com/v3/registration5-gz-semver2/",
+      "@type": "RegistrationsBaseUrl/Versioned",
+      "clientVersion": "4.3.0-alpha",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://api.example.com/v3-index/repository-signatures/4.7.0/index.json",
+      "@type": "RepositorySignatures/4.7.0",
+      "comment": "The endpoint for discovering information about this package source's repository signatures."
+    },
+    {
+      "@id": "https://api.example.com/v3-index/repository-signatures/5.0.0/index.json",
+      "@type": "RepositorySignatures/5.0.0",
+      "comment": "The endpoint for discovering information about this package source's repository signatures."
+    },
+    {
+      "@id": "https://api.example.com/v3/vulnerabilities/index.json",
+      "@type": "VulnerabilityInfo/6.7.0",
+      "comment": "The endpoint for discovering information about vulnerabilities of packages in this package source."
+    },
+    {
+      "@id": "https://api.example.com/v3/catalog0/index.json",
+      "@type": "Catalog/3.0.0",
+      "comment": "Index of the NuGet package catalog."
+    }
+  ],
+  "@context": {
+    "@vocab": "http://schema.example.com/services#",
+    "comment": "http://www.w3.org/2000/01/rdf-schema#comment"
+  }
+}

--- a/nuget/spec/fixtures/nuspecs/Microsoft.Extensions.DependencyModel_42.42.42_faked.nuspec
+++ b/nuget/spec/fixtures/nuspecs/Microsoft.Extensions.DependencyModel_42.42.42_faked.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Extensions.DependencyModel</id>
+    <version>42.42.42</version>
+    <authors>Microsoft.Extensions.DependencyModel</authors>
+    <owners>Microsoft.Extensions.DependencyModel</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Abstractions for reading `.deps` files.</description>
+    <tags/>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETStandard1.6">
+        <dependency id="Microsoft.NETCore.Platforms" version="[43.43.43, )" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/nuget/spec/fixtures/nuspecs/Microsoft.NETCore.Platforms_43.43.43_faked.nuspec
+++ b/nuget/spec/fixtures/nuspecs/Microsoft.NETCore.Platforms_43.43.43_faked.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>Microsoft.NETCore.Platforms</id>
+    <version>43.43.43</version>
+    <title>Microsoft.NETCore.Platforms</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+  </metadata>
+</package>


### PR DESCRIPTION
Fixes #8470 (2 issues)

1. `api.nuget.org` was always queried, even if not listed in the `NuGet.Config` file; this simply removes that and also adds a test to ensure it's not hit.
2. When searching `Directory.Build.props/.targets`, only the first found file was considered; instead, _all_ files up to the root of the repo need to be searched for the specified properties.