### PR TITLE
Fix milestone type for PullRequestCreator

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -106,7 +106,7 @@ module Dependabot
     sig { returns(T.nilable(T.any(T::Array[String], T::Array[Integer]))) }
     attr_reader :assignees
 
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(T.any(T::Array[String], Integer))) }
     attr_reader :milestone
 
     sig { returns(String) }
@@ -152,7 +152,7 @@ module Dependabot
         vulnerabilities_fixed: T::Hash[String, String],
         reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, T::Array[Integer]])),
         assignees: T.nilable(T.any(T::Array[String], T::Array[Integer])),
-        milestone: T.nilable(String),
+        milestone: T.nilable(T.any(T::Array[String], Integer)),
         branch_name_separator: String,
         branch_name_prefix: String,
         branch_name_max_length: T.nilable(Integer),


### PR DESCRIPTION
Should be the last fix regarding types of PullRequestCreator and GitLab implementation.

This updates `milestone` type which in case of GitLab is just a single integer.

I did ran gem built from this branch through my workflow to make sure some other thing isn't missing again and I think it should be it now.