### PR TITLE
Only create PRs for dependencies in the sorbet group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
         patterns:
           - "sorbet"
           - "tapioca"
+    allow:
+      - dependency-name: "sorbet"
+      - dependency-name: "tapioca"
 
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"


### PR DESCRIPTION
All other dependencies from common are already managed by the updater Dependabot configuration.