### PR TITLE
type DependencyGroupEngine

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -151,7 +151,7 @@ module Dependabot
     def calculate_job_group
       return nil unless job.dependency_group_to_refresh
 
-      @dependency_group_engine.find_group(name: job.dependency_group_to_refresh)
+      @dependency_group_engine.find_group(name: T.must(job.dependency_group_to_refresh))
     end
   end
 end


### PR DESCRIPTION
stacked on #8986

I'd like to merge this into that PR and then deploy them both. This was to make it easier to review. 

I can't use `typed: strong` yet because the dependency group passed in is untyped. In a followup refactor I'll try to address that.