### PR TITLE
Handle Update PackageReferences more correctly

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -349,6 +349,70 @@ public class MSBuildHelperTests
                 new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
             }
         };
+
+        // version is set in one file, used in another
+        yield return new object[]
+        {
+            // build file contents
+            new[]
+            {
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Azure.Identity" Version="1.6.0" />
+                        <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.4" />
+                      </ItemGroup>
+                    </Project>
+                """),
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Azure.Identity" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            },
+            // expected dependencies
+            new Dependency[]
+            {
+                new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+            }
+        };
+
+        // version is set in one file, used in another
+        yield return new object[]
+        {
+            // build file contents
+            new[]
+            {
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Azure.Identity" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Azure.Identity" Version="1.6.0" />
+                        <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.4" />
+                      </ItemGroup>
+                    </Project>
+                """)
+            },
+            // expected dependencies
+            new Dependency[]
+            {
+                new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+            }
+        };
     }
 
     public static IEnumerable<object[]> SolutionProjectPathTestData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -196,7 +196,7 @@ public class MSBuildHelperTests
         };
         var packages = new[] {
             new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
-            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown, UpdateOnly: true)
+            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown, IsUpdate: true)
         };
         var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "netstandard2.0", packages);
         Assert.Equal(expectedDependencies, actualDependencies);
@@ -410,7 +410,7 @@ public class MSBuildHelperTests
             new Dependency[]
             {
                 new("Azure.Identity", "1.6.0", DependencyType.Unknown),
-                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, UpdateOnly: true)
+                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, IsUpdate: true)
             }
         };
 
@@ -443,7 +443,7 @@ public class MSBuildHelperTests
             new Dependency[]
             {
                 new("Azure.Identity", "1.6.0", DependencyType.Unknown),
-                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, UpdateOnly: true)
+                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, IsUpdate: true)
             }
         };
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -401,7 +401,7 @@ public class MSBuildHelperTests
                         <TargetFramework>netstandard2.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Azure.Identity" />
+                        <PackageReference Include="Azure.Identity" Version="1.6.1" />
                       </ItemGroup>
                     </Project>
                     """)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -172,6 +172,37 @@ public class MSBuildHelperTests
     }
 
     [Fact]
+    public async Task AllPackageDependencies_DoNotIncludeUpdateOnlyPackages()
+    {
+        using var temp = new TemporaryDirectory();
+        var expectedDependencies = new Dependency[]
+        {
+            new("Microsoft.Bcl.AsyncInterfaces", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.DependencyInjection", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.DependencyInjection.Abstractions", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Logging", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Logging.Abstractions", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Options", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Primitives", "7.0.0", DependencyType.Unknown),
+            new("System.Buffers", "4.5.1", DependencyType.Unknown),
+            new("System.ComponentModel.Annotations", "5.0.0", DependencyType.Unknown),
+            new("System.Diagnostics.DiagnosticSource", "7.0.0", DependencyType.Unknown),
+            new("System.Memory", "4.5.5", DependencyType.Unknown),
+            new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown),
+            new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown),
+            new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown),
+            new("NETStandard.Library", "2.0.3", DependencyType.Unknown),
+        };
+        var packages = new[] {
+            new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
+            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown, UpdateOnly: true)
+        };
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "netstandard2.0", packages);
+        Assert.Equal(expectedDependencies, actualDependencies);
+    }
+
+    [Fact]
     public async Task AllPackageDependenciesCanBeFoundWithNuGetConfig()
     {
         var nugetPackagesDirectory = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
@@ -378,7 +409,8 @@ public class MSBuildHelperTests
             // expected dependencies
             new Dependency[]
             {
-                new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+                new("Azure.Identity", "1.6.0", DependencyType.Unknown),
+                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, UpdateOnly: true)
             }
         };
 
@@ -410,7 +442,8 @@ public class MSBuildHelperTests
             // expected dependencies
             new Dependency[]
             {
-                new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+                new("Azure.Identity", "1.6.0", DependencyType.Unknown),
+                new("Microsoft.Data.SqlClient", "5.1.4", DependencyType.Unknown, UpdateOnly: true)
             }
         };
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
@@ -1,3 +1,3 @@
 namespace NuGetUpdater.Core;
 
-public sealed record Dependency(string Name, string? Version, DependencyType Type, bool IsDevDependency = false, bool IsOverride = false, bool UpdateOnly = false);
+public sealed record Dependency(string Name, string? Version, DependencyType Type, bool IsDevDependency = false, bool IsOverride = false, bool IsUpdate = false);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
@@ -1,3 +1,3 @@
 namespace NuGetUpdater.Core;
 
-public sealed record Dependency(string Name, string? Version, DependencyType Type, bool IsDevDependency = false, bool IsOverride = false);
+public sealed record Dependency(string Name, string? Version, DependencyType Type, bool IsDevDependency = false, bool IsOverride = false, bool UpdateOnly = false);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -34,7 +34,7 @@ internal static partial class SdkPackageUpdater
         foreach (var tfm in tfms)
         {
             var dependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(repoRootPath, projectPath, tfm, topLevelDependencies, logger);
-            foreach (var (packageName, packageVersion, _, _, _) in dependencies)
+            foreach (var (packageName, packageVersion, _, _, _, _) in dependencies)
             {
                 if (packageName.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
                 {
@@ -76,7 +76,7 @@ internal static partial class SdkPackageUpdater
         var packagesAndVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (tfm, dependencies) in tfmsAndDependencies)
         {
-            foreach (var (packageName, packageVersion, _, _, _) in dependencies)
+            foreach (var (packageName, packageVersion, _, _, _, _) in dependencies)
             {
                 if (packagesAndVersions.TryGetValue(packageName, out var existingVersion) &&
                     existingVersion != packageVersion)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -209,7 +209,7 @@ internal static partial class MSBuildHelper
             // We don't know the version for range requirements or wildcard
             // requirements, so return "" for these.
             yield return packageVersion.Contains(',') || packageVersion.Contains('*')
-                ? new Dependency(name, string.Empty, DependencyType.Unknown, UpdateOnly: updateOnly) // isupdate
+                ? new Dependency(name, string.Empty, DependencyType.Unknown, UpdateOnly: updateOnly)
                 : new Dependency(name, packageVersion, DependencyType.Unknown, UpdateOnly: updateOnly);
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -160,8 +160,8 @@ internal static partial class MSBuildHelper
                             var existingUpdate = existingInfo.Item2;
                             var vSpec = string.IsNullOrEmpty(versionSpecification) || existingUpdate ? existingVersion : versionSpecification;
 
-                            var updateOnly = existingUpdate && string.IsNullOrEmpty(packageItem.Include);
-                            packageInfo[attributeValue] = (vSpec, updateOnly);
+                            var isUpdate = existingUpdate && string.IsNullOrEmpty(packageItem.Include);
+                            packageInfo[attributeValue] = (vSpec, isUpdate);
                         }
                         else
                         {
@@ -195,7 +195,7 @@ internal static partial class MSBuildHelper
 
         foreach (var (name, info) in packageInfo)
         {
-            var (version, updateOnly) = info;
+            var (version, isUpdate) = info;
             if (version.Length != 0 || !packageVersionInfo.TryGetValue(name, out var packageVersion))
             {
                 packageVersion = version;
@@ -209,8 +209,8 @@ internal static partial class MSBuildHelper
             // We don't know the version for range requirements or wildcard
             // requirements, so return "" for these.
             yield return packageVersion.Contains(',') || packageVersion.Contains('*')
-                ? new Dependency(name, string.Empty, DependencyType.Unknown, UpdateOnly: updateOnly)
-                : new Dependency(name, packageVersion, DependencyType.Unknown, UpdateOnly: updateOnly);
+                ? new Dependency(name, string.Empty, DependencyType.Unknown, IsUpdate: isUpdate)
+                : new Dependency(name, packageVersion, DependencyType.Unknown, IsUpdate: isUpdate);
         }
     }
 
@@ -299,7 +299,7 @@ internal static partial class MSBuildHelper
             packages
                 .Where(p => !string.IsNullOrWhiteSpace(p.Version)) // empty `Version` attributes will cause the temporary project to not build
                 // If all PackageReferences for a package are update-only mark it as such, otherwise it can cause package incoherence errors which do not exist in the repo.
-                .Select(static p => $"<PackageReference {(p.UpdateOnly ? "Update" : "Include")}=\"{p.Name}\" Version=\"[{p.Version}]\" />"));
+                .Select(static p => $"<PackageReference {(p.IsUpdate ? "Update" : "Include")}=\"{p.Name}\" Version=\"[{p.Version}]\" />"));
 
         var projectContents = $"""
                 <Project Sdk="Microsoft.NET.Sdk">

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -158,6 +158,8 @@ internal static partial class MSBuildHelper
                         {
                             var existingVersion = existingInfo.Item1;
                             var existingUpdate = existingInfo.Item2;
+                            // Retain the version from the Update reference since the intention
+                            // would be to override the version of the Include reference.
                             var vSpec = string.IsNullOrEmpty(versionSpecification) || existingUpdate ? existingVersion : versionSpecification;
 
                             var isUpdate = existingUpdate && string.IsNullOrEmpty(packageItem.Include);
@@ -165,8 +167,8 @@ internal static partial class MSBuildHelper
                         }
                         else
                         {
-                            var isUpdate = string.IsNullOrEmpty(packageItem.Update);
-                            packageInfo[attributeValue] = (versionSpecification, !string.IsNullOrEmpty(packageItem.Update));
+                            var isUpdate = !string.IsNullOrEmpty(packageItem.Update);
+                            packageInfo[attributeValue] = (versionSpecification, isUpdate);
                         }
                     }
                 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -158,7 +158,7 @@ internal static partial class MSBuildHelper
                         {
                             var existingVersion = existingInfo.Item1;
                             var existingUpdate = existingInfo.Item2;
-                            var vSpec = string.IsNullOrEmpty(versionSpecification) ? existingVersion : versionSpecification;
+                            var vSpec = string.IsNullOrEmpty(versionSpecification) || existingUpdate ? existingVersion : versionSpecification;
 
                             var updateOnly = existingUpdate && string.IsNullOrEmpty(packageItem.Include);
                             packageInfo[attributeValue] = (vSpec, updateOnly);


### PR DESCRIPTION
The existing code includes all packageReferences the TempProject as `<PackageReference Include`, regardless of how they were found in the original context. If (for a given project) a PackageReference exists only as `<PackageReference Update` MSBuild does not load that reference and it should not appear in the Dependencies list. The way I saw this manifesting was that packages which don't get a `<PackageReference Include` in the csproj were getting manually included due to `PR Update`s, which caused `NU1605` errors (package downgrade). I assume it could have other downstream effects that don't occur to me ATM as well.

My fix is that we start keeping track of if we have only seen `Update` versions of particular `PackageReference` items, and if so we should add them to our temp project only as `Update` references.