### PR TITLE
build(deps): bump Node.js to Active LTS (20.x)

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -10,7 +10,7 @@ ARG PNPM_VERSION=8.11.0
 ARG YARN_VERSION=3.7.0
 
 # See https://github.com/nodesource/distributions#installation-instructions
-ARG NODEJS_VERSION=18.x
+ARG NODEJS_VERSION=20.x
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well


### PR DESCRIPTION
Not upgrading the NPM version together is due to this issue 👉 https://github.com/npm/cli/issues/6742, and see more 👉 https://github.com/dependabot/dependabot-core/pull/7811, cc @yeikel.

<img width="772" alt="image" src="https://github.com/dependabot/dependabot-core/assets/4016742/3599ef5a-76f3-4df2-9e3f-7220b2b68663">

----

Node.js v20 is now Active LTS, would like to upgrade Node.js to v20 in order to allow the Dependabot updater to upgrade `semantic-release` from v22 to [v23](https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0), thanks.

<img width="921" alt="image" src="https://github.com/dependabot/dependabot-core/assets/4016742/7824a5e4-01bc-481d-9b91-676b6cff7719">