### PR TITLE
Fix reviewers, assignees types in PullReqeustCreator

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -150,7 +150,7 @@ module Dependabot
         signature_key: T.nilable(String),
         commit_message_options: T::Hash[Symbol, T.untyped],
         vulnerabilities_fixed: T::Hash[String, String],
-        reviewers: T.nilable(T::Array[String]),
+        reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, T::Array[Integer]])),
         assignees: T.nilable(T::Array[String]),
         milestone: T.nilable(String),
         branch_name_separator: String,

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -103,7 +103,7 @@ module Dependabot
     sig { returns(T.nilable(T.any(T::Array[String], T::Hash[Symbol, T::Array[Integer]]))) }
     attr_reader :reviewers
 
-    sig { returns(T.nilable(T::Array[String])) }
+    sig { returns(T.nilable(T.any(T::Array[String], T::Array[Integer]))) }
     attr_reader :assignees
 
     sig { returns(T.nilable(String)) }
@@ -151,7 +151,7 @@ module Dependabot
         commit_message_options: T::Hash[Symbol, T.untyped],
         vulnerabilities_fixed: T::Hash[String, String],
         reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, T::Array[Integer]])),
-        assignees: T.nilable(T::Array[String]),
+        assignees: T.nilable(T.any(T::Array[String], T::Array[Integer])),
         milestone: T.nilable(String),
         branch_name_separator: String,
         branch_name_prefix: String,


### PR DESCRIPTION
This is a follow up to https://github.com/dependabot/dependabot-core/pull/8793

I'm a bit new to sorbet and completely missed that the type is also defined on initializer params.

Also updated `assignees` attribute because in case of GitLab it is array of integers not strings.