### PR TITLE
Bump `elixir` to `1.15.7`

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update \
 
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.14.4
-ARG ELIXIR_CHECKSUM=b5705275d62ce3dae172d25d7ea567fffdabb45458abeb29c0189923b907367c
+ARG ELIXIR_VERSION=v1.15.7
+ARG ELIXIR_CHECKSUM=fca9001bafe705b3e8f1f91e7fc398e79452a532ee8d79182507c55fcd851b74
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \


### PR DESCRIPTION
Release notes:
* https://github.com/elixir-lang/elixir/releases/tag/v1.15.7

Supersedes:
* https://github.com/dependabot/dependabot-core/pull/7863