### PR TITLE
fix nil directory causing NilClass exception

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -334,8 +334,10 @@ module Dependabot
     def build_source(source_details)
       # Immediately normalize the source directory, ensure it starts with a "/"
       directory = source_details["directory"]
-      directory = Pathname.new(directory).cleanpath.to_s
-      source_details["directory"] = "/#{directory}" unless directory.start_with?("/")
+      unless directory.nil?
+        directory = Pathname.new(directory).cleanpath.to_s
+        source_details["directory"] = "/#{directory}" unless directory.start_with?("/")
+      end
 
       Dependabot::Source.new(
         **source_details.transform_keys { |k| k.tr("-", "_").to_sym }

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe Dependabot::Job do
         expect(job.source.directory).to eq("/hello")
       end
     end
+
+    context "when the directory is nil because it's a grouped security update" do
+      let(:directory) { nil }
+
+      it "doesn't raise an error" do
+        expect(job.source.directory).to eq(nil)
+      end
+    end
   end
 
   context "when lockfile_only is passed as true" do


### PR DESCRIPTION
fixes #8918

Introduced in https://github.com/dependabot/dependabot-core/pull/8912, when a GSU runs it has a nil directory so we must check for nil here. 

I was confused why the GSU multi-dir test didn't catch this, but it's because of https://github.com/dependabot/cli/pull/256 sending a blank String and thus no NilClass error.