### PR TITLE
try to perform environment variable expansion in `NuGet.Confing`

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -220,6 +220,7 @@ module Dependabot
             else
               key = node.attribute("key")&.value&.strip || node.at_xpath("./key")&.content&.strip
               url = node.attribute("value")&.value&.strip || node.at_xpath("./value")&.content&.strip
+              url = expand_windows_style_environment_variables(url) if url
               sources << { url: url, key: key }
             end
           end

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -314,8 +314,8 @@ module Dependabot
           # NuGet.Config files can have Windows-style environment variables that need to be replaced
           # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables
           string.gsub(/%([^%]+)%/) do
-            environment_variable_name = ::Regexp.last_match(1)
-            environment_variable_value = ENV.fetch(T.must(environment_variable_name), nil)
+            environment_variable_name = T.must(::Regexp.last_match(1))
+            environment_variable_value = ENV.fetch(environment_variable_name, nil)
             if environment_variable_value
               environment_variable_value
             else

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -315,7 +315,7 @@ module Dependabot
           # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables
           string.gsub(/%([^%]+)%/) do
             environment_variable_name = ::Regexp.last_match(1)
-            environment_variable_value = ENV.fetch(environment_variable_name, nil)
+            environment_variable_value = ENV.fetch(T.must(environment_variable_name), nil)
             if environment_variable_value
               environment_variable_value
             else

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         <configuration>
           <packageSources>
             <clear />
-            <add key="SomePackageSource" value="https://nuget.example.com/index.json" />
+            <add key="SomePackageSource" value="%FEED_URL%" />
           </packageSources>
           <packageSourceCredentials>
             <SomePackageSource>
@@ -64,12 +64,14 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
     context "are expanded" do
       before do
         allow(Dependabot.logger).to receive(:warn)
+        ENV["FEED_URL"] = "https://nuget.example.com/index.json"
         ENV["THIS_VARIBLE_EXISTS"] = "replacement-text"
         ENV.delete("THIS_VARIABLE_DOES_NOT")
       end
 
       it "contains the expected values and warns on unavailable" do
         repo = known_repositories[0]
+        expect(repo[:url]).to eq("https://nuget.example.com/index.json")
         expect(repo[:token]).to eq("user:(head)replacement-text(mid)%THIS_VARIABLE_DOES_NOT%(tail)")
         expect(Dependabot.logger).to have_received(:warn).with(
           <<~WARN

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -37,6 +37,54 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
     )
   end
 
+  describe "environment variables in NuGet.Config" do
+    let(:config_file) do
+      nuget_config_content = <<~XML
+        <configuration>
+          <packageSources>
+            <clear />
+            <add key="SomePackageSource" value="https://nuget.example.com/index.json" />
+          </packageSources>
+          <packageSourceCredentials>
+            <SomePackageSource>
+              <add key="Username" value="user" />
+              <add key="ClearTextPassword" value="(head)%THIS_VARIBLE_EXISTS%(mid)%THIS_VARIABLE_DOES_NOT%(tail)" />
+            </SomePackageSource>
+          </packageSourceCredentials>
+        </configuration>
+      XML
+      Dependabot::DependencyFile.new(
+        name: "NuGet.Config",
+        content: nuget_config_content
+      )
+    end
+
+    subject(:known_repositories) { finder.known_repositories }
+
+    context "are expanded" do
+      before do
+        allow(Dependabot.logger).to receive(:warn)
+        ENV["THIS_VARIBLE_EXISTS"] = "replacement-text"
+        ENV.delete("THIS_VARIABLE_DOES_NOT")
+      end
+
+      it "contains the expected values and warns on unavailable" do
+        repo = known_repositories[0]
+        expect(repo[:token]).to eq("user:(head)replacement-text(mid)%THIS_VARIABLE_DOES_NOT%(tail)")
+        expect(Dependabot.logger).to have_received(:warn).with(
+          <<~WARN
+            The variable '%THIS_VARIABLE_DOES_NOT%' could not be expanded in NuGet.Config
+          WARN
+        )
+      end
+
+      after do
+        ENV.delete("THIS_VARIBLE_EXISTS")
+        ENV.delete("THIS_VARIABLE_DOES_NOT")
+      end
+    end
+  end
+
   describe "dependency_urls" do
     subject(:dependency_urls) { finder.dependency_urls }
 


### PR DESCRIPTION
Expand environment variables in `NuGet.Config` as per [the documentation](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables).

There are several use cases around this, some which will work in the updater, others which will not.  One case where this won't help the updater, but is still interesting is the following:

``` xml
...
<add key="ClearTextPassword" value="%TOKEN_FROM_CI%" />
...
```

In this case the public dependabot updater won't have access to that token/environment variable, but if a user runs dependabot in their own isolated instance, they can inject that variable and it _will_ be replaced.

In the case where an environment variable couldn't be expanded, a warning is issued to help make it obvious to the user why their update may have failed.

To make this directly testable, the `known_repositories` field had to be exposed on the repository finder.

Fixes #8876.