### PR TITLE
Fix: Typo

### DIFF
--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -120,7 +120,7 @@ module Dependabot
 
           # Prevent updates that don't end up fixing any security advisories,
           # blocking any updates where dependabot-core updates to a vulnerable
-          # version. This happens for npm/yarn subdendencies where Dependabot has no
+          # version. This happens for npm/yarn sub-dependencies where Dependabot has no
           # control over the target version. Related issue:
           #   https://github.com/github/dependabot-api/issues/905
           return record_security_update_not_possible_error(checker) if updated_deps.none? { |d| job.security_fix?(d) }


### PR DESCRIPTION
This pull request

- [x] fixes a typo

💁‍♂️ Note that the spelling in current `main` is somewhat inconsistent.

Running

```shell
git grep -i sub-dependencies | wc -l
```

yields

```console
      227
```

and running

```shell
git grep -i subdependencies | wc -l
```

yields

```console
      82
```

and running

```shell
git grep -i subdendencies | wc -l
```

yields

```console
       1
```

