### PR TITLE
improve how branch images skips

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -20,6 +20,8 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   approval:
     runs-on: ubuntu-latest
+    outputs:
+        decision: ${{ steps.check.outputs.decision }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -38,26 +38,15 @@ jobs:
 
       # Skips push-updater-images by setting an output
       - name: Check if pull request is approved
+        id: decision
         run: |
           DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
-          echo "decision=$DECISION" >> $GITHUB_ENV
-
-      # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
-      - name: Skip forks
-        if: github.event.pull_request.head.repo.fork
-        run: echo "decision=FORK" >> $GITHUB_ENV
-
-      # Need an id to access the output, but you can't put id on two steps.
-      # In the future if you want to combine the previous two steps and get
-      # rid of this one that is good.
-      - name: Decision
-        id: decision
-        run: echo "decision=${{ env.decision }}" >> $GITHUB_OUTPUT
+          echo "decision=$DECISION" >> $GITHUB_OUTPUT
 
   push-updater-images:
     runs-on: ubuntu-latest
     needs: approval
-    if: needs.approval.outputs.decision == 'APPROVED:OPEN'
+    if: needs.approval.outputs.decision == 'APPROVED:OPEN' && !github.event.pull_request.head.repo.fork
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -46,7 +46,6 @@ jobs:
         run: echo "DECISION=FORK" >> $GITHUB_OUTPUT
 
   push-updater-images:
-    name: Deploy
     runs-on: ubuntu-latest
     needs: approval
     if: needs.approval.outputs.decision == 'APPROVED:OPEN'

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -18,9 +18,33 @@ on:  # yamllint disable-line rule:truthy
         description: PR number
 
 jobs:
+  approval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR
+        run: echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+        if: github.event_name != 'workflow_dispatch'
+
+      - name: Set PR (forks)
+        run: echo "PR=${{ inputs.pr }}" >> $GITHUB_ENV
+        if: github.event_name == 'workflow_dispatch'
+
+      # Skips push-updater-images by setting an output
+      - name: Check if pull request is approved
+        run: |
+          DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
+          echo "decision=$DECISION" >> $GITHUB_OUTPUT
+
+      # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
+      - name: Skip forks
+        if: github.event.pull_request.head.repo.fork
+        run: echo "DECISION=FORK" >> $GITHUB_OUTPUT
+
   push-updater-images:
     name: Deploy
     runs-on: ubuntu-latest
+    needs: approval
+    if: needs.approval.outputs.decision == 'APPROVED:OPEN'
     strategy:
       fail-fast: false
       matrix:
@@ -53,26 +77,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set PR
-        run: echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-        if: github.event_name != 'workflow_dispatch'
-
-      - name: Set PR (forks)
-        run: echo "PR=${{ inputs.pr }}" >> $GITHUB_ENV
-        if: github.event_name == 'workflow_dispatch'
-
-        # sets DECISION to the PR's review decision, handling the push-after-approval case
-      - name: Check if pull request is approved
-        run: |
-          DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
-          echo "Review decision is: $DECISION"
-          echo "DECISION=$DECISION" >> $GITHUB_ENV
-
-      # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
-      - name: Skip forks
-        if: github.event.pull_request.head.repo.fork
-        run: echo "DECISION=FORK" >> $GITHUB_ENV
-
       - name: Prepare tag
         run: echo "TAG=${{ github.sha }}" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
@@ -87,22 +91,18 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
 
       - name: Log in to GHCR
-        if: env.DECISION == 'APPROVED:OPEN'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build ecosystem image
-        if: env.DECISION == 'APPROVED:OPEN'
         run: script/build ${{ matrix.suite.name }}
 
       - name: Push branch image
-        if: env.DECISION == 'APPROVED:OPEN'
         run: |
           docker tag "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}" "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
           docker push "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
 
       - name: Set summary
-        if: env.DECISION == 'APPROVED:OPEN'
         run: |
           echo "updater uploaded with tag \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -43,7 +43,7 @@ jobs:
       # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
       - name: Skip forks
         if: github.event.pull_request.head.repo.fork
-        run: echo "DECISION=FORK" >> $GITHUB_OUTPUT
+        run: echo "decision=FORK" >> $GITHUB_OUTPUT
 
   push-updater-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -21,7 +21,7 @@ jobs:
   approval:
     runs-on: ubuntu-latest
     outputs:
-      decision: ${{ steps.check.outputs.decision }}
+      decision: ${{ steps.decision.outputs.decision }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,12 +40,19 @@ jobs:
       - name: Check if pull request is approved
         run: |
           DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
-          echo "decision=$DECISION" >> $GITHUB_OUTPUT
+          echo "decision=$DECISION" >> $GITHUB_ENV
 
       # overwrite the previous result on pull request events on forks since forks can't publish to GHCR
       - name: Skip forks
         if: github.event.pull_request.head.repo.fork
-        run: echo "decision=FORK" >> $GITHUB_OUTPUT
+        run: echo "decision=FORK" >> $GITHUB_ENV
+
+      # Need an id to access the output, but you can't put id on two steps.
+      # In the future if you want to combine the previous two steps and get
+      # rid of this one that is good.
+      - name: Decision
+        id: decision
+        run: echo "decision=${{ env.decision }}" >> $GITHUB_OUTPUT
 
   push-updater-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -21,7 +21,7 @@ jobs:
   approval:
     runs-on: ubuntu-latest
     outputs:
-        decision: ${{ steps.check.outputs.decision }}
+      decision: ${{ steps.check.outputs.decision }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -21,6 +21,11 @@ jobs:
   approval:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Set PR
         run: echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
         if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
It's difficult to tell if the branch images job was skipped or not, making it hard to pick the SHA out of the output and do a deployment.

This moves the part where it figures out if the PR is approved to a first step, and if it's not approved it skips the entire `push-updater-images` which makes it really obvious.