### PR TITLE
Allow BranchNamer to be passed a nil branch

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -389,7 +389,7 @@ module Dependabot
         BranchNamer.new(
           dependencies: dependencies,
           files: files,
-          target_branch: T.must(source.branch),
+          target_branch: source.branch,
           dependency_group: dependency_group,
           separator: branch_name_separator,
           prefix: branch_name_prefix,

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -210,6 +210,21 @@ RSpec.describe Dependabot::PullRequestCreator do
       end
     end
 
+    context "with a GitHub source and no target branch" do
+      let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bp") }
+      let(:dummy_creator) { instance_double(described_class::Github) }
+
+      it "delegates to PullRequestCreator::Github with a branch name that does not include any branch" do
+        expect(described_class::Github)
+          .to receive(:new)
+          .with(
+            a_hash_including(branch_name: "dependabot/bundler/business-1.5.0")
+          ).and_return(dummy_creator)
+        expect(dummy_creator).to receive(:create)
+        creator.create
+      end
+    end
+
     context "with a GitLab source" do
       let(:source) { Dependabot::Source.new(provider: "gitlab", repo: "gc/bp", branch: "main") }
       let(:dummy_creator) { instance_double(described_class::Gitlab) }


### PR DESCRIPTION
I think `BranchNamer` being passed a `target_branch: nil` is a supported use case. Actually, I believe it's the most common use case: Dependabot is targeting the default branch, so the branch name it creates does not include any target branch name.