### PR TITLE
properly resolve nuget search query when the api is versioned

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -97,9 +97,16 @@ module Dependabot
         end
 
         def search_url_from_v3_metadata(metadata)
+          # allowable values from here: https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#versioning
+          allowed_search_types = %w(
+            SearchQueryService
+            SearchQueryService/3.0.0-beta
+            SearchQueryService/3.0.0-rc
+            SearchQueryService/3.5.0
+          )
           metadata
             .fetch("resources", [])
-            .find { |r| r.fetch("@type") == "SearchQueryService" }
+            .find { |r| allowed_search_types.find { |s| r.fetch("@type") == s } }
             &.fetch("@id")
         end
 

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -431,6 +431,31 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         end
       end
 
+      context "that only provides versioned `SearchQueryService`` entries" do
+        let(:config_file_fixture_name) { "versioned_search.config" }
+
+        before do
+          repo_url = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+          stub_request(:get, repo_url)
+            .to_return(
+              status: 200,
+              body: fixture("nuget_responses", "index.json", "versioned_SearchQueryService.index.json")
+            )
+        end
+
+        it "gets the right URLs" do
+          expect(dependency_urls).to match_array(
+            [{
+              repository_url: "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json",
+              versions_url: "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/microsoft.extensions.dependencymodel/index.json",
+              search_url: "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/query2/?q=microsoft.extensions.dependencymodel&prerelease=true&semVerLevel=2.0.0",
+              auth_header: {},
+              repository_type: "v3"
+            }]
+          )
+        end
+      end
+
       context "that has a non-ascii key" do
         let(:config_file_fixture_name) { "non_ascii_key.config" }
 

--- a/nuget/spec/fixtures/configs/versioned_search.config
+++ b/nuget/spec/fixtures/configs/versioned_search.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="pkgs.dev.azure.com" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget/spec/fixtures/nuget_responses/index.json/versioned_SearchQueryService.index.json
+++ b/nuget/spec/fixtures/nuget_responses/index.json/versioned_SearchQueryService.index.json
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "@vocab": "http://schema.nuget.org/services#",
+    "comment": "http://www.w3.org/2000/01/rdf-schema#comment",
+    "label": "http://www.w3.org/2000/01/rdf-schema#label"
+  },
+  "resources": [
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v2/",
+      "@type": "PackagePublish/2.0.0"
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v2/",
+      "@type": "LegacyGallery/2.0.0"
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/registrations2/",
+      "@type": "RegistrationsBaseUrl/3.0.0-beta"
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/registrations2-semver2/",
+      "@type": "RegistrationsBaseUrl/3.6.0",
+      "comment": "This base URL includes SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/registrations2-semver2/",
+      "@type": "RegistrationsBaseUrl/Versioned",
+      "comment": "This base URL includes SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/query2/",
+      "@type": "SearchQueryService/3.0.0-beta"
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/",
+      "@type": "PackageBaseAddress/3.0.0"
+    },
+    {
+      "@id": "https://pkgs.dev.azure.com/dnceng/",
+      "@type": "VssBaseUrl"
+    },
+    {
+      "@id": "urn:uuid:516521bf-6417-457e-9a9c-0a4bdfde03e7",
+      "@type": "VssFeedId",
+      "label": "dotnet-libraries"
+    },
+    {
+      "@id": "com.visualstudio.feeds.feedview:516521bf-6417-457e-9a9c-0a4bdfde03e7",
+      "@type": "VssQualifiedFeedViewId",
+      "label": "dotnet-libraries"
+    },
+    {
+      "@id": "urn:uuid:9ee6d478-d288-47f7-aacc-f6e6d082ae6d",
+      "@type": "AzureDevOpsProjectId",
+      "label": "public"
+    }
+  ],
+  "version": "3.0.0-beta"
+}


### PR DESCRIPTION
From [this comment](https://github.com/dependabot/dependabot-core/pull/8502#issuecomment-1840756122), a NuGet repository's `:search_url` can't be found if it has a version suffix like `/3.0.0`, etc.  This PR checks in priority order for the specific `SearchQueryService` value.