### PR TITLE
Report Sorbet issue to sentry without raising

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <h1 align="center">
+
     <picture>
         <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg">
         <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg">

--- a/updater/lib/dependabot/setup.rb
+++ b/updater/lib/dependabot/setup.rb
@@ -8,6 +8,7 @@ require "dependabot/logger"
 require "dependabot/logger/formats"
 require "dependabot/opentelemetry"
 require "dependabot/sentry"
+require "dependabot/sorbet/runtime"
 
 Dependabot.logger = Logger.new($stdout).tap do |logger|
   logger.level = Dependabot::Environment.log_level
@@ -50,6 +51,7 @@ Sentry.init do |config|
 end
 
 Dependabot::OpenTelemetry.configure
+Dependabot::Sorbet::Runtime.silently_report_errors!
 
 # Ecosystems
 require "dependabot/python"

--- a/updater/lib/dependabot/sorbet/runtime.rb
+++ b/updater/lib/dependabot/sorbet/runtime.rb
@@ -15,7 +15,7 @@ module Dependabot
           error = InformationalError.new(opts[:pretty_message])
           error.set_backtrace(caller.dup)
 
-          Sentry.capture_exception(error)
+          ::Sentry.capture_exception(error)
         end
       end
     end

--- a/updater/lib/dependabot/sorbet/runtime.rb
+++ b/updater/lib/dependabot/sorbet/runtime.rb
@@ -1,13 +1,15 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
-#
+
 require "sorbet-runtime"
 
 module Dependabot
   module Sorbet
     module Runtime
       class InformationalError < StandardError; end
+      extend T::Sig
 
+      sig { void }
       def self.silently_report_errors!
         T::Configuration.call_validation_error_handler = lambda do |sig, opts|
           error = InformationalError.new(opts[:pretty_message])

--- a/updater/lib/dependabot/sorbet/runtime.rb
+++ b/updater/lib/dependabot/sorbet/runtime.rb
@@ -11,7 +11,7 @@ module Dependabot
 
       sig { void }
       def self.silently_report_errors!
-        T::Configuration.call_validation_error_handler = lambda do |sig, opts|
+        T::Configuration.call_validation_error_handler = lambda do |_sig, opts|
           error = InformationalError.new(opts[:pretty_message])
           error.set_backtrace(caller.dup)
 

--- a/updater/lib/dependabot/sorbet/runtime.rb
+++ b/updater/lib/dependabot/sorbet/runtime.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+#
+require "sorbet-runtime"
+
+module Dependabot
+  module Sorbet
+    module Runtime
+      class InformationalError < StandardError; end
+
+      def self.silently_report_errors!
+        T::Configuration.call_validation_error_handler = lambda do |sig, opts|
+          error = InformationalError.new(opts[:pretty_message])
+          error.set_backtrace(caller.dup)
+
+          Sentry.capture_exception(error)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously if Sorbet found runtime typecheck failures, these would result in an exception, halting further job execution.

While we should be informed of those failures, there is no reason why this should end up failing the job for our customers.

This PR configures Sorbet to report the exceptions to Sentry but continue processing.