### PR TITLE
No encoding conversions on cloned files

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -184,7 +184,8 @@ module Dependabot
         repo_path = File.join(clone_repo_contents, path)
         raise Dependabot::DependencyFileNotFound, path unless File.exist?(repo_path)
 
-        content = File.read(repo_path)
+        content = File.binread(repo_path)
+
         type = if File.symlink?(repo_path)
                  symlink_target = File.readlink(repo_path)
                  "symlink"


### PR DESCRIPTION
There's this repo where the `.npmrc` file has `UTF16_LE` encoding. Dependabot fails to run on it:

```
$ SECURITY_ADVISORIES='[{"dependency-name":"follow-redirects","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 1.14.7"]},{"dependency-name":"follow-redirects","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 1.14.8"]},{"dependency-name":"follow-redirects","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 1.15.4"]}]'  bin/dry-run.rb npm_and_yarn "Stuart-Wilcox/gameroom" --dir="/client" --dep="follow-redirects" --security-updates-only --updater-options=grouped_updates_experimental_rules,record_ecosystem_versions,record_update_job_unknown_error --commit=5a02652ca0840b728ddd96dee9afa0f935829dad
=> cloning into /home/dependabot/tmp/Stuart-Wilcox/gameroom
=> checking out commit 5a02652ca0840b728ddd96dee9afa0f935829dad
/home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb:560:in `match?': invalid byte sequence in UTF-8 (ArgumentError)
	from /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb:560:in `skip_package_lock?'
	from /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb:96:in `npm_files'
	from /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb:78:in `fetch_files'
	from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11142/lib/types/private/methods/call_validation.rb:256:in `bind_call'
	from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11142/lib/types/private/methods/call_validation.rb:256:in `validate_call'
	from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11142/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
	from /home/dependabot/common/lib/dependabot/file_fetchers/base.rb:108:in `files'
	from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11142/lib/types/private/methods/call_validation_2_7.rb:660:in `bind_call'
	from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11142/lib/types/private/methods/call_validation_2_7.rb:660:in `block in create_validator_method_medium0'
	from bin/dry-run.rb:402:in `fetch_files'
	from bin/dry-run.rb:487:in `<main>'
```

This change fixes the problem.

It's a bit risky because it affects all files for all ecosystems that clone, but I _think_ it may work fine.

The idea is to read the raw content, without any automatic conversions to our default encoding (UTF-8).

It may still fail for files with non standard encoding at write time, but in this case, the `.npmrc` is just a support file that's just read, so this allows that case to work.