### PR TITLE
[gradle] Parse repositories from the top-level buildfile

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -72,17 +72,21 @@ module Dependabot
         end
 
         def own_buildfile_repository_urls
-          buildfile_content = comment_free_content(target_dependency_file)
+          buildfile_content = comment_free_content(top_level_buildfile)
 
-          buildfile_content.dup.scan(/(?:^|\s)subprojects\s*\{/) do
+          own_buildfile_urls = []
+
+          subproject_buildfile_content = buildfile_content.dup.scan(/(?:^|\s)subprojects\s*\{/) do
             mtch = Regexp.last_match
-            buildfile_content.gsub!(
+            buildfile_content.gsub(
               mtch.post_match[0..closing_bracket_index(mtch.post_match)],
               ""
             )
           end
 
-          repository_urls_from(buildfile_content)
+          own_buildfile_urls += repository_urls_from(buildfile_content)
+          own_buildfile_urls += repository_urls_from(subproject_buildfile_content)
+          own_buildfile_urls
         end
 
         def repository_urls_from(buildfile_content)

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -70,7 +70,14 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
 
         it "doesn't include the subproject declarations" do
           expect(repository_urls)
-            .to match_array(%w(https://jcenter.bintray.com))
+            .to match_array(
+              %w(
+                https://jcenter.bintray.com
+                https://dl.bintray.com/magnusja/maven
+                https://maven.google.com
+                https://plugins.gradle.org/m2
+              )
+            )
         end
 
         context "and this is a subproject" do
@@ -113,15 +120,11 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
         let(:buildfile_fixture_name) { "variable_repos_build.gradle" }
 
         it "includes the additional declarations" do
-          pending("silenced due to persistent Gradle bug, see commit 08122f9 for context")
           expect(repository_urls).to match_array(
             %w(
               https://jcenter.bintray.com
               https://dl.bintray.com/magnusja/maven
               https://maven.google.com
-              https://kotlin.bintray.com/kotlinx
-              https://kotlin.bintray.com/ktor
-              https://kotlin.bintray.com/kotlin-dev/
             )
           )
         end


### PR DESCRIPTION
Gradle was previously ignoring repositories from the top level buildfile (/build.gradle.kts) which resulted in Dependabot looking for the dependency in the wrong repository.

Some repositories are still not getting picked up correctly, specifically ones that use a custom URI like https://kotlin.bintray.com/kotlin-dev/, although that will need to be addressed separately.

Side note: the bintray repository has been sunset, so we should eventually remove it. Also, the jCenter repository is marked as read-only currently and will likely be sunset in the future.

Trying to use a repository in a top-level buildfile before this PR:

```
updater | 2024/01/24 19:30:28 INFO <job_778363964> Checking if com.gradle:common-custom-user-data-gradle-plugin 1.8.1 needs updating
  proxy | 2024/01/24 19:30:28 [024] GET https://repo.maven.apache.org:443/maven2/com/gradle/common-custom-user-data-gradle-plugin/maven-metadata.xml
  proxy | 2024/01/24 19:30:28 [024] 404 https://repo.maven.apache.org:443/maven2/com/gradle/common-custom-user-data-gradle-plugin/maven-metadata.xml
updater | 2024/01/24 19:30:28 INFO <job_778363964> Latest version is 
updater | 2024/01/24 19:30:28 INFO <job_778363964> Requirements to unlock update_not_possible
updater | 2024/01/24 19:30:28 INFO <job_778363964> Requirements update strategy 
updater | 2024/01/24 19:30:28 INFO <job_778363964> No update possible for com.gradle:common-custom-user-data-gradle-plugin 1.8.1
```

and after:

```
2024/01/24 21:36:26 INFO Updating com.gradle:common-custom-user-data-gradle-plugin from 1.8.1 to 1.12.1
2024/01/24 21:36:26 INFO Submitting com.gradle:common-custom-user-data-gradle-plugin pull request for creation
2024/01/24 21:36:28 INFO Finished job processing
2024/01/24 21:36:28 INFO Results:
+-------------------------------------------------------------------------------------+
|                         Changes to Dependabot Pull Requests                         |
+---------+---------------------------------------------------------------------------+
| created | com.gradle:common-custom-user-data-gradle-plugin ( from 1.8.1 to 1.12.1 ) |
+---------+---------------------------------------------------------------------------+
```