### PR TITLE
help customers debug Python issues like update_not_possible

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -53,6 +53,7 @@ module Dependabot
         # the user-specified range of versions, not the version Dependabot chose to run.
         python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)
         language_version_manager = LanguageVersionManager.new(python_requirement_parser: python_requirement_parser)
+        Dependabot.logger.info("Dependabot is using Python version '#{language_version_manager.python_major_minor}'.")
         {
           languages: {
             python: {


### PR DESCRIPTION
It's not revealed anywhere what version of Python Dependabot is using.

This is helpful when Python users haven't specified what version of Python to use, and may be experience "update not possible" errors because their dependency doesn't support that version.