### PR TITLE
fix regression in json gem by using an older version

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "2.7.11"
   spec.add_dependency "faraday-retry", "2.2.0"
   spec.add_dependency "gitlab", "4.19.0"
+  spec.add_dependency "json", "< 2.7"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", ">= 4.6", "< 7.0"
   spec.add_dependency "opentelemetry-sdk", "~> 1.3"

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -23,6 +23,7 @@ PATH
       faraday (= 2.7.11)
       faraday-retry (= 2.2.0)
       gitlab (= 4.19.0)
+      json (< 2.7)
       nokogiri (~> 1.8)
       octokit (>= 4.6, < 7.0)
       opentelemetry-sdk (~> 1.3)


### PR DESCRIPTION
See https://github.com/flori/json/issues/553

Credit to @JamieMagee for spotting the issue.

`json` should probably be listed in the gemspec anyway since we use it directly. 