### PR TITLE
Raise a proper error when `package-json.lock` is not parseable

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -365,7 +365,7 @@ module Dependabot
         current_depth = File.join(directory, file.name).split("/").count { |path| !path.empty? }
         path_to_directory = "../" * current_depth
 
-        dep_types = NpmAndYarn::FileParser::DEPENDENCY_TYPES
+        dep_types = FileParser::DEPENDENCY_TYPES
         parsed_manifest = JSON.parse(file.content)
         dependency_objects = parsed_manifest.values_at(*dep_types).compact
         # Fetch yarn "file:" path "resolutions" so the lockfile can be resolved

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -130,7 +130,7 @@ module Dependabot
         return @inferred_npmrc = nil unless npmrc.nil? && package_lock
 
         known_registries = []
-        JSON.parse(package_lock.content).fetch("dependencies", {}).each do |dependency_name, details|
+        FileParser::JsonLock.new(package_lock).parsed.fetch("dependencies", {}).each do |dependency_name, details|
           resolved = details.fetch("resolved", DEFAULT_NPM_REGISTRY)
 
           begin

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1857,6 +1857,33 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
+  context "with an unparseable package-lock.json file" do
+    before do
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm/unparseable", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm/unparseable", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "raises a DependencyFileNotParseable error" do
+      expect { file_fetcher_instance.files }
+        .to raise_error(Dependabot::DependencyFileNotParseable) do |error|
+          expect(error.file_name).to eq("package-lock.json")
+        end
+    end
+  end
+
   context "with no .npmrc but package-lock.json contains a custom registry" do
     before do
       allow(file_fetcher_instance).to receive(:commit).and_return("sha")

--- a/npm_and_yarn/spec/fixtures/projects/npm/unparseable/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm/unparseable/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-red-contrib-ssafy-meoseon",
+  "version": "0.0.22",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@eslint/eslintrc": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
+      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+    "@humanwhocodes/config-array": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
+      "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm/unparseable/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm/unparseable/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-red-contrib-ssafy-meoseon",
+  "version": "0.0.22",
+  "description": "ssafy meoseon e-commerce extensions pack for Node-RED",
+  "license": "Apache 2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Meoseon-Division/node-red-contrib-ssafy-meoseon"
+  },
+  "devDependencies": {
+    "eslint": "^8.8.0"
+  }
+}


### PR DESCRIPTION
Currently this gets raised as an unknown error.