### PR TITLE
fix smoke tests failing because Dir.entries order is not deterministic

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -518,7 +518,7 @@ module Dependabot
         repo_path = File.join(clone_repo_contents, relative_path)
         return [] unless Dir.exist?(repo_path)
 
-        Dir.entries(repo_path).filter_map do |name|
+        Dir.entries(repo_path).sort.filter_map do |name|
           next if name == "." || name == ".."
 
           absolute_path = File.join(repo_path, name)


### PR DESCRIPTION
After https://github.com/dependabot/dependabot-core/pull/8933 I'm noticing some smoke tests are failing to pass and the depednency files are coming back in different order depending on what system is running the test.

I think I tracked it down to `Dir.entries` which doesn't guarantee any order, so by sorting we can have more deterministic tests.

Most likely this will break some smoke tests and I'll have to regenerate them.