### PR TITLE
Fix: Typo

### DIFF
--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -605,7 +605,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
             its([:requirement]) { is_expected.to eq("~2.5.1") }
           end
 
-          context "with a v prefix" do
+          context "with a v-prefix" do
             let(:composer_json_req_string) { "~v2.5.1" }
             its([:requirement]) { is_expected.to eq("~v2.5.1") }
           end

--- a/go_modules/spec/dependabot/go_modules/requirement_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/requirement_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Dependabot::GoModules::Requirement do
       let(:requirement_string) { "1.1.0" }
       it { is_expected.to eq(described_class.new(">= 1.1.0", "< 2.0.0.a")) }
 
-      context "and a v prefix" do
+      context "and a v-prefix" do
         let(:requirement_string) { "v1.1.0" }
         it { is_expected.to eq(described_class.new(">= 1.1.0", "< 2.0.0.a")) }
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
         let(:version) { Gem::Version.new("1.0.0") }
         it { is_expected.to eq(true) }
 
-        context "when the requirement includes a v prefix" do
+        context "when the requirement includes a v-prefix" do
           let(:requirement_string) { ">=v1.0.0" }
           it { is_expected.to eq(true) }
         end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
-    context "with a private module with v prefix" do
+    context "with a private module with v-prefix" do
       let(:project_name) { "private_module_with_v_prefix" }
 
       let(:dependencies) do
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         ]
       end
 
-      it "updates the private module version and drops the v prefix" do
+      it "updates the private module version and drops the v-prefix" do
         updated_file = subject.find { |file| file.name == "main.tf" }
 
         expect(updated_file.content).to include(<<~HCL)
@@ -462,7 +462,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         end
       end
 
-      context "with a legacy registry dependency with v prefix" do
+      context "with a legacy registry dependency with v-prefix" do
         let(:project_name) { "registry_with_v_prefix" }
         let(:dependencies) do
           [
@@ -495,7 +495,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
           ]
         end
 
-        it "updates the requirement and drops the v prefix" do
+        it "updates the requirement and drops the v-prefix" do
           updated_file = subject.find { |file| file.name == "main.tf" }
 
           expect(updated_file.content).to include(
@@ -555,7 +555,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
-    context "with an hcl2-based registry dependency with a v prefix" do
+    context "with an hcl2-based registry dependency with a v-prefix" do
       let(:project_name) { "registry_012_with_v_prefix" }
       let(:dependencies) do
         [
@@ -588,7 +588,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         ]
       end
 
-      it "updates the requirement and drops the v prefix" do
+      it "updates the requirement and drops the v-prefix" do
         updated_file = subject.find { |file| file.name == "main.tf" }
 
         expect(updated_file.content).to include(
@@ -1176,7 +1176,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
-    describe "for a nested module with a v prefix" do
+    describe "for a nested module with a v-prefix" do
       let(:project_name) { "nested_modules_with_v_prefix" }
       let(:dependencies) do
         [
@@ -1209,7 +1209,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         ]
       end
 
-      it "updates the requirement and drops the v prefix" do
+      it "updates the requirement and drops the v-prefix" do
         updated_file = subject.find { |file| file.name == "main.tf" }
 
         expect(updated_file.content).to include(
@@ -1316,7 +1316,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
-    describe "when updating a module with a v prefix in a project with a provider lockfile" do
+    describe "when updating a module with a v-prefix in a project with a provider lockfile" do
       let(:project_name) { "lockfile_with_modules_with_v_prefix" }
       let(:dependencies) do
         [
@@ -1349,7 +1349,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         ]
       end
 
-      it "updates the module version and drops the v prefix" do
+      it "updates the module version and drops the v-prefix" do
         module_file = subject.find { |file| file.name == "caf_module.tf" }
 
         expect(module_file.content).to include(


### PR DESCRIPTION
This pull request

- [x] fixes a typo

💁‍♂️ Spotted while investigating #8083.

Running

```shell
git grep -i 'v-prefix' | wc -l
```

on current `main` yields

```console
      13
```

and running

```shell
git grep -i 'v prefix' | wc -l
```

on current `main` yields

```console
      13
```

as well.
