### PR TITLE
clean directory at job start

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -332,6 +332,11 @@ module Dependabot
     end
 
     def build_source(source_details)
+      # Immediately normalize the source directory, ensure it starts with a "/"
+      directory = source_details["directory"]
+      directory = Pathname.new(directory).cleanpath.to_s
+      source_details["directory"] = "/#{directory}" unless directory.start_with?("/")
+
       Dependabot::Source.new(
         **source_details.transform_keys { |k| k.tr("-", "_").to_sym }
       )

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -93,6 +93,60 @@ RSpec.describe Dependabot::Job do
       expect(ruby_credential["host"]).to eql("my.rubygems-host.org")
       expect(ruby_credential.keys).not_to include("token")
     end
+
+    context "when the directory does not start with a slash" do
+      let(:attributes) do
+        {
+          id: 1,
+          token: "token",
+          dependencies: dependencies,
+          allowed_updates: allowed_updates,
+          existing_pull_requests: [],
+          ignore_conditions: [],
+          security_advisories: security_advisories,
+          package_manager: package_manager,
+          source: {
+            "provider" => "github",
+            "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
+            "directory" => "hello",
+            "api-endpoint" => "https://api.github.com/",
+            "hostname" => "github.com",
+            "branch" => nil
+          }
+        }
+      end
+
+      it "adds a slash to the directory" do
+        expect(new_update_job.source["directory"]).to eq("/hello")
+      end
+    end
+
+    context "when the directory uses relative path notation" do
+      let(:attributes) do
+        {
+          id: 1,
+          token: "token",
+          dependencies: dependencies,
+          allowed_updates: allowed_updates,
+          existing_pull_requests: [],
+          ignore_conditions: [],
+          security_advisories: security_advisories,
+          package_manager: package_manager,
+          source: {
+            "provider" => "github",
+            "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
+            "directory" => "hello/world/..",
+            "api-endpoint" => "https://api.github.com/",
+            "hostname" => "github.com",
+            "branch" => nil
+          }
+        }
+      end
+
+      it "cleans the path" do
+        expect(new_update_job.source["directory"]).to eq("/hello")
+      end
+    end
   end
 
   context "when lockfile_only is passed as true" do

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Dependabot::Job do
       end
 
       it "adds a slash to the directory" do
-        expect(new_update_job.source["directory"]).to eq("/hello")
+        expect(new_update_job.source.directory).to eq("/hello")
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Job do
       end
 
       it "cleans the path" do
-        expect(new_update_job.source["directory"]).to eq("/hello")
+        expect(new_update_job.source.directory).to eq("/hello")
       end
     end
   end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Dependabot::Job do
       source: {
         "provider" => "github",
         "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
-        "directory" => "/",
+        "directory" => directory,
         "api-endpoint" => "https://api.github.com/",
         "hostname" => "github.com",
         "branch" => nil
@@ -48,6 +48,7 @@ RSpec.describe Dependabot::Job do
     }
   end
 
+  let(:directory) { "/" }
   let(:dependencies) { nil }
   let(:security_advisories) { [] }
   let(:package_manager) { "bundler" }
@@ -95,56 +96,18 @@ RSpec.describe Dependabot::Job do
     end
 
     context "when the directory does not start with a slash" do
-      let(:attributes) do
-        {
-          id: 1,
-          token: "token",
-          dependencies: dependencies,
-          allowed_updates: allowed_updates,
-          existing_pull_requests: [],
-          ignore_conditions: [],
-          security_advisories: security_advisories,
-          package_manager: package_manager,
-          source: {
-            "provider" => "github",
-            "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
-            "directory" => "hello",
-            "api-endpoint" => "https://api.github.com/",
-            "hostname" => "github.com",
-            "branch" => nil
-          }
-        }
-      end
+      let(:directory) { "hello" }
 
       it "adds a slash to the directory" do
-        expect(new_update_job.source.directory).to eq("/hello")
+        expect(job.source.directory).to eq("/hello")
       end
     end
 
     context "when the directory uses relative path notation" do
-      let(:attributes) do
-        {
-          id: 1,
-          token: "token",
-          dependencies: dependencies,
-          allowed_updates: allowed_updates,
-          existing_pull_requests: [],
-          ignore_conditions: [],
-          security_advisories: security_advisories,
-          package_manager: package_manager,
-          source: {
-            "provider" => "github",
-            "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
-            "directory" => "hello/world/..",
-            "api-endpoint" => "https://api.github.com/",
-            "hostname" => "github.com",
-            "branch" => nil
-          }
-        }
-      end
+      let(:directory) { "hello/world/.." }
 
       it "cleans the path" do
-        expect(new_update_job.source.directory).to eq("/hello")
+        expect(job.source.directory).to eq("/hello")
       end
     end
   end


### PR DESCRIPTION
I noticed the new devcontainers smoke test has a directory that does not start with `/`. https://github.com/dependabot/smoke-tests/blob/5b012ee504a3ec30eb05af415d600aeff5cc00fd/tests/smoke-devcontainers.yaml#L16

It just happened to work but is now breaking as I [implement multi-dir support](https://github.com/dependabot/dependabot-core/pull/8742). 

I think we can be a little more flexible here and just add the `/` and also clean the path. 

In the future I'd like to explore changing the source directory type to a `Pathname` instead of a `String` to encourage comparisons to be for the cleaned path.