### PR TITLE
grouped security updates don't require an explicit group

### DIFF
--- a/silent/tests/testdata/su-group-default-multidir.txt
+++ b/silent/tests/testdata/su-group-default-multidir.txt
@@ -82,8 +82,3 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
-  dependency-groups:
-    - name: first
-      rules:
-        patterns:
-          - "*"

--- a/silent/tests/testdata/su-group-default.txt
+++ b/silent/tests/testdata/su-group-default.txt
@@ -57,8 +57,4 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
-  dependency-groups:
-    - name: first
-      rules:
-        patterns:
-          - "*"
+


### PR DESCRIPTION
This better captures the current state of how GSU works in ahead of #8742. 