### PR TITLE
Handle unexpected kub image shapes

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -113,6 +113,7 @@ module Dependabot
             # TODO: Support Docker references and path references
             details = string.match(IMAGE_SPEC)&.named_captures
             next if details.nil?
+
             details["registry"] = nil if details["registry"] == "docker.io"
 
             version = version_from(details)

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -111,7 +111,11 @@ module Dependabot
 
           images.each do |string|
             # TODO: Support Docker references and path references
-            details = string.match(IMAGE_SPEC).named_captures
+            match = string.match(IMAGE_SPEC)
+
+            next if match.nil?
+
+            details = match.named_captures
             details["registry"] = nil if details["registry"] == "docker.io"
 
             version = version_from(details)

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -111,11 +111,8 @@ module Dependabot
 
           images.each do |string|
             # TODO: Support Docker references and path references
-            match = string.match(IMAGE_SPEC)
-
-            next if match.nil?
-
-            details = match.named_captures
+            details = string.match(IMAGE_SPEC)&.named_captures
+            next if details.nil?
             details["registry"] = nil if details["registry"] == "docker.io"
 
             version = version_from(details)

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -679,6 +679,11 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
+    context "with unknown tag" do
+      let(:podfile_fixture_name) { "unexpected_image.yaml" }
+      its(:length) { is_expected.to eq(0) }
+    end
+
     context "with no tag or digest" do
       let(:podfile_fixture_name) { "bare.yaml" }
       its(:length) { is_expected.to eq(0) }

--- a/docker/spec/fixtures/kubernetes/yaml/unexpected_image.yaml
+++ b/docker/spec/fixtures/kubernetes/yaml/unexpected_image.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+spec:
+  containers:
+  - name: ubuntu
+    image: <<VAR>>/sdf/official/stuff/thing:<<VAR2>>
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
If the `image` field didn't match our regex we would throw when `.match` returned nil. It's possible we should handle a wider variety of image specs, but when all that fails we need to not throw nil exceptions.