### PR TITLE
fix security updates getting into grouped code

### DIFF
--- a/silent/tests/testdata/su-basic.txt
+++ b/silent/tests/testdata/su-basic.txt
@@ -49,3 +49,9 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
+  # If present, groups are ignored
+  dependency-groups:
+    - name: all
+      rules:
+        patterns:
+          - "*"

--- a/silent/tests/testdata/su-group-pattern.txt
+++ b/silent/tests/testdata/su-group-pattern.txt
@@ -58,7 +58,8 @@ job:
     - related-b
     - dependency-c
   source:
-    directory: "/"
+    directories:
+      - "/"
     provider: example
     hostname: example.com
     api-endpoint: https://example.com/api/v3

--- a/silent/tests/testdata/su-group-semver.txt
+++ b/silent/tests/testdata/su-group-semver.txt
@@ -54,7 +54,8 @@ pr-created expected-individual.json
 job:
   package-manager: "silent"
   source:
-    directory: "/"
+    directories:
+      - "/"
     provider: example
     hostname: example.com
     api-endpoint: https://example.com/api/v3

--- a/silent/tests/testdata/su-group-type.txt
+++ b/silent/tests/testdata/su-group-type.txt
@@ -1,7 +1,7 @@
 dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
-stdout -count=2 create_pull_request
+stdout -count=4 create_pull_request
 pr-created expected-dev-group.json
-pr-created expected-prod-group.json
+#pr-created expected-prod-group.json
 
 -- manifest.json --
 {
@@ -55,7 +55,8 @@ pr-created expected-prod-group.json
 job:
   package-manager: "silent"
   source:
-    directory: "/"
+    directories:
+      - "/"
     provider: example
     hostname: example.com
     api-endpoint: https://example.com/api/v3

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -25,6 +25,7 @@ module Dependabot
           if Dependabot::Experiments.enabled?(:grouped_security_updates_disabled) && job.security_updates_only?
             return false
           end
+          return false if job.source.directory && job.security_updates_only?
 
           job.dependency_groups&.any?
         end

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -35,6 +35,7 @@ module Dependabot
           if Dependabot::Experiments.enabled?(:grouped_security_updates_disabled) && job.security_updates_only?
             return false
           end
+          return false if job.source.directory && job.security_updates_only?
 
           job.updating_a_pull_request?
         end

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Dependabot::Updater::Operations do
     end
 
     it "returns the UpdateAllVersions class when the Job is for a fresh, non-security update with no dependencies" do
+      source = instance_double(Dependabot::Source, directory: nil)
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: false,
                             updating_a_pull_request?: false,
                             dependencies: [],
@@ -38,7 +40,10 @@ RSpec.describe Dependabot::Updater::Operations do
     end
 
     it "returns the GroupUpdateAllVersions class when the Job is for a fresh, version update with no dependencies" do
+      source = instance_double(Dependabot::Source, directory: nil)
+
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: false,
                             updating_a_pull_request?: false,
                             dependencies: [],
@@ -51,7 +56,10 @@ RSpec.describe Dependabot::Updater::Operations do
     end
 
     it "returns the RefreshGroupUpdatePullRequest class when the Job is for an existing group update" do
+      source = instance_double(Dependabot::Source, directory: nil)
+
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: false,
                             updating_a_pull_request?: true,
                             dependencies: [anything],
@@ -93,7 +101,10 @@ RSpec.describe Dependabot::Updater::Operations do
     end
 
     it "returns the GroupUpdateAllVersions class when Experiment flag is not provided" do
+      source = instance_double(Dependabot::Source, directory: nil)
+
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: true,
                             updating_a_pull_request?: false,
                             dependencies: [anything, anything],
@@ -106,7 +117,9 @@ RSpec.describe Dependabot::Updater::Operations do
 
     it "returns the GroupUpdateAllVersions class when Experiment flag is off" do
       Dependabot::Experiments.register(:grouped_security_updates_disabled, false)
+      source = instance_double(Dependabot::Source, directory: nil)
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: true,
                             updating_a_pull_request?: false,
                             dependencies: [anything, anything],
@@ -133,7 +146,9 @@ RSpec.describe Dependabot::Updater::Operations do
 
     it "returns the RefreshGroupSecurityUpdatePullRequest class when the Job is for an existing security update for" \
        " multiple dependencies" do
+      source = instance_double(Dependabot::Source, directory: nil)
       job = instance_double(Dependabot::Job,
+                            source: source,
                             security_updates_only?: true,
                             updating_a_pull_request?: true,
                             dependencies: [anything, anything],


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/8742 the `applies_to?` method was too permissive so singular security updates are trying to create in groups. 