### PR TITLE
Bump golang from 1.21.4-bookworm to 1.21.5-bookworm in /go_modules

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4-bookworm as go
+FROM golang:1.21.5-bookworm as go
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH


### PR DESCRIPTION
Similar to PR #8374. This allows Dependabot to function when used against Go projects that require Go 1.21.5