### PR TITLE
Don't assume `.nuspec` dependency group has a `targetFramework` attribute.

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -279,13 +279,13 @@ module Dependabot
         end
 
         def dependency_has_search_results?(dependency)
-          dependency_urls = UpdateChecker::RepositoryFinder.new(
+          dependency_urls = RepositoryFinder.new(
             dependency: dependency,
             credentials: credentials,
             config_files: nuget_configs
           ).dependency_urls
           if dependency_urls.empty?
-            dependency_urls = [UpdateChecker::RepositoryFinder.get_default_repository_details(dependency.name)]
+            dependency_urls = [RepositoryFinder.get_default_repository_details(dependency.name)]
           end
           dependency_urls.any? do |dependency_url|
             dependency_url_has_matching_result?(dependency.name, dependency_url)

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -284,9 +284,7 @@ module Dependabot
             credentials: credentials,
             config_files: nuget_configs
           ).dependency_urls
-          if dependency_urls.empty?
-            dependency_urls = [RepositoryFinder.get_default_repository_details(dependency.name)]
-          end
+          dependency_urls = [RepositoryFinder.get_default_repository_details(dependency.name)] if dependency_urls.empty?
           dependency_urls.any? do |dependency_url|
             dependency_url_has_matching_result?(dependency.name, dependency_url)
           end

--- a/nuget/lib/dependabot/nuget/nuget_client.rb
+++ b/nuget/lib/dependabot/nuget/nuget_client.rb
@@ -151,7 +151,7 @@ module Dependabot
         response
       rescue Excon::Error::Timeout, Excon::Error::Socket
         repo_url = repository_url
-        raise if repo_url == Dependabot::Nuget::UpdateChecker::RepositoryFinder::DEFAULT_REPOSITORY_URL
+        raise if repo_url == Dependabot::Nuget::RepositoryFinder::DEFAULT_REPOSITORY_URL
 
         raise PrivateSourceTimedOut, repo_url
       end

--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -48,9 +48,7 @@ module Dependabot
       end
 
       def parse_package_tfms(nuspec_xml)
-        nuspec_xml.xpath("//dependencies/group").map do |group|
-          group.attribute("targetFramework")
-        end
+        nuspec_xml.xpath("//dependencies/group").filter_map { |group| group.attribute("targetFramework") }
       end
 
       def project_tfms

--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -5,80 +5,78 @@ require "dependabot/update_checkers/base"
 
 module Dependabot
   module Nuget
-    class UpdateChecker < Dependabot::UpdateCheckers::Base
-      class CompatibilityChecker
-        require_relative "nuspec_fetcher"
-        require_relative "nupkg_fetcher"
-        require_relative "tfm_finder"
-        require_relative "tfm_comparer"
+    class CompatibilityChecker
+      require_relative "nuspec_fetcher"
+      require_relative "nupkg_fetcher"
+      require_relative "tfm_finder"
+      require_relative "tfm_comparer"
 
-        def initialize(dependency_urls:, dependency:, tfm_finder:)
-          @dependency_urls = dependency_urls
-          @dependency = dependency
-          @tfm_finder = tfm_finder
+      def initialize(dependency_urls:, dependency:, tfm_finder:)
+        @dependency_urls = dependency_urls
+        @dependency = dependency
+        @tfm_finder = tfm_finder
+      end
+
+      def compatible?(version)
+        nuspec_xml = NuspecFetcher.fetch_nuspec(dependency_urls, dependency.name, version)
+        return false unless nuspec_xml
+
+        # development dependencies are packages such as analyzers which need to be
+        # compatible with the compiler not the project itself.
+        return true if development_dependency?(nuspec_xml)
+
+        package_tfms = parse_package_tfms(nuspec_xml)
+        package_tfms = fetch_package_tfms(version) if package_tfms.empty?
+        # nil is a special return value that indicates that the package is likely a development dependency
+        return true if package_tfms.nil?
+        return false if package_tfms.empty?
+
+        return false if project_tfms.nil? || project_tfms.empty?
+
+        TfmComparer.are_frameworks_compatible?(project_tfms, package_tfms)
+      end
+
+      private
+
+      attr_reader :dependency_urls, :dependency, :tfm_finder
+
+      def development_dependency?(nuspec_xml)
+        contents = nuspec_xml.at_xpath("package/metadata/developmentDependency")&.content&.strip
+        return false unless contents
+
+        contents.casecmp("true").zero?
+      end
+
+      def parse_package_tfms(nuspec_xml)
+        nuspec_xml.xpath("//dependencies/group").map do |group|
+          group.attribute("targetFramework")
         end
+      end
 
-        def compatible?(version)
-          nuspec_xml = NuspecFetcher.fetch_nuspec(dependency_urls, dependency.name, version)
-          return false unless nuspec_xml
+      def project_tfms
+        return @project_tfms if defined?(@project_tfms)
 
-          # development dependencies are packages such as analyzers which need to be
-          # compatible with the compiler not the project itself.
-          return true if development_dependency?(nuspec_xml)
+        @project_tfms = tfm_finder.frameworks(dependency)
+      end
 
-          package_tfms = parse_package_tfms(nuspec_xml)
-          package_tfms = fetch_package_tfms(version) if package_tfms.empty?
-          # nil is a special return value that indicates that the package is likely a development dependency
-          return true if package_tfms.nil?
-          return false if package_tfms.empty?
+      def fetch_package_tfms(dependency_version)
+        nupkg_buffer = NupkgFetcher.fetch_nupkg_buffer(dependency_urls, dependency.name, dependency_version)
+        return [] unless nupkg_buffer
 
-          return false if project_tfms.nil? || project_tfms.empty?
+        # Parse tfms from the folders beneath the lib folder
+        folder_name = "lib/"
+        tfms = Set.new
+        Zip::File.open_buffer(nupkg_buffer) do |zip|
+          lib_file_entries = zip.select { |entry| entry.name.start_with?(folder_name) }
+          # If there is no lib folder in this package, assume it is a development dependency
+          return nil if lib_file_entries.empty?
 
-          TfmComparer.are_frameworks_compatible?(project_tfms, package_tfms)
-        end
-
-        private
-
-        attr_reader :dependency_urls, :dependency, :tfm_finder
-
-        def development_dependency?(nuspec_xml)
-          contents = nuspec_xml.at_xpath("package/metadata/developmentDependency")&.content&.strip
-          return false unless contents
-
-          contents.casecmp("true").zero?
-        end
-
-        def parse_package_tfms(nuspec_xml)
-          nuspec_xml.xpath("//dependencies/group").map do |group|
-            group.attribute("targetFramework")
+          lib_file_entries.each do |entry|
+            _, tfm = entry.name.split("/").first(2)
+            tfms << tfm
           end
         end
-
-        def project_tfms
-          return @project_tfms if defined?(@project_tfms)
-
-          @project_tfms = tfm_finder.frameworks(dependency)
-        end
-
-        def fetch_package_tfms(dependency_version)
-          nupkg_buffer = NupkgFetcher.fetch_nupkg_buffer(dependency_urls, dependency.name, dependency_version)
-          return [] unless nupkg_buffer
-
-          # Parse tfms from the folders beneath the lib folder
-          folder_name = "lib/"
-          tfms = Set.new
-          Zip::File.open_buffer(nupkg_buffer) do |zip|
-            lib_file_entries = zip.select { |entry| entry.name.start_with?(folder_name) }
-            # If there is no lib folder in this package, assume it is a development dependency
-            return nil if lib_file_entries.empty?
-
-            lib_file_entries.each do |entry|
-              _, tfm = entry.name.split("/").first(2)
-              tfms << tfm
-            end
-          end
-          tfms.to_a
-        end
+        tfms.to_a
       end
     end
   end

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -121,7 +121,7 @@ module Dependabot
 
         def dependency_urls
           @dependency_urls ||=
-            UpdateChecker::RepositoryFinder.new(
+            RepositoryFinder.new(
               dependency: @dependency,
               credentials: @credentials,
               config_files: nuget_configs

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -126,7 +126,7 @@ module Dependabot
               credentials: @credentials,
               config_files: nuget_configs
             ).dependency_urls
-                                           .select { |url| url.fetch(:repository_type) == "v3" }
+                            .select { |url| url.fetch(:repository_type) == "v3" }
         end
 
         def fetch_transitive_dependencies(package_id, package_version)

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -10,342 +10,340 @@ require "dependabot/nuget/cache_manager"
 
 module Dependabot
   module Nuget
-    class UpdateChecker < Dependabot::UpdateCheckers::Base
-      class RepositoryFinder
-        DEFAULT_REPOSITORY_URL = "https://api.nuget.org/v3/index.json"
-        DEFAULT_REPOSITORY_API_KEY = "nuget.org"
+    class RepositoryFinder
+      DEFAULT_REPOSITORY_URL = "https://api.nuget.org/v3/index.json"
+      DEFAULT_REPOSITORY_API_KEY = "nuget.org"
 
-        def initialize(dependency:, credentials:, config_files: [])
-          @dependency  = dependency
-          @credentials = credentials
-          @config_files = config_files
+      def initialize(dependency:, credentials:, config_files: [])
+        @dependency  = dependency
+        @credentials = credentials
+        @config_files = config_files
+      end
+
+      def dependency_urls
+        find_dependency_urls
+      end
+
+      def known_repositories
+        return @known_repositories if @known_repositories
+
+        @known_repositories = []
+        @known_repositories += credential_repositories
+        @known_repositories += config_file_repositories
+
+        @known_repositories << { url: DEFAULT_REPOSITORY_URL, token: nil } if @known_repositories.empty?
+
+        @known_repositories.uniq
+      end
+
+      def self.get_default_repository_details(dependency_name)
+        {
+          base_url: "https://api.nuget.org/v3-flatcontainer/",
+          registration_url: "https://api.nuget.org/v3/registration5-gz-semver2/#{dependency_name.downcase}/index.json",
+          repository_url: DEFAULT_REPOSITORY_URL,
+          versions_url: "https://api.nuget.org/v3-flatcontainer/" \
+                        "#{dependency_name.downcase}/index.json",
+          search_url: "https://azuresearch-usnc.nuget.org/query" \
+                      "?q=#{dependency_name.downcase}&prerelease=true&semVerLevel=2.0.0",
+          auth_header: {},
+          repository_type: "v3"
+        }
+      end
+
+      private
+
+      attr_reader :dependency, :credentials, :config_files
+
+      def find_dependency_urls
+        @find_dependency_urls ||=
+          known_repositories.flat_map do |details|
+            if details.fetch(:url) == DEFAULT_REPOSITORY_URL
+              # Save a request for the default URL, since we already know how
+              # it addresses packages
+              next default_repository_details
+            end
+
+            build_url_for_details(details)
+          end.compact.uniq
+      end
+
+      def build_url_for_details(repo_details)
+        response = get_repo_metadata(repo_details)
+        check_repo_response(response, repo_details)
+        return unless response.status == 200
+
+        body = remove_wrapping_zero_width_chars(response.body)
+        parsed_json = JSON.parse(body)
+        base_url = base_url_from_v3_metadata(parsed_json)
+        resolved_base_url = base_url || repo_details.fetch(:url).gsub("/index.json", "-flatcontainer")
+        search_url = search_url_from_v3_metadata(parsed_json)
+        registration_url = registration_url_from_v3_metadata(parsed_json)
+
+        details = {
+          base_url: resolved_base_url,
+          repository_url: repo_details.fetch(:url),
+          auth_header: auth_header_for_token(repo_details.fetch(:token)),
+          repository_type: "v3"
+        }
+        if base_url
+          details[:versions_url] =
+            File.join(base_url, dependency.name.downcase, "index.json")
+        end
+        if search_url
+          details[:search_url] =
+            search_url + "?q=#{dependency.name.downcase}&prerelease=true&semVerLevel=2.0.0"
         end
 
-        def dependency_urls
-          find_dependency_urls
+        if registration_url
+          details[:registration_url] = File.join(registration_url, dependency.name.downcase, "index.json")
         end
 
-        def known_repositories
-          return @known_repositories if @known_repositories
+        details
+      rescue JSON::ParserError
+        build_v2_url(response, repo_details)
+      rescue Excon::Error::Timeout, Excon::Error::Socket
+        handle_timeout(repo_metadata_url: repo_details.fetch(:url))
+      end
 
-          @known_repositories = []
-          @known_repositories += credential_repositories
-          @known_repositories += config_file_repositories
-
-          @known_repositories << { url: DEFAULT_REPOSITORY_URL, token: nil } if @known_repositories.empty?
-
-          @known_repositories.uniq
-        end
-
-        def self.get_default_repository_details(dependency_name)
-          {
-            base_url: "https://api.nuget.org/v3-flatcontainer/",
-            registration_url: "https://api.nuget.org/v3/registration5-gz-semver2/#{dependency_name.downcase}/index.json",
-            repository_url: DEFAULT_REPOSITORY_URL,
-            versions_url: "https://api.nuget.org/v3-flatcontainer/" \
-                          "#{dependency_name.downcase}/index.json",
-            search_url: "https://azuresearch-usnc.nuget.org/query" \
-                        "?q=#{dependency_name.downcase}&prerelease=true&semVerLevel=2.0.0",
-            auth_header: {},
-            repository_type: "v3"
-          }
-        end
-
-        private
-
-        attr_reader :dependency, :credentials, :config_files
-
-        def find_dependency_urls
-          @find_dependency_urls ||=
-            known_repositories.flat_map do |details|
-              if details.fetch(:url) == DEFAULT_REPOSITORY_URL
-                # Save a request for the default URL, since we already know how
-                # it addresses packages
-                next default_repository_details
-              end
-
-              build_url_for_details(details)
-            end.compact.uniq
-        end
-
-        def build_url_for_details(repo_details)
-          response = get_repo_metadata(repo_details)
-          check_repo_response(response, repo_details)
-          return unless response.status == 200
-
-          body = remove_wrapping_zero_width_chars(response.body)
-          parsed_json = JSON.parse(body)
-          base_url = base_url_from_v3_metadata(parsed_json)
-          resolved_base_url = base_url || repo_details.fetch(:url).gsub("/index.json", "-flatcontainer")
-          search_url = search_url_from_v3_metadata(parsed_json)
-          registration_url = registration_url_from_v3_metadata(parsed_json)
-
-          details = {
-            base_url: resolved_base_url,
-            repository_url: repo_details.fetch(:url),
-            auth_header: auth_header_for_token(repo_details.fetch(:token)),
-            repository_type: "v3"
-          }
-          if base_url
-            details[:versions_url] =
-              File.join(base_url, dependency.name.downcase, "index.json")
-          end
-          if search_url
-            details[:search_url] =
-              search_url + "?q=#{dependency.name.downcase}&prerelease=true&semVerLevel=2.0.0"
-          end
-
-          if registration_url
-            details[:registration_url] = File.join(registration_url, dependency.name.downcase, "index.json")
-          end
-
-          details
-        rescue JSON::ParserError
-          build_v2_url(response, repo_details)
-        rescue Excon::Error::Timeout, Excon::Error::Socket
-          handle_timeout(repo_metadata_url: repo_details.fetch(:url))
-        end
-
-        def get_repo_metadata(repo_details)
-          url = repo_details.fetch(:url)
-          cache = CacheManager.cache("repo_finder_metadatacache")
-          if cache[url]
-            cache[url]
-          else
-            result = Dependabot::RegistryClient.get(
-              url: url,
-              headers: auth_header_for_token(repo_details.fetch(:token))
-            )
-            cache[url] = result
-            result
-          end
-        end
-
-        def base_url_from_v3_metadata(metadata)
-          metadata
-            .fetch("resources", [])
-            .find { |r| r.fetch("@type") == "PackageBaseAddress/3.0.0" }
-            &.fetch("@id")
-        end
-
-        def registration_url_from_v3_metadata(metadata)
-          allowed_registration_types = %w(
-            RegistrationsBaseUrl
-            RegistrationsBaseUrl/3.0.0-beta
-            RegistrationsBaseUrl/3.0.0-rc
-            RegistrationsBaseUrl/3.4.0
-            RegistrationsBaseUrl/3.6.0
+      def get_repo_metadata(repo_details)
+        url = repo_details.fetch(:url)
+        cache = CacheManager.cache("repo_finder_metadatacache")
+        if cache[url]
+          cache[url]
+        else
+          result = Dependabot::RegistryClient.get(
+            url: url,
+            headers: auth_header_for_token(repo_details.fetch(:token))
           )
-          metadata
-            .fetch("resources", [])
-            .find { |r| allowed_registration_types.find { |s| r.fetch("@type") == s } }
-            &.fetch("@id")
+          cache[url] = result
+          result
         end
+      end
 
-        def search_url_from_v3_metadata(metadata)
-          # allowable values from here: https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#versioning
-          allowed_search_types = %w(
-            SearchQueryService
-            SearchQueryService/3.0.0-beta
-            SearchQueryService/3.0.0-rc
-            SearchQueryService/3.5.0
-          )
-          metadata
-            .fetch("resources", [])
-            .find { |r| allowed_search_types.find { |s| r.fetch("@type") == s } }
-            &.fetch("@id")
-        end
+      def base_url_from_v3_metadata(metadata)
+        metadata
+          .fetch("resources", [])
+          .find { |r| r.fetch("@type") == "PackageBaseAddress/3.0.0" }
+          &.fetch("@id")
+      end
 
-        def build_v2_url(response, repo_details)
-          doc = Nokogiri::XML(response.body)
+      def registration_url_from_v3_metadata(metadata)
+        allowed_registration_types = %w(
+          RegistrationsBaseUrl
+          RegistrationsBaseUrl/3.0.0-beta
+          RegistrationsBaseUrl/3.0.0-rc
+          RegistrationsBaseUrl/3.4.0
+          RegistrationsBaseUrl/3.6.0
+        )
+        metadata
+          .fetch("resources", [])
+          .find { |r| allowed_registration_types.find { |s| r.fetch("@type") == s } }
+          &.fetch("@id")
+      end
 
-          doc.remove_namespaces!
-          base_url = doc.at_xpath("service")&.attributes
-                        &.fetch("base", nil)&.value
+      def search_url_from_v3_metadata(metadata)
+        # allowable values from here: https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#versioning
+        allowed_search_types = %w(
+          SearchQueryService
+          SearchQueryService/3.0.0-beta
+          SearchQueryService/3.0.0-rc
+          SearchQueryService/3.5.0
+        )
+        metadata
+          .fetch("resources", [])
+          .find { |r| allowed_search_types.find { |s| r.fetch("@type") == s } }
+          &.fetch("@id")
+      end
 
-          base_url ||= repo_details.fetch(:url)
+      def build_v2_url(response, repo_details)
+        doc = Nokogiri::XML(response.body)
 
-          {
-            base_url: base_url,
-            repository_url: base_url,
-            versions_url: File.join(
-              base_url,
-              "FindPackagesById()?id='#{dependency.name}'"
-            ),
-            auth_header: auth_header_for_token(repo_details.fetch(:token)),
-            repository_type: "v2"
-          }
-        end
+        doc.remove_namespaces!
+        base_url = doc.at_xpath("service")&.attributes
+                      &.fetch("base", nil)&.value
 
-        def check_repo_response(response, details)
-          return unless [401, 402, 403].include?(response.status)
-          raise if details.fetch(:url) == DEFAULT_REPOSITORY_URL
+        base_url ||= repo_details.fetch(:url)
 
-          raise PrivateSourceAuthenticationFailure, details.fetch(:url)
-        end
+        {
+          base_url: base_url,
+          repository_url: base_url,
+          versions_url: File.join(
+            base_url,
+            "FindPackagesById()?id='#{dependency.name}'"
+          ),
+          auth_header: auth_header_for_token(repo_details.fetch(:token)),
+          repository_type: "v2"
+        }
+      end
 
-        def handle_timeout(repo_metadata_url:)
-          raise if repo_metadata_url == DEFAULT_REPOSITORY_URL
+      def check_repo_response(response, details)
+        return unless [401, 402, 403].include?(response.status)
+        raise if details.fetch(:url) == DEFAULT_REPOSITORY_URL
 
-          raise PrivateSourceTimedOut, repo_metadata_url
-        end
+        raise PrivateSourceAuthenticationFailure, details.fetch(:url)
+      end
 
-        def credential_repositories
-          @credential_repositories ||=
-            credentials
-            .select { |cred| cred["type"] == "nuget_feed" }
-            .map { |c| { url: c.fetch("url"), token: c["token"] } }
-        end
+      def handle_timeout(repo_metadata_url:)
+        raise if repo_metadata_url == DEFAULT_REPOSITORY_URL
 
-        def config_file_repositories
-          config_files.flat_map { |file| repos_from_config_file(file) }
-        end
+        raise PrivateSourceTimedOut, repo_metadata_url
+      end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/AbcSize
-        def repos_from_config_file(config_file)
-          doc = Nokogiri::XML(config_file.content)
-          doc.remove_namespaces!
-          # analogous to having a root config with the default repository
-          base_sources = [{ url: DEFAULT_REPOSITORY_URL, key: "nuget.org" }]
+      def credential_repositories
+        @credential_repositories ||=
+          credentials
+          .select { |cred| cred["type"] == "nuget_feed" }
+          .map { |c| { url: c.fetch("url"), token: c["token"] } }
+      end
 
-          sources = []
+      def config_file_repositories
+        config_files.flat_map { |file| repos_from_config_file(file) }
+      end
 
-          # regular package sources
-          doc.css("configuration > packageSources").children.each do |node|
-            if node.name == "clear"
-              sources.clear
-              base_sources.clear
-            else
-              key = node.attribute("key")&.value&.strip || node.at_xpath("./key")&.content&.strip
-              url = node.attribute("value")&.value&.strip || node.at_xpath("./value")&.content&.strip
-              url = expand_windows_style_environment_variables(url) if url
-              sources << { url: url, key: key }
-            end
-          end
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
+      def repos_from_config_file(config_file)
+        doc = Nokogiri::XML(config_file.content)
+        doc.remove_namespaces!
+        # analogous to having a root config with the default repository
+        base_sources = [{ url: DEFAULT_REPOSITORY_URL, key: "nuget.org" }]
 
-          # signed package sources
-          # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section
-          doc.xpath("/configuration/trustedSigners/repository").each do |node|
-            name = node.attribute("name")&.value&.strip
-            service_index = node.attribute("serviceIndex")&.value&.strip
-            sources << { url: service_index, key: name }
-          end
+        sources = []
 
-          sources += base_sources # TODO: quirky overwrite behavior
-          disabled_sources = disabled_sources(doc)
-          sources.reject! do |s|
-            disabled_sources.include?(s[:key])
-          end
-
-          sources.reject! do |s|
-            known_urls = credential_repositories.map { |cr| cr.fetch(:url) }
-            known_urls.include?(s.fetch(:url))
-          end
-
-          sources.select! { |s| s.fetch(:url)&.include?("://") }
-
-          add_config_file_credentials(sources: sources, doc: doc)
-          sources.each { |details| details.delete(:key) }
-
-          sources
-        end
-        # rubocop:enable Metrics/AbcSize
-        # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Metrics/CyclomaticComplexity
-
-        def default_repository_details
-          RepositoryFinder.get_default_repository_details(dependency.name)
-        end
-
-        # rubocop:disable Metrics/PerceivedComplexity
-        def disabled_sources(doc)
-          doc.css("configuration > disabledPackageSources > add").filter_map do |node|
-            value = node.attribute("value")&.value ||
-                    node.at_xpath("./value")&.content
-
-            if value&.strip&.downcase == "true"
-              node.attribute("key")&.value&.strip ||
-                node.at_xpath("./key")&.content&.strip
-            end
-          end
-        end
-        # rubocop:enable Metrics/PerceivedComplexity
-
-        # rubocop:disable Metrics/PerceivedComplexity
-        def add_config_file_credentials(sources:, doc:)
-          sources.each do |source_details|
-            key = source_details.fetch(:key)
-            next source_details[:token] = nil unless key
-            next source_details[:token] = nil if key.match?(/^\d/)
-
-            tag = key.gsub(" ", "_x0020_")
-            creds_nodes = doc.css("configuration > packageSourceCredentials " \
-                                  "> #{tag} > add")
-
-            username =
-              creds_nodes
-              .find { |n| n.attribute("key")&.value == "Username" }
-              &.attribute("value")&.value
-            password =
-              creds_nodes
-              .find { |n| n.attribute("key")&.value == "ClearTextPassword" }
-              &.attribute("value")&.value
-
-            # NOTE: We have to look for plain text passwords, as we have no
-            # way of decrypting encrypted passwords. For the same reason we
-            # don't fetch API keys from the nuget.config at all.
-            next source_details[:token] = nil unless username && password
-
-            expanded_username = expand_windows_style_environment_variables(username)
-            expanded_password = expand_windows_style_environment_variables(password)
-            source_details[:token] = "#{expanded_username}:#{expanded_password}"
-          rescue Nokogiri::XML::XPath::SyntaxError
-            # Any non-ascii characters in the tag with cause a syntax error
-            next source_details[:token] = nil
-          end
-
-          sources
-        end
-        # rubocop:enable Metrics/PerceivedComplexity
-
-        def expand_windows_style_environment_variables(string)
-          # NuGet.Config files can have Windows-style environment variables that need to be replaced
-          # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables
-          string.gsub(/%([^%]+)%/) do
-            environment_variable_name = T.must(::Regexp.last_match(1))
-            environment_variable_value = ENV.fetch(environment_variable_name, nil)
-            if environment_variable_value
-              environment_variable_value
-            else
-              # report that the variable couldn't be expanded, then replace it as-is
-              Dependabot.logger.warn <<~WARN
-                The variable '%#{environment_variable_name}%' could not be expanded in NuGet.Config
-              WARN
-              "%#{environment_variable_name}%"
-            end
-          end
-        end
-
-        def remove_wrapping_zero_width_chars(string)
-          string.force_encoding("UTF-8").encode
-                .gsub(/\A[\u200B-\u200D\uFEFF]/, "")
-                .gsub(/[\u200B-\u200D\uFEFF]\Z/, "")
-        end
-
-        def auth_header_for_token(token)
-          return {} unless token
-
-          if token.include?(":")
-            encoded_token = Base64.encode64(token).delete("\n")
-            { "Authorization" => "Basic #{encoded_token}" }
-          elsif Base64.decode64(token).ascii_only? &&
-                Base64.decode64(token).include?(":")
-            { "Authorization" => "Basic #{token.delete("\n")}" }
+        # regular package sources
+        doc.css("configuration > packageSources").children.each do |node|
+          if node.name == "clear"
+            sources.clear
+            base_sources.clear
           else
-            { "Authorization" => "Bearer #{token}" }
+            key = node.attribute("key")&.value&.strip || node.at_xpath("./key")&.content&.strip
+            url = node.attribute("value")&.value&.strip || node.at_xpath("./value")&.content&.strip
+            url = expand_windows_style_environment_variables(url) if url
+            sources << { url: url, key: key }
           end
+        end
+
+        # signed package sources
+        # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#trustedsigners-section
+        doc.xpath("/configuration/trustedSigners/repository").each do |node|
+          name = node.attribute("name")&.value&.strip
+          service_index = node.attribute("serviceIndex")&.value&.strip
+          sources << { url: service_index, key: name }
+        end
+
+        sources += base_sources # TODO: quirky overwrite behavior
+        disabled_sources = disabled_sources(doc)
+        sources.reject! do |s|
+          disabled_sources.include?(s[:key])
+        end
+
+        sources.reject! do |s|
+          known_urls = credential_repositories.map { |cr| cr.fetch(:url) }
+          known_urls.include?(s.fetch(:url))
+        end
+
+        sources.select! { |s| s.fetch(:url)&.include?("://") }
+
+        add_config_file_credentials(sources: sources, doc: doc)
+        sources.each { |details| details.delete(:key) }
+
+        sources
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def default_repository_details
+        RepositoryFinder.get_default_repository_details(dependency.name)
+      end
+
+      # rubocop:disable Metrics/PerceivedComplexity
+      def disabled_sources(doc)
+        doc.css("configuration > disabledPackageSources > add").filter_map do |node|
+          value = node.attribute("value")&.value ||
+                  node.at_xpath("./value")&.content
+
+          if value&.strip&.downcase == "true"
+            node.attribute("key")&.value&.strip ||
+              node.at_xpath("./key")&.content&.strip
+          end
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # rubocop:disable Metrics/PerceivedComplexity
+      def add_config_file_credentials(sources:, doc:)
+        sources.each do |source_details|
+          key = source_details.fetch(:key)
+          next source_details[:token] = nil unless key
+          next source_details[:token] = nil if key.match?(/^\d/)
+
+          tag = key.gsub(" ", "_x0020_")
+          creds_nodes = doc.css("configuration > packageSourceCredentials " \
+                                "> #{tag} > add")
+
+          username =
+            creds_nodes
+            .find { |n| n.attribute("key")&.value == "Username" }
+            &.attribute("value")&.value
+          password =
+            creds_nodes
+            .find { |n| n.attribute("key")&.value == "ClearTextPassword" }
+            &.attribute("value")&.value
+
+          # NOTE: We have to look for plain text passwords, as we have no
+          # way of decrypting encrypted passwords. For the same reason we
+          # don't fetch API keys from the nuget.config at all.
+          next source_details[:token] = nil unless username && password
+
+          expanded_username = expand_windows_style_environment_variables(username)
+          expanded_password = expand_windows_style_environment_variables(password)
+          source_details[:token] = "#{expanded_username}:#{expanded_password}"
+        rescue Nokogiri::XML::XPath::SyntaxError
+          # Any non-ascii characters in the tag with cause a syntax error
+          next source_details[:token] = nil
+        end
+
+        sources
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      def expand_windows_style_environment_variables(string)
+        # NuGet.Config files can have Windows-style environment variables that need to be replaced
+        # https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables
+        string.gsub(/%([^%]+)%/) do
+          environment_variable_name = T.must(::Regexp.last_match(1))
+          environment_variable_value = ENV.fetch(environment_variable_name, nil)
+          if environment_variable_value
+            environment_variable_value
+          else
+            # report that the variable couldn't be expanded, then replace it as-is
+            Dependabot.logger.warn <<~WARN
+              The variable '%#{environment_variable_name}%' could not be expanded in NuGet.Config
+            WARN
+            "%#{environment_variable_name}%"
+          end
+        end
+      end
+
+      def remove_wrapping_zero_width_chars(string)
+        string.force_encoding("UTF-8").encode
+              .gsub(/\A[\u200B-\u200D\uFEFF]/, "")
+              .gsub(/[\u200B-\u200D\uFEFF]\Z/, "")
+      end
+
+      def auth_header_for_token(token)
+        return {} unless token
+
+        if token.include?(":")
+          encoded_token = Base64.encode64(token).delete("\n")
+          { "Authorization" => "Basic #{encoded_token}" }
+        elsif Base64.decode64(token).ascii_only? &&
+              Base64.decode64(token).include?(":")
+          { "Authorization" => "Basic #{token.delete("\n")}" }
+        else
+          { "Authorization" => "Bearer #{token}" }
         end
       end
     end

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_comparer.rb
@@ -9,22 +9,20 @@ require "dependabot/shared_helpers"
 
 module Dependabot
   module Nuget
-    class UpdateChecker < Dependabot::UpdateCheckers::Base
-      class TfmComparer
-        def self.are_frameworks_compatible?(project_tfms, package_tfms)
-          return false if package_tfms.empty?
-          return false if project_tfms.empty?
+    class TfmComparer
+      def self.are_frameworks_compatible?(project_tfms, package_tfms)
+        return false if package_tfms.empty?
+        return false if project_tfms.empty?
 
-          key = "project_ftms:#{project_tfms.sort.join(',')}:package_tfms:#{package_tfms.sort.join(',')}".downcase
+        key = "project_ftms:#{project_tfms.sort.join(',')}:package_tfms:#{package_tfms.sort.join(',')}".downcase
 
-          @cached_framework_check ||= {}
-          unless @cached_framework_check.key?(key)
-            @cached_framework_check[key] =
-              NativeHelpers.run_nuget_framework_check(project_tfms,
-                                                      package_tfms)
-          end
-          @cached_framework_check[key]
+        @cached_framework_check ||= {}
+        unless @cached_framework_check.key?(key)
+          @cached_framework_check[key] =
+            NativeHelpers.run_nuget_framework_check(project_tfms,
+                                                    package_tfms)
         end
+        @cached_framework_check[key]
       end
     end
   end

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
@@ -12,115 +12,113 @@ require "dependabot/shared_helpers"
 
 module Dependabot
   module Nuget
-    class UpdateChecker < Dependabot::UpdateCheckers::Base
-      class TfmFinder
-        require "dependabot/nuget/file_parser/packages_config_parser"
-        require "dependabot/nuget/file_parser/project_file_parser"
+    class TfmFinder
+      require "dependabot/nuget/file_parser/packages_config_parser"
+      require "dependabot/nuget/file_parser/project_file_parser"
 
-        def initialize(dependency_files:, credentials:)
-          @dependency_files       = dependency_files
-          @credentials            = credentials
+      def initialize(dependency_files:, credentials:)
+        @dependency_files       = dependency_files
+        @credentials            = credentials
+      end
+
+      def frameworks(dependency)
+        tfms = Set.new
+        tfms += project_file_tfms(dependency)
+        tfms += project_import_file_tfms
+        tfms.to_a
+      end
+
+      private
+
+      attr_reader :dependency_files, :credentials
+
+      def project_file_tfms(dependency)
+        project_files_with_dependency(dependency).flat_map do |file|
+          project_file_parser.target_frameworks(project_file: file)
         end
+      end
 
-        def frameworks(dependency)
-          tfms = Set.new
-          tfms += project_file_tfms(dependency)
-          tfms += project_import_file_tfms
-          tfms.to_a
+      def project_files_with_dependency(dependency)
+        project_files.select do |file|
+          packages_config_contains_dependency?(file, dependency) ||
+            project_file_contains_dependency?(file, dependency)
         end
+      end
 
-        private
+      def packages_config_contains_dependency?(file, dependency)
+        config_file = find_packages_config_file(file)
+        return false unless config_file
 
-        attr_reader :dependency_files, :credentials
-
-        def project_file_tfms(dependency)
-          project_files_with_dependency(dependency).flat_map do |file|
-            project_file_parser.target_frameworks(project_file: file)
-          end
+        config_parser = FileParser::PackagesConfigParser.new(packages_config: config_file)
+        config_parser.dependency_set.dependencies.any? do |d|
+          d.name.casecmp(dependency.name).zero?
         end
+      end
 
-        def project_files_with_dependency(dependency)
-          project_files.select do |file|
-            packages_config_contains_dependency?(file, dependency) ||
-              project_file_contains_dependency?(file, dependency)
-          end
+      def project_file_contains_dependency?(file, dependency)
+        project_file_parser.dependency_set(project_file: file).dependencies.any? do |d|
+          d.name.casecmp(dependency.name).zero?
         end
+      end
 
-        def packages_config_contains_dependency?(file, dependency)
-          config_file = find_packages_config_file(file)
-          return false unless config_file
+      def find_packages_config_file(file)
+        return file if file.name.end_with?("packages.config")
 
-          config_parser = FileParser::PackagesConfigParser.new(packages_config: config_file)
-          config_parser.dependency_set.dependencies.any? do |d|
-            d.name.casecmp(dependency.name).zero?
-          end
+        filename = File.basename(file.name)
+        search_path = file.name.sub(filename, "packages.config")
+
+        dependency_files.find { |f| f.name.casecmp(search_path).zero? }
+      end
+
+      def project_import_file_tfms
+        @project_import_file_tfms ||= project_import_files.flat_map do |file|
+          project_file_parser.target_frameworks(project_file: file)
         end
+      end
 
-        def project_file_contains_dependency?(file, dependency)
-          project_file_parser.dependency_set(project_file: file).dependencies.any? do |d|
-            d.name.casecmp(dependency.name).zero?
-          end
+      def project_file_parser
+        @project_file_parser ||=
+          FileParser::ProjectFileParser.new(
+            dependency_files: dependency_files,
+            credentials: credentials
+          )
+      end
+
+      def project_files
+        projfile = /\.[a-z]{2}proj$/
+        packageprops = /[Dd]irectory.[Pp]ackages.props/
+
+        dependency_files.select do |df|
+          df.name.match?(projfile) ||
+            df.name.match?(packageprops)
         end
+      end
 
-        def find_packages_config_file(file)
-          return file if file.name.end_with?("packages.config")
-
-          filename = File.basename(file.name)
-          search_path = file.name.sub(filename, "packages.config")
-
-          dependency_files.find { |f| f.name.casecmp(search_path).zero? }
+      def packages_config_files
+        dependency_files.select do |f|
+          f.name.split("/").last.casecmp("packages.config").zero?
         end
+      end
 
-        def project_import_file_tfms
-          @project_import_file_tfms ||= project_import_files.flat_map do |file|
-            project_file_parser.target_frameworks(project_file: file)
-          end
-        end
+      def project_import_files
+        dependency_files -
+          project_files -
+          packages_config_files -
+          nuget_configs -
+          [global_json] -
+          [dotnet_tools_json]
+      end
 
-        def project_file_parser
-          @project_file_parser ||=
-            FileParser::ProjectFileParser.new(
-              dependency_files: dependency_files,
-              credentials: credentials
-            )
-        end
+      def nuget_configs
+        dependency_files.select { |f| f.name.match?(/nuget\.config$/i) }
+      end
 
-        def project_files
-          projfile = /\.[a-z]{2}proj$/
-          packageprops = /[Dd]irectory.[Pp]ackages.props/
+      def global_json
+        dependency_files.find { |f| f.name.casecmp("global.json").zero? }
+      end
 
-          dependency_files.select do |df|
-            df.name.match?(projfile) ||
-              df.name.match?(packageprops)
-          end
-        end
-
-        def packages_config_files
-          dependency_files.select do |f|
-            f.name.split("/").last.casecmp("packages.config").zero?
-          end
-        end
-
-        def project_import_files
-          dependency_files -
-            project_files -
-            packages_config_files -
-            nuget_configs -
-            [global_json] -
-            [dotnet_tools_json]
-        end
-
-        def nuget_configs
-          dependency_files.select { |f| f.name.match?(/nuget\.config$/i) }
-        end
-
-        def global_json
-          dependency_files.find { |f| f.name.casecmp("global.json").zero? }
-        end
-
-        def dotnet_tools_json
-          dependency_files.find { |f| f.name.casecmp(".config/dotnet-tools.json").zero? }
-        end
+      def dotnet_tools_json
+        dependency_files.find { |f| f.name.casecmp(".config/dotnet-tools.json").zero? }
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/update_checker/compatibility_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/compatibility_checker_spec.rb
@@ -1,0 +1,120 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/nuget/update_checker/compatibility_checker"
+require "dependabot/nuget/update_checker/repository_finder"
+require "dependabot/nuget/update_checker/tfm_finder"
+
+RSpec.describe Dependabot::Nuget::CompatibilityChecker do
+  subject(:checker) do
+    described_class.new(
+      dependency_urls: dependency_urls,
+      dependency: dependency,
+      tfm_finder: tfm_finder
+    )
+  end
+
+  let(:dependency_urls) do
+    Dependabot::Nuget::RepositoryFinder.new(
+      dependency: dependency,
+      credentials: credentials,
+      config_files: []
+    ).dependency_urls
+  end
+
+  let(:credentials) do
+    [{
+      "type" => "nuget_feed",
+      "url" => "https://api.nuget.org/v3/index.json",
+      "token" => "my:passw0rd"
+    }]
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: dependency_version,
+      requirements: dependency_requirements,
+      package_manager: "nuget"
+    )
+  end
+
+  let(:dependency_name) { "Microsoft.AppCenter.Crashes" }
+  let(:dependency_version) { "5.0.2" }
+  let(:dependency_requirements) do
+    [{ file: "my.csproj", requirement: "5.0.2", groups: ["dependencies"], source: nil }]
+  end
+
+  let(:tfm_finder) do
+    Dependabot::Nuget::TfmFinder.new(
+      dependency_files: dependency_files,
+      credentials: credentials
+    )
+  end
+
+  let(:dependency_files) { [csproj] }
+  let(:csproj) do
+    Dependabot::DependencyFile.new(name: "my.csproj", content: csproj_body)
+  end
+  let(:csproj_body) do
+    <<~XML
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <TargetFramework>uap10.0.16299</TargetFramework>
+        </PropertyGroup>
+        <ItemGroup>
+          <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.2" />
+        </ItemGroup>
+      </Project>
+    XML
+  end
+
+  context "#compatible?" do
+    subject(:compatible) { checker.compatible?(version) }
+
+    context "when the `.nuspec` has groups without a `targetFramework` attribute" do
+      let(:version) { "5.0.3" }
+
+      before do
+        stub_request(:get, "https://api.nuget.org/v3-flatcontainer/microsoft.appcenter.crashes/5.0.2/microsoft.appcenter.crashes.nuspec")
+          .to_return(
+            status: 200,
+            body: fixture("nuspecs", "Microsoft.AppCenter.Crashes_faked.nuspec")
+          )
+        stub_request(:get, "https://api.nuget.org/v3-flatcontainer/microsoft.appcenter.crashes/5.0.3/microsoft.appcenter.crashes.nuspec")
+          .to_return(
+            status: 200,
+            body: fixture("nuspecs", "Microsoft.AppCenter.Crashes_faked.nuspec")
+          )
+        stub_request(:get, "https://api.nuget.org/v3/registration5-gz-semver2/microsoft.appcenter.crashes/index.json")
+          .to_return(
+            status: 200,
+            body: {
+              items: [
+                items: [
+                  {
+                    catalogEntry: {
+                      listed: true,
+                      version: "5.0.2"
+                    }
+                  },
+                  {
+                    catalogEntry: {
+                      listed: true,
+                      version: "5.0.3"
+                    }
+                  }
+                ]
+              ]
+            }.to_json
+          )
+      end
+
+      it "returns the correct data" do
+        expect(compatible).to be_truthy
+      end
+    end
+  end
+end

--- a/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
     end
     let(:repository_finder) do
       Dependabot::Nuget::RepositoryFinder.new(dependency: dependency, credentials: credentials,
-                                                             config_files: config_files)
+                                              config_files: config_files)
     end
     let(:repository_details) { repository_finder.dependency_urls.first }
     subject(:nupkg_url) do

--- a/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
       XML
     end
     let(:repository_finder) do
-      Dependabot::Nuget::UpdateChecker::RepositoryFinder.new(dependency: dependency, credentials: credentials,
+      Dependabot::Nuget::RepositoryFinder.new(dependency: dependency, credentials: credentials,
                                                              config_files: config_files)
     end
     let(:repository_details) { repository_finder.dependency_urls.first }

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -6,7 +6,7 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/nuget/update_checker/repository_finder"
 
-RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
+RSpec.describe Dependabot::Nuget::RepositoryFinder do
   subject(:finder) do
     described_class.new(
       dependency: dependency,

--- a/nuget/spec/dependabot/nuget/update_checker/tfm_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/tfm_finder_spec.rb
@@ -6,7 +6,7 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/nuget/update_checker/tfm_finder"
 
-RSpec.describe Dependabot::Nuget::UpdateChecker::TfmFinder do
+RSpec.describe Dependabot::Nuget::TfmFinder do
   subject(:finder) do
     described_class.new(
       dependency_files: dependency_files,

--- a/nuget/spec/fixtures/nuspecs/Microsoft.AppCenter.Crashes_faked.nuspec
+++ b/nuget/spec/fixtures/nuspecs/Microsoft.AppCenter.Crashes_faked.nuspec
@@ -1,0 +1,11 @@
+<package>
+  <metadata>
+    <dependencies>
+      <group>
+      <!-- this group is missing the `targetFramework` attribute -->
+      </group>
+      <group targetFramework="UAP10.0.16299">
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
When checking a package for TFM compatibility, the `targetFramework` attribute might be missing, so don't try to return the `nil` value.

This includes other changes as separate commits, namely:
1. Make individual classes more easily testable by lifting them directly into the `Nuget` module, and not a subclass of `UpdateChecker`.
2. Make `rubocop` happy.

The second commit is the interesting one.

Fixes #8804.