### PR TITLE
Add a test for Azure sources

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -148,7 +148,6 @@ module Dependabot
         end
 
         def build_details_tag(summary:, body:)
-          # Azure DevOps does not support <details> tag (https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html)
           # Bitbucket does not support <details> tag (https://jira.atlassian.com/browse/BCLOUD-20231)
           # CodeCommit does not support the <details> tag (no url available)
           if source_provider_supports_html?
@@ -244,7 +243,7 @@ module Dependabot
         end
 
         def source_provider_supports_html?
-          !%w(azure bitbucket codecommit).include?(source.provider)
+          !%w(bitbucket codecommit).include?(source.provider)
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe namespace::MetadataPresenter do
       it "removes all content after the 50th line" do
         expect(presenter.to_s).not_to include("## 1.0.0 - June 11, 2014")
       end
+
+      context "with an azure source" do
+        let(:source) { Dependabot::Source.new(provider: "azure", repo: "gc/bp") }
+
+        it "adds a truncation notice" do
+          expect(presenter.to_s).to include("(truncated)")
+        end
+
+        it "does not include a closing table fragment" do
+          expect(presenter.to_s).not_to include("></tr></table>")
+        end
+
+        it "removes all content after the 50th line" do
+          expect(presenter.to_s).not_to include("## 1.0.0 - June 11, 2014")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Depends on, this should get merged first:
* https://github.com/dependabot/dependabot-core/pull/8628

--

I noticed in https://github.com/dependabot/dependabot-core/pull/6467 that @brrygrdn had added some nice tests for Azure / HTML fragments. He did some refactoring work to change the behavior of what got sanitized that I was a little hesitant to grab without further investigation. However, I'm no longer on the :dependabot: team and my free time open source efforts are currently focused elsewhere so I'm not going to dig into the full refactoring.

However, I did want to cherry-pick over this small set of tests for Azure out of that PR, as it is straightforward.