### PR TITLE
Fix up some of the open telemetry issues

### DIFF
--- a/sorbet/rbi/shims/opentelemetry-sdk.rbi
+++ b/sorbet/rbi/shims/opentelemetry-sdk.rbi
@@ -62,6 +62,12 @@ module OpenTelemetry
     class TracerProvider
       sig { params(name: T.nilable(String), version: T.nilable(String)).returns(Tracer) }
       def tracer(name = nil, version = nil); end
+
+      sig { params(timeout: T.nilable(Numeric)).void }
+      def shutdown(timeout: nil); end
+
+      sig { params(timeout: T.nilable(Numeric)).void }
+      def force_flush(timeout: nil); end
     end
 
     class Link; end

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -56,6 +56,8 @@ module Dependabot
       handle_exception(e)
       service.mark_job_as_processed(base_commit_sha)
     ensure
+      # Ensure that we shut down the open telemetry exporter.
+      ::Dependabot::OpenTelemetry.shutdown
       Dependabot.logger.formatter = Dependabot::Logger::BasicFormatter.new
       Dependabot.logger.info(service.summary) unless service.noop?
       raise Dependabot::RunFailure if Dependabot::Environment.github_actions? && service.failure?

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -14,10 +14,11 @@ module Dependabot
     # NotImplementedError if it is referenced
     attr_reader :base_commit_sha
 
-    def perform_job # rubocop:disable Metrics/PerceivedComplexity
+    def perform_job # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize
       @base_commit_sha = nil
 
       span = ::Dependabot::OpenTelemetry.tracer&.start_span("perform_job", kind: :internal)
+      span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)
 
       begin
         connectivity_check if ENV["ENABLE_CONNECTIVITY_CHECK"] == "1"

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -17,7 +17,7 @@ module Dependabot
     def perform_job # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize
       @base_commit_sha = nil
 
-      span = ::Dependabot::OpenTelemetry.tracer&.start_span("perform_job", kind: :internal)
+      span = ::Dependabot::OpenTelemetry.tracer&.start_span("file_fetcher", kind: :internal)
       span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)
 
       begin

--- a/updater/lib/dependabot/opentelemetry.rb
+++ b/updater/lib/dependabot/opentelemetry.rb
@@ -51,6 +51,14 @@ module Dependabot
       ::OpenTelemetry.tracer_provider.tracer("dependabot", Dependabot::VERSION)
     end
 
+    sig { void }
+    def self.shutdown
+      return unless should_configure?
+
+      ::OpenTelemetry.tracer_provider.force_flush
+      ::OpenTelemetry.tracer_provider.shutdown
+    end
+
     sig do
       params(
         job_id: T.any(String, Integer),

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -15,6 +15,8 @@ module Dependabot
       # them, decode and parse them into an object that knows the current state
       # of the project's dependencies.
       span = ::Dependabot::OpenTelemetry.tracer&.start_span("perform_job", kind: :internal)
+      span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)
+
       begin
         dependency_snapshot = Dependabot::DependencySnapshot.create_from_job_definition(
           job: job,

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -14,7 +14,7 @@ module Dependabot
       # encoded files and commit information in the environment, so let's retrieve
       # them, decode and parse them into an object that knows the current state
       # of the project's dependencies.
-      span = ::Dependabot::OpenTelemetry.tracer&.start_span("perform_job", kind: :internal)
+      span = ::Dependabot::OpenTelemetry.tracer&.start_span("update_files", kind: :internal)
       span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)
 
       begin


### PR DESCRIPTION
This pull request primarily focuses on enhancing the OpenTelemetry integration within the Dependabot system, with changes spanning across multiple files. The main changes include the addition of `shutdown` and `force_flush` methods to the `TracerProvider` class, ensuring the shutdown of the OpenTelemetry exporter in the `run` method, and renaming the spans in `perform_job` methods while also setting the attribute for `JOB_ID`.

Changes to Dependabot's OpenTelemetry usage:

* <a href="diffhunk://#diff-0ae3ea6b30ef21b78d5b11abdd5a8b478e3df86e9c2d681c88fc4d03f49e170bR59-R60">`updater/lib/dependabot/base_command.rb`</a>: Ensured the shutdown of the OpenTelemetry exporter in the `run` method. This ensures that the OpenTelemetry system is properly closed when the run method finishes execution.
* <a href="diffhunk://#diff-2bd2ce9445c04b07391fccad568e355e5e15ef5516d842efd887a0357c8f8410R54-R61">`updater/lib/dependabot/opentelemetry.rb`</a>: Added a `shutdown` method to the `OpenTelemetry` class in Dependabot. This method invokes the `force_flush` and `shutdown` methods on the `tracer_provider` of OpenTelemetry if it should be configured.

Changes to OpenTelemetry spans:

* `updater/lib/dependabot/file_fetcher_command.rb` and `updater/lib/dependabot/update_files_command.rb`: Renamed the spans in `perform_job` methods from "perform_job" to "file_fetcher" and "update_files" respectively. Also, set the attribute for `JOB_ID` on the span. This provides more specific information about the job being performed in the telemetry data. <a href="diffhunk://#diff-4c01bde1823e41430372a425ad88fc23267edb4c723890ec6dee64d9581a64c4L17-R21">[1]</a> <a href="diffhunk://#diff-b4b880c69008ab386f67bd253c4cbfc68fae8de2aeb5dfad140208f278f1008fL17-R19">[2]</a>