### PR TITLE
add tests around incidental updates

### DIFF
--- a/script/updater-e2e
+++ b/script/updater-e2e
@@ -25,9 +25,11 @@ cd silent/tests
 # If there's 1 argument, use it as a regex to match the test name.
 if [ $# -eq 1 ]
 then
-    go test ./... -test.run "/.*$1.*/"
+    # count=1 is used to prevent Go from caching test results.
+    # It can occasionally be confusing without this.
+    go test ./... -count=1 -test.run "/.*$1.*/"
 else
-    go test ./...
+    go test ./... -count=1
 fi
 
 cd -

--- a/silent/lib/dependabot/silent/file_updater.rb
+++ b/silent/lib/dependabot/silent/file_updater.rb
@@ -42,6 +42,10 @@ module SilentPackageManager
         next unless name == dependency.name
 
         info["version"] = requirements(file).first[:requirement]
+        if info["depends-on"]
+          # also bump dependants to the same version
+          original_content[info["depends-on"]]["version"] = requirements(file).first[:requirement]
+        end
       end
       c = JSON.pretty_generate(original_content)
       puts c

--- a/silent/tests/testdata/vu-group-incidental.txt
+++ b/silent/tests/testdata/vu-group-incidental.txt
@@ -1,0 +1,62 @@
+dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stdout -count=2 create_pull_request
+stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+stderr 'created \| dependency-b \( from 1.2.3 to 1.2.5 \)'
+pr-created expected-1.json
+pr-created expected-2.json
+
+# When Dependabot goes to update dependency-a it will also bump dependency-b to the same version.
+# This test checks what the behavior is when using grouped updates.
+
+-- manifest.json --
+{
+  "dependency-a": { "version": "1.2.3", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.3" }
+}
+
+-- expected-1.json --
+{
+  "dependency-a": { "version": "1.2.5", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.5" }
+}
+
+-- expected-2.json --
+{
+  "dependency-a": { "version": "1.2.3", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.5" }
+}
+
+-- dependency-a --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- dependency-b --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  grouped-update: true
+  dependency-groups:
+    - name: first
+      rules:
+        update-types:
+          - minor
+          - patch

--- a/silent/tests/testdata/vu-incidental.txt
+++ b/silent/tests/testdata/vu-incidental.txt
@@ -1,0 +1,55 @@
+dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stdout -count=2 create_pull_request
+stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+stderr 'created \| dependency-b \( from 1.2.3 to 1.2.5 \)'
+pr-created expected-1.json
+pr-created expected-2.json
+
+# When Dependabot goes to update dependency-a it will also bump dependency-b to the same version.
+# This test checks what the behavior is when not using grouped updates.
+
+-- manifest.json --
+{
+  "dependency-a": { "version": "1.2.3", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.3" }
+}
+
+-- expected-1.json --
+{
+  "dependency-a": { "version": "1.2.5", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.5" }
+}
+
+-- expected-2.json --
+{
+  "dependency-a": { "version": "1.2.3", "depends-on": "dependency-b" },
+  "dependency-b": { "version": "1.2.5" }
+}
+
+-- dependency-a --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- dependency-b --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests


### PR DESCRIPTION
Documenting the behavior of the updater with tests!

When a dependency depends on a specific version of another dependency they will get bumped together, but the interesting part is what Dependabot does next. 

Currently there's a bug with grouped updates using semver grouping, it will create an extra PR, so I've captured that behavior here which should be fixed by https://github.com/dependabot/dependabot-core/pull/8803. 
