### PR TITLE
fix TypeError: no implicit conversion of Credential into Hash

### DIFF
--- a/common/lib/dependabot/credential.rb
+++ b/common/lib/dependabot/credential.rb
@@ -8,7 +8,7 @@ module Dependabot
     extend T::Sig
     extend Forwardable
 
-    def_delegators :@credential, :fetch, :keys, :[]=, :delete
+    def_delegators :@credential, :fetch, :keys, :[]=, :delete, :slice, :values, :entries
 
     sig { params(credential: T::Hash[String, T.any(T::Boolean, String)]).void }
     def initialize(credential)
@@ -25,6 +25,16 @@ module Dependabot
     sig { params(key: String).returns(T.nilable(String)) }
     def [](key)
       @credential[key]
+    end
+
+    sig { params(other: Credential).returns(Credential) }
+    def merge(other)
+      Credential.new(@credential.merge(other.to_h))
+    end
+
+    sig { returns(T::Hash[String, String]) }
+    def to_h
+      @credential
     end
   end
 end

--- a/hex/lib/dependabot/hex/credential_helpers.rb
+++ b/hex/lib/dependabot/hex/credential_helpers.rb
@@ -9,7 +9,7 @@ module Dependabot
       end
 
       def self.organization_credentials(credentials)
-        defaults = { "organization" => "", "token" => "" }
+        defaults = Dependabot::Credential.new({ "organization" => "", "token" => "" })
         keys = %w(type organization token)
 
         credentials
@@ -20,7 +20,7 @@ module Dependabot
       def self.repo_credentials(credentials)
         # Credentials are serialized as an array that may not have optional fields. Using a
         # default ensures that the array is always the same length, even if values are empty.
-        defaults = { "url" => "", "auth_key" => "", "public_key_fingerprint" => "" }
+        defaults = Dependabot::Credential.new({ "url" => "", "auth_key" => "", "public_key_fingerprint" => "" })
         keys = %w(type repo url auth_key public_key_fingerprint)
 
         credentials

--- a/hex/spec/dependabot/hex/credential_helpers_spec.rb
+++ b/hex/spec/dependabot/hex/credential_helpers_spec.rb
@@ -1,0 +1,37 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/hex/credential_helpers"
+
+RSpec.describe Dependabot::Hex::CredentialHelpers do
+  describe ".organization_credentials" do
+    subject(:organization_credentials) { described_class.organization_credentials(credentials) }
+
+    let(:credentials) do
+      [
+        Dependabot::Credential.new({ "type" => "hex_organization", "organization" => "organization",
+                                     "token" => "token" })
+      ]
+    end
+
+    it "populates the credentials with default properties" do
+      expect(organization_credentials).to eq(%w(hex_organization organization token))
+    end
+  end
+
+  describe ".repo_credentials" do
+    subject(:repo_credentials) { described_class.repo_credentials(credentials) }
+
+    let(:credentials) do
+      [
+        Dependabot::Credential.new({ "type" => "hex_repository", "url" => "url", "auth_key" => "auth_key",
+                                     "public_key_fingerprint" => "public_key_fingerprint" })
+      ]
+    end
+
+    it "populates the credentials with default properties" do
+      expect(repo_credentials).to eq(%w(hex_repository url auth_key public_key_fingerprint))
+    end
+  end
+end

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -351,12 +351,12 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       let(:lockfile_fixture_name) { "private_repo" }
 
       let(:credentials) do
-        {
+        Dependabot::Credential.new({
           "type" => "hex_repository",
           "repo" => "dependabot",
           "auth_key" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4",
           "url" => "https://dependabot-private.fly.dev"
-        }
+        })
       end
 
       let(:dependency) do

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
   end
 
   let(:credentials) do
-    [{
+    [Dependabot::Credential.new({
       "type" => "git_source",
       "host" => "github.com",
       "username" => "x-access-token",
       "password" => "token"
-    }]
+    })]
   end
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
@@ -278,16 +278,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       context "with good credentials" do
         let(:hex_pm_org_token) { ENV.fetch("HEX_PM_ORGANIZATION_TOKEN", nil) }
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "git_source",
             "host" => "github.com",
             "username" => "x-access-token",
             "password" => "token"
-          }, {
+          }), Dependabot::Credential.new({
             "type" => "hex_organization",
             "organization" => "dependabot",
             "token" => hex_pm_org_token
-          }]
+          })]
         end
 
         it "returns the expected version" do
@@ -298,16 +298,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with bad credentials" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "git_source",
             "host" => "github.com",
             "username" => "x-access-token",
             "password" => "token"
-          }, {
+          }), Dependabot::Credential.new({
             "type" => "hex_organization",
             "organization" => "dependabot",
             "token" => "111f6cbeffc6e14c6a884f0111caff3e"
-          }]
+          })]
         end
 
         it "raises a helpful error" do
@@ -321,15 +321,15 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with no token" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "git_source",
             "host" => "github.com",
             "username" => "x-access-token",
             "password" => "token"
-          }, {
+          }), Dependabot::Credential.new({
             "type" => "hex_organization",
             "organization" => "dependabot"
-          }]
+          })]
         end
 
         # This needs to changes to the Elixir helper
@@ -344,12 +344,12 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with no credentials" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "git_source",
             "host" => "github.com",
             "username" => "x-access-token",
             "password" => "token"
-          }]
+          })]
         end
 
         # The Elixir process hangs waiting for input in this case. This spec
@@ -378,12 +378,12 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with good credentials" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "hex_repository",
             "repo" => "dependabot",
             "auth_key" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4",
             "url" => "https://dependabot-private.fly.dev"
-          }]
+          })]
         end
 
         it { is_expected.to eq(Dependabot::Hex::Version.new("1.1.0")) }
@@ -391,12 +391,12 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with bad credentials" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "hex_repository",
             "repo" => "dependabot",
             "auth_key" => "111f6cbeffc6e14c6a884f0111caff3e",
             "url" => "https://dependabot-private.fly.dev"
-          }]
+          })]
         end
 
         it "raises a helpful error" do
@@ -411,13 +411,13 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with correct public key fingerprint verification" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "hex_repository",
             "repo" => "dependabot",
             "auth_key" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4",
             "url" => "https://dependabot-private.fly.dev",
             "public_key_fingerprint" => "SHA256:jn36tNgSXuEljoob8fkejX9LIyXqCcwShjRGps7RVgw"
-          }]
+          })]
         end
 
         it { is_expected.to eq(Dependabot::Hex::Version.new("1.1.0")) }
@@ -425,13 +425,13 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with incorrect public key fingerprint verification" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "hex_repository",
             "repo" => "dependabot",
             "auth_key" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4",
             "url" => "https://dependabot-private.fly.dev",
             "public_key_fingerprint" => "SHA256:kejX9LIyXqCcwShjRGps7RVgjn36tNgSXuEljoob8fw"
-          }]
+          })]
         end
 
         it "raises a helpful error" do
@@ -446,16 +446,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
       context "with dependencies on both a private organization and private repo" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "hex_organization",
             "organization" => "dependabot",
             "token" => "855f6cbeffc6e14c6a884f0111caff3e"
-          }, {
+          }), Dependabot::Credential.new({
             "type" => "hex_repository",
             "repo" => "dependabot",
             "auth_key" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4",
             "url" => "https://dependabot-private.fly.dev"
-          }]
+          })]
         end
 
         it { is_expected.to eq(Dependabot::Hex::Version.new("1.1.0")) }


### PR DESCRIPTION
Introduced by https://github.com/dependabot/dependabot-core/pull/8967, this is some untested and untyped code which is failing. 

I added the missing functionality required by this code to the Credential class and added a test for good measure.