### PR TITLE
Use a hash in the branch name for multi-directory grouped security updates

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -266,7 +266,8 @@ module Dependabot
           dependency_group: dependency_group,
           separator: branch_name_separator,
           prefix: branch_name_prefix,
-          max_length: branch_name_max_length
+          max_length: branch_name_max_length,
+          includes_security_fixes: includes_security_fixes?
         )
     end
 

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -11,10 +11,10 @@ require "dependabot/pull_request_creator/branch_namer/dependency_group_strategy"
 module Dependabot
   class PullRequestCreator
     class BranchNamer
-      attr_reader :dependencies, :files, :target_branch, :separator, :prefix, :max_length, :dependency_group
+      attr_reader :dependencies, :files, :target_branch, :separator, :prefix, :max_length, :dependency_group, :includes_security_fixes
 
       def initialize(dependencies:, files:, target_branch:, dependency_group: nil,
-                     separator: "/", prefix: "dependabot", max_length: nil)
+                     separator: "/", prefix: "dependabot", max_length: nil, includes_security_fixes: false)
         @dependencies  = dependencies
         @files         = files
         @target_branch = target_branch
@@ -22,6 +22,7 @@ module Dependabot
         @separator     = separator
         @prefix        = prefix
         @max_length    = max_length
+        @includes_security_fixes = includes_security_fixes
       end
 
       def new_branch_name
@@ -49,7 +50,8 @@ module Dependabot
               dependency_group: dependency_group,
               separator: separator,
               prefix: prefix,
-              max_length: max_length
+              max_length: max_length,
+              includes_security_fixes: includes_security_fixes
             )
           end
       end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -11,7 +11,8 @@ require "dependabot/pull_request_creator/branch_namer/dependency_group_strategy"
 module Dependabot
   class PullRequestCreator
     class BranchNamer
-      attr_reader :dependencies, :files, :target_branch, :separator, :prefix, :max_length, :dependency_group, :includes_security_fixes
+      attr_reader :dependencies, :files, :target_branch, :separator, :prefix, :max_length, :dependency_group,
+                  :includes_security_fixes
 
       def initialize(dependencies:, files:, target_branch:, dependency_group: nil,
                      separator: "/", prefix: "dependabot", max_length: nil, includes_security_fixes: false)

--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -8,17 +8,18 @@ module Dependabot
     class BranchNamer
       class DependencyGroupStrategy < Base
         def initialize(dependencies:, files:, target_branch:, dependency_group:,
-                       separator: "/", prefix: "dependabot", max_length: nil)
+                       separator: "/", prefix: "dependabot", max_length: nil, includes_security_fixes:)
           super(
             dependencies: dependencies,
             files: files,
             target_branch: target_branch,
             separator: separator,
             prefix: prefix,
-            max_length: max_length
+            max_length: max_length,
           )
 
           @dependency_group = dependency_group
+          @includes_security_fixes = includes_security_fixes
         end
 
         def new_branch_name
@@ -45,7 +46,11 @@ module Dependabot
         # Let's append a short hash digest of the dependency changes so that we can
         # meet this guarantee.
         def group_name_with_dependency_digest
-          "#{dependency_group.name}-#{dependency_digest}"
+          if @includes_security_fixes
+            "group-security-#{package_manager}-#{dependency_digest}"
+          else
+            "#{dependency_group.name}-#{dependency_digest}"
+          end
         end
 
         def dependency_digest

--- a/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
       target_branch: target_branch,
       separator: separator,
       dependency_group: dependency_group,
-      max_length: max_length
+      max_length: max_length,
+      includes_security_fixes: includes_security_fixes
     )
   end
 
@@ -44,6 +45,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
     Dependabot::DependencyGroup.new(name: "my-dependency-group", rules: { patterns: ["*"] })
   end
   let(:max_length) { nil }
+  let(:includes_security_fixes) { false }
 
   describe "#new_branch_name" do
     subject(:new_branch_name) { namer.new_branch_name }
@@ -64,7 +66,8 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
           files: [gemfile],
           target_branch: target_branch,
           separator: separator,
-          dependency_group: dependency_group
+          dependency_group: dependency_group,
+          includes_security_fixes: includes_security_fixes
         )
         sleep 1 # ensure the timestamp changes
         expect(new_namer.new_branch_name).to eql(branch_name)
@@ -86,7 +89,8 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
           files: [gemfile],
           target_branch: target_branch,
           separator: separator,
-          dependency_group: dependency_group
+          dependency_group: dependency_group,
+          includes_security_fixes: includes_security_fixes
         )
         expect(new_namer.new_branch_name).not_to eql(namer.new_branch_name)
       end
@@ -107,7 +111,8 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
           files: [gemfile],
           target_branch: target_branch,
           separator: separator,
-          dependency_group: dependency_group
+          dependency_group: dependency_group,
+          includes_security_fixes: includes_security_fixes
         )
 
         backward_namer = described_class.new(
@@ -115,10 +120,28 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
           files: [gemfile],
           target_branch: target_branch,
           separator: separator,
-          dependency_group: dependency_group
+          dependency_group: dependency_group,
+          includes_security_fixes: includes_security_fixes
         )
 
         expect(forward_namer.new_branch_name).to eql(backward_namer.new_branch_name)
+      end
+    end
+
+    context "with a grouped security update" do
+      let(:directory) { "/" }
+      let(:target_branch) { nil }
+      let(:separator) { "/" }
+      let(:includes_security_fixes) { true }
+      let(:dependency_group) do
+        Dependabot::DependencyGroup.new(
+          name: "bundler-group",
+          rules: { patterns: ["*"] }
+        )
+      end
+
+      it "returns the name of the security dependency group prefixed correctly" do
+        expect(namer.new_branch_name).to eq("dependabot/bundler/group-security-bundler-b8d660191d")
       end
     end
 


### PR DESCRIPTION
This PR passes the `includes_security_fixes` param to the BranchNamer so that we use special branch names for multi-directory grouped security updates.

The branch name for these PRs now read:
`dependabot/bundler/group-security-bundler-b8d660191d`

This shouldn't change the branch name for any other type of PR.