### PR TITLE
Compare the Docker digest when processing version updates

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -16,7 +16,17 @@ module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       def latest_version
-        latest_version_from(dependency.version)
+        # When Dependabot checks if an existing version update PR is present
+        # it only knows about the semver version of the PRs.
+        # That's a problem for Docker since the tag can have the same version but
+        # a newer digest.
+        # Thus, we can't tell if the matching_tag has been updated or not if it 
+        # has a digest, so we force Dependabot to attempt an update
+        matching_tag = latest_tag_from(dependency.version)
+
+        return nil if matching_tag.digest?
+
+        matching_tag.name
       end
 
       def latest_resolvable_version

--- a/docker/spec/fixtures/docker/registry_tags/ubi-no-updates.json
+++ b/docker/spec/fixtures/docker/registry_tags/ubi-no-updates.json
@@ -1,0 +1,6 @@
+{
+    "name": "ubi8/ubi-minimal",
+    "tags": [
+        "8.5"
+    ]
+}


### PR DESCRIPTION
Dependabot does compare Docker digests checking for updates. So Dependabot does not currently update a PR if there is a newer tag for the same version.

This is an attempt at fixing the issue by forcing Dependabot to attempt an update to an existing Docker PR if the image uses a digest. 

A more complete solution might be parsing the SHA from existing PRs and passing that along to Dependabot to compare (instead of always attempting an update).