### PR TITLE
Branch names use the job_directory if the directory is nil

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -64,7 +64,7 @@ module Dependabot
         end
 
         def directory
-          T.must(files.first).directory.tr(" ", "-")
+          T.must(files.first).directory.&tr(" ", "-") || T.must(files.first).job_directory.tr(" ", "-")
         end
       end
     end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -58,10 +58,7 @@ module Dependabot
     end
 
     def updated_dependency_files_hash
-      files = updated_dependency_files.map(&:to_h)
-      # incidental to the job, no need to send to the server
-      files.each { |f| f.delete("job_directory") }
-      files
+      updated_dependency_files.map(&:to_h)
     end
 
     def grouped_update?


### PR DESCRIPTION
WIP

We are seeing an error around creating the branch name for grouped security updates where the `directory` is nil for some [DependencyFiles](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/dependency_file.rb#L18).

> undefined method `directory' for nil:NilClass files.first.directory.tr(" ", "-")

The default value is [actually `"/"`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/dependency_file.rb#L79), so it's explicitly being set to nil somewhere.

We could pass in an empty string for the directory, or we could use the `job_directory`, which is the directory that triggered the security update job. I chose the latter approach in this PR.