### PR TITLE
Use dotnet credential provider

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -24,7 +24,8 @@ RUN cd /tmp \
   && chmod +x dotnet-install.sh \
   && mkdir -p "${DOTNET_INSTALL_DIR}" \
   && ./dotnet-install.sh --version "${DOTNET_SDK_VERSION}" --install-dir "${DOTNET_INSTALL_DIR}" \
-  && rm dotnet-install.sh
+  && rm dotnet-install.sh \
+  && sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"
 
 ENV PATH="${PATH}:${DOTNET_INSTALL_DIR}"
 RUN dotnet --list-runtimes

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -113,10 +113,14 @@ module Dependabot
         (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
                                                                 dependency: dependency, is_transitive: is_transitive)
 
+        env = NuGetConfigCredentialHelpers.get_credentials_to_credential_helper_env(credentials)
+
         puts "running NuGet updater:\n" + command
 
         NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
-          output = SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, fingerprint: fingerprint)
+          output = SharedHelpers.run_shell_command(command,
+                                                   allow_unsafe_shell_command: true, fingerprint: fingerprint,
+                                                   env: env)
           puts output
         end
       end


### PR DESCRIPTION
Using dotnet credential helper, we do not need to juggle with Nuget.config (current solution works only sometimes).

With Credential Provider, we can use it as it is and do not care much about it. It should just work.

When it does not work:
- when the repository uses `packageSourceMapping`
- when the repository replace global sources `<packageSources><clear /></packageSources>`
- probably there is more; I hit these myself

___
As @brettfo pointed out, this fixes these issues only for Azure DevOps repositories. Not other providers