### PR TITLE
Retry transient git clone errors

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -809,7 +809,11 @@ module Dependabot
             if GIT_RETRYABLE_ERRORS.any? { |error| error.match?(e.message) } && retries < 5
               retries += 1
               # 3, 6, 12, 24, 48, ...
-              sleep((2 ^ (retries - 1)) * 3)
+              sleep_seconds = (2 ^ (retries - 1)) * 3
+              Dependabot.logger.warn(
+                "Failed to clone repo #{source.url} due to #{e.message}. Retrying in #{sleep_seconds} seconds..."
+              )
+              sleep(sleep_seconds)
               retry
             end
             raise unless e.message.match(GIT_SUBMODULE_ERROR_REGEX) && e.message.downcase.include?("submodule")

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -51,6 +51,24 @@ module Dependabot
       GIT_SUBMODULE_CLONE_ERROR =
         /^fatal: clone of '(?<url>.*)' into submodule path '.*' failed$/
       GIT_SUBMODULE_ERROR_REGEX = /(#{GIT_SUBMODULE_INACCESSIBLE_ERROR})|(#{GIT_SUBMODULE_CLONE_ERROR})/
+      GIT_RETRYABLE_ERRORS =
+        T.let(
+          [
+            /remote error: Internal Server Error/,
+            /fatal: Couldn\'t find remote ref/,
+            %r{git fetch_pack: expected ACK/NAK, got},
+            /protocol error: bad pack header/,
+            /The remote end hung up unexpectedly/,
+            /TLS packet with unexpected length was received/,
+            /RPC failed; result=\d+, HTTP code = \d+/,
+            /Connection timed out/,
+            /Connection reset by peer/,
+            /Unable to look up/,
+            /Couldn\'t resolve host/,
+            /The requested URL returned error: (429|5\d{2})/
+          ].freeze,
+          T::Array[Regexp]
+        )
 
       sig { overridable.params(filenames: T::Array[String]).returns(T::Boolean) }
       def self.required_files_in?(filenames)
@@ -757,6 +775,7 @@ module Dependabot
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/CyclomaticComplexity
       sig { params(target_directory: T.nilable(String)).returns(String) }
       def _clone_repo_contents(target_directory:)
         SharedHelpers.with_git_configured(credentials: credentials) do
@@ -777,6 +796,7 @@ module Dependabot
           clone_options << " --branch #{source.branch} --single-branch" if source.branch
 
           submodule_cloning_failed = false
+          retries = 0
           begin
             SharedHelpers.run_shell_command(
               <<~CMD
@@ -786,6 +806,12 @@ module Dependabot
 
             @submodules = find_submodules(path) if recurse_submodules_when_cloning?
           rescue SharedHelpers::HelperSubprocessFailed => e
+            if GIT_RETRYABLE_ERRORS.any? { |error| error.match?(e.message) } && retries < 5
+              retries += 1
+              # 3, 6, 12, 24, 48, ...
+              sleep((2 ^ (retries - 1)) * 3)
+              retry
+            end
             raise unless e.message.match(GIT_SUBMODULE_ERROR_REGEX) && e.message.downcase.include?("submodule")
 
             submodule_cloning_failed = true
@@ -831,6 +857,7 @@ module Dependabot
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/BlockLength
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       sig { params(str: String).returns(String) }
       def decode_binary_string(str)


### PR DESCRIPTION
This change allows for Dependabot to retry transient git errors with an exponential backoff. The errors below are either ones we've seen from telemetry, or possible errors in git source code.

The current backoff strategy is configured to retry 5 times, with sleep times of 3, 6, 12, 24, and 48 seconds.