### PR TITLE
Point again to latest pipenv release

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -2,7 +2,7 @@ pip==23.3.2
 pip-tools==7.3.0
 flake8==7.0.0
 hashin==0.17.0
-pipenv@git+https://github.com/pypa/pipenv@main
+pipenv==2023.11.17
 pipfile==0.0.2
 poetry==1.7.1
 


### PR DESCRIPTION
Since our fixes are now [out](https://github.com/pypa/pipenv/releases/tag/v2023.11.17)!