### PR TITLE
pin Sorbet's version so it doesn't randomly break

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -29,8 +29,8 @@ gem "solargraph", group: :development
 # This conditional is necessary because Sorbet does not support aarch64-linux (Docker on Apple Silicon) yet.
 # See https://github.com/sorbet/sorbet/issues/4119
 if RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("x86_64")
-  gem "sorbet", group: :development
-  gem "tapioca", require: false, group: :development
+  gem "sorbet", "0.5.11156", group: :development
+  gem "tapioca", "0.11.14", require: false, group: :development
 end
 
 gemspec


### PR DESCRIPTION
The CI on `main` is randomly breaking because we don't have `sorbet` pinned.

This will make it so we update our types in a more controlled manor when Dependabot bumps the dependency.