### PR TITLE
Fix vscode rdbg launch command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Tests",
+      "name": "Debug current file",
       "type": "rdbg",
       "request": "launch",
       "command": "rspec",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,9 +1,15 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
+    {
+      "name": "Debug Tests",
+      "type": "rdbg",
+      "request": "launch",
+      "command": "rspec",
+      "cwd": "${workspaceRoot}/${input:ecosystem}",
+      "useBundler": true,
+      "script": "${file}"
+    },
     {
       "name": "Debug dry run",
       "type": "rdbg",
@@ -11,21 +17,7 @@
       "script": "${workspaceRoot}/bin/dry-run.rb",
       "cwd": "${workspaceRoot}",
       "useBundler": true,
-      "args": [
-        "${input:package_manager}",
-        "${input:repository}"
-      ]
-    },
-    {
-      "name": "Debug Tests",
-      "type": "rdbg",
-      "request": "launch",
-      "script": "${workspaceRoot}/omnibus/.bundle/bin/rspec",
-      "cwd": "${workspaceRoot}/${input:ecosystem}",
-      "useBundler": true,
-      "args": [
-        "${input:test_path}"
-      ],
+      "args": ["${input:package_manager}", "${input:repository}"]
     },
     {
       "type": "rdbg",
@@ -127,13 +119,7 @@
         "python",
         "terraform"
       ],
-      "default": "python"
-    },
-    {
-      "type": "promptString",
-      "id": "test_path",
-      "description": "Enter the path of the test(s) to run.",
-      "default": "spec"
+      "default": "common"
     },
     {
       "type": "promptString",


### PR DESCRIPTION
The `omnibus` directory doesn't include `.bundle/bin/rspec` anymore, so I use the `rspec` command from `$PATH` instead. I also changed it to run the current file by default, instead of asking you to input the file path.

I also moved the tests command to the top of the list, so it runs by default when  hitting F5. I think it's more common than debugging `dry-run.rb`.