### PR TITLE
directory is the job directory

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -14,6 +14,8 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_accessor :content
 
+    # This is the directory of the job source, not the directory of the file itself.
+    # The name actually contains the relative path from the job directory.
     sig { returns(String) }
     attr_accessor :directory
 

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -38,11 +38,6 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_accessor :mode
 
-    # The directory that this file was fetched for. This is useful for multi-directory
-    # updates, where a set of files that are related to each other are updated together.
-    sig { returns(T.nilable(String)) }
-    attr_accessor :job_directory
-
     class ContentEncoding
       UTF_8 = "utf-8"
       BASE64 = "base64"
@@ -71,15 +66,14 @@ module Dependabot
         content_encoding: String,
         deleted: T::Boolean,
         operation: String,
-        mode: T.nilable(String),
-        job_directory: T.nilable(String)
+        mode: T.nilable(String)
       )
         .void
     end
     def initialize(name:, content:, directory: "/", type: "file",
                    support_file: false, vendored_file: false, symlink_target: nil,
                    content_encoding: ContentEncoding::UTF_8, deleted: false,
-                   operation: Operation::UPDATE, mode: nil, job_directory: nil)
+                   operation: Operation::UPDATE, mode: nil)
       @name = name
       @content = content
       @directory = T.let(clean_directory(directory), String)
@@ -88,7 +82,6 @@ module Dependabot
       @vendored_file = vendored_file
       @content_encoding = content_encoding
       @operation = operation
-      @job_directory = job_directory
 
       # Make deleted override the operation. Deleted is kept when operation
       # was introduced to keep compatibility with downstream dependants.
@@ -127,7 +120,6 @@ module Dependabot
         "mode" => mode
       }
 
-      details["job_directory"] = job_directory if job_directory
       details["symlink_target"] = symlink_target if symlink_target
       details
     end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -104,10 +104,7 @@ module Dependabot
 
       sig { returns(T::Array[DependencyFile]) }
       def files
-        @files ||= T.let(
-          fetch_files.each { |f| f.job_directory = directory },
-          T.nilable(T::Array[DependencyFile])
-        )
+        @files ||= T.let(fetch_files, T.nilable(T::Array[DependencyFile]))
       end
 
       sig { abstract.returns(T::Array[DependencyFile]) }

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -58,10 +58,7 @@ module Dependabot
     end
 
     def updated_dependency_files_hash
-      files = updated_dependency_files.map(&:to_h)
-      # incidental to the job, no need to send to the server
-      files.each { |f| f.delete("job_directory") }
-      files
+      updated_dependency_files.map(&:to_h)
     end
 
     def grouped_update?

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -28,9 +28,9 @@ module Dependabot
         directory = Pathname.new(job.source.directory).cleanpath.to_s
 
         @dependency_file_batch.filter_map do |_path, data|
-          next data[:file] if data[:file].job_directory.nil?
+          next data[:file] if data[:file].directory.nil?
 
-          data[:file] if Pathname.new(data[:file].job_directory).cleanpath.to_s == directory
+          data[:file] if Pathname.new(data[:file].directory).cleanpath.to_s == directory
         end
       end
 

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -11,15 +11,11 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
   describe "current_dependency_files" do
     let(:files) do
       [
-        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-gemfile", directory: "/", job_directory: "/"),
-        Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-gemfile-lock", directory: "/hello/..",
-                                       job_directory: "/"),
-        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "/elsewhere",
-                                       job_directory: "/other"),
-        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown",
-                                       job_directory: "/hello"),
-        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob",
-                                       job_directory: "/oob")
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-gemfile", directory: "/"),
+        Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-gemfile-lock", directory: "/hello/.."),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "/elsewhere"),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown"),
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob")
       ]
     end
 


### PR DESCRIPTION
In #8405 I was under the impression that `DependencyFile`'s `directory` was the directory of the file, and name was just the basename, but that's not the case. A `DependencyFile`'s `directory` should always be the job (source) directory, and the `name` contains the relative path from the `directory` and also the filename. 

Not sure what problem I was running into before, but removing `job_directory` and filtering on directory alone is passing the smoke tests, so this is confirmed!