### PR TITLE
improvements to querying nuget apis for versions

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -13,6 +13,7 @@ require "dependabot/nuget/cache_manager"
 module Dependabot
   module Nuget
     class FileParser
+      # rubocop:disable Metrics/ClassLength
       class ProjectFileParser
         require "dependabot/file_parsers/base/dependency_set"
         require_relative "property_value_finder"
@@ -290,29 +291,62 @@ module Dependabot
             dependency_urls = [UpdateChecker::RepositoryFinder.get_default_repository_details(dependency.name)]
           end
           dependency_urls_with_package = dependency_urls.select do |dependency_url|
-            response = execute_search_for_dependency_url(dependency_url)
-            next unless response.status == 200
-
-            body = JSON.parse(response.body)
-            data = body["data"]
-            next unless data.length.positive?
-
-            found_matching_result = data.any? { |result| result["id"].casecmp?(dependency.name) }
-            found_matching_result
+            dependency_url_has_matching_result?(dependency.name, dependency_url)
           end
 
           dependency_urls_with_package.any?
         end
 
-        def execute_search_for_dependency_url(dependency_url)
-          search_url = dependency_url.fetch(:search_url)
+        def dependency_url_has_matching_result?(dependency_name, dependency_url)
+          repository_type = dependency_url.fetch(:repository_type)
+          if repository_type == "v3"
+            dependency_url_has_matching_result_v3?(dependency_name, dependency_url)
+          elsif repository_type == "v2"
+            dependency_url_has_matching_result_v2?(dependency_name, dependency_url)
+          else
+            raise "Unknown repository type: #{repository_type}"
+          end
+        end
+
+        def dependency_url_has_matching_result_v3?(dependency_name, dependency_url)
+          url = dependency_url.fetch(:search_url)
+          auth_header = dependency_url.fetch(:auth_header)
+          response = execute_search_for_dependency_url(url, auth_header)
+          return false unless response.status == 200
+
+          body = JSON.parse(response.body)
+          data = body["data"]
+          return false unless data.length.positive?
+
+          found_matching_result = data.any? { |result| result["id"].casecmp?(dependency_name) }
+          found_matching_result
+        end
+
+        def dependency_url_has_matching_result_v2?(dependency_name, dependency_url)
+          url = dependency_url.fetch(:versions_url)
+          auth_header = dependency_url.fetch(:auth_header)
+          response = execute_search_for_dependency_url(url, auth_header)
+          return false unless response.status == 200
+
+          doc = Nokogiri::XML(response.body)
+          doc.remove_namespaces!
+          id_nodes = doc.xpath("/feed/entry/properties/Id")
+          found_matching_result = id_nodes.any? do |id_node|
+            return false unless id_node.text
+
+            id_node.text.casecmp?(dependency_name)
+          end
+          found_matching_result
+        end
+
+        def execute_search_for_dependency_url(url, auth_header)
           cache = ProjectFileParser.dependency_url_search_cache
-          cache[search_url] ||= Dependabot::RegistryClient.get(
-            url: search_url,
-            headers: dependency_url.fetch(:auth_header)
+          cache[url] ||= Dependabot::RegistryClient.get(
+            url: url,
+            headers: auth_header
           )
 
-          cache[search_url]
+          cache[url]
         end
 
         def dependency_name(dependency_node, project_file)
@@ -471,6 +505,7 @@ module Dependabot
           dependency_files.find { |f| f.name.casecmp(".config/dotnet-tools.json").zero? }
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -290,11 +290,9 @@ module Dependabot
           if dependency_urls.empty?
             dependency_urls = [UpdateChecker::RepositoryFinder.get_default_repository_details(dependency.name)]
           end
-          dependency_urls_with_package = dependency_urls.select do |dependency_url|
+          dependency_urls.any? do |dependency_url|
             dependency_url_has_matching_result?(dependency.name, dependency_url)
           end
-
-          dependency_urls_with_package.any?
         end
 
         def dependency_url_has_matching_result?(dependency_name, dependency_url)
@@ -318,8 +316,7 @@ module Dependabot
           data = body["data"]
           return false unless data.length.positive?
 
-          found_matching_result = data.any? { |result| result["id"].casecmp?(dependency_name) }
-          found_matching_result
+          data.any? { |result| result["id"].casecmp?(dependency_name) }
         end
 
         def dependency_url_has_matching_result_v2?(dependency_name, dependency_url)

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -176,6 +176,8 @@ module Dependabot
           base_sources = [{ url: DEFAULT_REPOSITORY_URL, key: "nuget.org" }]
 
           sources = []
+
+          # regular package sources
           doc.css("configuration > packageSources").children.each do |node|
             if node.name == "clear"
               sources.clear
@@ -186,6 +188,15 @@ module Dependabot
               sources << { url: url, key: key }
             end
           end
+
+          # signed package sources
+          # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section
+          doc.xpath("/configuration/trustedSigners/repository").each do |node|
+            name = node.attribute("name")&.value&.strip
+            service_index = node.attribute("serviceIndex")&.value&.strip
+            sources << { url: service_index, key: name }
+          end
+
           sources += base_sources # TODO: quirky overwrite behavior
           disabled_sources = disabled_sources(doc)
           sources.reject! do |s|

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -12,13 +12,13 @@ module NuGetSearchStubs
       .to_return(status: 200, body: fixture("nuget_responses", "search_no_data.json"))
   end
 
-  def stub_search_results_with_versions(name, versions)
-    json = search_results_with_versions(name, versions)
+  def stub_search_results_with_versions_v3(name, versions)
+    json = search_results_with_versions_v3(name, versions)
     stub_request(:get, "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=#{name}&semVerLevel=2.0.0")
       .to_return(status: 200, body: json)
   end
 
-  def search_results_with_versions(name, versions)
+  def search_results_with_versions_v3(name, versions)
     versions_block = versions.map do |version|
       {
         "version" => version,
@@ -54,6 +54,77 @@ module NuGetSearchStubs
     }
     response.to_json
   end
+
+  # rubocop:disable Metrics/MethodLength
+  def search_results_with_versions_v2(name, versions)
+    entries = versions.map do |version|
+      xml = <<~XML
+        <entry>
+          <id>https://www.nuget.org/api/v2/Packages(Id='#{name}',Version='#{version}')</id>
+          <category term="NuGetGallery.OData.V2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+          <link rel="edit" href="https://www.nuget.org/api/v2/Packages(Id='#{name}',Version='#{version}')" />
+          <link rel="self" href="https://www.nuget.org/api/v2/Packages(Id='#{name}',Version='#{version}')" />
+          <title type="text">#{name}</title>
+          <updated>2015-07-28T23:37:16Z</updated>
+          <author>
+              <name>FakeAuthor</name>
+          </author>
+          <content type="application/zip" src="https://www.nuget.org/api/v2/package/#{name}/#{version}" />
+          <m:properties>
+            <d:Id>#{name}</d:Id>
+            <d:Version>#{version}</d:Version>
+            <d:NormalizedVersion>#{version}</d:NormalizedVersion>
+            <d:Authors>FakeAuthor</d:Authors>
+            <d:Copyright>FakeCopyright</d:Copyright>
+            <d:Created m:type="Edm.DateTime">2015-07-28T23:37:16.85+00:00</d:Created>
+            <d:Dependencies></d:Dependencies>
+            <d:Description>FakeDescription</d:Description>
+            <d:DownloadCount m:type="Edm.Int64">42</d:DownloadCount>
+            <d:GalleryDetailsUrl>https://www.nuget.org/packages/#{name}/#{version}</d:GalleryDetailsUrl>
+            <d:IconUrl m:null="true" />
+            <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+            <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+            <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+            <d:Language m:null="true" />
+            <d:LastUpdated m:type="Edm.DateTime">2015-07-28T23:37:16.85+00:00</d:LastUpdated>
+            <d:Published m:type="Edm.DateTime">2015-07-28T23:37:16.85+00:00</d:Published>
+            <d:PackageHash>FakeHash</d:PackageHash>
+            <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+            <d:PackageSize m:type="Edm.Int64">42</d:PackageSize>
+            <d:ProjectUrl>https://example.com/#{name}</d:ProjectUrl>
+            <d:ReportAbuseUrl>https://example.com/#{name}</d:ReportAbuseUrl>
+            <d:ReleaseNotes m:null="true" />
+            <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+            <d:Summary></d:Summary>
+            <d:Tags></d:Tags>
+            <d:Title>#{name}</d:Title>
+            <d:VersionDownloadCount m:type="Edm.Int64">42</d:VersionDownloadCount>
+            <d:MinClientVersion m:null="true" />
+            <d:LastEdited m:type="Edm.DateTime">2018-12-08T05:53:10.917+00:00</d:LastEdited>
+            <d:LicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</d:LicenseUrl>
+            <d:LicenseNames m:null="true" />
+            <d:LicenseReportUrl m:null="true" />
+          </m:properties>
+        </entry>
+      XML
+      xml = xml.split("\n").map { |line| "  #{line}" }.join("\n")
+      xml
+    end.join("\n")
+    xml = <<~XML
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xml:base="https://www.nuget.org/api/v2" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+        xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+        <m:count>#{versions.length}</m:count>
+        <id>http://schemas.datacontract.org/2004/07/</id>
+        <title />
+        <updated>2023-12-05T23:35:30Z</updated>
+        <link rel="self" href="https://www.nuget.org/api/v2/Packages" />
+        #{entries}
+      </feed>
+    XML
+    xml
+  end
+  # rubocop:enable Metrics/MethodLength
 end
 
 RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
@@ -79,18 +150,18 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
     # these search results are used by many tests; for these tests, the actual versions don't matter, it just matters
     # that search returns _something_
     versions = ["2.2.2", "1.1.1", "1.0.0"]
-    stub_search_results_with_versions("gitversion.commandline", versions)
-    stub_search_results_with_versions("microsoft.aspnetcore.app", versions)
-    stub_search_results_with_versions("microsoft.extensions.dependencymodel", versions)
-    stub_search_results_with_versions("microsoft.extensions.platformabstractions", versions)
-    stub_search_results_with_versions("microsoft.net.test.sdk", versions)
-    stub_search_results_with_versions("microsoft.sourcelink.github", versions)
-    stub_search_results_with_versions("newtonsoft.json", versions)
-    stub_search_results_with_versions("nanoframework.corelibrary", versions)
-    stub_search_results_with_versions("nuke.codegeneration", versions)
-    stub_search_results_with_versions("nuke.common", versions)
-    stub_search_results_with_versions("serilog", versions)
-    stub_search_results_with_versions("system.collections.specialized", versions)
+    stub_search_results_with_versions_v3("gitversion.commandline", versions)
+    stub_search_results_with_versions_v3("microsoft.aspnetcore.app", versions)
+    stub_search_results_with_versions_v3("microsoft.extensions.dependencymodel", versions)
+    stub_search_results_with_versions_v3("microsoft.extensions.platformabstractions", versions)
+    stub_search_results_with_versions_v3("microsoft.net.test.sdk", versions)
+    stub_search_results_with_versions_v3("microsoft.sourcelink.github", versions)
+    stub_search_results_with_versions_v3("newtonsoft.json", versions)
+    stub_search_results_with_versions_v3("nanoframework.corelibrary", versions)
+    stub_search_results_with_versions_v3("nuke.codegeneration", versions)
+    stub_search_results_with_versions_v3("nuke.common", versions)
+    stub_search_results_with_versions_v3("serilog", versions)
+    stub_search_results_with_versions_v3("system.collections.specialized", versions)
   end
 
   describe "dependency_set" do
@@ -186,10 +257,10 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
       its(:length) { is_expected.to eq(5) }
 
       before do
-        stub_search_results_with_versions("system.askjeeves", ["1.0.0", "1.1.0"])
-        stub_search_results_with_versions("system.google", ["1.0.0", "1.1.0"])
-        stub_search_results_with_versions("system.lycos", ["1.0.0", "1.1.0"])
-        stub_search_results_with_versions("system.webcrawler", ["1.0.0", "1.1.0"])
+        stub_search_results_with_versions_v3("system.askjeeves", ["1.0.0", "1.1.0"])
+        stub_search_results_with_versions_v3("system.google", ["1.0.0", "1.1.0"])
+        stub_search_results_with_versions_v3("system.lycos", ["1.0.0", "1.1.0"])
+        stub_search_results_with_versions_v3("system.webcrawler", ["1.0.0", "1.1.0"])
       end
 
       describe "the first dependency" do
@@ -252,12 +323,12 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
         its(:length) { is_expected.to eq(6) }
 
         before do
-          stub_search_results_with_versions("dep1", ["1.1.0", "1.2.0"])
-          stub_search_results_with_versions("dep2", ["1.1.0", "1.2.0"])
-          stub_search_results_with_versions("dep3", ["0.9.0", "1.0.0"])
-          stub_search_results_with_versions("dep4", ["1.0.0", "1.0.1"])
-          stub_search_results_with_versions("dep5", ["1.1.0", "1.2.0"])
-          stub_search_results_with_versions("dep6", ["1.1.0", "1.2.0"])
+          stub_search_results_with_versions_v3("dep1", ["1.1.0", "1.2.0"])
+          stub_search_results_with_versions_v3("dep2", ["1.1.0", "1.2.0"])
+          stub_search_results_with_versions_v3("dep3", ["0.9.0", "1.0.0"])
+          stub_search_results_with_versions_v3("dep4", ["1.0.0", "1.0.1"])
+          stub_search_results_with_versions_v3("dep5", ["1.1.0", "1.2.0"])
+          stub_search_results_with_versions_v3("dep6", ["1.1.0", "1.2.0"])
         end
 
         it "has the right details" do
@@ -372,7 +443,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
           end
 
           before do
-            stub_search_results_with_versions("nuke.uncommon", ["0.1.434"])
+            stub_search_results_with_versions_v3("nuke.uncommon", ["0.1.434"])
           end
 
           it "has the right details" do
@@ -623,7 +694,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
 
             before do
               stub_request(:get, "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=this.dependency.does.not.exist&semVerLevel=2.0.0")
-                .to_return(status: 200, body: search_results_with_versions(
+                .to_return(status: 200, body: search_results_with_versions_v3(
                   "this.dependency.does.not.exist_but.this.one.does", ["1.0.0"]
                 ))
             end
@@ -682,10 +753,66 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
                 .to_return(status: 200, body: fixture("nuget_responses", "index.json",
                                                       "with-results.api.example.com.index.json"))
               stub_request(:get, "https://with-results.api.example.com/query?prerelease=true&q=microsoft.extensions.dependencymodel&semVerLevel=2.0.0")
-                .to_return(status: 200, body: search_results_with_versions("microsoft.extensions.dependencymodel",
-                                                                           ["1.1.1", "1.1.0"]))
+                .to_return(status: 200, body: search_results_with_versions_v3("microsoft.extensions.dependencymodel",
+                                                                              ["1.1.1", "1.1.0"]))
               stub_request(:get, "https://with-results.api.example.com/query?prerelease=true&q=this.dependency.does.not.exist&semVerLevel=2.0.0")
                 .to_return(status: 200, body: fixture("nuget_responses", "search_no_data.json"))
+            end
+
+            it "has the right details" do
+              expect(top_level_dependencies.count).to eq(1)
+              expect(top_level_dependencies.first).to be_a(Dependabot::Dependency)
+              expect(top_level_dependencies.first.name).to eq("Microsoft.Extensions.DependencyModel")
+              expect(top_level_dependencies.first.version).to eq("1.1.1")
+              expect(top_level_dependencies.first.requirements).to eq(
+                [{
+                  requirement: "1.1.1",
+                  file: "my.csproj",
+                  groups: ["dependencies"],
+                  source: nil
+                }]
+              )
+            end
+          end
+
+          describe "v2 apis can be queried" do
+            let(:file_body) do
+              <<~XML
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net7.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
+                  </ItemGroup>
+                </Project>
+              XML
+            end
+            let(:file) do
+              Dependabot::DependencyFile.new(name: "my.csproj", content: file_body)
+            end
+            let(:nuget_config_body) do
+              <<~XML
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+                  </packageSources>
+                </configuration>
+              XML
+            end
+            let(:nuget_config_file) do
+              Dependabot::DependencyFile.new(name: "NuGet.config", content: nuget_config_body)
+            end
+            let(:parser) { described_class.new(dependency_files: [file, nuget_config_file], credentials: credentials) }
+
+            before do
+              stub_request(:get, "https://www.nuget.org/api/v2/")
+                .to_return(status: 200, body: fixture("nuget_responses", "v2_base.xml"))
+              stub_request(:get, "https://www.nuget.org/api/v2/FindPackagesById()?id=%27Microsoft.Extensions.DependencyModel%27")
+                .to_return(status: 200, body: search_results_with_versions_v2("microsoft.extensions.dependencymodel",
+                                                                              ["1.1.1", "1.1.0"]))
             end
 
             it "has the right details" do
@@ -743,8 +870,8 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             end
 
             it "has the right details" do
-              query_stub = stub_search_results_with_versions("microsoft.extensions.dependencymodel_cached",
-                                                             ["1.1.1", "1.1.0"])
+              query_stub = stub_search_results_with_versions_v3("microsoft.extensions.dependencymodel_cached",
+                                                                ["1.1.1", "1.1.0"])
               expect(top_level_dependencies.count).to eq(1)
               expect(top_level_dependencies.first).to be_a(Dependabot::Dependency)
               expect(top_level_dependencies.first.name).to eq("Microsoft.Extensions.DependencyModel_cached")
@@ -767,7 +894,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
         let(:file_body) { fixture("csproj", "basic.nuproj") }
 
         before do
-          stub_search_results_with_versions("nanoframework.coreextra", [])
+          stub_search_results_with_versions_v3("nanoframework.coreextra", [])
         end
 
         it "gets the right number of dependencies" do
@@ -817,8 +944,8 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
 
       context "with a versioned sdk reference" do
         before do
-          stub_search_results_with_versions("awesome.sdk", ["1.2.3"])
-          stub_search_results_with_versions("prototype.sdk", ["1.2.3"])
+          stub_search_results_with_versions_v3("awesome.sdk", ["1.2.3"])
+          stub_search_results_with_versions_v3("prototype.sdk", ["1.2.3"])
         end
 
         context "specified in the Project tag" do

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -456,6 +456,38 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         end
       end
 
+      context "includes repositories in the `trustedSigners` section" do
+        let(:config_file_fixture_name) { "with_trustedSigners.config" }
+
+        before do
+          repo_url = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+          stub_request(:get, repo_url)
+            .to_return(
+              status: 200,
+              body: fixture("nuget_responses", "index.json", "versioned_SearchQueryService.index.json")
+            )
+        end
+
+        it "gets the right URLs" do
+          expect(dependency_urls).to eq(
+            [{
+              repository_url: "https://api.nuget.org/v3/index.json",
+              versions_url: "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/index.json",
+              search_url: "https://azuresearch-usnc.nuget.org/query?q=microsoft.extensions.dependencymodel&prerelease=true&semVerLevel=2.0.0",
+              auth_header: {},
+              repository_type: "v3"
+            },
+             {
+               repository_url: "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json",
+               versions_url: "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/microsoft.extensions.dependencymodel/index.json",
+               search_url: "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/query2/?q=microsoft.extensions.dependencymodel&prerelease=true&semVerLevel=2.0.0",
+               auth_header: {},
+               repository_type: "v3"
+             }]
+          )
+        end
+      end
+
       context "that has a non-ascii key" do
         let(:config_file_fixture_name) { "non_ascii_key.config" }
 

--- a/nuget/spec/fixtures/configs/with_trustedSigners.config
+++ b/nuget/spec/fixtures/configs/with_trustedSigners.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+  <config>
+    <add key="signatureValidationMode" value="require" />
+  </config>
+  <trustedSigners>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+    </repository>
+    <repository name="pkgs.dev.azure.com" serviceIndex="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json">
+    </repository>
+  </trustedSigners>
+</configuration>


### PR DESCRIPTION
This fixes 2 issues with querying NuGet apis:

1. Allow querying from the `trustedSigners` section of `NuGet.Config`
2. Allow querying v2 APIs to determine dependency eligibility