### PR TITLE
[NuGet] add dotnet 8.0 support

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-ARG DOTNET_SDK_VERSION=7.0.305
+ARG DOTNET_SDK_VERSION=8.0.100
 ARG DOTNET_SDK_INSTALL_URL=https://dot.net/v1/dotnet-install.sh
 ENV DOTNET_INSTALL_DIR=/usr/local/dotnet/current
 ENV DOTNET_NOLOGO=true
+ENV DOTNET_ROOT="${DOTNET_INSTALL_DIR}"
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 ENV NUGET_SCRATCH=/opt/nuget/helpers/tmp
 
@@ -26,6 +27,7 @@ RUN cd /tmp \
   && rm dotnet-install.sh
 
 ENV PATH="${PATH}:${DOTNET_INSTALL_DIR}"
+RUN dotnet --list-runtimes
 RUN dotnet --list-sdks
 
 USER dependabot

--- a/nuget/helpers/build
+++ b/nuget/helpers/build
@@ -32,7 +32,7 @@ cd "$install_dir/lib/NuGetUpdater/NuGetUpdater.Cli"
 dotnet publish \
     --configuration Release \
     --output "$install_dir/NuGetUpdater" \
-    --framework net7.0 \
+    --framework net8.0 \
     --runtime "$os-$arch"
 dotnet clean
 

--- a/nuget/helpers/lib/NuGetUpdater/.gitignore
+++ b/nuget/helpers/lib/NuGetUpdater/.gitignore
@@ -1,3 +1,4 @@
 .vs/
+artifacts/
 bin/
 obj/

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
@@ -5,4 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <Import Project="Directory.Common.props" />
+
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <!--
+      When updating the common target framework below, you will also need to:
+
+      1. Copy the latest `SupportedFrameworks.cs` from
+            https://github.com/NuGet/NuGetGallery/blob/main/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+         to
+            NuGetUpdater\NuGetUpdater.Core\FrameworkChecker\SupportedFrameworks.cs
+      2. Update tests as needed at `NuGetUpdater\NuGetUpdater.Core.Test\FrameworkChecker\CompatibilityCheckerFacts.cs`
+    -->
+    <CommonTargetFramework>net8.0</CommonTargetFramework>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+  </PropertyGroup>
+</Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
@@ -9,4 +9,6 @@
     <Version>6.7.0</Version>
   </PropertyGroup>
 
+  <Import Project="..\Directory.Common.props" />
+
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Commands/NuGet.Commands.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Commands/NuGet.Commands.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Common/NuGet.Common.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Common/NuGet.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Configuration/NuGet.Configuration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Credentials/NuGet.Credentials.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Credentials/NuGet.Credentials.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Protocol/NuGet.Protocol.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <DefineConstants>$(DefineConstants);IS_DESKTOP</DefineConstants>
   </PropertyGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Resolver/NuGet.Resolver.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Resolver/NuGet.Resolver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Versioning/NuGet.Versioning.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Versioning/NuGet.Versioning.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/NuGetUpdater.Cli.Test.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/NuGetUpdater.Cli.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/NuGetUpdater.Cli.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/NuGetUpdater.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/CompatibilityCheckerFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/CompatibilityCheckerFacts.cs
@@ -7,6 +7,7 @@ namespace NuGetUpdater.Core.Test.FrameworkChecker;
 public class CompatibilityCheckerFacts
 {
     [Theory]
+    [InlineData("net8.0", "net8.0")]
     [InlineData("net8.0", "net7.0")]
     [InlineData("net7.0", "net7.0")]
     [InlineData("net7.0", "net6.0")]
@@ -42,8 +43,8 @@ public class CompatibilityCheckerFacts
     }
 
     [Theory]
-    [InlineData(new[] { "net7.0", "net472" }, new[] { "netstandard2.0" })]
-    [InlineData(new[] { "net7.0", "net472" }, new[] { "net5.0", "net461" })]
+    [InlineData(new[] { "net8.0", "net7.0", "net472" }, new[] { "netstandard2.0" })]
+    [InlineData(new[] { "net8.0", "net7.0", "net472" }, new[] { "net5.0", "net461" })]
     [InlineData(new[] { "net6.0", "net6.0-windows10.0.19041" }, new[] { "net6.0", ".NETStandard2.0" })]
     public void PackageContainsCompatibleFrameworks(string[] projectTfms, string[] packageTfms)
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/SupportedFrameworkFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/SupportedFrameworkFacts.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 using NuGet.Frameworks;
 
-using NuGetUpdater.Core.FrameworkChecker;
+using NuGetGallery.Frameworks;
 
 using Xunit;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -17,6 +17,9 @@ public partial class UpdateWorkerTests
         [InlineData("net472")]
         [InlineData("netstandard2.0")]
         [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        [InlineData("net7.0")]
+        [InlineData("net8.0")]
         public async Task UpdateVersionAttribute_InProjectFile_ForPackageReferenceInclude(string tfm)
         {
             // update Newtonsoft.Json from 9.0.1 to 13.0.1

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
@@ -124,20 +124,13 @@ namespace NuGetUpdater.Core.Test.Utilities
         public async Task BuildFileEnumerationWithUnsuccessfulImport()
         {
             using var temporaryDirectory = TemporaryDirectory.CreateWithContents(
-                ("global.json", """
-                    {
-                      "msbuild-sdks": {
-                        "Microsoft.Build.NoTargets": "3.7.0"
-                      }
-                    }
-                    """),
                 ("Directory.Build.props", """
                     <Project>
                       <Import Project="file-that-does-not-exist.targets" />
                     </Project>
                     """),
                 ("NonBuildingProject.csproj", """
-                    <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.NET.Sdk">
                     </Project>
                     """)
             );

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/FrameworkCompatibilityService.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/FrameworkCompatibilityService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using NuGet.Frameworks;
+using NuGetGallery.Frameworks;
 
 namespace NuGetUpdater.Core.FrameworkChecker;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -3,148 +3,144 @@
 
 using System;
 using System.Collections.Generic;
-
 using NuGet.Frameworks;
-
 using static NuGet.Frameworks.FrameworkConstants;
 using static NuGet.Frameworks.FrameworkConstants.CommonFrameworks;
 
-namespace NuGetUpdater.Core.FrameworkChecker;
-
-/// <summary>
-/// This class contains documented supported frameworks.
-/// </summary>
-/// <remarks>
-/// All these frameworks were retrieved from the following sources:
-/// dotnet documentation: https://docs.microsoft.com/en-us/dotnet/standard/frameworks.
-/// nuget documentation: https://docs.microsoft.com/en-us/nuget/reference/target-frameworks.
-/// nuget client FrameworkConstants.CommonFrameworks: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs.
-/// Deprecated frameworks are not included on the list https://docs.microsoft.com/en-us/dotnet/standard/frameworks#deprecated-target-frameworks.
-/// </remarks>
-public static class SupportedFrameworks
+namespace NuGetGallery.Frameworks
 {
-    public static readonly Version Version8 = new Version(8, 0, 0, 0);
-
-    public static readonly NuGetFramework MonoAndroid = new NuGetFramework(FrameworkIdentifiers.MonoAndroid, EmptyVersion);
-    public static readonly NuGetFramework MonoTouch = new NuGetFramework(FrameworkIdentifiers.MonoTouch, EmptyVersion);
-    public static readonly NuGetFramework MonoMac = new NuGetFramework(FrameworkIdentifiers.MonoMac, EmptyVersion);
-    public static readonly NuGetFramework Net3 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(3, 0, 0, 0));
-    public static readonly NuGetFramework Net48 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 0, 0));
-    public static readonly NuGetFramework Net481 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 1, 0));
-    public static readonly NuGetFramework Net50Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5, "windows", EmptyVersion);
-    public static readonly NuGetFramework Net60Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "android", EmptyVersion);
-    public static readonly NuGetFramework Net60Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "ios", EmptyVersion);
-    public static readonly NuGetFramework Net60MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "macos", EmptyVersion);
-    public static readonly NuGetFramework Net60MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "maccatalyst", EmptyVersion);
-    public static readonly NuGetFramework Net60Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "tizen", EmptyVersion);
-    public static readonly NuGetFramework Net60TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "tvos", EmptyVersion);
-    public static readonly NuGetFramework Net60Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", EmptyVersion);
-    public static readonly NuGetFramework Net70Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "android", EmptyVersion);
-    public static readonly NuGetFramework Net70Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "ios", EmptyVersion);
-    public static readonly NuGetFramework Net70MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "macos", EmptyVersion);
-    public static readonly NuGetFramework Net70MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "maccatalyst", EmptyVersion);
-    public static readonly NuGetFramework Net70Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tizen", EmptyVersion);
-    public static readonly NuGetFramework Net70TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tvos", EmptyVersion);
-    public static readonly NuGetFramework Net70Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", EmptyVersion);
-    public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8);
-    public static readonly NuGetFramework Net80Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "android", EmptyVersion);
-    public static readonly NuGetFramework Net80Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "ios", EmptyVersion);
-    public static readonly NuGetFramework Net80MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "macos", EmptyVersion);
-    public static readonly NuGetFramework Net80MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "maccatalyst", EmptyVersion);
-    public static readonly NuGetFramework Net80Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tizen", EmptyVersion);
-    public static readonly NuGetFramework Net80TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tvos", EmptyVersion);
-    public static readonly NuGetFramework Net80Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", EmptyVersion);
-    public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
-    public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
-    public static readonly NuGetFramework UAP = new NuGetFramework(FrameworkIdentifiers.UAP, EmptyVersion);
-    public static readonly NuGetFramework WP = new NuGetFramework(FrameworkIdentifiers.WindowsPhone, EmptyVersion);
-    public static readonly NuGetFramework XamarinIOs = new NuGetFramework(FrameworkIdentifiers.XamarinIOs, EmptyVersion);
-    public static readonly NuGetFramework XamarinMac = new NuGetFramework(FrameworkIdentifiers.XamarinMac, EmptyVersion);
-    public static readonly NuGetFramework XamarinTvOs = new NuGetFramework(FrameworkIdentifiers.XamarinTVOS, EmptyVersion);
-    public static readonly NuGetFramework XamarinWatchOs = new NuGetFramework(FrameworkIdentifiers.XamarinWatchOS, EmptyVersion);
-
-    public static readonly NuGetFramework Net60Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", Version7);
-    public static readonly NuGetFramework Net70Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", Version7);
-
-    public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
-
-    static SupportedFrameworks()
-    {
-        AllSupportedNuGetFrameworks = new List<NuGetFramework>
-        {
-            MonoAndroid, MonoMac, MonoTouch,
-            Native,
-            Net11, Net2, Net35, Net4, Net403, Net45, Net451, Net452, Net46, Net461, Net462, Net463, Net47, Net471, Net472, Net48, Net481,
-            Net50, Net50Windows,
-            Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows,
-            Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows,
-            Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows,
-            NetCore, NetCore45, NetCore451,
-            NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
-            NetMf,
-            NetStandard, NetStandard10, NetStandard11, NetStandard12, NetStandard13, NetStandard14, NetStandard15, NetStandard16, NetStandard20, NetStandard21,
-            SL4, SL5,
-            Tizen3, Tizen4, Tizen6,
-            UAP, UAP10,
-            WP, WP7, WP75, WP8, WP81, WPA81,
-            XamarinIOs, XamarinMac, XamarinTvOs, XamarinWatchOs
-        };
-    }
-
     /// <summary>
-    /// Lists of TFMs that users can filter packages by (for each Framework Generation) on NuGet.org search
+    /// This class contains documented supported frameworks.
     /// </summary>
-    public static class TfmFilters
+    /// <remarks>
+    /// All these frameworks were retrieved from the following sources:
+    /// dotnet documentation: https://docs.microsoft.com/en-us/dotnet/standard/frameworks.
+    /// nuget documentation: https://docs.microsoft.com/en-us/nuget/reference/target-frameworks.
+    /// nuget client FrameworkConstants.CommonFrameworks: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs.
+    /// Deprecated frameworks are not included on the list https://docs.microsoft.com/en-us/dotnet/standard/frameworks#deprecated-target-frameworks.
+    /// </remarks>
+    public static class SupportedFrameworks
     {
-        public static readonly List<NuGetFramework> NetTfms = new List<NuGetFramework>
-        {
-            Net80,
-            Net70,
-            Net60,
-            Net50
-        };
+        public static readonly Version Version8 = new Version(8, 0, 0, 0); // https://github.com/NuGet/Engineering/issues/5112
 
-        public static readonly List<NuGetFramework> NetCoreAppTfms = new List<NuGetFramework>
-        {
-            NetCoreApp31,
-            NetCoreApp30,
-            NetCoreApp22,
-            NetCoreApp21,
-            NetCoreApp20,
-            NetCoreApp11,
-            NetCoreApp10
-        };
+        public static readonly NuGetFramework MonoAndroid = new NuGetFramework(FrameworkIdentifiers.MonoAndroid, EmptyVersion);
+        public static readonly NuGetFramework MonoTouch = new NuGetFramework(FrameworkIdentifiers.MonoTouch, EmptyVersion);
+        public static readonly NuGetFramework MonoMac = new NuGetFramework(FrameworkIdentifiers.MonoMac, EmptyVersion);
+        public static readonly NuGetFramework Net3 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(3, 0, 0, 0));
+        public static readonly NuGetFramework Net48 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 0, 0));
+        public static readonly NuGetFramework Net481 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 8, 1, 0));
+        public static readonly NuGetFramework Net50Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version5, "windows", EmptyVersion);
+        public static readonly NuGetFramework Net60Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "android", EmptyVersion);
+        public static readonly NuGetFramework Net60Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "ios", EmptyVersion);
+        public static readonly NuGetFramework Net60MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "macos", EmptyVersion);
+        public static readonly NuGetFramework Net60MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "maccatalyst", EmptyVersion);
+        public static readonly NuGetFramework Net60TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "tvos", EmptyVersion);
+        public static readonly NuGetFramework Net60Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", EmptyVersion);
+        public static readonly NuGetFramework Net70Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "android", EmptyVersion);
+        public static readonly NuGetFramework Net70Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "ios", EmptyVersion);
+        public static readonly NuGetFramework Net70MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "macos", EmptyVersion);
+        public static readonly NuGetFramework Net70MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "maccatalyst", EmptyVersion);
+        public static readonly NuGetFramework Net70TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tvos", EmptyVersion);
+        public static readonly NuGetFramework Net70Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", EmptyVersion);
+        public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8); // https://github.com/NuGet/Engineering/issues/5112
+        public static readonly NuGetFramework Net80Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "android", EmptyVersion);
+        public static readonly NuGetFramework Net80Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "ios", EmptyVersion);
+        public static readonly NuGetFramework Net80MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "macos", EmptyVersion);
+        public static readonly NuGetFramework Net80MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "maccatalyst", EmptyVersion);
+        public static readonly NuGetFramework Net80TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tvos", EmptyVersion);
+        public static readonly NuGetFramework Net80Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", EmptyVersion);
+        public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
+        public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
+        public static readonly NuGetFramework UAP = new NuGetFramework(FrameworkIdentifiers.UAP, EmptyVersion);
+        public static readonly NuGetFramework WP = new NuGetFramework(FrameworkIdentifiers.WindowsPhone, EmptyVersion);
+        public static readonly NuGetFramework XamarinIOs = new NuGetFramework(FrameworkIdentifiers.XamarinIOs, EmptyVersion);
+        public static readonly NuGetFramework XamarinMac = new NuGetFramework(FrameworkIdentifiers.XamarinMac, EmptyVersion);
+        public static readonly NuGetFramework XamarinTvOs = new NuGetFramework(FrameworkIdentifiers.XamarinTVOS, EmptyVersion);
+        public static readonly NuGetFramework XamarinWatchOs = new NuGetFramework(FrameworkIdentifiers.XamarinWatchOS, EmptyVersion);
 
-        public static readonly List<NuGetFramework> NetStandardTfms = new List<NuGetFramework>
-        {
-            NetStandard21,
-            NetStandard20,
-            NetStandard16,
-            NetStandard15,
-            NetStandard14,
-            NetStandard13,
-            NetStandard12,
-            NetStandard11,
-            NetStandard10
-        };
+        public static readonly NuGetFramework Net60Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", Version7);
+        public static readonly NuGetFramework Net70Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", Version7);
 
-        public static readonly List<NuGetFramework> NetFrameworkTfms = new List<NuGetFramework>
+        public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
+
+        static SupportedFrameworks()
         {
-            Net481,
-            Net48,
-            Net472,
-            Net471,
-            Net47,
-            Net462,
-            Net461,
-            Net46,
-            Net452,
-            Net451,
-            Net45,
-            Net4,
-            Net35,
-            Net3,
-            Net2
-        };
+            AllSupportedNuGetFrameworks = new List<NuGetFramework>
+            {
+                MonoAndroid, MonoMac, MonoTouch,
+                Native,
+                Net11, Net2, Net35, Net4, Net403, Net45, Net451, Net452, Net46, Net461, Net462, Net463, Net47, Net471, Net472, Net48, Net481,
+                Net50, Net50Windows,
+                Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows,
+                Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows,
+                Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows,
+                NetCore, NetCore45, NetCore451,
+                NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
+                NetMf,
+                NetStandard, NetStandard10, NetStandard11, NetStandard12, NetStandard13, NetStandard14, NetStandard15, NetStandard16, NetStandard20, NetStandard21,
+                SL4, SL5,
+                Tizen3, Tizen4, Tizen6,
+                UAP, UAP10,
+                WP, WP7, WP75, WP8, WP81, WPA81,
+                XamarinIOs, XamarinMac, XamarinTvOs, XamarinWatchOs
+            };
+        }
+
+        /// <summary>
+        /// Lists of TFMs that users can filter packages by (for each Framework Generation) on NuGet.org search
+        /// </summary>
+        public static class TfmFilters
+        {
+            public static readonly List<NuGetFramework> NetTfms = new List<NuGetFramework>
+            {
+                Net80,
+                Net70,
+                Net60,
+                Net50
+            };
+
+            public static readonly List<NuGetFramework> NetCoreAppTfms = new List<NuGetFramework>
+            {
+                NetCoreApp31,
+                NetCoreApp30,
+                NetCoreApp22,
+                NetCoreApp21,
+                NetCoreApp20,
+                NetCoreApp11,
+                NetCoreApp10
+            };
+
+            public static readonly List<NuGetFramework> NetStandardTfms = new List<NuGetFramework>
+            {
+                NetStandard21,
+                NetStandard20,
+                NetStandard16,
+                NetStandard15,
+                NetStandard14,
+                NetStandard13,
+                NetStandard12,
+                NetStandard11,
+                NetStandard10
+            };
+
+            public static readonly List<NuGetFramework> NetFrameworkTfms = new List<NuGetFramework>
+            {
+                Net481,
+                Net48,
+                Net472,
+                Net471,
+                Net47,
+                Net462,
+                Net461,
+                Net46,
+                Net452,
+                Net451,
+                Net45,
+                Net4,
+                Net35,
+                Net3,
+                Net2
+            };
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <GeneratePathProperty>true</GeneratePathProperty>


### PR DESCRIPTION
Update the NuGet updater to `net8.0` and also allow updating projects with that `TargetFramework`.  Some project content refactoring was done to make future upgrades easier via `$(CommonTargetFramework)`.

I also did some cleanup by forcing each project's `bin/` and `obj/` directory into `artifacts/` at the root of the C# helpers.  This is to make local development easier because I commonly build/rebuild on Windows and WSL and that can cause conflicting changes in the intermediate directories and I didn't like manually clearing them out one project at a time so I put everything under one place to make deletion easier.  This is also inline with what the github.com/dotnet org does with all of their repos.

## **There is a caveat with redirecting to the `artifacts/` directory.**

If a user has previously built the C# NuGet updater tool and then update their sources and do a re-build, there will be multiple build failures because their machine will still contain the old `bin/` and `obj/` directories in each project.  The fix is to do a one-time clean and they'll be good to go again.  This issue will not affect new clones or CI.
 
Fixes #8530 and #8505.