### PR TITLE
dynamically discover smoke tests

### DIFF
--- a/.github/smoke-matrix.json
+++ b/.github/smoke-matrix.json
@@ -5,16 +5,6 @@
     "ecosystem": "bundler"
   },
   {
-    "core": "bundler",
-    "test": "bundler-group-rules",
-    "ecosystem": "bundler"
-  },
-  {
-    "core": "bundler",
-    "test": "bundler-group-vendoring",
-    "ecosystem": "bundler"
-  },
-  {
     "core": "cargo",
     "test": "cargo",
     "ecosystem": "cargo"
@@ -50,33 +40,8 @@
     "ecosystem": "gomod"
   },
   {
-    "core": "go_modules",
-    "test": "go-close-pr",
-    "ecosystem": "gomod"
-  },
-  {
-    "core": "go_modules",
-    "test": "go-group-rules",
-    "ecosystem": "gomod"
-  },
-  {
-    "core": "go_modules",
-    "test": "go-security",
-    "ecosystem": "gomod"
-  },
-  {
-    "core": "go_modules",
-    "test": "go-update-pr",
-    "ecosystem": "gomod"
-  },
-  {
     "core": "gradle",
     "test": "gradle",
-    "ecosystem": "gradle"
-  },
-  {
-    "core": "gradle",
-    "test": "gradle-version-catalog",
     "ecosystem": "gradle"
   },
   {
@@ -92,36 +57,6 @@
   {
     "core": "npm_and_yarn",
     "test": "npm",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "npm-group-rules",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "npm-remove-transitive",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "pnpm",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "yarn",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "yarn-berry",
-    "ecosystem": "npm"
-  },
-  {
-    "core": "npm_and_yarn",
-    "test": "yarn-berry-workspaces",
     "ecosystem": "npm"
   },
   {
@@ -141,22 +76,7 @@
   },
   {
     "core": "python",
-    "test": "pip",
-    "ecosystem": "pip"
-  },
-  {
-    "core": "python",
-    "test": "pipenv",
-    "ecosystem": "pip"
-  },
-  {
-    "core": "python",
-    "test": "pip-compile",
-    "ecosystem": "pip"
-  },
-  {
-    "core": "python",
-    "test": "poetry",
+    "test": "python",
     "ecosystem": "pip"
   },
   {

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,7 +52,7 @@ jobs:
           jq -c '.[]' filtered.json | while read -r i; do
             test=$(echo "$i" | jq -r '.test')
             jq --argjson i "$i" --arg test "$test" -r '.[] | select(.name | contains($test)) | {core: ($i | .core), ecosystem: ($i | .ecosystem), name: .name}' tests.json
-          done | jq -s . > suites.json
+          done | jq -cs . > suites.json
 
           # Set the step output
           echo "suites=$(cat suites.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -49,7 +49,10 @@ jobs:
 
           # Select the names that match smoke-$test*.yaml, where $test is the .text value from filtered.json
           # We end up with, for example: [{core: "bundler", ecosystem: "rubygems", name: "smoke-bundler.yaml"}]
-          jq -cr --arg test "$(jq -r '.[0].test' filtered.json)" '[.[] | select(.name | contains($test)) | {core: $test, ecosystem: $test, name: .name}]' tests.json > suites.json
+          jq -c '.[]' filtered.json | while read -r i; do
+            test=$(echo "$i" | jq -r '.test')
+            jq --argjson i "$i" --arg test "$test" -r '.[] | select(.name | contains($test)) | {core: ($i | .core), ecosystem: ($i | .ecosystem), name: .name}' tests.json
+          done | jq -s . > suites.json
 
           # Set the step output
           echo "suites=$(cat suites.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,7 +51,7 @@ jobs:
           # We end up with, for example: [{core: "bundler", ecosystem: "rubygems", name: "smoke-bundler.yaml"}]
           jq -c '.[]' filtered.json | while read -r i; do
             test=$(echo "$i" | jq -r '.test')
-            jq --argjson i "$i" --arg test "$test" -r '.[] | select(.name | contains($test)) | {core: ($i | .core), ecosystem: ($i | .ecosystem), name: .name}' tests.json
+            jq --argjson i "$i" --arg test "-$test" -r '.[] | select(.name | contains($test)) | {core: ($i | .core), ecosystem: ($i | .ecosystem), name: .name}' tests.json
           done | jq -cs . > suites.json
 
           # Set the step output

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -43,8 +43,16 @@ jobs:
           jq -c --argjson changes "$(cat changes.json)" '[.[] | select(.core as $p | $changes | index($p))]' .github/smoke-matrix.json > filtered.json
           cat filtered.json
 
+          # Curl the smoke-test tests directory to get a list of tests to run
+          URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests
+          curl $URL > tests.json
+
+          # Select the names that match smoke-$test*.yaml, where $test is the .text value from filtered.json
+          # We end up with, for example: [{core: "bundler", ecosystem: "rubygems", name: "smoke-bundler.yaml"}]
+          jq -cr --arg test "$(jq -r '.[0].test' filtered.json)" '[.[] | select(.name | contains($test)) | {core: $test, ecosystem: $test, name: .name}]' tests.json > suites.json
+
           # Set the step output
-          echo "suites=$(cat filtered.json)" >> $GITHUB_OUTPUT
+          echo "suites=$(cat suites.json)" >> $GITHUB_OUTPUT
   e2e:
     needs: discover
     runs-on: ubuntu-latest
@@ -62,14 +70,21 @@ jobs:
           gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
           tar xzvf *.tar.gz >/dev/null 2>&1
           ./dependabot --version
-          URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite.test }}.yaml
+          URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/${{ matrix.suite.name }}
           curl $(gh api $URL --jq .download_url) -o smoke.yaml
 
       # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
       # Allowed to fail to get out of checking and egg situations, for example, when adding a new ecosystem.
       - name: Download cache
         run: |
-          gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite.test }} --dir cache
+          # The name of the cache is derived from the test name, e.g. smoke-bundler.yaml -> cache-bundler
+          TEST=${{ matrix.suite.name }}
+          # Remove the smoke- and the .yaml or .yml suffix
+          CACHE=${TEST#smoke-}
+          CACHE=${CACHE%.yaml}
+          CACHE=${CACHE%.yml}
+
+          gh run download --repo dependabot/smoke-tests --name cache-$CACHE --dir cache
         continue-on-error: true
 
       - name: Build ecosystem image


### PR DESCRIPTION
When adding a new smoke test, we had to remember to also add it to this list of tests, which inevitably means we forgot.

This change pulls the list of tests from the smoke test so as long as it's on main it will be run!

It relies on convention that the "test" value in smoke-matrix.json matches the test name like so: `smoke-$test-.yaml`.

So I need to rename a few tests after merging this.