### PR TITLE
build(deps): bump elixir to 1.16.0

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.14.4
+ARG ELIXIR_VERSION=v1.16.0
 ARG ELIXIR_CHECKSUM=b5705275d62ce3dae172d25d7ea567fffdabb45458abeb29c0189923b907367c
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
 ARG ELIXIR_VERSION=v1.16.0
-ARG ELIXIR_CHECKSUM=b5705275d62ce3dae172d25d7ea567fffdabb45458abeb29c0189923b907367c
+ARG ELIXIR_CHECKSUM=8eb6485da786a5eabb2ad4c962bc7f8f765c673469e40e8c0e0b1b554b7c9184
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \


### PR DESCRIPTION
Release notes : 

https://github.com/elixir-lang/elixir/releases/tag/v1.16.0
https://github.com/elixir-lang/elixir/releases/tag/v1.15.7
https://github.com/elixir-lang/elixir/releases/tag/v1.15.6
https://github.com/elixir-lang/elixir/releases/tag/v1.15.4
https://github.com/elixir-lang/elixir/releases/tag/v1.15.3
https://github.com/elixir-lang/elixir/releases/tag/v1.15.2
https://github.com/elixir-lang/elixir/releases/tag/v1.15.0
https://github.com/elixir-lang/elixir/releases/tag/v1.14.5
