### PR TITLE
fix exception when Action is pinned to a SHA with no tags

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -100,6 +100,8 @@ module Dependabot
         return unless git_checker.ref_looks_like_commit_sha?(old_ref)
 
         previous_version_tag = git_checker.most_specific_version_tag_for_sha(old_ref)
+        return unless previous_version_tag # There's no tag for this commit
+
         previous_version = version_class.new(previous_version_tag).to_s
         return unless comment.end_with? previous_version
 

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -407,6 +407,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           expect(subject.content).not_to include "Versions older than v#{dependency.version} have a security vulnerability"
           # rubocop:enable Layout/LineLength
         end
+
+        context "but the previous SHA is not tagged" do
+          before do
+            dependency.previous_requirements.first[:source][:ref] = "85b1f35505da871133b65f059e96210c65650a8b"
+          end
+
+          it "updates SHA version but not the comment" do
+            new_sha = dependency.requirements.first.dig(:source, :ref)
+            expect(subject.content).to match(/#{new_sha}['"]?\s+#.*#{dependency.previous_version}/)
+          end
+        end
       end
     end
   end

--- a/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
+++ b/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81  #   v2.1.0
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
     # The comment on the next line has a trailing tab. The version should still be updated.
-    - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
+    - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0 
     - uses: "actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81" # v2.1.0
     - uses: 'actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81' # v2.1.0
   integration:

--- a/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
+++ b/github_actions/spec/fixtures/workflow_files/pinned_sources_version_comments.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81  #   v2.1.0
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
     # The comment on the next line has a trailing tab. The version should still be updated.
-    - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0 
+    - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 #v2.1.0
     - uses: "actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81" # v2.1.0
     - uses: 'actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81' # v2.1.0
   integration:
@@ -29,3 +29,7 @@ jobs:
     # for the SHA commit, and the second version as a concrete version
     # that shouldn't change. For simplicity, we don't update either.
     - uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 # v2.1.0 - Versions older than v2.1.0 have a security vulnerability
+
+    # This is pinned to the version before v2.1.0, so the comment is incorrect.
+    # Rather than failing to update, it will just leave the comment as-is.
+    - uses: actions/checkout@85b1f35505da871133b65f059e96210c65650a8b # v2.1.0


### PR DESCRIPTION
Fixes #8559

If an Action is pinned to a SHA with no tag, then it would fail to find the tag and try to create a Version with `nil` which raises an exception.

So adding a guard clause to fix that and let the update complete. The comment will not be updated since it can't match a tag that doesn't exist.