### PR TITLE
Allow `submodule_path` to be nilable

### DIFF
--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -66,7 +66,7 @@ module Dependabot
           )
       end
 
-      sig { params(submodule_path: String).returns(Dependabot::DependencyFile) }
+      sig { params(submodule_path: T.nilable(String)).returns(Dependabot::DependencyFile) }
       def fetch_submodule_ref_from_host(submodule_path)
         path = Pathname.new(File.join(directory, submodule_path))
                        .cleanpath.to_path.gsub(%r{^/*}, "")


### PR DESCRIPTION
Fixes the following `TypeError`

```
Parameter 'submodule_path': Expected type String, got type NilClass
Caller: /home/dependabot/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb:50
Definition: /home/dependabot/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb:70
```