### PR TITLE
require correct FileFetcher

### DIFF
--- a/maven/lib/dependabot/maven/metadata_finder.rb
+++ b/maven/lib/dependabot/maven/metadata_finder.rb
@@ -4,7 +4,7 @@
 require "nokogiri"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
-require "dependabot/file_fetchers/base"
+require "dependabot/maven/file_fetcher"
 require "dependabot/maven/file_parser"
 require "dependabot/maven/file_parser/repositories_finder"
 require "dependabot/maven/utils/auth_headers_finder"


### PR DESCRIPTION
In #8327 the FileFetcher was switched from Base to the Maven one, but the require was missed, so sometimes tests fail due to this if it didn't happen to be required by another file first. 