### PR TITLE
Bump golang from 1.21.5-bookworm to 1.21.6-bookworm in /go_modules

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-bookworm as go
+FROM golang:1.21.6-bookworm as go
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH


### PR DESCRIPTION
Go 1.21.6 was released on 2024-01-09, without this Dependabot currently sees the following issue:

```
updater | 2024/01/10 21:30:34 ERROR <job_772665481> go: go.mod requires go >= 1.21.6 (running go 1.21.5; GOTOOLCHAIN=local)
```
