### PR TITLE
Remove unnecessary gitignore rules

### DIFF
--- a/bundler/.gitignore
+++ b/bundler/.gitignore
@@ -3,7 +3,5 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock
 spec/fixtures/projects/*/.bundle/
-!spec/fixtures/projects/**/Gemfile.lock
 !spec/fixtures/projects/**/vendor

--- a/cargo/.gitignore
+++ b/cargo/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/composer/.gitignore
+++ b/composer/.gitignore
@@ -5,4 +5,3 @@
 /dependabot-*.gem
 /helpers/vendor/
 .php-cs-fixer.cache
-Gemfile.lock

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/elm/.gitignore
+++ b/elm/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/git_submodules/.gitignore
+++ b/git_submodules/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/github_actions/.gitignore
+++ b/github_actions/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/go_modules/.gitignore
+++ b/go_modules/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/gradle/.gitignore
+++ b/gradle/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/hex/.gitignore
+++ b/hex/.gitignore
@@ -6,4 +6,3 @@
 /helpers/deps/
 /helpers/install-dir
 /dependabot-*.gem
-Gemfile.lock

--- a/maven/.gitignore
+++ b/maven/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/npm_and_yarn/.gitignore
+++ b/npm_and_yarn/.gitignore
@@ -5,4 +5,3 @@
 /dependabot-*.gem
 /helpers/node_modules
 /helpers/install-dir
-Gemfile.lock

--- a/nuget/.gitignore
+++ b/nuget/.gitignore
@@ -3,5 +3,4 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock
 Properties/

--- a/omnibus/.gitignore
+++ b/omnibus/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/pub/.gitignore
+++ b/pub/.gitignore
@@ -3,6 +3,5 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock
 .dart_tool/
 .packages

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,5 +3,4 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock
 helpers/install-dir

--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -3,4 +3,3 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,5 +3,4 @@
 /.env
 /tmp
 /dependabot-*.gem
-Gemfile.lock
 .terraform


### PR DESCRIPTION
Since ecosystem specific gemfiles where removed, these can be removed too. All `Gemfile.lock` files are now in source control.