### PR TITLE
patch user-level `NuGet.Config` before invoking dotnet/nuget tools

### DIFF
--- a/nuget/helpers/build
+++ b/nuget/helpers/build
@@ -38,3 +38,8 @@ dotnet clean
 
 echo "verifying NuGetUpdater tool"
 "$install_dir/NuGetUpdater/NuGetUpdater.Cli" --version
+
+if [ ! -f "$HOME/.nuget/NuGet/NuGet.Config" ]; then
+  echo "user-level NuGet.Config not found; credential patching will not work"
+  exit 1
+fi

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -62,8 +62,9 @@ module Dependabot
 
           next unless project_dependencies.any? { |dep| dep.name.casecmp(dependency.name).zero? }
 
-          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?,
-                                               credentials)
+          NativeHelpers.run_nuget_updater_tool(repo_root: repo_contents_path, proj_path: proj_path,
+                                               dependency: dependency, is_transitive: !dependency.top_level?,
+                                               credentials: credentials)
           update_ran = true
         end
 
@@ -78,8 +79,9 @@ module Dependabot
           project_file = project_files.first
           proj_path = dependency_file_path(project_file)
 
-          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?,
-                                               credentials)
+          NativeHelpers.run_nuget_updater_tool(repo_root: repo_contents_path, proj_path: proj_path,
+                                               dependency: dependency, is_transitive: !dependency.top_level?,
+                                               credentials: credentials)
           return true
         end
 

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -62,7 +62,8 @@ module Dependabot
 
           next unless project_dependencies.any? { |dep| dep.name.casecmp(dependency.name).zero? }
 
-          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?)
+          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?,
+                                               credentials)
           update_ran = true
         end
 
@@ -77,7 +78,8 @@ module Dependabot
           project_file = project_files.first
           proj_path = dependency_file_path(project_file)
 
-          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?)
+          NativeHelpers.run_nuget_updater_tool(repo_contents_path, proj_path, dependency, !dependency.top_level?,
+                                               credentials)
           return true
         end
 

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -48,7 +48,7 @@ module Dependabot
       end
 
       # rubocop:disable Metrics/MethodLength
-      def self.run_nuget_updater_tool(repo_root, proj_path, dependency, is_transitive, credentials)
+      def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command = [
           exe_path,

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -86,10 +86,10 @@ module Dependabot
 
         puts "running NuGet updater:\n" + command
 
-        NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials, lambda {
+        NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
           output = SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
           puts output
-        })
+        end
       end
       # rubocop:enable Metrics/MethodLength
     end

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative "nuget_config_credential_helpers.rb"
+
 module Dependabot
   module Nuget
     module NativeHelpers
@@ -46,7 +48,7 @@ module Dependabot
       end
 
       # rubocop:disable Metrics/MethodLength
-      def self.run_nuget_updater_tool(repo_root, proj_path, dependency, is_transitive)
+      def self.run_nuget_updater_tool(repo_root, proj_path, dependency, is_transitive, credentials)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command = [
           exe_path,
@@ -84,9 +86,10 @@ module Dependabot
 
         puts "running NuGet updater:\n" + command
 
-        output = SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
-
-        puts output
+        NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials, lambda {
+          output = SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+          puts output
+        })
       end
       # rubocop:enable Metrics/MethodLength
     end

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require_relative "nuget_config_credential_helpers.rb"
+require_relative "nuget_config_credential_helpers"
 
 module Dependabot
   module Nuget

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -36,7 +36,6 @@ module Dependabot
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
             <packageSources>
-              <clear />
           #{package_sources.join("\n")}
             </packageSources>
             <packageSourceCredentials>

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -1,0 +1,70 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Nuget
+    module NuGetConfigCredentialHelpers
+      def self.user_nuget_config_path
+        home_directory = Dir.home
+        File.join(home_directory, ".nuget", "NuGet", "NuGet.Config")
+      end
+
+      def self.temporary_nuget_config_path
+        user_nuget_config_path + "_ORIGINAL"
+      end
+
+      def self.add_credentials_to_nuget_config(credentials)
+        return unless File.exist?(user_nuget_config_path)
+
+        nuget_credentials = credentials.select { |cred| cred["type"] == "nuget_feed" }
+        return if nuget_credentials.empty?
+
+        File.rename(user_nuget_config_path, temporary_nuget_config_path)
+
+        package_sources = []
+        package_source_credentials = []
+        nuget_credentials.each_with_index do |c, i|
+          source_name = "credentialed_source_#{i + 1}"
+          package_sources << "    <add key=\"#{source_name}\" value=\"#{c.fetch('url')}\" />"
+          package_source_credentials << "    <#{source_name}>"
+          package_source_credentials << "      <add key=\"Username\" value=\"user\" />"
+          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{c.fetch('token')}\" />"
+          package_source_credentials << "    </#{source_name}>"
+        end
+
+        nuget_config = <<~NUGET_XML
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+          #{package_sources.join("\n")}
+            </packageSources>
+            <packageSourceCredentials>
+          #{package_source_credentials.join("\n")}
+            </packageSourceCredentials>
+          </configuration>
+        NUGET_XML
+        File.write(user_nuget_config_path, nuget_config)
+      end
+
+      def self.restore_user_nuget_config
+        return unless File.exist?(temporary_nuget_config_path)
+
+        File.delete(user_nuget_config_path)
+        File.rename(temporary_nuget_config_path, user_nuget_config_path)
+      end
+
+      # rubocop:disable Lint/SuppressedException
+      def self.patch_nuget_config_for_action(credentials, action)
+        add_credentials_to_nuget_config(credentials)
+        begin
+          action.call
+        rescue StandardError
+        ensure
+          restore_user_nuget_config
+        end
+      end
+      # rubocop:enable Lint/SuppressedException
+    end
+  end
+end

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -24,11 +24,13 @@ module Dependabot
         package_sources = []
         package_source_credentials = []
         nuget_credentials.each_with_index do |c, i|
-          source_name = "credentialed_source_#{i + 1}"
-          package_sources << "    <add key=\"#{source_name}\" value=\"#{c.fetch('url')}\" />"
+          source_name = "nuget_source_#{i + 1}"
+          package_sources << "    <add key=\"#{source_name}\" value=\"#{c['url']}\" />"
+          next unless c["token"]
+
           package_source_credentials << "    <#{source_name}>"
           package_source_credentials << "      <add key=\"Username\" value=\"user\" />"
-          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{c.fetch('token')}\" />"
+          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{c['token']}\" />"
           package_source_credentials << "    </#{source_name}>"
         end
 

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -54,10 +54,10 @@ module Dependabot
       end
 
       # rubocop:disable Lint/SuppressedException
-      def self.patch_nuget_config_for_action(credentials, action)
+      def self.patch_nuget_config_for_action(credentials, &_block)
         add_credentials_to_nuget_config(credentials)
         begin
-          action.call
+          yield
         rescue StandardError
         ensure
           restore_user_nuget_config

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
   let(:user_nuget_config_contents_during_and_after_action) do
     path = Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path
     content_during_action = nil
-    Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials, lambda {
+    Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
       content_during_action = File.read(path)
-    })
+    end
     content_after_action = File.read(path)
     { content_during_action: content_during_action, content_after_action: content_after_action }
   end
@@ -43,12 +43,9 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
 
       context "when exception is raised" do
         it "restores the original file after an exception" do
-          Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(
-            credentials,
-            lambda {
-              raise "This exception was raised when the NuGet.Config file was patched"
-            }
-          )
+          Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
+            raise "This exception was raised when the NuGet.Config file was patched"
+          end
           nuget_config_content = File.read(Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path)
           expect(nuget_config_content).not_to include("https://nuget.example.com/index.json")
           expect(nuget_config_content).to include("https://api.nuget.org/v3/index.json")

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -1,0 +1,59 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/nuget/nuget_config_credential_helpers"
+
+RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
+  let(:user_nuget_config_contents_during_and_after_action) do
+    path = Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path
+    content_during_action = nil
+    Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials, lambda {
+      content_during_action = File.read(path)
+    })
+    content_after_action = File.read(path)
+    { content_during_action: content_during_action, content_after_action: content_after_action }
+  end
+
+  subject(:result) { user_nuget_config_contents_during_and_after_action }
+
+  describe "user level NuGet.Config patching" do
+    context "with an empty credential set" do
+      let(:credentials) { [] }
+
+      it "does not change the contents of the file" do
+        expect(result[:content_during_action]).to include("https://api.nuget.org/v3/index.json")
+        expect(result[:content_after_action]).to include("https://api.nuget.org/v3/index.json")
+      end
+    end
+
+    context "with non-empty credential set" do
+      let(:credentials) do
+        [{ "type" => "nuget_feed", "url" => "https://nuget.example.com/index.json", "token" => "secret_token" }]
+      end
+
+      context "with credentials given" do
+        it "changes the content of the config file, then changes it back" do
+          expect(result[:content_during_action]).to include("https://nuget.example.com/index.json")
+          expect(result[:content_during_action]).not_to include("https://api.nuget.org/v3/index.json")
+
+          expect(result[:content_after_action]).not_to include("https://nuget.example.com/index.json")
+          expect(result[:content_after_action]).to include("https://api.nuget.org/v3/index.json")
+        end
+      end
+
+      context "when exception is raised" do
+        it "restores the original file after an exception" do
+          Dependabot::Nuget::NuGetConfigCredentialHelpers.patch_nuget_config_for_action(
+            credentials,
+            lambda {
+              raise "This exception was raised when the NuGet.Config file was patched"
+            }
+          )
+          nuget_config_content = File.read(Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path)
+          expect(nuget_config_content).not_to include("https://nuget.example.com/index.json")
+          expect(nuget_config_content).to include("https://api.nuget.org/v3/index.json")
+        end
+      end
+    end
+  end
+end

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -15,29 +15,50 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
   end
 
   subject(:result) { user_nuget_config_contents_during_and_after_action }
+  let(:default_nuget_config_contents) do
+    File.read(Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path)
+  end
 
   describe "user level NuGet.Config patching" do
     context "with an empty credential set" do
       let(:credentials) { [] }
 
       it "does not change the contents of the file" do
-        expect(result[:content_during_action]).to include("https://api.nuget.org/v3/index.json")
-        expect(result[:content_after_action]).to include("https://api.nuget.org/v3/index.json")
+        expect(result[:content_during_action]).to eq(default_nuget_config_contents)
+        expect(result[:content_after_action]).to eq(default_nuget_config_contents)
       end
     end
 
     context "with non-empty credential set" do
       let(:credentials) do
-        [{ "type" => "nuget_feed", "url" => "https://nuget.example.com/index.json", "token" => "secret_token" }]
+        [
+          { "type" => "nuget_feed", "url" => "https://private.nuget.example.com/index.json",
+            "token" => "secret_token" },
+          { "type" => "nuget_feed", "url" => "https://public.nuget.example.com/index.json" },
+          { "type" => "not_nuget", "some_other_field" => "some other value" }
+        ]
       end
 
       context "with credentials given" do
         it "changes the content of the config file, then changes it back" do
-          expect(result[:content_during_action]).to include("https://nuget.example.com/index.json")
-          expect(result[:content_during_action]).not_to include("https://api.nuget.org/v3/index.json")
-
-          expect(result[:content_after_action]).not_to include("https://nuget.example.com/index.json")
-          expect(result[:content_after_action]).to include("https://api.nuget.org/v3/index.json")
+          expect(result[:content_during_action]).to eq(
+            <<~XML
+              <?xml version="1.0" encoding="utf-8"?>
+              <configuration>
+                <packageSources>
+                  <add key="nuget_source_1" value="https://private.nuget.example.com/index.json" />
+                  <add key="nuget_source_2" value="https://public.nuget.example.com/index.json" />
+                </packageSources>
+                <packageSourceCredentials>
+                  <nuget_source_1>
+                    <add key="Username" value="user" />
+                    <add key="ClearTextPassword" value="secret_token" />
+                  </nuget_source_1>
+                </packageSourceCredentials>
+              </configuration>
+            XML
+          )
+          expect(result[:content_after_action]).to eq(default_nuget_config_contents)
         end
       end
 
@@ -47,8 +68,7 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
             raise "This exception was raised when the NuGet.Config file was patched"
           end
           nuget_config_content = File.read(Dependabot::Nuget::NuGetConfigCredentialHelpers.user_nuget_config_path)
-          expect(nuget_config_content).not_to include("https://nuget.example.com/index.json")
-          expect(nuget_config_content).to include("https://api.nuget.org/v3/index.json")
+          expect(nuget_config_content).to eq(default_nuget_config_contents)
         end
       end
     end


### PR DESCRIPTION
When dependabot is launched, private NuGet feed credentials might be passed in via the `credentials` object.  These credentials are used to query NuGet, but when the C# command line tool is launched, these credentials are not passed through.  Since the command line tool may start other dotnet or NuGet processes, the proper way to propagate credentials is to patch the user-level `NuGet.Config` file located at `~/.nuget/NuGet/NuGet.Config`.  This patching is handled in a wrapper function that ensures the original config file is restored after calling the command line tool.  In production this file restore shouldn't matter, because a single dependabot run launches a new container then it's discarded, but when running locally it's best to restore this file.

Fixes #8721.