### PR TITLE
create azure nuget package urls directly from endpoint types

### DIFF
--- a/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
@@ -7,77 +7,6 @@ require "dependabot/dependency_file"
 require "dependabot/nuget/update_checker/nupkg_fetcher"
 
 RSpec.describe Dependabot::Nuget::NupkgFetcher do
-  describe "#try_match_azure_url" do
-    context "when checking with a azure feed url" do
-      let(:url) { "https://pkgs.dev.azure.com/dependabot/dependabot-test/_packaging/dependabot-feed/nuget/v3/index.json" }
-      subject(:match) { described_class.try_match_azure_url(url) }
-
-      it { is_expected.to be_truthy }
-      it { expect(match[:organization]).to eq("dependabot") }
-      it { expect(match[:project]).to eq("dependabot-test") }
-      it { expect(match[:feedId]).to eq("dependabot-feed") }
-    end
-
-    context "when checking with a azure feed url (no project)" do
-      let(:url) { "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot-feed/nuget/v3/index.json" }
-      subject(:match) { described_class.try_match_azure_url(url) }
-
-      it { is_expected.to be_truthy }
-      it { expect(match[:organization]).to eq("dependabot") }
-      it { expect(match[:project]).to be_empty }
-      it { expect(match[:feedId]).to eq("dependabot-feed") }
-    end
-
-    context "when checking with a visual studio feed url" do
-      let(:url) { "https://dynamicscrm.pkgs.visualstudio.com/_packaging/CRM.Engineering/nuget/v3/index.json" }
-      subject(:match) { described_class.try_match_azure_url(url) }
-
-      it { is_expected.to be_truthy }
-      it { expect(match[:organization]).to eq("dynamicscrm") }
-      it { expect(match[:project]).to be_empty }
-      it { expect(match[:feedId]).to eq("CRM.Engineering") }
-    end
-
-    context "when checking with the nuget.org feed url" do
-      let(:url) { "https://api.nuget.org/v3/index.json" }
-      subject(:match) { described_class.try_match_azure_url(url) }
-
-      it { is_expected.to be_falsey }
-    end
-  end
-
-  describe "#get_azure_package_url" do
-    context "when checking with a azure feed url" do
-      let(:url) { "https://pkgs.dev.azure.com/dependabot/dependabot-test/_packaging/dependabot-feed/nuget/v3/index.json" }
-      let(:match) { described_class.try_match_azure_url(url) }
-      let(:package_name) { "Newtonsoft.Json" }
-      let(:package_version) { "13.0.1" }
-      subject(:package_url) { described_class.get_azure_package_url(match, package_name, package_version) }
-
-      it { is_expected.to eq("https://pkgs.dev.azure.com/dependabot/dependabot-test/_apis/packaging/feeds/dependabot-feed/nuget/packages/Newtonsoft.Json/versions/13.0.1/content?sourceProtocolVersion=nuget&api-version=7.0-preview") }
-    end
-
-    context "when checking with a azure feed url (no project)" do
-      let(:url) { "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot-feed/nuget/v3/index.json" }
-      let(:match) { described_class.try_match_azure_url(url) }
-      let(:package_name) { "Newtonsoft.Json" }
-      let(:package_version) { "13.0.1" }
-      subject(:package_url) { described_class.get_azure_package_url(match, package_name, package_version) }
-
-      it { is_expected.to eq("https://pkgs.dev.azure.com/dependabot/_apis/packaging/feeds/dependabot-feed/nuget/packages/Newtonsoft.Json/versions/13.0.1/content?sourceProtocolVersion=nuget&api-version=7.0-preview") }
-    end
-
-    context "when checking with a visual studio feed url" do
-      let(:url) { "https://dynamicscrm.pkgs.visualstudio.com/_packaging/CRM.Engineering/nuget/v3/index.json" }
-      let(:match) { described_class.try_match_azure_url(url) }
-      let(:package_name) { "Newtonsoft.Json" }
-      let(:package_version) { "13.0.1" }
-      subject(:package_url) { described_class.get_azure_package_url(match, package_name, package_version) }
-
-      it { is_expected.to eq("https://pkgs.dev.azure.com/dynamicscrm/_apis/packaging/feeds/CRM.Engineering/nuget/packages/Newtonsoft.Json/versions/13.0.1/content?sourceProtocolVersion=nuget&api-version=7.0-preview") }
-    end
-  end
-
   describe "#fetch_nupkg_url_from_repository" do
     let(:dependency) { Dependabot::Dependency.new(name: package_name, requirements: [], package_manager: "nuget") }
     let(:package_name) { "Newtonsoft.Json" }
@@ -135,7 +64,7 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
           )
       end
 
-      it { is_expected.to eq("https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-public/nuget/packages/Newtonsoft.Json/versions/13.0.1/content?sourceProtocolVersion=nuget&api-version=7.0-preview") }
+      it { is_expected.to eq("https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg") }
     end
 
     context "with a github feed url" do


### PR DESCRIPTION
Previously we would create Azure NuGet package URLs in a "friendly" format like this:

```
https://pkgs.dev.azure.com/dnceng/public/_apis/packaging/feeds/dotnet-public/nuget/packages/Newtonsoft.Json/versions/13.0.1/content?sourceProtocolVersion=nuget&api-version=7.0-preview
```

Azure would then return a `303` with the "real" download URL, something like this:

```
https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg
```

Given that we've already pulled in the `index.json`, we know exactly what the "real" URL will be, so we simply create that directly, since we know it's a V3 API.

This allows us to simplify the code a bit.

There was an internal PR earlier today that updated the auth appending to include the `SearchQueryService/3.0.0-beta` endpoint (because that's what Azure currently returns), and that PR along with this fixes #8600.