### PR TITLE
only directly query `.nuspec` files from nuget and azure devops

### DIFF
--- a/nuget/lib/dependabot/nuget/nuget_client.rb
+++ b/nuget/lib/dependabot/nuget/nuget_client.rb
@@ -68,7 +68,11 @@ module Dependabot
             # inlined entries
             items.each do |item|
               catalog_entry = item["catalogEntry"]
-              if catalog_entry["listed"] == true
+
+              # a package is considered listed if the `listed` property is either `true` or missing
+              listed_property = catalog_entry["listed"]
+              is_listed = listed_property.nil? || listed_property == true
+              if is_listed
                 vers = catalog_entry["version"]
                 versions << vers
               end

--- a/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
@@ -26,17 +26,9 @@ module Dependabot
 
         nuspec_xml = nil
 
-        if azure_package_feed?(feed_url)
-          # this is an azure devops url we can extract the nuspec from the nupkg
-          package_data = NupkgFetcher.fetch_nupkg_buffer_from_repository(repository_details, package_id,
-                                                                         package_version)
-          return if package_data.nil?
-
-          nuspec_string = extract_nuspec(package_data, package_id)
-          nuspec_xml = Nokogiri::XML(nuspec_string)
-        else
+        if feed_supports_nuspec_download?(feed_url)
           # we can use the normal nuget apis to get the nuspec and list out the dependencies
-          base_url = feed_url.gsub("/index.json", "-flatcontainer")
+          base_url = repository_details[:base_url].delete_suffix("/")
           package_id_downcased = package_id.downcase
           nuspec_url = "#{base_url}/#{package_id_downcased}/#{package_version}/#{package_id_downcased}.nuspec"
 
@@ -49,20 +41,30 @@ module Dependabot
 
           nuspec_response_body = remove_wrapping_zero_width_chars(nuspec_response.body)
           nuspec_xml = Nokogiri::XML(nuspec_response_body)
+        else
+          # no guarantee we can directly query the .nuspec; fall back to extracting it from the .nupkg
+          package_data = NupkgFetcher.fetch_nupkg_buffer_from_repository(repository_details, package_id,
+                                                                         package_version)
+          return if package_data.nil?
+
+          nuspec_string = extract_nuspec(package_data, package_id)
+          nuspec_xml = Nokogiri::XML(nuspec_string)
         end
 
         nuspec_xml.remove_namespaces!
         nuspec_xml
       end
 
-      def self.azure_package_feed?(feed_url)
-        # if url is azure devops
-        azure_devops_regexs = [
+      def self.feed_supports_nuspec_download?(feed_url)
+        feed_rexexs = [
+          # nuget
+          %r{https://api\.nuget\.org/v3/index\.json},
+          # azure devops
           %r{https://pkgs\.dev\.azure\.com/(?<organization>[^/]+)/(?<project>[^/]+)/_packaging/(?<feedId>[^/]+)/nuget/v3/index\.json},
           %r{https://pkgs\.dev\.azure\.com/(?<organization>[^/]+)/_packaging/(?<feedId>[^/]+)/nuget/v3/index\.json(?<project>)},
           %r{https://(?<organization>[^\.\/]+)\.pkgs\.visualstudio\.com/_packaging/(?<feedId>[^/]+)/nuget/v3/index\.json(?<project>)}
         ]
-        azure_devops_regexs.any? { |reg| reg.match(feed_url) }
+        feed_rexexs.any? { |reg| reg.match(feed_url) }
       end
 
       def self.extract_nuspec(zip_stream, package_id)

--- a/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
@@ -56,7 +56,7 @@ module Dependabot
       end
 
       def self.feed_supports_nuspec_download?(feed_url)
-        feed_rexexs = [
+        feed_regexs = [
           # nuget
           %r{https://api\.nuget\.org/v3/index\.json},
           # azure devops
@@ -64,7 +64,7 @@ module Dependabot
           %r{https://pkgs\.dev\.azure\.com/(?<organization>[^/]+)/_packaging/(?<feedId>[^/]+)/nuget/v3/index\.json(?<project>)},
           %r{https://(?<organization>[^\.\/]+)\.pkgs\.visualstudio\.com/_packaging/(?<feedId>[^/]+)/nuget/v3/index\.json(?<project>)}
         ]
-        feed_rexexs.any? { |reg| reg.match(feed_url) }
+        feed_regexs.any? { |reg| reg.match(feed_url) }
       end
 
       def self.extract_nuspec(zip_stream, package_id)

--- a/nuget/spec/dependabot/nuget/nuget_client_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_client_spec.rb
@@ -1,0 +1,66 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nuget/nuget_client"
+
+RSpec.describe Dependabot::Nuget::NugetClient do
+  describe "#get_package_versions" do
+    let(:dependency_name) { "Some.Dependency" }
+
+    subject(:package_versions) do
+      Dependabot::Nuget::NugetClient.get_package_versions(dependency_name, repository_details)
+    end
+
+    context "package versions _might_ have the `listed` flag" do
+      before do
+        stub_request(:get, "https://api.nuget.org/v3/registration5-gz-semver2/#{dependency_name.downcase}/index.json")
+          .to_return(
+            status: 200,
+            body: {
+              items: [
+                items: [
+                  {
+                    catalogEntry: {
+                      listed: true, # nuget.org provides this flag and it should be honored
+                      version: "0.1.0"
+                    }
+                  },
+                  {
+                    catalogEntry: {
+                      listed: false, # if this is ever false, the package should not be included
+                      version: "0.1.1"
+                    }
+                  },
+                  {
+                    catalogEntry: {
+                      # e.g., github doesn't have the `listed` flag, but should still be returned
+                      version: "0.1.2"
+                    }
+                  }
+                ]
+              ]
+            }.to_json
+          )
+      end
+
+      let(:repository_details) do
+        {
+          base_url: "https://api.nuget.org/v3-flatcontainer/",
+          registration_url: "https://api.nuget.org/v3/registration5-gz-semver2/#{dependency_name.downcase}/index.json",
+          repository_url: "https://api.nuget.org/v3/index.json",
+          versions_url: "https://api.nuget.org/v3-flatcontainer/" \
+                        "#{dependency_name.downcase}/index.json",
+          search_url: "https://azuresearch-usnc.nuget.org/query" \
+                      "?q=#{dependency_name.downcase}&prerelease=true&semVerLevel=2.0.0",
+          auth_header: {},
+          repository_type: "v3"
+        }
+      end
+
+      it "returns the correct version information" do
+        expect(package_versions).to eq(Set["0.1.0", "0.1.2"])
+      end
+    end
+  end
+end

--- a/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
     let(:dependency_files) { [csproj, nuget_config] }
     subject(:transitive_dependencies) { finder.transitive_dependencies }
 
+    def create_nupkg(nuspec_name, nuspec_fixture_path)
+      content = Zip::OutputStream.write_buffer do |zio|
+        zio.put_next_entry("#{nuspec_name}.nuspec")
+        zio.write(fixture("nuspecs", nuspec_fixture_path))
+      end
+      content.rewind
+      content.sysread
+    end
+
     before(:context) do
       disallowed_urls = %w(
         https://api.nuget.org/v3/index.json
@@ -72,10 +81,12 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
 
       stub_request(:get, "https://nuget.example.com/v3/index.json")
         .to_return(status: 200, body: fixture("nuget_responses", "example_index.json"))
-      stub_request(:get, "https://nuget.example.com/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.nuspec")
-        .to_return(status: 200, body: fixture("nuspecs", "Microsoft.Extensions.DependencyModel_42.42.42_faked.nuspec"))
-      stub_request(:get, "https://nuget.example.com/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.nuspec")
-        .to_return(status: 200, body: fixture("nuspecs", "Microsoft.NETCore.Platforms_43.43.43_faked.nuspec"))
+      stub_request(:get, "https://api.example.com/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.42.42.42.nupkg")
+        .to_return(status: 200, body: create_nupkg("Microsoft.Extensions.DependencyModel",
+                                                   "Microsoft.Extensions.DependencyModel_42.42.42_faked.nuspec"))
+      stub_request(:get, "https://api.example.com/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.43.43.43.nupkg")
+        .to_return(status: 200, body: create_nupkg("Microsoft.NETCore.Platforms",
+                                                   "Microsoft.NETCore.Platforms_43.43.43_faked.nuspec"))
     end
 
     # this test doesn't really care about the dependency count, we just need to ensure that `api.nuget.org` wasn't hit

--- a/nuget/spec/dependabot/nuget/update_checker/nuspec_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nuspec_fetcher_spec.rb
@@ -7,31 +7,38 @@ require "dependabot/dependency_file"
 require "dependabot/nuget/update_checker/nuspec_fetcher"
 
 RSpec.describe Dependabot::Nuget::NuspecFetcher do
-  describe "#azure_package_feed?" do
+  describe "#feed_supports_nuspec_download?" do
     context "when checking with a azure feed url" do
       let(:url) { "https://pkgs.dev.azure.com/dependabot/dependabot-test/_packaging/dependabot-feed/nuget/v3/index.json" }
-      subject(:result) { described_class.azure_package_feed?(url) }
+      subject(:result) { described_class.feed_supports_nuspec_download?(url) }
 
       it { is_expected.to be_truthy }
     end
 
     context "when checking with a azure feed url (no project)" do
       let(:url) { "https://pkgs.dev.azure.com/dependabot/_packaging/dependabot-feed/nuget/v3/index.json" }
-      subject(:result) { described_class.azure_package_feed?(url) }
+      subject(:result) { described_class.feed_supports_nuspec_download?(url) }
 
       it { is_expected.to be_truthy }
     end
 
     context "when checking with a visual studio feed url" do
       let(:url) { "https://dynamicscrm.pkgs.visualstudio.com/_packaging/CRM.Engineering/nuget/v3/index.json" }
-      subject(:result) { described_class.azure_package_feed?(url) }
+      subject(:result) { described_class.feed_supports_nuspec_download?(url) }
 
       it { is_expected.to be_truthy }
     end
 
     context "when checking with the nuget.org feed url" do
       let(:url) { "https://api.nuget.org/v3/index.json" }
-      subject(:result) { described_class.azure_package_feed?(url) }
+      subject(:result) { described_class.feed_supports_nuspec_download?(url) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when checking with github feed url" do
+      let(:url) { "https://nuget.pkg.github.com/some_namespace/index.json" }
+      subject(:result) { described_class.feed_supports_nuspec_download?(url) }
 
       it { is_expected.to be_falsy }
     end


### PR DESCRIPTION
Previously the NuGet updater would directly query every package feed _except_ Azure DevOps for the `.nuspec` contents, but this didn't account for both GitHub and AWS package feeds that return 404 on a `.nuspec`.

The fix is to _only_ directly pull the `.nuspec` file from the feeds that support it, specifically NuGet.org and Azure DevOps; all other feeds we pull the `.nupkg` then manually extract the `.nuspec`.  If/when we find more package feeds that _do_ allow direct pulling of the `.nuspec` files, we can add them to the allow list.

This will fix issues like the following, where the `.nuspec` couldn't be queried which meant we weren't able to parse any meaningful version numbers:

```
  proxy | 2024/01/17 22:16:38 [078] GET https://nuget.example.com/some.package/1.2.3/some.package.nuspec
  proxy | 2024/01/17 22:16:38 [078] 404 https://nuget.example.com/some.package/1.2.3/some.package.nuspec
...
updater | 2024/01/17 22:16:45 ERROR <job_775557849> undefined method `fetch' for nil:NilClass
updater | 
updater |           latest_version: preferred_resolvable_version_details.fetch(:version)&.to_s,
```

This also fixes an issue with GitHub package feeds which don't include the `listed` property.

Fixes #8837 (and likely many other issues; I'll have to review each of them)