### PR TITLE
allow folllowing HTTP 307 when resolving `.nupkg` contents

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -73,7 +73,7 @@ module Dependabot
             response_block: response_block
           )
 
-          if response.status == 303
+          if response.status == 303 || response.status == 307
             current_redirects += 1
             return nil if current_redirects > max_redirects
 


### PR DESCRIPTION
Private AWS NuGet feeds return `HTTP 307` when requesting the `.nupkg` contents, but the `NupkgFetcher` currently only allows `303` redirects.  The result is that `nil` is returned which causes problems much later on, including another instance of `undefined method 'fetch' for nil:NilClass`.  This PR adds a `307` redirect handler as well as a test that verifies both `303` and `307` redirects.

Fixes #9021