### PR TITLE
Track errored dependencies in a DependencyChange

### DIFF
--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -16,6 +16,9 @@ module Dependabot
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       attr_reader :dependency_files
 
+      sig { returns(T::Array[String]) }
+      attr_reader :errored_dependencies
+
       sig { returns(T.nilable(String)) }
       attr_reader :repo_contents_path
 
@@ -45,6 +48,7 @@ module Dependabot
         @repo_contents_path = repo_contents_path
         @credentials = credentials
         @options = options
+        @errored_dependencies = []
 
         check_required_files
       end
@@ -52,6 +56,10 @@ module Dependabot
       sig { overridable.returns(T::Array[::Dependabot::DependencyFile]) }
       def updated_dependency_files
         raise NotImplementedError
+      end
+
+      def add_errored_dependency(dependency)
+        errored_dependencies << dependency
       end
 
       private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -434,6 +434,7 @@ module Dependabot
           dependency_names = dependencies.map(&:name).join(", ")
           msg = "Error whilst updating #{dependency_names} in " \
                 "#{lockfile.path}:\n#{error_message}"
+          add_errored_dependency(dependency_names)
           raise Dependabot::DependencyFileNotResolvable, msg
         end
 

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -14,11 +14,12 @@ module Dependabot
   class DependencyChange
     attr_reader :job, :updated_dependencies, :errored_dependencies, :updated_dependency_files, :dependency_group
 
-    def initialize(job:, updated_dependencies:, updated_dependency_files:, dependency_group: nil)
+    def initialize(job:, updated_dependencies:, updated_dependency_files:, errored_dependencies: [], dependency_group: nil)
       @job = job
       @updated_dependencies = updated_dependencies
       @updated_dependency_files = updated_dependency_files
       @dependency_group = dependency_group
+      @errored_dependencies = errored_dependencies
     end
 
     def pr_message

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -12,7 +12,7 @@
 # by adapters to create a Pull Request, apply the changes on disk, etc.
 module Dependabot
   class DependencyChange
-    attr_reader :job, :updated_dependencies, :updated_dependency_files, :dependency_group
+    attr_reader :job, :updated_dependencies, :errored_dependencies, :updated_dependency_files, :dependency_group
 
     def initialize(job:, updated_dependencies:, updated_dependency_files:, dependency_group: nil)
       @job = job

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -31,6 +31,7 @@ module Dependabot
       @dependency_files = dependency_files
       @updated_dependencies = updated_dependencies
       @change_source = change_source
+      @errored_dependencies = []
     end
 
     def run
@@ -51,6 +52,7 @@ module Dependabot
         job: job,
         updated_dependencies: updated_deps,
         updated_dependency_files: updated_files,
+        errored_dependencies: errored_dependencies,
         dependency_group: source_dependency_group
       )
     end
@@ -58,6 +60,7 @@ module Dependabot
     private
 
     attr_reader :job, :dependency_files, :updated_dependencies, :change_source
+    attr_accessor :errored_dependencies
 
     def source_dependency_name
       return nil unless change_source.is_a? Dependabot::Dependency
@@ -86,7 +89,12 @@ module Dependabot
       # updated indirectly as a result of a parent dependency update and are
       # only included here to be included in the PR info.
       relevant_dependencies = updated_dependencies.reject(&:informational_only?)
-      file_updater_for(relevant_dependencies).updated_dependency_files
+
+      file_updater = file_updater_for(relevant_dependencies)
+      updated_files = file_updater.updated_dependency_file
+      errored_dependencies = file_updater.errored_dependencies
+
+      updated_files
     end
 
     def file_updater_for(dependencies)

--- a/updater/lib/dependabot/updater/group_update_refreshing.rb
+++ b/updater/lib/dependabot/updater/group_update_refreshing.rb
@@ -15,6 +15,8 @@ module Dependabot
       def upsert_pull_request_with_error_handling(dependency_change, group)
         if dependency_change.updated_dependencies.any?
           upsert_pull_request(dependency_change, group)
+        elsif dependency_change.errored_dependencies.any?
+          Dependabot.logger.info("Grouped update encountered errors. No dependencies could be updated.")
         else
           Dependabot.logger.info("Dependencies are up to date, closing existing Pull Request")
           close_pull_request(reason: :up_to_date, group: group)


### PR DESCRIPTION
During a grouped (security) update refresh, we have no way of knowing whether the `updated_dependencies` list is empty because all of the dependencies during the update errored, or if the users have manually updated the dependencies themselves, so Dependabot closes out a PR during a rebase/recreate when it should leave the PR open and explain any errors.

This PR adds in an `errored_dependencies` array to a DependencyChange. Alternatively, we could create a flag instead of an array if we don't want to do anything with these errors (other than know they occurred).

This isn't a great approach imo, because we would need to call `FileUpdater#add_errored_dependency` for every error across all ecosystems. It might be a nicer implementation if we intercept/re-raise Dependabot all FileUpdater errors and make errored_dependencies a flag. We wouldn't know which dependencies errored without checking the logs, but that might be okay.