### PR TITLE
handle both `token` and `username`/`password` for NuGet feeds

### DIFF
--- a/nuget/lib/dependabot/nuget/credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/credential_helpers.rb
@@ -1,0 +1,19 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Nuget
+    module CredentialHelpers
+      def self.get_token_from_credentials(credentials)
+        token = credentials["token"]
+        username = credentials["username"]
+        password = credentials["password"]
+
+        return token if token
+        return "#{username}:#{password}" if username && password
+
+        nil
+      end
+    end
+  end
+end

--- a/nuget/lib/dependabot/nuget/credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/credential_helpers.rb
@@ -4,10 +4,10 @@
 module Dependabot
   module Nuget
     module CredentialHelpers
-      def self.get_token_from_credentials(credentials)
-        token = credentials["token"]
-        username = credentials["username"]
-        password = credentials["password"]
+      def self.get_token_from_credential(credential)
+        token = credential["token"]
+        username = credential["username"]
+        password = credential["password"]
 
         return token if token
         return "#{username}:#{password}" if username && password

--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -145,12 +145,12 @@ module Dependabot
                            .find { |r| r.fetch(:source) }&.fetch(:source)
         url = source&.fetch(:url, nil) || source&.fetch("url")
 
-        matching_credentials = credentials
-                               .select { |cred| cred["type"] == "nuget_feed" }
-                               .find { |cred| cred["url"] == url }
-        return {} unless matching_credentials
+        matching_credential = credentials
+                              .select { |cred| cred["type"] == "nuget_feed" }
+                              .find { |cred| cred["url"] == url }
+        return {} unless matching_credential
 
-        token = CredentialHelpers.get_token_from_credentials(matching_credentials)
+        token = CredentialHelpers.get_token_from_credential(matching_credential)
         return {} unless token
 
         if token.include?(":")

--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
 require "dependabot/registry_client"
+require "dependabot/nuget/credential_helpers"
 
 module Dependabot
   module Nuget
@@ -144,11 +145,12 @@ module Dependabot
                            .find { |r| r.fetch(:source) }&.fetch(:source)
         url = source&.fetch(:url, nil) || source&.fetch("url")
 
-        token = credentials
-                .select { |cred| cred["type"] == "nuget_feed" }
-                .find { |cred| cred["url"] == url }
-                &.fetch("token", nil)
+        matching_credentials = credentials
+                               .select { |cred| cred["type"] == "nuget_feed" }
+                               .find { |cred| cred["url"] == url }
+        return {} unless matching_credentials
 
+        token = CredentialHelpers.get_token_from_credentials(matching_credentials)
         return {} unless token
 
         if token.include?(":")

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -29,7 +29,7 @@ module Dependabot
         nuget_credentials.each_with_index do |c, i|
           source_name = "nuget_source_#{i + 1}"
           package_sources << "    <add key=\"#{source_name}\" value=\"#{c['url']}\" />"
-          token = CredentialHelpers.get_token_from_credentials(c)
+          token = CredentialHelpers.get_token_from_credential(c)
           next unless token
 
           if token.include?(":")

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -1,6 +1,9 @@
 # typed: true
 # frozen_string_literal: true
 
+require "dependabot/logger"
+require "dependabot/nuget/credential_helpers"
+
 module Dependabot
   module Nuget
     module NuGetConfigCredentialHelpers
@@ -26,11 +29,21 @@ module Dependabot
         nuget_credentials.each_with_index do |c, i|
           source_name = "nuget_source_#{i + 1}"
           package_sources << "    <add key=\"#{source_name}\" value=\"#{c['url']}\" />"
-          next unless c["token"]
+          token = CredentialHelpers.get_token_from_credentials(c)
+          next unless token
+
+          if token.include?(":")
+            parts = token.split(":", 2)
+            username = parts[0]
+            password = parts[1]
+          else
+            username = "user"
+            password = token
+          end
 
           package_source_credentials << "    <#{source_name}>"
-          package_source_credentials << "      <add key=\"Username\" value=\"user\" />"
-          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{c['token']}\" />"
+          package_source_credentials << "      <add key=\"Username\" value=\"#{username}\" />"
+          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{password}\" />"
           package_source_credentials << "    </#{source_name}>"
         end
 

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -197,7 +197,7 @@ module Dependabot
         @credential_repositories ||=
           credentials
           .select { |cred| cred["type"] == "nuget_feed" }
-          .map { |cred| { url: cred.fetch("url"), token: CredentialHelpers.get_token_from_credentials(cred) } }
+          .map { |cred| { url: cred.fetch("url"), token: CredentialHelpers.get_token_from_credential(cred) } }
       end
 
       def config_file_repositories

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -7,6 +7,7 @@ require "dependabot/errors"
 require "dependabot/update_checkers/base"
 require "dependabot/registry_client"
 require "dependabot/nuget/cache_manager"
+require "dependabot/nuget/credential_helpers"
 
 module Dependabot
   module Nuget
@@ -196,7 +197,7 @@ module Dependabot
         @credential_repositories ||=
           credentials
           .select { |cred| cred["type"] == "nuget_feed" }
-          .map { |c| { url: c.fetch("url"), token: c["token"] } }
+          .map { |cred| { url: cred.fetch("url"), token: CredentialHelpers.get_token_from_credentials(cred) } }
       end
 
       def config_file_repositories

--- a/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
 
         it { is_expected.to be_nil }
 
-        context "with details in the credentials" do
+        context "with token in the credentials" do
           let(:credentials) do
             [{
               "type" => "git_source",
@@ -151,6 +151,25 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
               "url" => "https://www.myget.org/F/exceptionless/api/v3/" \
                        "index.json",
               "token" => "my:passw0rd"
+            }]
+          end
+
+          it { is_expected.to eq("https://github.com/dotnet/core-setup") }
+        end
+
+        context "with username/password in the credentials" do
+          let(:credentials) do
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "nuget_feed",
+              "url" => "https://www.myget.org/F/exceptionless/api/v3/" \
+                       "index.json",
+              "username" => "my",
+              "password" => "passw0rd"
             }]
           end
 

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -32,8 +32,13 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
     context "with non-empty credential set" do
       let(:credentials) do
         [
-          { "type" => "nuget_feed", "url" => "https://private.nuget.example.com/index.json",
+          # private feed with a token
+          { "type" => "nuget_feed", "url" => "https://private1.nuget.example.com/index.json",
             "token" => "secret_token" },
+          # private feed with a username and password
+          { "type" => "nuget_feed", "url" => "https://private2.nuget.example.com/index.json", "username" => "my",
+            "password" => "passw0rd" },
+          # public feed
           { "type" => "nuget_feed", "url" => "https://public.nuget.example.com/index.json" },
           { "type" => "not_nuget", "some_other_field" => "some other value" }
         ]
@@ -46,14 +51,19 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
               <?xml version="1.0" encoding="utf-8"?>
               <configuration>
                 <packageSources>
-                  <add key="nuget_source_1" value="https://private.nuget.example.com/index.json" />
-                  <add key="nuget_source_2" value="https://public.nuget.example.com/index.json" />
+                  <add key="nuget_source_1" value="https://private1.nuget.example.com/index.json" />
+                  <add key="nuget_source_2" value="https://private2.nuget.example.com/index.json" />
+                  <add key="nuget_source_3" value="https://public.nuget.example.com/index.json" />
                 </packageSources>
                 <packageSourceCredentials>
                   <nuget_source_1>
                     <add key="Username" value="user" />
                     <add key="ClearTextPassword" value="secret_token" />
                   </nuget_source_1>
+                  <nuget_source_2>
+                    <add key="Username" value="my" />
+                    <add key="ClearTextPassword" value="passw0rd" />
+                  </nuget_source_2>
                 </packageSourceCredentials>
               </configuration>
             XML

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
     context "with non-empty credential set" do
       let(:credentials) do
         [
-          # private feed with a token
+          # private feed with a token is preferred over user/pass
           { "type" => "nuget_feed", "url" => "https://private1.nuget.example.com/index.json",
-            "token" => "secret_token" },
+            "token" => "secret_token", "username" => "user-not-used", "password" => "pass-not-used" },
           # private feed with a username and password
           { "type" => "nuget_feed", "url" => "https://private2.nuget.example.com/index.json", "username" => "my",
             "password" => "passw0rd" },


### PR DESCRIPTION
Private NuGet feed information can be specified in the `dependabot.yml` file either with a `token` field, or with both `username` and `password`.  Previously we only honored the `token` field and even then, this wasn't properly handled when we patched the local `NuGet.Config` file; we hard-coded the username to `user` and left the token intact for the password.

This PR fixes the issue in 2 ways:

1. When reading feed data from the `credentials` object, we first use the `token` field if present, otherwise we construct a token from `<username>:<password>`, and finally fall back to `nil` (as before).  This value is then stored in the `token` property of the repository details.
2. When patching the local `NuGet.Config`, instead of simply pulling out the `token` field and using it as a password, we first try to split back out the `username` and `password` parts and apply those as appropriate.  If we couldn't split it apart, we then treat it like a normal token as before with a hard-coded username of `user`.

There were 2 places where this token creation occurred in the past so I introduced `credential_helpers.rb` to consolidate this into one location.

Aside from unit tests, I also ran a manual test against a private GitHub NuGet feed with the following values:

``` yaml
registries:
  some-private-feed:
    type: nuget-feed
    url: https://nuget.example.com/index.json
    token: "myuser:mypass"
```

and

``` yaml
registries:
  some-private-feed:
    type: nuget-feed
    url: https://nuget.example.com/index.json
    username: myuser
    password: mypass
```

Fixes #8887 and #8910.