### PR TITLE
report and search `*.proj` files as dependencies

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -70,6 +70,7 @@ module Dependabot
             project_files += vbproj_file
             project_files += fsproj_file
             project_files += sln_project_files
+            project_files += proj_files
             project_files += project_files.filter_map { |f| directory_packages_props_file_from_project_file(f) }
             project_files
           end
@@ -183,6 +184,10 @@ module Dependabot
 
       def fsproj_file
         @fsproj_file ||= find_and_fetch_with_suffix(".fsproj")
+      end
+
+      def proj_files
+        @proj_files ||= find_and_fetch_with_suffix(".proj")
       end
 
       def directory_packages_props_file_from_project_file(project_file)

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -330,6 +330,33 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
     # end
   end
 
+  context "with a dirs.proj" do
+    before do
+      GitHubHelpers.stub_requests_for_directory(
+        ->(a, b) { stub_request(a, b) },
+        File.join(__dir__, "..", "..", "fixtures", "github", "with_dirs.proj_as_entry"),
+        "",
+        url,
+        "token token",
+        "org",
+        "repo",
+        "main"
+      )
+    end
+
+    it "fetches the projects through many `dirs.proj`" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to match_array(
+          %w(
+            dirs.proj
+            solutions/dirs.proj
+            src/LibraryA/LibraryA.csproj
+            src/LibraryB/LibraryB.csproj
+          )
+        )
+    end
+  end
+
   context "from a sub-directory with Directory.Build.props further up the tree" do
     let(:directory) { "/src" }
 

--- a/nuget/spec/fixtures/github/with_dirs.proj_as_entry/dirs.proj
+++ b/nuget/spec/fixtures/github/with_dirs.proj_as_entry/dirs.proj
@@ -1,0 +1,5 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectFile Include="solutions\dirs.proj" />
+  </ItemGroup>
+</Project>

--- a/nuget/spec/fixtures/github/with_dirs.proj_as_entry/solutions/dirs.proj
+++ b/nuget/spec/fixtures/github/with_dirs.proj_as_entry/solutions/dirs.proj
@@ -1,0 +1,6 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectFile Include="..\src\LibraryA\LibraryA.csproj" />
+    <ProjectFile Include="..\src\LibraryB\LibraryB.csproj" />
+  </ItemGroup>
+</Project>

--- a/nuget/spec/fixtures/github/with_dirs.proj_as_entry/src/LibraryA/LibraryA.csproj
+++ b/nuget/spec/fixtures/github/with_dirs.proj_as_entry/src/LibraryA/LibraryA.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/nuget/spec/fixtures/github/with_dirs.proj_as_entry/src/LibraryB/LibraryB.csproj
+++ b/nuget/spec/fixtures/github/with_dirs.proj_as_entry/src/LibraryB/LibraryB.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>


### PR DESCRIPTION
During all of the NuGet refactoring I must have dropped the search of `*.proj` files (commonly `dirs.proj`).  This simply re-adds them to the initial search; the rest of the code works as expected.