### PR TITLE
Filter out NuGet feeds which don't have URLs

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -195,7 +195,7 @@ module Dependabot
       def credential_repositories
         @credential_repositories ||=
           credentials
-          .select { |cred| cred["type"] == "nuget_feed" && cred["url"] && cred["token"] }
+          .select { |cred| cred["type"] == "nuget_feed" && cred["url"] }
           .map { |c| { url: c.fetch("url"), token: c["token"] } }
       end
 

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -195,7 +195,7 @@ module Dependabot
       def credential_repositories
         @credential_repositories ||=
           credentials
-          .select { |cred| cred["type"] == "nuget_feed" }
+          .select { |cred| cred["type"] == "nuget_feed" && cred["url"] && cred["token"] }
           .map { |c| { url: c.fetch("url"), token: c["token"] } }
       end
 


### PR DESCRIPTION
Since https://github.com/dependabot/cli/pull/268 we're passing Azure Artifacts feeds as `nuget_feed` (correctly) instead of `git_source`. The CLI passes the credentials to the proxy, but the updater only [gets the `host` and `type`][1].

This might conflict with #9004 

[1]: https://github.com/dependabot/cli/blob/35deb52c81b16ce706ec8601b85c589b7d483503/cmd/dependabot/internal/cmd/update.go#L361-L367