### PR TITLE
Docker fetcher: support filenames with a `.` in the middle of the name

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -12,7 +12,7 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
-      YAML_REGEXP = /^[^\.]+\.ya?ml$/i
+      YAML_REGEXP = /^[^\.].*\.ya?ml$/i
       DOCKER_REGEXP = /dockerfile/i
 
       def self.required_files_in?(filenames)

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -272,6 +272,8 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     context "with a Helm values file" do
       matching_filenames = [
+        "other.values.yml",
+        "other.values.yaml",
         "other-values.yml",
         "other-values.yaml",
         "other_values.yml",

--- a/docker/spec/fixtures/github/contents_helm_repo.json
+++ b/docker/spec/fixtures/github/contents_helm_repo.json
@@ -96,6 +96,38 @@
     }
   },
   {
+    "name": "other.values.yml",
+    "path": "other.values.yml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "other.values.yaml",
+    "path": "other.values.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
     "name": "other-values.yml",
     "path": "other-values.yml",
     "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",


### PR DESCRIPTION
## Description

Our helm charts have `.`'s in the middle of the file name (ie. not denoting a hidden `.file`). Dependabot isn't finding these files due to a bug in the filter regex. This fixes that issue and adds our file name pattern to the spec files.

Closes: https://github.com/dependabot/dependabot-core/issues/7008

## Changes

- Fix the `docker/lib/dependabot/docker/file_fetcher.rb` yaml regex
- Update the `docker/spec/dependabot/docker/file_fetcher_spec.rb` spec to avoid regressions

