### PR TITLE
Terraform supports having an optional prefix of 'v' for version

### DIFF
--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -22,7 +22,7 @@ module Dependabot
         # See terraform specs: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions
         @version_string = @version_string.gsub(/^v/, "")
 
-        super(@version_string)
+        super
       end
 
       sig { override.params(version: VersionParameter).returns(Dependabot::Terraform::Version) }

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -22,7 +22,7 @@ module Dependabot
         # See terraform specs: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions
         @version_string = @version_string.gsub(/^v/, "")
 
-        super
+        super(@version_string)
       end
 
       sig { override.params(version: VersionParameter).returns(Dependabot::Terraform::Version) }

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,7 +19,9 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
-        super
+        @version_string = @version_string.gsub(/^v/, '')
+
+        super(@version_string)
       end
 
       sig { override.params(version: VersionParameter).returns(Dependabot::Terraform::Version) }

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,7 +19,7 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
-       # See terraform specs: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions
+        # See terraform specs: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions
         @version_string = @version_string.gsub(/^v/, "")
 
         super(@version_string)

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,6 +19,7 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
+       # See terraform specs: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions
         @version_string = @version_string.gsub(/^v/, "")
 
         super(@version_string)

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,7 +19,7 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
-        @version_string = @version_string.gsub(/^v/, '')
+        @version_string = @version_string.gsub(/^v/, "")
 
         super(@version_string)
       end

--- a/terraform/spec/dependabot/terraform/version_spec.rb
+++ b/terraform/spec/dependabot/terraform/version_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::Terraform::Version do
 
       it { is_expected.to eq "1.0.0" }
     end
-    
+ 
     context "allow optional v on release" do
       let(:version_string) { "v1.0.0" }
       it { is_expected.to eq "1.0.0" }

--- a/terraform/spec/dependabot/terraform/version_spec.rb
+++ b/terraform/spec/dependabot/terraform/version_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::Terraform::Version do
 
       it { is_expected.to eq "1.0.0" }
     end
- 
+
     context "allow optional v on release" do
       let(:version_string) { "v1.0.0" }
       it { is_expected.to eq "1.0.0" }

--- a/terraform/spec/dependabot/terraform/version_spec.rb
+++ b/terraform/spec/dependabot/terraform/version_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Dependabot::Terraform::Version do
 
       it { is_expected.to eq "1.0.0" }
     end
+    
+    context "allow optional v on release" do
+      let(:version_string) { "v1.0.0" }
+      it { is_expected.to eq "1.0.0" }
+    end
 
     context "with a normal prerelease" do
       let(:version_string) { "1.0.0.pre1" }


### PR DESCRIPTION
Example of this would be v1.0.0 and this is also equal to 1.0.0.  The RubyGems Version Class will throw an exception when given a string of "v1.0.0" stating that the version is malformed.  This PR extends terraform/lib/dependabot/terraform/version.rb to allow a versions with a string containing "v" and removing it via regex if present.  Terraform Docs can be found here for versioning: https://developer.hashicorp.com/terraform/registry/modules/publish#releasing-new-versions.