### PR TITLE
Don't escape dependency names in tarball URLs since it doesn't always work

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -7,13 +7,14 @@ require "dependabot/dependency_file"
 require "dependabot/npm_and_yarn/update_checker/latest_version_finder"
 
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
-  let(:registry_listing_url) { "https://registry.npmjs.org/#{escaped_dependency_name}" }
+  let(:registry_base) { "https://registry.npmjs.org" }
+  let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
   let(:registry_response) { fixture("npm_responses", "#{escaped_dependency_name}.json") }
   let(:login_form) { fixture("npm_responses", "login_form.html") }
   before do
     stub_request(:get, registry_listing_url)
       .to_return(status: 200, body: registry_response)
-    stub_request(:head, registry_listing_url + "/-/#{unscoped_dependency_name}-#{target_version}.tgz")
+    stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
       .to_return(status: 200)
   end
 
@@ -262,7 +263,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         stub_request(:get, "https://registry.npmjs.org/@dependabot%2Fblep")
           .with(headers: { "Authorization" => "Bearer secret_token" })
           .to_return(status: 200, body: body)
-        stub_request(:head, "https://registry.npmjs.org/@dependabot%2Fblep/-/blep-1.7.0.tgz")
+        stub_request(:head, "https://registry.npmjs.org/@dependabot/blep/-/blep-1.7.0.tgz")
           .to_return(status: 200)
       end
 
@@ -695,9 +696,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         body = fixture("npm_responses", "old_latest.json")
         stub_request(:get, registry_listing_url)
           .to_return(status: 200, body: body)
-        stub_request(:head, registry_listing_url + "/-/etag-1.7.0.tgz")
+        stub_request(:head, "#{registry_base}/etag/-/etag-1.7.0.tgz")
           .to_return(status: 404)
-        stub_request(:head, registry_listing_url + "/-/etag-1.6.0.tgz")
+        stub_request(:head, "#{registry_base}/etag/-/etag-1.6.0.tgz")
           .to_return(status: 200)
       end
 
@@ -808,7 +809,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         body = fixture("npm_responses", "old_latest.json")
         stub_request(:get, registry_listing_url)
           .to_return(status: 200, body: body)
-        stub_request(:head, registry_listing_url + "/-/etag-1.6.0.tgz")
+        stub_request(:head, "#{registry_base}/etag/-/etag-1.6.0.tgz")
           .to_return(status: 200)
       end
 
@@ -958,9 +959,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
 
     context "when the lowest version has been yanked" do
       before do
-        stub_request(:head, registry_listing_url + "/-/etag-1.2.1.tgz")
+        stub_request(:head, "#{registry_base}/etag/-/etag-1.2.1.tgz")
           .to_return(status: 404)
-        stub_request(:head, registry_listing_url + "/-/etag-1.3.1.tgz")
+        stub_request(:head, "#{registry_base}/etag/-/etag-1.3.1.tgz")
           .to_return(status: 200)
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -11,14 +11,15 @@ require_common_spec "update_checkers/shared_examples_for_update_checkers"
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   it_behaves_like "an update checker"
 
-  let(:registry_listing_url) { "https://registry.npmjs.org/#{escaped_dependency_name}" }
+  let(:registry_base) { "https://registry.npmjs.org" }
+  let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
   let(:registry_response) do
     fixture("npm_responses", "#{escaped_dependency_name}.json")
   end
   before do
     stub_request(:get, registry_listing_url)
       .to_return(status: 200, body: registry_response)
-    stub_request(:head, registry_listing_url + "/-/#{unscoped_dependency_name}-#{target_version}.tgz")
+    stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
       .to_return(status: 200)
   end
 
@@ -1790,7 +1791,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
     end
     context "with a security advisory" do
       before do
-        stub_request(:head, registry_listing_url + "/-/#{unscoped_dependency_name}-3.4.1.tgz")
+        stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-3.4.1.tgz")
           .to_return(status: 200)
       end
       let(:security_advisories) do
@@ -1942,7 +1943,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         .to_return(status: 200)
       stub_request(:get, types_listing_url)
         .to_return(status: 200, body: types_response)
-      stub_request(:head, types_listing_url + "/-/node-forge-1.0.1.tgz")
+      stub_request(:head, "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.0.1.tgz")
         .to_return(status: 200)
     end
     let(:dependency_files) { project_dependency_files("yarn/ts_fully_typed") }


### PR DESCRIPTION
~Apparently a `HEAD` request is incorrectly returning 404 sometimes. Downloading the full tgz may be heavy, but I think it won't happen often and correctness should come before speed. We can iterate later if this fixes the problem.~

After testing with OP, it was found that it was the %2F in tarball URLs that was causing this, so this PR was changed to not escape dependency names when building tarball URLs for yanked detection.  

Closes #8544.