### PR TITLE
Test that file_parser reads .proj files

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -74,7 +74,7 @@ module Dependabot
       end
 
       def project_files
-        projfile = /\.[a-z]{2}proj$/
+        projfile = /\.([a-z]{2})?proj$/
         packageprops = /[Dd]irectory.[Pp]ackages.props/
 
         dependency_files.select do |df|

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
           dependencies_from_info(proj_dependencies)
         )
       end
-      its(:length) {is_expected.to eq(2) }
+      its(:length) { is_expected.to eq(2) }
 
       describe "the first dependency" do
         subject(:dependency) { top_level_dependencies.first }


### PR DESCRIPTION
Right now if Dependabot is checking a directory which contains only .proj files (but that .proj file may reference a csproj higher up) it will fail with  `No project file or packages.config!`. That's because the regex used in this case is `/\.[a-z]{2}proj$/`, if we make the 2 characters optional we get the .proj file we were expecting.