### PR TITLE
Make `toml` an explicit requirement

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -13,6 +13,8 @@ from pip._internal.req.constructors import (
 )
 
 from packaging.requirements import InvalidRequirement, Requirement
+# TODO: Replace 3p package `toml` with 3.11's new stdlib `tomllib` once we drop
+# support for Python 3.10.
 import toml
 
 # Inspired by pips internal check:

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -5,6 +5,8 @@ hashin==0.17.0
 pipenv==2023.11.17
 pipfile==0.0.2
 poetry==1.7.1
+# TODO: Replace 3p package `toml` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
+toml==0.10.2
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.8

--- a/python/helpers/run.py
+++ b/python/helpers/run.py
@@ -6,6 +6,8 @@ from lib import parser, hasher
 if __name__ == "__main__":
     args = json.loads(sys.stdin.read())
 
+    # TODO Python 3.10 added native switch statements, so switch this if/elif
+    # to that once we drop support for 3.9.
     if args["function"] == "parse_requirements":
         print(parser.parse_requirements(args["args"][0]))
     elif args["function"] == "parse_setup":


### PR DESCRIPTION
I couldn't figure out why the tests were failing for:
* https://github.com/dependabot/dependabot-core/pull/7741 (which was superseded by https://github.com/dependabot/dependabot-core/pull/8627)

until I realized that `pipfile` imports `toml`:
https://github.com/pypa/pipfile/blob/4706d2cbd35e0b47a05a6421fa17f93827bc454f/setup.py#L44

which then gets used over in the unrelated file `parser.py`: https://github.com/dependabot/dependabot-core/blob/89ebc55dac8630574301a10917425f80a56e4763/python/helpers/lib/parser.py#L24

So let's make the import of `toml` explicit so that we aren't relying on the side effects of importing `pipfile`. The `toml` requirement from `pipfile` isn't pinned, so I simply pinned to the latest release.

Python `3.11` added a native `tomllib` library, so once we drop support for `Python 3.10` we can drop this 3p lib entirely.