### PR TITLE
Update pyenv and pythons

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,12 +1,14 @@
 # This list must match the versions specified in
 # python/lib/dependabot/python/language_version_manager.rb: PRE_INSTALLED_PYTHON_VERSIONS
-ARG PY_3_11=3.11.5
+ARG PY_3_12=3.12.1
+ARG PY_3_11=3.11.7
 ARG PY_3_10=3.10.13
 ARG PY_3_9=3.9.18
 ARG PY_3_8=3.8.18
-ARG PYENV_VERSION=v2.3.25
+ARG PYENV_VERSION=v2.3.35
 
 FROM ghcr.io/dependabot/dependabot-updater-core as python-core
+ARG PY_3_12
 ARG PY_3_11
 ARG PY_3_10
 ARG PY_3_9
@@ -100,6 +102,23 @@ RUN find $PYTHON_INSTALL_LOCATION/bin -type f -exec sed -i "1s|^#!/usr/local/bin
 # Ensure pyenv works and it's the python version we expect
 RUN PYENV_VERSION=$PY_3_11 pyenv exec python --version | grep "Python $PY_3_11" || exit 1
 RUN bash /opt/python/helpers/build $PY_3_11
+RUN cd $PYENV_ROOT/versions \
+  && tar -acf $PY_3_11.tar.zst $PY_3_11
+
+## 3.12
+# Docker doesn't support parametrizing `COPY --from:python:$PY_1_23-bookworm`, so work around it using an alias.
+# TODO: If upstream adds support for Ubuntu, use that instead of Debian as the base suffix: https://github.com/docker-library/python/pull/791
+FROM python:$PY_3_12-bookworm as upstream-python-3.12
+FROM python-core as python-3.12
+ARG PYTHON_INSTALL_LOCATION="$PYENV_ROOT/versions/$PY_3_12"
+COPY --from=upstream-python-3.12 --chown=dependabot:dependabot /usr/local/bin $PYTHON_INSTALL_LOCATION/bin
+COPY --from=upstream-python-3.12 --chown=dependabot:dependabot /usr/local/include $PYTHON_INSTALL_LOCATION/include
+COPY --from=upstream-python-3.12 --chown=dependabot:dependabot /usr/local/lib $PYTHON_INSTALL_LOCATION/lib
+# `pip` and other scripts need their shebangs rewritten for the new location
+RUN find $PYTHON_INSTALL_LOCATION/bin -type f -exec sed -i "1s|^#!/usr/local/bin/python|#!${PYTHON_INSTALL_LOCATION}/bin/python|" {} +
+# Ensure pyenv works and it's the python version we expect
+RUN PYENV_VERSION=$PY_3_12 pyenv exec python --version | grep "Python $PY_3_12" || exit 1
+RUN bash /opt/python/helpers/build $PY_3_12
 # This is the default Python, so no need to tar it
 
 FROM python-core
@@ -131,9 +150,10 @@ COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 COPY --from=python-3.8 $PYENV_ROOT/versions/$PY_3_8.tar.zst $PYENV_ROOT/versions/$PY_3_8.tar.zst
 COPY --from=python-3.9 $PYENV_ROOT/versions/$PY_3_9.tar.zst $PYENV_ROOT/versions/$PY_3_9.tar.zst
 COPY --from=python-3.10 $PYENV_ROOT/versions/$PY_3_10.tar.zst $PYENV_ROOT/versions/$PY_3_10.tar.zst
-COPY --from=python-3.11 $PYENV_ROOT/versions/ $PYENV_ROOT/versions/
+COPY --from=python-3.11 $PYENV_ROOT/versions/$PY_3_11.tar.zst $PYENV_ROOT/versions/$PY_3_11.tar.zst
+COPY --from=python-3.12 $PYENV_ROOT/versions/ $PYENV_ROOT/versions/
 
 # Copy the output of the build script, it should be identical across Python versions
-COPY --from=python-3.11 /opt/python/ /opt/python/
+COPY --from=python-3.12 /opt/python/ /opt/python/
 
-RUN pyenv global $PY_3_11
+RUN pyenv global $PY_3_12

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -9,7 +9,8 @@ module Dependabot
     class LanguageVersionManager
       # This list must match the versions specified at the top of `python/Dockerfile`
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.11.5
+        3.12.1
+        3.11.7
         3.10.13
         3.9.18
         3.8.18


### PR DESCRIPTION
Python 3.12 now exists, so this updates pyenv to a version that knows about it and does the dance in the docker file to install that version