### PR TITLE
only consider the `Include` attribute when parsing project files

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -270,8 +270,7 @@ module Dependabot
         end
 
         def dependency_name(dependency_node, project_file)
-          raw_name = get_attribute_value(dependency_node, "Include") ||
-                     get_attribute_value(dependency_node, "Update")
+          raw_name = get_attribute_value(dependency_node, "Include")
           return unless raw_name
 
           # If the item contains @(ItemGroup) then ignore as it

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -223,12 +223,32 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             .to match_array(
               %w(
                 Microsoft.SourceLink.GitHub
-                System.AskJeeves
-                System.Google
-                System.Lycos
-                System.WebCrawler
               )
             )
+        end
+      end
+
+      context "with both `Include`` and `Update`` attributes" do
+        let(:file_body) do
+          <<~XML
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+              </ItemGroup>
+            </Project>
+          XML
+        end
+
+        context "only the `Include` attribute is used" do
+          it "has the right details" do
+            expect(top_level_dependencies.map(&:name))
+              .to match_array(
+                %w(
+                  Newtonsoft.Json
+                )
+              )
+          end
         end
       end
 
@@ -461,14 +481,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
                 groups: ["dependencies"],
                 source: nil,
                 metadata: { property_name: "NewtonsoftJsonVersion" }
-              },
-               {
-                 requirement: "9.0.1",
-                 file: "Directory.Build.targets",
-                 groups: ["dependencies"],
-                 source: nil,
-                 metadata: { property_name: "NewtonsoftJsonVersion" }
-               }]
+              }]
             )
           end
         end


### PR DESCRIPTION
This fixes one specific instance of the issue

```
ERROR undefined method `fetch' for nil:NilClass

           latest_version: preferred_resolvable_version_details.fetch(:version)&.to_s,
                                                               ^^^^^^
```

The problem arises when there is a line like this in a project:

``` xml
...
<ProjectReference Update="PackageThatDoesNotExist" Version="1.2.3" />
...
```

That's perfectly valid MSBuild and at restore/build time results in a noop because there is no dependency with that name (marked with `Include=`) so there is nothing to update, but since that package doesn't exist, trying to later determine the latest version predictably fails because not only is there no latest version, but there is no version at all.

Even if that `<ProjectReference>` node was for a valid package, just the presence of the `Update` attribute isn't enough, because if it wasn't `Include`d to begin with, there is nothing to update so it shouldn't be reported as a dependency.

There is the possibility that just the presence of the `Update` attribute is sufficient to properly fix a dependency version, but that only happens if the package being `Update`d is a transitive dependency of an existing package, and that's a scenario that's now properly covered where an entirely new `<PackageReference Include="" />` line will be added, so updating just the `Update` attribute is superfluous.
 
There is another work item to not even consider packages that don't have any versions that will be addressed later in #8502.