### PR TITLE
Added Ruby 3.3.0 to RubyRequirementSetter version requirements

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -12,7 +12,7 @@ module Dependabot
         class RubyVersionNotFound < StandardError; end
 
         RUBY_VERSIONS = %w(
-          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.4 3.2.2
+          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.4 3.2.2 3.3.0
         ).freeze
 
         attr_reader :gemspec

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -126,6 +126,17 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
       end
 
+      context "when requiring ruby 3.3" do
+        let(:gemspec) do
+          bundler_project_dependency_file("gemfile_require_ruby_3_3", filename: "example.gemspec")
+        end
+        let(:content) do
+          bundler_project_dependency_file("gemfile", filename: "Gemfile").content
+        end
+        it { is_expected.to include("ruby '3.3.0'\n") }
+        it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
+      end
+
       context "that can't be evaluated" do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_3/example.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 3.3.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   2.5.3

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_3/example.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 3.3.0"
+  spec.required_rubygems_version = ">= 3.5.3"
+
+  spec.add_dependency 'business', '~> 1.0'
+end


### PR DESCRIPTION
Added Ruby 3.3.0 to `RubyRequirementSetter` version requirements.

<img width="1050" alt="Screenshot 2024-01-10 at 15 16 01" src="https://github.com/dependabot/dependabot-core/assets/163900/34e255eb-3079-496c-89d9-a648db80483e">

Think this will fix the `Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound` error raised in https://github.com/dependabot/dependabot-core/issues/8739