### PR TITLE
Handle Version Elements in Update

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/.gitignore
+++ b/nuget/helpers/lib/NuGetUpdater/.gitignore
@@ -2,3 +2,4 @@
 artifacts/
 bin/
 obj/
+Properties/launchSettings.json

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -187,6 +187,29 @@ public class MSBuildHelperTests
             }
         };
 
+        // version is a child-node of the package reference
+        yield return new object[]
+        {
+            // build file contents
+            new[]
+            {
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json">
+                            <Version>12.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            },
+            // expected dependencies
+            new Dependency[]
+            {
+                new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+            }
+        };
+
         // version is in property in same file
         yield return new object[]
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
@@ -9,7 +9,7 @@ namespace NuGetUpdater.Core.Test.Utilities
     public class SdkPackageUpdaterHelperTests
     {
         [Fact]
-        public async void DirectoryBuildFilesAreOnlyPulledInFromParentDirectories()
+        public async Task DirectoryBuildFilesAreOnlyPulledInFromParentDirectories()
         {
             using var temporaryDirectory = TemporaryDirectory.CreateWithContents(
                 ("src/SomeProject.csproj", """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class SdkPackageUpdaterTests
+{
+    [Theory]
+    [MemberData(nameof(GetDependencyUpdates))]
+    public async Task UpdateDependency_UpdatesDependencies((string Path, string Contents)[] startingContents, (string Path, string Contents)[] expectedContents,
+        string dependencyName, string previousVersion, string newDependencyVersion, bool isTransitive)
+    {
+        // Arrange
+        using var directory = TemporaryDirectory.CreateWithContents(startingContents);
+        var projectPath = Path.Combine(directory.DirectoryPath, startingContents.First().Path);
+        var logger = new Logger(verbose: false);
+        // Act
+        await SdkPackageUpdater.UpdateDependencyAsync(directory.DirectoryPath, projectPath, dependencyName, previousVersion, newDependencyVersion, isTransitive, logger);
+
+        // Assert
+        AssertContentsEqual(expectedContents, directory);
+    }
+
+    public static IEnumerable<object[]> GetDependencyUpdates()
+    {
+        // Simple case
+        yield return new object[]
+        {
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // starting contents
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // expected contents
+            "Newtonsoft.Json", "12.0.1", "13.0.1", false // isTransitive
+        };
+
+        // Multiple references
+        yield return new object[]
+        {
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+                        <PackageReference Include="Newtonsoft.Json">
+                            <Version>12.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // starting contents
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                        <PackageReference Include="Newtonsoft.Json">
+                            <Version>13.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // expected contents
+            "Newtonsoft.Json", "12.0.1", "13.0.1", false // isTransitive
+        };
+
+        // PackageReference with Version as child element
+        yield return new object[]
+        {
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json">
+                            <Version>12.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // starting contents
+            new []
+            {
+                (Path: "src/Project.csproj", Content: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json">
+                            <Version>13.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            }, // expected contents
+            "Newtonsoft.Json", "12.0.1", "13.0.1", false // isTransitive
+        };
+    }
+
+    private static void AssertContentsEqual((string Path, string Contents)[] expectedContents, TemporaryDirectory directory)
+    {
+        var actualFiles = Directory.GetFiles(directory.DirectoryPath, "*", SearchOption.AllDirectories);
+        Assert.Equal(expectedContents.Length, actualFiles.Length);
+        foreach (var (path, contents) in expectedContents)
+        {
+            var fullPath = Path.Combine(directory.DirectoryPath, path);
+            Assert.True(File.Exists(fullPath));
+            Assert.Equal(contents, File.ReadAllText(fullPath));
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -254,8 +254,8 @@ internal static partial class SdkPackageUpdater
 
         foreach (var buildFile in buildFiles)
         {
-            var updateAttributes = new List<XmlAttributeSyntax>();
-            var packageNodes = FindPackageNode(buildFile, dependencyName);
+            var updateNodes = new List<XmlNodeSyntax>();
+            var packageNodes = FindPackageNodes(buildFile, dependencyName);
 
             var previousPackageVersion = previousDependencyVersion;
 
@@ -263,53 +263,124 @@ internal static partial class SdkPackageUpdater
             {
                 var versionAttribute = packageNode.GetAttribute("Version", StringComparison.OrdinalIgnoreCase)
                     ?? packageNode.GetAttribute("VersionOverride", StringComparison.OrdinalIgnoreCase);
-                if (versionAttribute is null)
+                var versionElement = packageNode.Elements.FirstOrDefault(e => e.Name.Equals("Version", StringComparison.OrdinalIgnoreCase))
+                    ?? packageNode.Elements.FirstOrDefault(e => e.Name.Equals("VersionOverride", StringComparison.OrdinalIgnoreCase));
+                if (versionAttribute is not null)
                 {
-                    continue;
-                }
-
-                // Is this the case where version is specified with property substitution?
-                if (versionAttribute.Value.StartsWith("$(") && versionAttribute.Value.EndsWith(")"))
-                {
-                    propertyNames.Add(versionAttribute.Value.Substring(2, versionAttribute.Value.Length - 3));
-                }
-                // Is this the case that the version is specified directly in the package node?
-                else
-                {
-                    var currentVersion = versionAttribute.Value.TrimStart('[', '(').TrimEnd(']', ')');
-                    if (currentVersion.Contains(',') || currentVersion.Contains('*'))
+                    // Is this the case where version is specified with property substitution?
+                    if (versionAttribute.Value.StartsWith("$(") && versionAttribute.Value.EndsWith(")"))
                     {
-                        logger.Log($"    Found unsupported [{packageNode.Name}] version attribute value [{versionAttribute.Value}] in [{buildFile.RepoRelativePath}].");
-                        foundUnsupported = true;
+                        propertyNames.Add(versionAttribute.Value.Substring(2, versionAttribute.Value.Length - 3));
                     }
-                    else if (currentVersion == previousDependencyVersion)
+                    // Is this the case that the version is specified directly in the package node?
+                    else
                     {
-                        logger.Log($"    Found incorrect [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
-                        updateAttributes.Add(versionAttribute);
-                    }
-                    else if (previousDependencyVersion == null && NuGetVersion.TryParse(currentVersion, out var previousVersion))
-                    {
-                        var newVersion = NuGetVersion.Parse(newDependencyVersion);
-                        if (previousVersion < newVersion)
+                        var currentVersion = versionAttribute.Value.TrimStart('[', '(').TrimEnd(']', ')');
+                        if (currentVersion.Contains(',') || currentVersion.Contains('*'))
                         {
-                            previousPackageVersion = currentVersion;
+                            logger.Log($"    Found unsupported [{packageNode.Name}] version attribute value [{versionAttribute.Value}] in [{buildFile.RepoRelativePath}].");
+                            foundUnsupported = true;
+                        }
+                        else if (currentVersion == previousDependencyVersion)
+                        {
+                            logger.Log($"    Found incorrect [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
+                            updateNodes.Add(versionAttribute);
+                        }
+                        else if (previousDependencyVersion == null && NuGetVersion.TryParse(currentVersion, out var previousVersion))
+                        {
+                            var newVersion = NuGetVersion.Parse(newDependencyVersion);
+                            if (previousVersion < newVersion)
+                            {
+                                previousPackageVersion = currentVersion;
 
-                            logger.Log($"    Found incorrect peer [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
-                            updateAttributes.Add(versionAttribute);
+                                logger.Log($"    Found incorrect peer [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
+                                updateNodes.Add(versionAttribute);
+                            }
+                        }
+                        else if (currentVersion == newDependencyVersion)
+                        {
+                            logger.Log($"    Found correct [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
+                            foundCorrect = true;
                         }
                     }
-                    else if (currentVersion == newDependencyVersion)
+                }
+                else if (versionElement is not null)
+                {
+                    var versionValue = versionElement.GetContentValue();
+                    if (versionValue.StartsWith("$(") && versionValue.EndsWith(")"))
                     {
-                        logger.Log($"    Found correct [{packageNode.Name}] version attribute in [{buildFile.RepoRelativePath}].");
-                        foundCorrect = true;
+                        propertyNames.Add(versionValue.Substring(2, versionValue.Length - 3));
                     }
+                    else
+                    {
+                        var currentVersion = versionValue.TrimStart('[', '(').TrimEnd(']', ')');
+                        if (currentVersion.Contains(',') || currentVersion.Contains('*'))
+                        {
+                            logger.Log($"    Found unsupported [{packageNode.Name}] version node value [{versionValue}] in [{buildFile.RepoRelativePath}].");
+                            foundUnsupported = true;
+                        }
+                        else if (currentVersion == previousDependencyVersion)
+                        {
+                            logger.Log($"    Found incorrect [{packageNode.Name}] version node in [{buildFile.RepoRelativePath}].");
+                            if (versionElement is XmlElementSyntax elementSyntax)
+                            {
+                                updateNodes.Add(elementSyntax);
+                            }
+                            else
+                            {
+                                throw new InvalidDataException("A concrete type was required for updateNodes. This should not happen.");
+                            }
+                        }
+                        else if (previousDependencyVersion == null && NuGetVersion.TryParse(currentVersion, out var previousVersion))
+                        {
+                            var newVersion = NuGetVersion.Parse(newDependencyVersion);
+                            if (previousVersion < newVersion)
+                            {
+                                previousPackageVersion = currentVersion;
+
+                                logger.Log($"    Found incorrect peer [{packageNode.Name}] version node in [{buildFile.RepoRelativePath}].");
+                                if (versionElement is XmlElementSyntax elementSyntax)
+                                {
+                                    updateNodes.Add(elementSyntax);
+                                }
+                                else
+                                {
+                                    throw new InvalidDataException("A concrete type was required for updateNodes. This should not happen.");
+                                }
+                            }
+                        }
+                        else if (currentVersion == newDependencyVersion)
+                        {
+                            logger.Log($"    Found correct [{packageNode.Name}] version node in [{buildFile.RepoRelativePath}].");
+                            foundCorrect = true;
+                        }
+                    }
+                }
+                else
+                {
+                    // We weren't able to find the version node. Central package management?
+                    continue;
                 }
             }
 
-            if (updateAttributes.Count > 0)
+            if (updateNodes.Count > 0)
             {
                 var updatedXml = buildFile.Contents
-                    .ReplaceNodes(updateAttributes, (o, n) => n.WithValue(o.Value.Replace(previousPackageVersion!, newDependencyVersion)));
+                    .ReplaceNodes(updateNodes, (o, n) =>
+                    {
+                        if (n is XmlAttributeSyntax attributeSyntax)
+                        {
+                            return attributeSyntax.WithValue(attributeSyntax.Value.Replace(previousPackageVersion!, newDependencyVersion));
+                        }
+                        else if (n is XmlElementSyntax elementsSyntax)
+                        {
+                            return WithConcreateContent(elementsSyntax, elementsSyntax.GetContentValue().Replace(previousPackageVersion!, newDependencyVersion));
+                        }
+                        else
+                        {
+                            throw new InvalidDataException($"Unsupported SyntaxType {n.GetType().Name} marked for update");
+                        }
+                    });
                 buildFile.Update(updatedXml);
                 updateWasPerformed = true;
             }
@@ -398,12 +469,18 @@ internal static partial class SdkPackageUpdater
                 : foundUnsupported
                     ? UpdateResult.NotSupported
                     : UpdateResult.NotFound;
+
+        static XmlElementSyntax WithConcreateContent(XmlElementSyntax element, string content)
+        {
+            var textSyntax = SyntaxFactory.XmlText(SyntaxFactory.Token(null, SyntaxKind.XmlTextLiteralToken, null, content));
+            return element.WithContent(SyntaxFactory.SingletonList(textSyntax));
+        }
     }
 
-    private static IEnumerable<IXmlElementSyntax> FindPackageNode(ProjectBuildFile buildFile, string packageName)
+    private static IEnumerable<IXmlElementSyntax> FindPackageNodes(ProjectBuildFile buildFile, string packageName)
     {
         return buildFile.PackageItemNodes.Where(e =>
-            string.Equals(e.GetAttributeValueCaseInsensitive("Include") ?? e.GetAttributeValueCaseInsensitive("Update"), packageName, StringComparison.OrdinalIgnoreCase) &&
-            (e.GetAttributeCaseInsensitive("Version") ?? e.GetAttributeCaseInsensitive("VersionOverride")) is not null);
+            string.Equals(e.GetAttributeOrSubElementValue("Include", StringComparison.OrdinalIgnoreCase) ?? e.GetAttributeOrSubElementValue("Update", StringComparison.OrdinalIgnoreCase), packageName, StringComparison.OrdinalIgnoreCase) &&
+            (e.GetAttributeOrSubElementValue("Version", StringComparison.OrdinalIgnoreCase) ?? e.GetAttributeOrSubElementValue("VersionOverride", StringComparison.OrdinalIgnoreCase)) is not null);
     }
 }


### PR DESCRIPTION
This enables the NuGetUpdater to handle "old-style" csproj files where the Version is a child of the PackageReference instead of just attributes.

Recommend reviewing with `&w=1` in the URL to disable whitespace diff.