### PR TITLE
Use proper discovery logic for dotnet-tools.json files.

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
@@ -67,6 +67,42 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task NoChangeWhenDotNetToolsJsonInUnexpectedLocation()
+        {
+            await TestNoChangeforProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+                // initial
+                projectFilePath: "src/project/project.csproj",
+                projectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                  </ItemGroup>
+                </Project>
+                """,
+                additionalFiles: new[]
+                {
+                    ("eng/.config/dotnet-tools.json", """
+                      {
+                        "version": 1,
+                        "isRoot": true,
+                        "tools": {
+                          "dotnetsay": {
+                            "version": "2.1.3",
+                            "commands": [
+                              "dotnetsay"
+                            ]
+                          }
+                        }
+                      }
+                      """)
+                });
+        }
+
+        [Fact]
         public async Task UpdateSingleDependencyInDirsProj()
         {
             await TestUpdateForProject("Microsoft.BotSay", "1.0.0", "1.1.0",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/DotNetToolsJsonUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/DotNetToolsJsonUpdater.cs
@@ -8,9 +8,9 @@ namespace NuGetUpdater.Core;
 
 internal static partial class DotNetToolsJsonUpdater
 {
-    public static async Task UpdateDependencyAsync(string repoRootPath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, Logger logger)
+    public static async Task UpdateDependencyAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, Logger logger)
     {
-        var buildFiles = LoadBuildFiles(repoRootPath, logger);
+        var buildFiles = LoadBuildFiles(repoRootPath, workspacePath, logger);
         if (buildFiles.Length == 0)
         {
             logger.Log($"  No dotnet-tools.json files found.");
@@ -49,18 +49,11 @@ internal static partial class DotNetToolsJsonUpdater
         }
     }
 
-    private static ImmutableArray<DotNetToolsJsonBuildFile> LoadBuildFiles(string repoRootPath, Logger logger)
+    private static ImmutableArray<DotNetToolsJsonBuildFile> LoadBuildFiles(string repoRootPath, string workspacePath, Logger logger)
     {
-        var options = new EnumerationOptions()
-        {
-            RecurseSubdirectories = true,
-            MatchType = MatchType.Win32,
-            AttributesToSkip = 0,
-            IgnoreInaccessible = false,
-            MatchCasing = MatchCasing.CaseInsensitive,
-        };
-        return Directory.EnumerateFiles(repoRootPath, "dotnet-tools.json", options)
-            .Select(path => DotNetToolsJsonBuildFile.Open(repoRootPath, path, logger))
-            .ToImmutableArray();
+        var dotnetToolsJsonPath = PathHelper.GetFileInDirectoryOrParent(workspacePath, repoRootPath, "./.config/dotnet-tools.json");
+        return dotnetToolsJsonPath is not null
+            ? [DotNetToolsJsonBuildFile.Open(repoRootPath, dotnetToolsJsonPath, logger)]
+            : [];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -15,33 +15,33 @@ public partial class UpdaterWorker
         _logger = logger;
     }
 
-    public async Task RunAsync(string repoRootPath, string filePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
+    public async Task RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
     {
         MSBuildHelper.RegisterMSBuild();
 
-        if (!Path.IsPathRooted(filePath) || !File.Exists(filePath))
+        if (!Path.IsPathRooted(workspacePath) || !File.Exists(workspacePath))
         {
-            filePath = Path.GetFullPath(Path.Join(repoRootPath, filePath));
+            workspacePath = Path.GetFullPath(Path.Join(repoRootPath, workspacePath));
         }
 
         if (!isTransitive)
         {
-            await DotNetToolsJsonUpdater.UpdateDependencyAsync(repoRootPath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
+            await DotNetToolsJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
         }
 
-        var extension = Path.GetExtension(filePath).ToLowerInvariant();
+        var extension = Path.GetExtension(workspacePath).ToLowerInvariant();
         switch (extension)
         {
             case ".sln":
-                await RunForSolutionAsync(repoRootPath, filePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                await RunForSolutionAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             case ".proj":
-                await RunForProjFileAsync(repoRootPath, filePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                await RunForProjFileAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             case ".csproj":
             case ".fsproj":
             case ".vbproj":
-                await RunForProjectAsync(repoRootPath, filePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             default:
                 _logger.Log($"File extension [{extension}] is not supported.");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -39,6 +39,11 @@ internal static class PathHelper
     /// <returns>The path of the found file or null.</returns>
     public static string? GetFileInDirectoryOrParent(string initialPath, string rootPath, string fileName, bool caseSensitive = true)
     {
+        if (File.Exists(initialPath))
+        {
+            initialPath = Path.GetDirectoryName(initialPath)!;
+        }
+
         var candidatePaths = new List<string>();
         var rootDirectory = new DirectoryInfo(rootPath);
         var candidateDirectory = new DirectoryInfo(initialPath);
@@ -56,11 +61,18 @@ internal static class PathHelper
 
         foreach (var candidatePath in candidatePaths)
         {
-            var files = Directory.EnumerateFiles(candidatePath, fileName, caseSensitive ? _caseSensitiveEnumerationOptions : _caseInsensitiveEnumerationOptions);
-
-            if (files.Any())
+            try
             {
-                return files.First();
+                var files = Directory.EnumerateFiles(candidatePath, fileName, caseSensitive ? _caseSensitiveEnumerationOptions : _caseInsensitiveEnumerationOptions);
+
+                if (files.Any())
+                {
+                    return files.First();
+                }
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // When searching for a file in a directory that doesn't exist, Directory.EnumerateFiles throws a DirectoryNotFoundException.
             }
         }
 


### PR DESCRIPTION
Similar to how we weren't using proper discovery logic for global.json files (#8815), this change has us walk the file tree from the workspace folder up to the root looking for the dotnet-tools.json file.