### PR TITLE
Fix missing version in commit message for dependency group with 1 update

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -492,7 +492,7 @@ module Dependabot
       end
 
       def metadata_links
-        return metadata_links_for_dep(dependencies.first) if dependencies.count == 1
+        return metadata_links_for_dep(dependencies.first) if dependencies.count == 1 && dependency_group.nil?
 
         dependencies.map do |dep|
           if dep.removed?

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1956,15 +1956,32 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })
         end
 
-        it "has the correct message" do
+        let(:commit_message) { builder.commit_message }
+
+        it "has the correct PR message" do
           expect(pr_message).to start_with(
             "Bumps the all-the-things group with 1 update: " \
             "[business](https://github.com/gocardless/business)."
           )
         end
 
-        it "includes the version from -> to" do
+        it "includes the version from -> to in the PR message" do
           expect(pr_message).to include(
+            "from 1.4.0 to 1.5.0"
+          )
+        end
+
+        it "has the correct commit message" do
+          expect(commit_message).to start_with(
+            "Bump the all-the-things group with 1 update\n\n" \
+            "Bumps the all-the-things group with 1 update: " \
+            "[business](https://github.com/gocardless/business).\n\n\n" \
+            "Updates `business` from 1.4.0 to 1.5.0"
+          )
+        end
+
+        it "includes the version from -> to in the commit message" do
+          expect(commit_message).to include(
             "from 1.4.0 to 1.5.0"
           )
         end
@@ -2021,11 +2038,29 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
           end
 
-          it "has the correct message" do
+          it "has the correct PR message" do
             expect(pr_message).to start_with(
               "Bumps the all-the-things group with 2 updates: " \
               "[business](https://github.com/gocardless/business) and " \
               "[business2](https://github.com/gocardless/business2)."
+            )
+          end
+
+          it "has the correct commit message" do
+            expect(commit_message).to start_with(
+              "Bump the all-the-things group with 2 updates\n\n" \
+              "Bumps the all-the-things group with 2 updates: " \
+              "[business](https://github.com/gocardless/business) and " \
+              "[business2](https://github.com/gocardless/business2)."
+            )
+          end
+
+          it "includes the versions from -> to in the commit message" do
+            expect(commit_message).to include(
+              "Updates `business` from 1.4.0 to 1.5.0"
+            )
+            expect(commit_message).to include(
+              "Updates `business2` from 1.7.0 to 1.8.0"
             )
           end
         end


### PR DESCRIPTION
Fix version information missing from the commit message when a dependency group only updates one dependency.

Relates to #8217.

For example:

#### Update to 1 dependency in a group:

https://github.com/martincostello/project-euler/pull/317/commits/62bf0f9046a782d0233aed41e9fe466aa6751f95

```text
Bump the xunit group with 1 update
Bumps the xunit group with 1 update: [xunit](https://github.com/xunit/xunit).

- [Commits](https://github.com/xunit/xunit/compare/2.6.2...2.6.3)

---
updated-dependencies:
- dependency-name: xunit
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: xunit
...

Signed-off-by: dependabot[bot] <support@github.com>
```

#### Update to 2 dependencies in a group:

https://github.com/martincostello/project-euler/pull/315/commits/741ea1e80fb1bd5c9ab6dbf24001860ccc62efaf

```text
Bump the xunit group with 2 updates
Bumps the xunit group with 2 updates: [xunit](https://github.com/xunit/xunit) and [xunit.runner.visualstudio](https://github.com/xunit/visualstudio.xunit).


Updates `xunit` from 2.6.2 to 2.6.3
- [Commits](https://github.com/xunit/xunit/compare/2.6.2...2.6.3)

Updates `xunit.runner.visualstudio` from 2.5.4 to 2.5.5
- [Release notes](https://github.com/xunit/visualstudio.xunit/releases)
- [Commits](https://github.com/xunit/visualstudio.xunit/compare/2.5.4...2.5.5)

---
updated-dependencies:
- dependency-name: xunit
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: xunit
- dependency-name: xunit.runner.visualstudio
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: xunit
...

Signed-off-by: dependabot[bot] <support@github.com>
```