### PR TITLE
Fix docker attempting to append digest for helm

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -182,7 +182,7 @@ module Dependabot
 
         image = "#{repo}:#{tag}"
         image.prepend("#{registry}/") if registry
-        image.append("@sha256:#{digest}/") if digest
+        image << "@sha256:#{digest}/" if digest
         [image]
       end
     end


### PR DESCRIPTION
When attempting to append a digest for helm charts, the docker updater is failing because the `.append` method does not exist.  This corrects that behavior to use the proper append syntax.