### PR TITLE
Fix docker updates for tags with a v prefix

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -52,7 +52,7 @@ module Dependabot
 
             dependency_set << Dependency.new(
               name: parsed_from_line.fetch("image"),
-              version: version.sub(/^v/, ""),
+              version: version,
               package_manager: "docker",
               requirements: [
                 requirement: nil,
@@ -129,7 +129,7 @@ module Dependabot
       def build_image_dependency(file, details, version)
         Dependency.new(
           name: details.fetch("image"),
-          version: version.sub(/^v/, ""),
+          version: version,
           package_manager: "docker",
           requirements: [
             requirement: nil,

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -1143,7 +1143,7 @@ RSpec.describe Dependabot::Docker::FileParser do
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("sql/sql")
-          expect(dependency.version).to eq("1.2.3")
+          expect(dependency.version).to eq("v1.2.3")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end

--- a/docker/spec/fixtures/docker/registry_tags/bar_with_v.json
+++ b/docker/spec/fixtures/docker/registry_tags/bar_with_v.json
@@ -1,0 +1,7 @@
+{
+    "name": "foo/bar",
+    "tags": [
+        "v3.10-master-777",
+        "v3.10-master-999"
+    ]
+}


### PR DESCRIPTION
This reverts https://github.com/dependabot/dependabot-core/pull/8165 which caused a regression in updates for docker tags with a 'v' prefix. We missed this because we didn't have test coverage across the FileParser and UpdateChecker for this case. I added a test to help prevent reoccurrence.