### PR TITLE
properly locate `nuget.config` when it's further up-directory from a project

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -78,6 +78,10 @@ module Dependabot
           ["net#{value[1..-1].delete('.')}"]
         end
 
+        def nuget_configs
+          dependency_files.select { |f| f.name.match?(%r{(^|/)nuget\.config$}i) }
+        end
+
         private
 
         attr_reader :dependency_files, :credentials
@@ -281,7 +285,6 @@ module Dependabot
         end
 
         def dependency_has_search_results?(dependency)
-          nuget_configs = dependency_files.select { |f| f.name.casecmp?("nuget.config") }
           dependency_urls = UpdateChecker::RepositoryFinder.new(
             dependency: dependency,
             credentials: credentials,
@@ -488,10 +491,6 @@ module Dependabot
           dependency_files.select do |f|
             f.name.split("/").last.casecmp("packages.config").zero?
           end
-        end
-
-        def nuget_configs
-          dependency_files.select { |f| f.name.match?(/nuget\.config$/i) }
         end
 
         def global_json

--- a/nuget/spec/fixtures/github/csproj_in_subdirectory/NuGet.Config
+++ b/nuget/spec/fixtures/github/csproj_in_subdirectory/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget/spec/fixtures/github/csproj_in_subdirectory/src/some-project/some-project.csproj
+++ b/nuget/spec/fixtures/github/csproj_in_subdirectory/src/some-project/some-project.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
If dependabot is started from a deep directory, a `NuGet.config` file further up the tree (e.g., at the root) wasn't properly found.  This fixes the search behavior to look further up when the file name might not be `NuGet.config`, but `../../NuGet.config`.