### PR TITLE
Stop printing pointless `git` default branch warning into logs/tests

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -84,6 +84,7 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: []) do
             `git config --global user.email "no-reply@github.com"`
             `git config --global user.name "Dependabot"`
+            `git config --global init.defaultBranch "placeholder-default-branch"`
             `git init .`
             `git add .`
             `git commit -m'fake repo_contents_path'`


### PR DESCRIPTION
While running the `go_modules` tests, I noticed that the `git` warning about an unspecified default branch was being repeatedly thrown in tests.

Originally I assumed it was a bad test fixture setup (similar to @deivid-rodriguez 's fixes in  https://github.com/dependabot/dependabot-core/pull/8100 / https://github.com/dependabot/dependabot-core/pull/8113), but I tracked it down to here which appears to run in production... so it may be filling production logs in addition to CI logs.

Before adding this line:
```
[dependabot-core-dev] ~/go_modules $ rspec ./spec/dependabot/go_modules/file_updater_spec.rb:179

Randomized with seed 30583
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
.

Finished in 1.32 seconds (files took 0.56 seconds to load)
1 examples, 0 failures

Randomized with seed 30583
```

After adding this:
```
[dependabot-core-dev] ~/go_modules $ rspec ./spec/dependabot/go_modules/file_updater_spec.rb:179

Randomized with seed 51472
.

Finished in 1.24 seconds (files took 0.53 seconds to load)
1 examples, 0 failures

Randomized with seed 51472
```