### PR TITLE
fix unsupported Go modules preventing updates

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -249,7 +249,7 @@ module Dependabot
           write_go_mod(body)
         end
 
-        def handle_subprocess_error(stderr) # rubocop:disable Metrics/AbcSize
+        def handle_subprocess_error(stderr)
           stderr = stderr.gsub(Dir.getwd, "")
 
           # Package version doesn't match the module major version
@@ -264,10 +264,7 @@ module Dependabot
           end
 
           repo_error_regex = REPO_RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
-          if repo_error_regex
-            error_message = filter_error_message(message: stderr, regex: repo_error_regex)
-            ResolvabilityErrors.handle(error_message, goprivate: @goprivate)
-          end
+          ResolvabilityErrors.handle(stderr, goprivate: @goprivate) if repo_error_regex
 
           path_regex = MODULE_PATH_MISMATCH_REGEXES.find { |r| stderr =~ r }
           if path_regex

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -8,7 +8,9 @@ module Dependabot
 
       def self.handle(message, goprivate:)
         mod_path = message.scan(GITHUB_REPO_REGEX).last
-        raise Dependabot::DependencyFileNotResolvable, message unless mod_path
+        unless mod_path && message.include?("If this is a private repository")
+          raise Dependabot::DependencyFileNotResolvable, message
+        end
 
         # Module not found on github.com - query for _any_ version to know if it
         # doesn't exist (or is private) or we were just given a bad revision by this manifest

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -23,7 +23,10 @@ module Dependabot
           /unrecognized import path/,
           /malformed module path/,
           # (Private) module could not be fetched
-          /module .*: git ls-remote .*: exit status 128/m
+          /module .*: git ls-remote .*: exit status 128/m,
+          # The module was retracted from the proxy
+          # OR the version of Go required is greater than what Dependabot supports
+          /go: loading module retractions for/
         ].freeze
         INVALID_VERSION_REGEX = /version "[^"]+" invalid/m
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/
@@ -94,8 +97,8 @@ module Dependabot
               env = { "GOPRIVATE" => @goprivate }
 
               versions_json = SharedHelpers.run_shell_command(
-                "go list -e -m -versions -json #{dependency.name}",
-                fingerprint: "go list -e -m -versions -json <dependency_name>",
+                "go list -m -versions -json #{dependency.name}",
+                fingerprint: "go list -m -versions -json <dependency_name>",
                 env: env
               )
               version_strings = JSON.parse(versions_json)["Versions"]

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -94,8 +94,8 @@ module Dependabot
               env = { "GOPRIVATE" => @goprivate }
 
               versions_json = SharedHelpers.run_shell_command(
-                "go list -m -versions -json #{dependency.name}",
-                fingerprint: "go list -m -versions -json <dependency_name>",
+                "go list -e -m -versions -json #{dependency.name}",
+                fingerprint: "go list -e -m -versions -json <dependency_name>",
                 env: env
               )
               version_strings = JSON.parse(versions_json)["Versions"]

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -23,7 +23,7 @@ module Dependabot
           /unrecognized import path/,
           /malformed module path/,
           # (Private) module could not be fetched
-          /module .*: git ls-remote .*: exit status 128/m,
+          /module .*: git ls-remote .*: exit status 128/m
         ].freeze
         # The module was retracted from the proxy
         # OR the version of Go required is greater than what Dependabot supports

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -24,11 +24,11 @@ module Dependabot
           /malformed module path/,
           # (Private) module could not be fetched
           /module .*: git ls-remote .*: exit status 128/m,
-          # The module was retracted from the proxy
-          # OR the version of Go required is greater than what Dependabot supports
-          /go: loading module retractions for/
         ].freeze
-        INVALID_VERSION_REGEX = /version "[^"]+" invalid/m
+        # The module was retracted from the proxy
+        # OR the version of Go required is greater than what Dependabot supports
+        # OR other go.mod version errors
+        INVALID_VERSION_REGEX = /(go: loading module retractions for)|(version "[^"]+" invalid)/m
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/
 
         def initialize(dependency:, dependency_files:, credentials:,

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -114,17 +114,7 @@ module Dependabot
           retry_count += 1
           retry if transitory_failure?(e) && retry_count < 2
 
-          handle_subprocess_error(e)
-        end
-
-        def handle_subprocess_error(error)
-          if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
-            ResolvabilityErrors.handle(error.message, goprivate: @goprivate)
-          elsif INVALID_VERSION_REGEX.match?(error.message)
-            raise Dependabot::DependencyFileNotResolvable, error.message
-          end
-
-          raise
+          ResolvabilityErrors.handle(e.message, goprivate: @goprivate)
         end
 
         def transitory_failure?(error)

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
     )
   end
 
+  before do
+    ENV["GOTOOLCHAIN"] = "local"
+  end
+
   describe "#latest_version" do
     context "when there's a newer major version but not a new minor version" do
       before do
@@ -255,6 +259,20 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
           .to raise_error(error_class) do |error|
           expect(error.message).to include("github.com/dependabot-fixtures/go-modules-lib")
           expect(error.message).to include("version \"v3.0.0\" invalid")
+        end
+      end
+    end
+
+    context "when the dependency's Go version isn't supported by Dependabot" do
+      let(:dependency_name) { "github.com/dependabot-fixtures/future-go" }
+      let(:dependency_version) { "0.0.0-1" }
+
+      it "raises a DependencyFileNotResolvable error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { finder.latest_version }
+          .to raise_error(error_class) do |error|
+          expect(error.message).to include("github.com/dependabot-fixtures/future-go")
+          expect(error.message).to include("requires go >= 99.21.3")
         end
       end
     end


### PR DESCRIPTION
fix #8700

As @JamieMagee mentions, without the -e flag unsupported versions of modules breaks updates for the entire run since `go list` errors out.

It might be worth throwing this into the Go smoke test to prevent regressions.