### PR TITLE
Remove invalid UTF-8 characters from nuspec response body

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
@@ -39,7 +39,7 @@ module Dependabot
 
           return unless nuspec_response.status == 200
 
-          nuspec_response_body = remove_wrapping_zero_width_chars(nuspec_response.body)
+          nuspec_response_body = remove_invalid_characters(nuspec_response.body)
           nuspec_xml = Nokogiri::XML(nuspec_response_body)
         else
           # no guarantee we can directly query the .nuspec; fall back to extracting it from the .nupkg
@@ -75,8 +75,11 @@ module Dependabot
         nil
       end
 
-      def self.remove_wrapping_zero_width_chars(string)
-        string.force_encoding("UTF-8").encode
+      def self.remove_invalid_characters(string)
+        string.dup
+              .force_encoding(Encoding::UTF_8)
+              .encode
+              .scrub("")
               .gsub(/\A[\u200B-\u200D\uFEFF]/, "")
               .gsub(/[\u200B-\u200D\uFEFF]\Z/, "")
       end

--- a/nuget/spec/dependabot/nuget/update_checker/nuspec_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nuspec_fetcher_spec.rb
@@ -43,4 +43,13 @@ RSpec.describe Dependabot::Nuget::NuspecFetcher do
       it { is_expected.to be_falsy }
     end
   end
+
+  describe "remove_invalid_characters" do
+    context "when a utf-16 bom is present" do
+      let(:response_body) { "\xFE\xFF<xml></xml>" }
+      subject(:result) { described_class.remove_invalid_characters(response_body) }
+
+      it { is_expected.to eq("<xml></xml>") }
+    end
+  end
 end


### PR DESCRIPTION
We've seen some responses that are encoded as UTF-16LE, not UTF-8. As a result we error out when trying to force encoding and remove invalid bytes manually:

```
invalid byte sequence in UTF-8
/home/dependabot/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb:80:in `gsub'
...
```

I tried forcing the content-encoding by adding a `Accept: text/xml;content-encoding=utf-8` header, but this wasn't respected.

Using [`String#scrub`][1] seems to be the best approach here, as it replaces invalid byte sequences in the chosen encoding with the provided replacement. For our use case, I provided an empty string as the replacement.

[1]: https://docs.ruby-lang.org/en/3.1/String.html#method-i-scrub