### PR TITLE
Skip Maven snapshots repositories from versions checking - fix 2

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -80,7 +80,7 @@ module Dependabot
         end
 
         def snapshot_repo(entry)
-          entry[:snapshots] == "true" && (entry[:releases].nil? || entry[:releases] == "false")
+          entry[:releases] == "false" && (entry[:snapshots].nil? || entry[:snapshots] == "true")
         end
 
         def serialize_urls(entry, pom)

--- a/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
           %w(
             http://scala-tools.org/repo-releases
             http://repository.jboss.org/maven2
-            https://oss.sonatype.org/content/repositories/snapshots-only
+            https://oss.sonatype.org/content/repositories/releases-false-only
             https://oss.sonatype.org/content/repositories/snapshots-with-releases
             http://plugin-repository.jboss.org/maven2
-            https://oss.sonatype.org/content/repositories/plugin-snapshots-only
+            https://oss.sonatype.org/content/repositories/plugin-releases-false-only
             https://oss.sonatype.org/content/repositories/plugin-snapshots-with-releases
             https://repo.maven.apache.org/maven2
           )

--- a/maven/spec/fixtures/poms/custom_repositories_pom.xml
+++ b/maven/spec/fixtures/poms/custom_repositories_pom.xml
@@ -92,11 +92,11 @@ url>http://github.com/davidB/${project.artifactId}</url
       </snapshots>
     </repository>
     <repository>
-      <id>snapshot-only-repository</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots-only</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
+      <id>releases-false-only-repository</id>
+      <url>https://oss.sonatype.org/content/repositories/releases-false-only</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
     <repository>
       <id>snapshot-with-releases-repository</id>
@@ -123,11 +123,11 @@ url>http://github.com/davidB/${project.artifactId}</url
       </snapshots>
     </pluginRepository>
     <pluginRepository>
-      <id>plugin-snapshot-only-repository</id>
-      <url>https://oss.sonatype.org/content/repositories/plugin-snapshots-only</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
+      <id>plugin-releases-false-only-repository</id>
+      <url>https://oss.sonatype.org/content/repositories/plugin-releases-false-only</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </pluginRepository>
     <pluginRepository>
       <id>plugin-snapshot-with-releases-repository</id>


### PR DESCRIPTION
Items repository -> snapshots,releases -> enabled has a default value as true, 
so it is enough to defined releases as false for snapshots repositories

fix #5947