### PR TITLE
raise a specific exception when the FileUpdater doesn't produce a change

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -35,6 +35,8 @@ module Dependabot
 
     def run
       updated_files = generate_dependency_files
+      raise DependabotError, "FileUpdater failed" unless updated_files.any?
+
       # Remove any unchanged dependencies from the updated list
       updated_deps = updated_dependencies.reject do |d|
         # Avoid rejecting the source dependency

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -152,8 +152,6 @@ module Dependabot
             change_source: checker.dependency
           )
 
-          raise DependabotError, "FileUpdater failed" unless dependency_change.updated_dependency_files.any?
-
           create_pull_request(dependency_change)
         rescue Dependabot::AllVersionsIgnored
           Dependabot.logger.info("All updates for #{dependency.name} were ignored")

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -121,5 +121,31 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
         expect(dependency_change).to be_grouped_update
       end
     end
+
+    context "when there are no file changes" do
+      let(:change_source) do
+        Dependabot::Dependency.new(
+          name: "dummy-pkg-b",
+          package_manager: "bundler",
+          version: "1.1.0",
+          requirements: [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.1.0",
+              groups: [],
+              source: nil
+            }
+          ]
+        )
+      end
+
+      before do
+        allow_any_instance_of(Dependabot::Bundler::FileUpdater).to receive(:updated_dependency_files).and_return([])
+      end
+
+      it "raises an exception" do
+        expect { create_change }.to raise_error(Dependabot::DependabotError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a better approach to https://github.com/dependabot/dependabot-core/pull/8782

Now no matter which Operation runs it will raise an error when there are no updated files.

Also by moving it into the DependencyChangeBuilder, it's testable!