### PR TITLE
fix(gitlab): pr creator missing default for target_project_id

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -295,7 +295,7 @@ module Dependabot
         approvers: reviewers,
         assignees: assignees,
         milestone: milestone,
-        target_project_id: provider_metadata&.fetch(:target_project_id)
+        target_project_id: provider_metadata&.fetch(:target_project_id, nil)
       )
     end
 


### PR DESCRIPTION
Before #8729 `target_project_id` was `nil` when it was not provided.
Version ^0.240.0 upward is therefore broken for consumers on Gitlab.
This should be the default behaviour again.