### PR TITLE
Add a guard for nil top level buildfiles

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -72,6 +72,8 @@ module Dependabot
         end
 
         def own_buildfile_repository_urls
+          return [] unless top_level_buildfile
+
           buildfile_content = comment_free_content(top_level_buildfile)
 
           own_buildfile_urls = []


### PR DESCRIPTION
Add a guard for nil top level buildfiles

Fixes a sentry error:

```
undefined method `content' for nil:NilClass

          buildfile.content
                   ^^^^^^^^
```