### PR TITLE
Handle STDOUT more correctly

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -172,6 +172,113 @@ public class MSBuildHelperTests
     }
 
     [Fact]
+    public async Task AllPackageDependencies_DoNotTruncateLongDependencyLists()
+    {
+        using var temp = new TemporaryDirectory();
+        var expectedDependencies = new Dependency[]
+        {
+            new("Castle.Core", "4.4.1", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights", "2.10.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.Agent.Intercept", "2.4.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.DependencyCollector", "2.10.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.PerfCounterCollector", "2.10.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.WindowsServer", "2.10.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel", "2.10.0", DependencyType.Unknown),
+            new("Microsoft.AspNet.TelemetryCorrelation", "1.0.5", DependencyType.Unknown),
+            new("Microsoft.Bcl.AsyncInterfaces", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Caching.Abstractions", "1.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Caching.Memory", "1.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.DependencyInjection", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.DependencyInjection.Abstractions", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.DiagnosticAdapter", "1.1.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Logging", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Logging.Abstractions", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Options", "7.0.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.Unknown),
+            new("Microsoft.Extensions.Primitives", "7.0.0", DependencyType.Unknown),
+            new("Moq", "4.16.1", DependencyType.Unknown),
+            new("MSTest.TestFramework", "2.1.0", DependencyType.Unknown),
+            new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown),
+            new("System", "4.1.311.2", DependencyType.Unknown),
+            new("System.Buffers", "4.5.1", DependencyType.Unknown),
+            new("System.Collections.Concurrent", "4.3.0", DependencyType.Unknown),
+            new("System.Collections.Immutable", "1.3.0", DependencyType.Unknown),
+            new("System.Collections.NonGeneric", "4.3.0", DependencyType.Unknown),
+            new("System.Collections.Specialized", "4.3.0", DependencyType.Unknown),
+            new("System.ComponentModel", "4.3.0", DependencyType.Unknown),
+            new("System.ComponentModel.Annotations", "5.0.0", DependencyType.Unknown),
+            new("System.ComponentModel.Primitives", "4.3.0", DependencyType.Unknown),
+            new("System.ComponentModel.TypeConverter", "4.3.0", DependencyType.Unknown),
+            new("System.Core", "3.5.21022.801", DependencyType.Unknown),
+            new("System.Data.Common", "4.3.0", DependencyType.Unknown),
+            new("System.Diagnostics.DiagnosticSource", "7.0.0", DependencyType.Unknown),
+            new("System.Diagnostics.PerformanceCounter", "4.5.0", DependencyType.Unknown),
+            new("System.Diagnostics.StackTrace", "4.3.0", DependencyType.Unknown),
+            new("System.Dynamic.Runtime", "4.3.0", DependencyType.Unknown),
+            new("System.IO.FileSystem.Primitives", "4.3.0", DependencyType.Unknown),
+            new("System.Linq", "4.3.0", DependencyType.Unknown),
+            new("System.Linq.Expressions", "4.3.0", DependencyType.Unknown),
+            new("System.Memory", "4.5.5", DependencyType.Unknown),
+            new("System.Net.WebHeaderCollection", "4.3.0", DependencyType.Unknown),
+            new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown),
+            new("System.ObjectModel", "4.3.0", DependencyType.Unknown),
+            new("System.Private.DataContractSerialization", "4.3.0", DependencyType.Unknown),
+            new("System.Reflection.Emit", "4.3.0", DependencyType.Unknown),
+            new("System.Reflection.Emit.ILGeneration", "4.3.0", DependencyType.Unknown),
+            new("System.Reflection.Emit.Lightweight", "4.3.0", DependencyType.Unknown),
+            new("System.Reflection.Metadata", "1.4.1", DependencyType.Unknown),
+            new("System.Reflection.TypeExtensions", "4.3.0", DependencyType.Unknown),
+            new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown),
+            new("System.Runtime.InteropServices.RuntimeInformation", "4.3.0", DependencyType.Unknown),
+            new("System.Runtime.Numerics", "4.3.0", DependencyType.Unknown),
+            new("System.Runtime.Serialization.Json", "4.3.0", DependencyType.Unknown),
+            new("System.Runtime.Serialization.Primitives", "4.3.0", DependencyType.Unknown),
+            new("System.Security.Claims", "4.3.0", DependencyType.Unknown),
+            new("System.Security.Cryptography.OpenSsl", "4.3.0", DependencyType.Unknown),
+            new("System.Security.Cryptography.Primitives", "4.3.0", DependencyType.Unknown),
+            new("System.Security.Principal", "4.3.0", DependencyType.Unknown),
+            new("System.Text.RegularExpressions", "4.3.0", DependencyType.Unknown),
+            new("System.Threading", "4.3.0", DependencyType.Unknown),
+            new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown),
+            new("System.Threading.Thread", "4.3.0", DependencyType.Unknown),
+            new("System.Threading.ThreadPool", "4.3.0", DependencyType.Unknown),
+            new("System.Xml.ReaderWriter", "4.3.0", DependencyType.Unknown),
+            new("System.Xml.XDocument", "4.3.0", DependencyType.Unknown),
+            new("System.Xml.XmlDocument", "4.3.0", DependencyType.Unknown),
+            new("System.Xml.XmlSerializer", "4.3.0", DependencyType.Unknown),
+            new("Microsoft.ApplicationInsights.Web", "2.10.0", DependencyType.Unknown),
+            new("MSTest.TestAdapter", "2.1.0", DependencyType.Unknown),
+            new("NETStandard.Library", "2.0.3", DependencyType.Unknown),
+        };
+        var packages = new[] {
+            new Dependency("System", "4.1.311.2", DependencyType.Unknown),
+            new Dependency("System.Core", "3.5.21022.801", DependencyType.Unknown),
+            new Dependency("Moq", "4.16.1", DependencyType.Unknown),
+            new Dependency("Castle.Core", "4.4.1", DependencyType.Unknown),
+            new Dependency("MSTest.TestAdapter", "2.1.0", DependencyType.Unknown),
+            new Dependency("MSTest.TestFramework", "2.1.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.Agent.Intercept", "2.4.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.DependencyCollector", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.PerfCounterCollector", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.Web", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.ApplicationInsights.WindowsServer", "2.10.0", DependencyType.Unknown),
+            new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
+            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+        };
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "netstandard2.0", packages);
+        for(int i = 0; i < actualDependencies.Length; i++)
+        {
+            var ad = actualDependencies[i];
+            var ed = expectedDependencies[i];
+            Assert.Equal(ed, ad);
+        }
+        Assert.Equal(expectedDependencies, actualDependencies);
+    }
+
+    [Fact]
     public async Task AllPackageDependencies_DoNotIncludeUpdateOnlyPackages()
     {
         using var temp = new TemporaryDirectory();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NuGetUpdater.Core;
@@ -11,6 +12,7 @@ public static class ProcessEx
     {
         var tcs = new TaskCompletionSource<(int, string, string)>();
 
+        var redirectInitiated = new ManualResetEventSlim();
         var process = new Process
         {
             StartInfo =
@@ -37,8 +39,20 @@ public static class ProcessEx
 
         process.Exited += (sender, args) =>
         {
-            tcs.TrySetResult((process.ExitCode, stdout.ToString(), stderr.ToString()));
-            process.Dispose();
+            // We must call WaitForExit to make sure we've received all OutputDataReceived/ErrorDataReceived calls
+            // or else we'll be returning a list we're still modifying. For paranoia, we'll start a task here rather
+            // than enter right back into the Process type and start a wait which isn't guaranteed to be safe.
+            Task.Run(() =>
+            {
+               redirectInitiated.Wait();
+               redirectInitiated.Dispose();
+               redirectInitiated = null;
+
+               process.WaitForExit();
+
+               tcs.TrySetResult((process.ExitCode, stdout.ToString(), stderr.ToString()));
+               process.Dispose();
+            });
         };
 
 #if DEBUG
@@ -60,6 +74,8 @@ public static class ProcessEx
 
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
+
+        redirectInitiated.Set();
 
         return tcs.Task;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -39,7 +39,8 @@ public static class ProcessEx
 
         process.Exited += (sender, args) =>
         {
-            // We must call WaitForExit to make sure we've received all OutputDataReceived/ErrorDataReceived calls
+            // It is necessary to wait until we have invoked 'BeginXReadLine' for our redirected IO. Then,
+            // we must call WaitForExit to make sure we've received all OutputDataReceived/ErrorDataReceived calls
             // or else we'll be returning a list we're still modifying. For paranoia, we'll start a task here rather
             // than enter right back into the Process type and start a wait which isn't guaranteed to be safe.
             Task.Run(() =>


### PR DESCRIPTION
There are cases where we are failing to look at the entire result of a ProcessExtensions call because we return our result as soon as `process.Exited` is Invoked. But `process.Exited` does not indicate that all the STDOUT and STDERR events have been handled, only that the process has entered the Exited state. So I took a look at [what they do in dotnet/format](https://github.com/dotnet/format/blob/main/src/Utilities/ProcessRunner.cs) and made some changes. Of particular note here is the call to `WaitForExit` which guarantees that all events currently in-flight returns before returning.

This could express itself in a lot of ways, but what I observed was that not all transitive dependencies of a project were being correctly reported (we shell that work out to MSBuild). I was unable to write a unit-test which replicated that behavior (unsurprising since it's technically a timing issue), but did find that my changes fixed local runs which were exhibiting this behavior. If anyone can come up with a Unit Test of `ProcessExtensions.RunAsync` which could reliably test this I'm all ear, otherwise I think we'll have to rely on the practical test I did and the fact that we're cribbing off of dotnet/format and roslyn.

Huge thanks to @JoeRobich for pairing with me on this one.