### PR TITLE
Docker parser/updater: also support files with a `.` in the name

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -13,6 +13,8 @@ module Dependabot
     class FileParser < Dependabot::FileParsers::Base
       require "dependabot/file_parsers/base/dependency_set"
 
+      YAML_REGEXP = /^[^\.].*\.ya?ml$/i
+
       # Details of Docker regular expressions is at
       # https://github.com/docker/distribution/blob/master/reference/regexp.go
       DOMAIN_COMPONENT = /(?:[[:alnum:]]|[[:alnum:]][[[:alnum:]]-]*[[:alnum:]])/
@@ -75,7 +77,7 @@ module Dependabot
 
       def dockerfiles
         # The Docker file fetcher fetches Dockerfiles and yaml files. Reject yaml files.
-        dependency_files.reject { |f| f.type == "file" && f.name.match?(/^[^\.]+\.ya?ml/i) }
+        dependency_files.reject { |f| f.type == "file" && f.name.match?(YAML_REGEXP) }
       end
 
       def version_from(parsed_from_line)
@@ -167,7 +169,7 @@ module Dependabot
 
       def manifest_files
         # Dependencies include both Dockerfiles and yaml, select yaml.
-        dependency_files.select { |f| f.type == "file" && f.name.match?(/^[^\.]+\.ya?ml/i) }
+        dependency_files.select { |f| f.type == "file" && f.name.match?(YAML_REGEXP) }
       end
 
       def parse_helm(img_hash)

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -11,10 +11,13 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       FROM_REGEX = /FROM(\s+--platform\=\S+)?/i
 
+      YAML_REGEXP = /^[^\.].*\.ya?ml$/i
+      DOCKER_REGEXP = /dockerfile/i
+
       def self.updated_files_regex
         [
-          /dockerfile/i,
-          /^[^\.]+\.ya?ml/i
+          DOCKER_REGEXP,
+          YAML_REGEXP
         ]
       end
 
@@ -23,7 +26,7 @@ module Dependabot
         dependency_files.each do |file|
           next unless requirement_changed?(file, dependency)
 
-          updated_files << if file.name.match?(/^[^\.]+\.ya?ml/i)
+          updated_files << if file.name.match?(YAML_REGEXP)
                              updated_file(
                                file: file,
                                content: updated_yaml_content(file)


### PR DESCRIPTION
## Description

Follow up to this PR: https://github.com/dependabot/dependabot-core/pull/8862

Looks like we use a similar regex to filter out/in the yaml Helm charts when parsing/updating the dependencies. This PR does the following:

- Moves the regexs to instance variables for reuse
- Allows `.` in the file names
- Sets the ending anchor on the regex (this was used in the fetcher but not in the parser/updater)
