### PR TITLE
Use upstream pipenv again

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -2,7 +2,7 @@ pip==23.3.1
 pip-tools==7.3.0
 flake8==6.1.0
 hashin==0.17.0
-pipenv@git+https://github.com/dependabot/pipenv@vendor-latest-tomlkit
+pipenv@git+https://github.com/pypa/pipenv@main
 pipfile==0.0.2
 poetry==1.7.1
 


### PR DESCRIPTION
The [PR](https://github.com/pypa/pipenv/pull/6024) that we were cherry-picking has been merged, and also [another one](https://github.com/pypa/pipenv/pull/6021) that will fix more Dependabot errors.

Still no release but we can switch back to the upstream repo.