### PR TITLE
Fix broken nuget CI

### DIFF
--- a/nuget/lib/dependabot/nuget/cache_manager.rb
+++ b/nuget/lib/dependabot/nuget/cache_manager.rb
@@ -13,6 +13,8 @@ module Dependabot
       end
 
       def self.cache(name)
+        return {} if caching_disabled?
+
         @cache ||= {}
         @cache[name] ||= {}
         @cache[name]

--- a/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
@@ -26,8 +26,6 @@ module Dependabot
         end
 
         def dependency_set
-          return parse_dependencies if CacheManager.caching_disabled?
-
           key = "#{packages_config.name.downcase}::#{packages_config.content.hash}"
           cache = PackagesConfigParser.dependency_set_cache
 

--- a/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
@@ -32,10 +32,6 @@ module Dependabot
           cache = PackagesConfigParser.dependency_set_cache
 
           cache[key] ||= parse_dependencies
-
-          dependency_set = Dependabot::FileParsers::Base::DependencySet.new
-          dependency_set += cache[key]
-          dependency_set
         end
 
         private

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -50,8 +50,6 @@ module Dependabot
         end
 
         def dependency_set(project_file:)
-          return parse_dependencies(project_file) if CacheManager.caching_disabled?
-
           key = "#{project_file.name.downcase}::#{project_file.content.hash}"
           cache = ProjectFileParser.dependency_set_cache
 

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -56,10 +56,6 @@ module Dependabot
           cache = ProjectFileParser.dependency_set_cache
 
           cache[key] ||= parse_dependencies(project_file)
-
-          dependency_set = Dependabot::FileParsers::Base::DependencySet.new
-          dependency_set += cache[key]
-          dependency_set
         end
 
         def target_frameworks(project_file:)

--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -1,11 +1,11 @@
 # typed: true
 # frozen_string_literal: true
 
-require "dependabot/nuget/update_checker"
+require "dependabot/update_checkers/base"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class CompatibilityChecker
         require_relative "nuspec_fetcher"
         require_relative "nupkg_fetcher"

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -4,12 +4,12 @@
 require "nokogiri"
 require "zip"
 require "stringio"
-require "dependabot/nuget/update_checker"
+require "dependabot/update_checkers/base"
 require "dependabot/nuget/version"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class DependencyFinder
         require_relative "requirements_updater"
         require_relative "nuspec_fetcher"

--- a/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
@@ -1,12 +1,12 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/update_checkers/base"
 require "dependabot/nuget/file_parser"
-require "dependabot/nuget/update_checker"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class PropertyUpdater
         require_relative "version_finder"
         require_relative "requirements_updater"

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -4,12 +4,12 @@
 require "excon"
 require "nokogiri"
 require "dependabot/errors"
-require "dependabot/nuget/update_checker"
+require "dependabot/update_checkers/base"
 require "dependabot/registry_client"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class RepositoryFinder
         DEFAULT_REPOSITORY_URL = "https://api.nuget.org/v3/index.json"
         DEFAULT_REPOSITORY_API_KEY = "nuget.org"

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -97,7 +97,7 @@ module Dependabot
         def get_repo_metadata(repo_details)
           url = repo_details.fetch(:url)
           cache = CacheManager.cache("repo_finder_metadatacache")
-          if !CacheManager.caching_disabled? && cache[url]
+          if cache[url]
             cache[url]
           else
             result = Dependabot::RegistryClient.get(

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -6,6 +6,7 @@ require "nokogiri"
 require "dependabot/errors"
 require "dependabot/update_checkers/base"
 require "dependabot/registry_client"
+require "dependabot/nuget/cache_manager"
 
 module Dependabot
   module Nuget

--- a/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
@@ -6,12 +6,12 @@
 # https://docs.microsoft.com/en-us/nuget/reference/package-versioning #
 #######################################################################
 
-require "dependabot/nuget/update_checker"
+require "dependabot/update_checkers/base"
 require "dependabot/nuget/version"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class RequirementsUpdater
         def initialize(requirements:, latest_version:, source_details:)
           @requirements = requirements

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
@@ -1,15 +1,15 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/update_checkers/base"
 require "dependabot/nuget/version"
 require "dependabot/nuget/requirement"
 require "dependabot/nuget/native_helpers"
-require "dependabot/nuget/update_checker"
 require "dependabot/shared_helpers"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class TfmComparer
         def self.are_frameworks_compatible?(project_tfms, package_tfms)
           return false if package_tfms.empty?

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
@@ -4,15 +4,15 @@
 require "excon"
 require "nokogiri"
 
+require "dependabot/update_checkers/base"
 require "dependabot/nuget/version"
 require "dependabot/nuget/requirement"
 require "dependabot/nuget/native_helpers"
-require "dependabot/nuget/update_checker"
 require "dependabot/shared_helpers"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class TfmFinder
         require "dependabot/nuget/file_parser/packages_config_parser"
         require "dependabot/nuget/file_parser/project_file_parser"

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -3,13 +3,13 @@
 
 require "dependabot/nuget/version"
 require "dependabot/nuget/requirement"
+require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/version_filters"
-require "dependabot/nuget/update_checker"
 require "dependabot/nuget/nuget_client"
 
 module Dependabot
   module Nuget
-    class UpdateChecker
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
       class VersionFinder
         require_relative "compatibility_checker"
         require_relative "repository_finder"

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -906,6 +906,8 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             end
 
             it "has the right details" do
+              ENV["DEPENDABOT_NUGET_CACHE_DISABLED"] = "false"
+
               registry_stub = stub_registry_v3("microsoft.extensions.dependencymodel_cached", ["1.1.1", "1.1.0"])
 
               expect(top_level_dependencies.count).to eq(1)
@@ -921,6 +923,9 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
                 }]
               )
               expect(WebMock::RequestRegistry.instance.times_executed(registry_stub.request_pattern)).to eq(1)
+            ensure
+              ENV["DEPENDABOT_NUGET_CACHE_DISABLED"] = "true"
+              Dependabot::Nuget::CacheManager.instance_variable_set(:@cache, nil)
             end
           end
         end


### PR DESCRIPTION
Nuget CI is currently broken.

Issues are order dependent (although seem to be happening consistently), and can be reproduced with:

```
$ rspec './spec/dependabot/nuget/update_checker/version_finder_spec.rb[1:1:15:1:1:1,1:1:17:1:1]' --seed 17384
```

The issue is dependency caching.

This PR fixes the problem by making sure specs always avoid caching, except when the caching itself is being explicitly tested.

In addition to this, this PR also introduces some changes to make it possible to actually reproduce the failure, because running specs in isolation currently fails with another error, namely:

```
$ rspec ./spec/dependabot/nuget/update_checker/version_finder_spec.rb:407

An error occurred while loading ./spec/dependabot/nuget/update_checker/version_finder_spec.rb.
Failure/Error:
      class UpdateChecker < Dependabot::UpdateCheckers::Base
        require_relative "update_checker/version_finder"
        require_relative "update_checker/property_updater"
        require_relative "update_checker/requirements_updater"
        require_relative "update_checker/dependency_finder"

        def latest_version
          # No need to find latest version for transitive dependencies unless they have a vulnerability.
          return dependency.version if !dependency.top_level? && !vulnerable?

TypeError:
  superclass mismatch for class UpdateChecker
# ./lib/dependabot/nuget/update_checker.rb:10:in `<module:Nuget>'
# ./lib/dependabot/nuget/update_checker.rb:9:in `<module:Dependabot>'
# ./lib/dependabot/nuget/update_checker.rb:8:in `<top (required)>'
# ./lib/dependabot/nuget/update_checker/version_finder.rb:7:in `require'
# ./lib/dependabot/nuget/update_checker/version_finder.rb:7:in `<top (required)>'
# ./spec/dependabot/nuget/update_checker/version_finder_spec.rb:7:in `require'
# ./spec/dependabot/nuget/update_checker/version_finder_spec.rb:7:in `<top (required)>'
```