### PR TITLE
only run suites that have changes

### DIFF
--- a/.github/smoke-filters.yml
+++ b/.github/smoke-filters.yml
@@ -1,0 +1,40 @@
+common:
+  - .github/workflows/smoke.yml
+  - .dockerignore
+  - Dockerfile.updater-core
+  - 'common/**'
+  - 'updater/**'
+github_actions:
+  - 'github_actions/**'
+bundler:
+  - 'bundler/**'
+cargo:
+  - 'cargo/**'
+composer:
+  - 'composer/**'
+docker:
+  - 'docker/**'
+elm:
+  - 'elm/**'
+go_modules:
+  - 'go_modules/**'
+gradle:
+  - 'gradle/**'
+hex:
+  - 'hex/**'
+maven:
+  - 'maven/**'
+npm_and_yarn:
+  - 'npm_and_yarn/**'
+nuget:
+  - 'nuget/**'
+python:
+  - 'python/**'
+pub:
+  - 'pub/**'
+git_submodules:
+  - 'git_submodules/**'
+swift:
+  - 'swift/**'
+terraform:
+  - 'terraform/**'

--- a/.github/smoke-filters.yml
+++ b/.github/smoke-filters.yml
@@ -1,40 +1,57 @@
-common:
+common: &common
   - .github/workflows/smoke.yml
   - .dockerignore
   - Dockerfile.updater-core
   - 'common/**'
   - 'updater/**'
 github_actions:
+  - *common
   - 'github_actions/**'
 bundler:
+  - *common
   - 'bundler/**'
 cargo:
+  - *common
   - 'cargo/**'
 composer:
+  - *common
   - 'composer/**'
 docker:
+  - *common
   - 'docker/**'
 elm:
+  - *common
   - 'elm/**'
 go_modules:
+  - *common
   - 'go_modules/**'
 gradle:
+  - *common
   - 'gradle/**'
 hex:
+  - *common
   - 'hex/**'
 maven:
+  - *common
   - 'maven/**'
 npm_and_yarn:
+  - *common
   - 'npm_and_yarn/**'
 nuget:
+  - *common
   - 'nuget/**'
 python:
+  - *common
   - 'python/**'
 pub:
+  - *common
   - 'pub/**'
 git_submodules:
+  - *common
   - 'git_submodules/**'
 swift:
+  - *common
   - 'swift/**'
 terraform:
+  - *common
   - 'terraform/**'

--- a/.github/smoke-matrix.json
+++ b/.github/smoke-matrix.json
@@ -1,0 +1,172 @@
+[
+  {
+    "core": "bundler",
+    "test": "bundler",
+    "ecosystem": "bundler"
+  },
+  {
+    "core": "bundler",
+    "test": "bundler-group-rules",
+    "ecosystem": "bundler"
+  },
+  {
+    "core": "bundler",
+    "test": "bundler-group-vendoring",
+    "ecosystem": "bundler"
+  },
+  {
+    "core": "cargo",
+    "test": "cargo",
+    "ecosystem": "cargo"
+  },
+  {
+    "core": "composer",
+    "test": "composer",
+    "ecosystem": "composer"
+  },
+  {
+    "core": "docker",
+    "test": "docker",
+    "ecosystem": "docker"
+  },
+  {
+    "core": "elm",
+    "test": "elm",
+    "ecosystem": "elm"
+  },
+  {
+    "core": "git_submodules",
+    "test": "submodules",
+    "ecosystem": "gitsubmodule"
+  },
+  {
+    "core": "github_actions",
+    "test": "actions",
+    "ecosystem": "github-actions"
+  },
+  {
+    "core": "go_modules",
+    "test": "go",
+    "ecosystem": "gomod"
+  },
+  {
+    "core": "go_modules",
+    "test": "go-close-pr",
+    "ecosystem": "gomod"
+  },
+  {
+    "core": "go_modules",
+    "test": "go-group-rules",
+    "ecosystem": "gomod"
+  },
+  {
+    "core": "go_modules",
+    "test": "go-security",
+    "ecosystem": "gomod"
+  },
+  {
+    "core": "go_modules",
+    "test": "go-update-pr",
+    "ecosystem": "gomod"
+  },
+  {
+    "core": "gradle",
+    "test": "gradle",
+    "ecosystem": "gradle"
+  },
+  {
+    "core": "gradle",
+    "test": "gradle-version-catalog",
+    "ecosystem": "gradle"
+  },
+  {
+    "core": "hex",
+    "test": "hex",
+    "ecosystem": "mix"
+  },
+  {
+    "core": "maven",
+    "test": "maven",
+    "ecosystem": "maven"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "npm",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "npm-group-rules",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "npm-remove-transitive",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "pnpm",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "yarn",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "yarn-berry",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "npm_and_yarn",
+    "test": "yarn-berry-workspaces",
+    "ecosystem": "npm"
+  },
+  {
+    "core": "nuget",
+    "test": "nuget",
+    "ecosystem": "nuget"
+  },
+  {
+    "core": "nuget",
+    "test": "nuget-resolvability",
+    "ecosystem": "nuget"
+  },
+  {
+    "core": "pub",
+    "test": "pub",
+    "ecosystem": "pub"
+  },
+  {
+    "core": "python",
+    "test": "pip",
+    "ecosystem": "pip"
+  },
+  {
+    "core": "python",
+    "test": "pipenv",
+    "ecosystem": "pip"
+  },
+  {
+    "core": "python",
+    "test": "pip-compile",
+    "ecosystem": "pip"
+  },
+  {
+    "core": "python",
+    "test": "poetry",
+    "ecosystem": "pip"
+  },
+  {
+    "core": "swift",
+    "test": "swift",
+    "ecosystem": "swift"
+  },
+  {
+    "core": "terraform",
+    "test": "terraform",
+    "ecosystem": "terraform"
+  }
+]

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,7 +39,6 @@ jobs:
           echo "suites=$(cat matrix.json)" >> $GITHUB_OUTPUT
 
       - name: Generate suites to run
-        if: steps.changes.outputs['common'] != 'true'
         id: suites
         run: |
           # Write the changes.json file which is an array of paths

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,8 +37,12 @@ jobs:
         run: |
           # Write the changes.json file which is an array of paths
           echo "${{ toJson(steps.changes.outputs.changes) }}" > changes.json
+          cat changes.json
+
           # Read smoke-matrix.json, filtering out paths not in changes.json
           jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' .github/smoke-matrix.json > filtered.json
+          cat filtered.json
+
           # Set the step output
           echo "suites=$(cat filtered.json)" >> $GITHUB_OUTPUT
   e2e:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Output all matrix.json
         if: steps.changes.outputs['common'] == 'true'
+        id: suites
         run: |
           echo "suites=$(cat matrix.json)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,101 +17,49 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
-  e2e:
+  discover:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-          # core - the directory name in dependabot-core for the ecosystem
-          # test - the test name in smoke-tests: tests/smoke-${test}.yaml
-          # ecosystem - the ecosystem name in the Docker image
-          - { core: bundler, test: bundler, ecosystem: bundler }
-          - { core: bundler, test: bundler-group-rules, ecosystem: bundler }
-          - { core: bundler, test: bundler-group-vendoring, ecosystem: bundler }
-          - { core: cargo, test: cargo, ecosystem: cargo }
-          - { core: composer, test: composer, ecosystem: composer }
-          - { core: docker, test: docker, ecosystem: docker }
-          - { core: elm, test: elm, ecosystem: elm }
-          - { core: git_submodules, test: submodules, ecosystem: gitsubmodule }
-          - { core: github_actions, test: actions, ecosystem: github-actions }
-          - { core: go_modules, test: go, ecosystem: gomod }
-          - { core: go_modules, test: go-close-pr, ecosystem: gomod }
-          - { core: go_modules, test: go-group-rules, ecosystem: gomod }
-          - { core: go_modules, test: go-security, ecosystem: gomod }
-          - { core: go_modules, test: go-update-pr, ecosystem: gomod }
-          - { core: gradle, test: gradle, ecosystem: gradle }
-          - { core: gradle, test: gradle-version-catalog, ecosystem: gradle }
-          - { core: hex, test: hex, ecosystem: mix }
-          - { core: maven, test: maven, ecosystem: maven }
-          - { core: npm_and_yarn, test: npm, ecosystem: npm }
-          - { core: npm_and_yarn, test: npm-group-rules, ecosystem: npm }
-          - { core: npm_and_yarn, test: npm-remove-transitive, ecosystem: npm }
-          - { core: npm_and_yarn, test: pnpm, ecosystem: npm }
-          - { core: npm_and_yarn, test: yarn, ecosystem: npm }
-          - { core: npm_and_yarn, test: yarn-berry, ecosystem: npm }
-          - { core: npm_and_yarn, test: yarn-berry-workspaces, ecosystem: npm }
-          - { core: nuget, test: nuget, ecosystem: nuget }
-          - { core: nuget, test: nuget-resolvability, ecosystem: nuget }
-          - { core: pub, test: pub, ecosystem: pub }
-          - { core: python, test: pip, ecosystem: pip }
-          - { core: python, test: pipenv, ecosystem: pip }
-          - { core: python, test: pip-compile, ecosystem: pip }
-          - { core: python, test: poetry, ecosystem: pip }
-          - { core: swift, test: swift, ecosystem: swift }
-          - { core: terraform, test: terraform, ecosystem: terraform }
+    outputs:
+      suites: ${{ steps.suites.outputs.suites }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - uses: dorny/paths-filter@v2
         if: github.event_name != 'workflow_dispatch'
         id: changes
         with:
-          filters: |
-            common:
-              - .github/workflows/smoke.yml
-              - .dockerignore
-              - Dockerfile.updater-core
-              - 'common/**'
-              - 'updater/**'
-            github_actions:
-              - 'github_actions/**'
-            bundler:
-              - 'bundler/**'
-            cargo:
-              - 'cargo/**'
-            composer:
-              - 'composer/**'
-            docker:
-              - 'docker/**'
-            elm:
-              - 'elm/**'
-            go_modules:
-              - 'go_modules/**'
-            gradle:
-              - 'gradle/**'
-            hex:
-              - 'hex/**'
-            maven:
-              - 'maven/**'
-            npm_and_yarn:
-              - 'npm_and_yarn/**'
-            nuget:
-              - 'nuget/**'
-            python:
-              - 'python/**'
-            pub:
-              - 'pub/**'
-            git_submodules:
-              - 'git_submodules/**'
-            swift:
-              - 'swift/**'
-            terraform:
-              - 'terraform/**'
+          filters: .github/smoke-filters.yml
+
+      - name: Output all matrix.json
+        if: steps.changes.outputs['common'] == 'true'
+        run: |
+          echo "suites=$(cat matrix.json)" >> $GITHUB_OUTPUT
+
+      - name: Generate suites to run
+        if: steps.changes.outputs['common'] != 'true'
+        id: suites
+        run: |
+          # Write the changes.json file which is an array of paths
+          echo "${{ toJson(steps.changes.outputs.changes) }}" > changes.json
+          # Read matrix.json, filtering out paths not in changes.json
+          jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' matrix.json > filtered.json
+          # Set the step output
+          echo "suites=$(cat filtered.json)" >> $GITHUB_OUTPUT
+  e2e:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.discover.outputs.suites) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download CLI and test
-        if: steps.changes.outputs[matrix.suite.core] == 'true' || steps.changes.outputs['common'] == 'true'
         run: |
           gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
           tar xzvf *.tar.gz >/dev/null 2>&1
@@ -122,17 +70,14 @@ jobs:
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       # Allowed to fail to get out of checking and egg situations, for example, when adding a new ecosystem.
       - name: Download cache
-        if: steps.changes.outputs[matrix.suite.core] == 'true' || steps.changes.outputs['common'] == 'true'
         run: |
           gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite.test }} --dir cache
         continue-on-error: true
 
       - name: Build ecosystem image
-        if: steps.changes.outputs[matrix.suite.core] == 'true' || steps.changes.outputs['common'] == 'true'
         run: script/build ${{ matrix.suite.core }}
 
       - name: ${{ matrix.suite.core }}
-        if: steps.changes.outputs[matrix.suite.core] == 'true' || steps.changes.outputs['common'] == 'true'
         id: test
         env:
           LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,12 +92,10 @@ jobs:
             2>&1 | tee -a log.txt
 
       - name: Diff
-        if: steps.test.outcome != 'skipped'
         continue-on-error: true
         run: diff --ignore-space-change smoke.yaml result.yaml && echo "Contents are identical"
 
       - name: Create summary
-        if: steps.changes.outputs[matrix.suite.core] == 'true' || steps.changes.outputs['common'] == 'true'
         run: tail -n100 log.txt | grep -P '\d+/\d+ calls cached \(\d+%\)' >> $GITHUB_STEP_SUMMARY
 
         # No upload at the end:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,8 +37,8 @@ jobs:
         run: |
           # Write the changes.json file which is an array of paths
           echo "${{ toJson(steps.changes.outputs.changes) }}" > changes.json
-          # Read matrix.json, filtering out paths not in changes.json
-          jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' .github/matrix.json > filtered.json
+          # Read smoke-matrix.json, filtering out paths not in changes.json
+          jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' .github/smoke-matrix.json > filtered.json
           # Set the step output
           echo "suites=$(cat filtered.json)" >> $GITHUB_OUTPUT
   e2e:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -38,7 +38,7 @@ jobs:
           # Write the changes.json file which is an array of paths
           echo "${{ toJson(steps.changes.outputs.changes) }}" > changes.json
           # Read matrix.json, filtering out paths not in changes.json
-          jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' matrix.json > filtered.json
+          jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' .github/matrix.json > filtered.json
           # Set the step output
           echo "suites=$(cat filtered.json)" >> $GITHUB_OUTPUT
   e2e:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,12 +32,6 @@ jobs:
         with:
           filters: .github/smoke-filters.yml
 
-      - name: Output all matrix.json
-        if: steps.changes.outputs['common'] == 'true'
-        id: suites
-        run: |
-          echo "suites=$(cat matrix.json)" >> $GITHUB_OUTPUT
-
       - name: Generate suites to run
         id: suites
         run: |


### PR DESCRIPTION
Another step towards dynamic discovery of smoke tests.

In this PR I split the filter and matrix out into separate files. The filter was just for vanity, makes it much easier to read the workflow. Having the matrix suites in a file allows us to run the dorny/paths-filter action first and then filter the matrix.json to only tests that needs to run. 

In other words, going forward when you change a file in `go_modules`, it won't run the `bundler` smoke test only to skip all steps. Instead it won't even run in the first place!