### PR TITLE
support Composer artifact repositories

### DIFF
--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -72,7 +72,12 @@ module Dependabot
                           .map { |file| File.join(url, file.name) }
 
               zip_files.map do |zip_file|
-                fetch_file_with_root_fallback(zip_file)
+                DependencyFile.new(
+                  name: zip_file,
+                  content: _fetch_file_content(zip_file),
+                  directory: directory,
+                  type: "file"
+                )
               end
             end
           end.flatten
@@ -82,7 +87,7 @@ module Dependabot
           DependencyFile.new(
             name: File.join(url, ".gitkeep"),
             content: "",
-            directory: Pathname.new(File.join(directory, url)).cleanpath.to_path,
+            directory: directory,
             type: "file"
           )
         end

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -64,21 +64,19 @@ module Dependabot
       def artifact_dependencies
         return @artifact_dependencies if defined?(@artifact_dependencies)
 
+        # Find zip files in the artifact sources and download them.
         @artifact_dependencies =
-          begin
-            artifact_sources.map do |url|
-              zip_files = repo_contents(dir: url)
-                          .select { |file| file.type == "file" && file.name.end_with?(".zip") }
-                          .map { |file| File.join(url, file.name) }
-
-              zip_files.map do |zip_file|
-                DependencyFile.new(
-                  name: zip_file,
-                  content: _fetch_file_content(zip_file),
-                  directory: directory,
-                  type: "file"
-                )
-              end
+          artifact_sources.map do |url|
+            repo_contents(dir: url)
+              .select { |file| file.type == "file" && file.name.end_with?(".zip") }
+              .map { |file| File.join(url, file.name) }
+              .map do |zip_file|
+              DependencyFile.new(
+                name: zip_file,
+                content: _fetch_file_content(zip_file),
+                directory: directory,
+                type: "file"
+              )
             end
           end.flatten
 

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -242,6 +242,12 @@ module Dependabot
         end
 
         def write_temporary_dependency_files
+          artifact_dependencies.each do |file|
+            path = file.name
+            FileUtils.mkdir_p(Pathname.new(path).dirname)
+            File.write(file.name, file.content)
+          end
+
           path_dependencies.each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
@@ -507,6 +513,11 @@ module Dependabot
 
         def auth_json
           @auth_json ||= dependency_files.find { |f| f.name == "auth.json" }
+        end
+
+        def artifact_dependencies
+          @artifact_dependencies ||=
+            dependency_files.select { |f| f.name.end_with?(".zip", ".gitkeep") }
         end
 
         def path_dependencies

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -91,8 +91,16 @@ module Dependabot
         def write_temporary_dependency_files(unlock_requirement: true)
           write_dependency_file(unlock_requirement: unlock_requirement)
           write_path_dependency_files
+          write_zipped_path_dependency_files
           write_lockfile
           write_auth_file
+        end
+
+        def write_zipped_path_dependency_files
+          zipped_path_dependency_files.each do |file|
+            FileUtils.mkdir_p(Pathname.new(file.name).dirname)
+            File.write(file.name, file.content)
+          end
         end
 
         def write_dependency_file(unlock_requirement:)
@@ -469,6 +477,11 @@ module Dependabot
         def path_dependency_files
           @path_dependency_files ||=
             dependency_files.select { |f| f.name.end_with?("/composer.json") }
+        end
+
+        def zipped_path_dependency_files
+          @zip_path_dependency_files ||=
+            dependency_files.select { |f| f.name.end_with?(".zip") || f.name.end_with?(".gitkeep") }
         end
 
         def lockfile

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -480,8 +480,8 @@ module Dependabot
         end
 
         def zipped_path_dependency_files
-          @zip_path_dependency_files ||=
-            dependency_files.select { |f| f.name.end_with?(".zip") || f.name.end_with?(".gitkeep") }
+          @zipped_path_dependency_files ||=
+            dependency_files.select { |f| f.name.end_with?(".zip", ".gitkeep") }
         end
 
         def lockfile

--- a/composer/spec/fixtures/github/artifact_directory_listing.json
+++ b/composer/spec/fixtures/github/artifact_directory_listing.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "dependency.zip",
+    "path": "artifact/dependency.zip",
+    "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+    "size": 11,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/artifact/dependency.zip?ref=5c7b3419e0056515122b981f1566ebe22c208251",
+    "html_url": "https://github.com/gocardless/bump/blob/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/2c3d0fefcb583cdaef2026c0e0b8b81ded83b038",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/bump/contents/artifact/dependency.zip?ref=15eebf3376360773b3a743d5e419cc67e1bfb99c",
+      "git": "https://api.github.com/repos/gocardless/bump/git/blobs/2c3d0fefcb583cdaef2026c0e0b8b81ded83b038",
+      "html": "https://github.com/gocardless/bump/blob/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip"
+    }
+  }
+]

--- a/composer/spec/fixtures/github/composer_json_with_artifact_deps.json
+++ b/composer/spec/fixtures/github/composer_json_with_artifact_deps.json
@@ -1,0 +1,18 @@
+{
+  "name": "composer.json",
+  "path": "composer.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/composer.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/composer.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/composer.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "ewogICAgInJlcG9zaXRvcmllcyI6IFsKICAgICAgICB7CiAgICAgICAgICAgICJ0eXBlIjogImFydGlmYWN0IiwKICAgICAgICAgICAgInVybCI6ICJhcnRpZmFjdHMiCiAgICAgICAgfQogICAgXSwKICAgICJyZXF1aXJlIjogewogICAgICAgICJtb25vbG9nL21vbm9sb2ciOiAiMS4wLioiLAogICAgICAgICJzeW1mb255L3BvbHlmaWxsLW1ic3RyaW5nIjogIjEuMC4qIgogICAgfQp9",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/composer.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/composer.json"
+  }
+}

--- a/composer/spec/fixtures/github/dependency.json
+++ b/composer/spec/fixtures/github/dependency.json
@@ -1,0 +1,18 @@
+{
+  "name": "dependency.zip",
+  "path": "artifact/dependency.zip",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 11,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/artifact/dependency.zip?ref=5c7b3419e0056515122b981f1566ebe22c208251",
+  "html_url": "https://github.com/gocardless/bump/blob/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/2c3d0fefcb583cdaef2026c0e0b8b81ded83b038",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip",
+  "type": "file",
+  "content": "hello world",
+  "encoding": "none",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/artifact/dependency.zip?ref=15eebf3376360773b3a743d5e419cc67e1bfb99c",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/2c3d0fefcb583cdaef2026c0e0b8b81ded83b038",
+    "html": "https://github.com/gocardless/bump/blob/15eebf3376360773b3a743d5e419cc67e1bfb99c/artifact/dependency.zip"
+  }
+}


### PR DESCRIPTION
With Composer it's possible to have artifact repositories which are a local directory of zipped dependencies: https://getcomposer.org/doc/05-repositories.md#artifact

Since Dependabot wasn't fetching these archives, or even the empty directories, Composer was throwing errors saying the file wasn't found:

```
RecursiveDirectoryIterator::__construct(path/to/zipped/packages): failed to open dir: No such file or directory
```

This PR tries downloading the zipped files if they exist. If not a fake `.gitkeep` is added so it will create the directory to appease Composer.