### PR TITLE
Azure DevOps now supports HTML in PR descriptions

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -148,7 +148,6 @@ module Dependabot
         end
 
         def build_details_tag(summary:, body:)
-          # Azure DevOps does not support <details> tag (https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html)
           # Bitbucket does not support <details> tag (https://jira.atlassian.com/browse/BCLOUD-20231)
           # CodeCommit does not support the <details> tag (no url available)
           if source_provider_supports_html?
@@ -244,7 +243,7 @@ module Dependabot
         end
 
         def source_provider_supports_html?
-          !%w(azure bitbucket codecommit).include?(source.provider)
+          !%w(bitbucket codecommit).include?(source.provider)
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)


### PR DESCRIPTION
Re-opening this PR from my own repo since I'm no longer on the :dependabot: team so no longer have write access to the main repo:
* https://github.com/dependabot/dependabot-core/pull/6455

As noted in that PR, https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html eventually leads to https://developercommunity.visualstudio.com/t/add-support-for-the-html-tag-in-markdown/609415#T-N1190213 specifies that Azure ADO now supports the `<details>` tag in Markdown.

Users also chimed in on https://github.com/dependabot/dependabot-core/pull/6455 to provide proof that it works as expected.

Fix #6453