### PR TITLE
Remove unused `requires` of deleted `go` native helper functionality

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -5,7 +5,6 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/logger"
 require "dependabot/go_modules/file_updater"
-require "dependabot/go_modules/native_helpers"
 require "dependabot/go_modules/replace_stubber"
 require "dependabot/go_modules/resolvability_errors"
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -5,7 +5,6 @@ require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
-require "dependabot/go_modules/native_helpers"
 require "dependabot/go_modules/version"
 
 module Dependabot


### PR DESCRIPTION
Over the past couple of years, we've significantly thinned out the `go` native helper functionality in favor of leveraging `go mod` CLI.

I'm reasonably confident we've removed the ruby calls in these two files to the native helper, so this removes the orphaned/leftover `require` statements.