### PR TITLE
fix directories in use for non-grouped updates

### DIFF
--- a/silent/tests/testdata/vu-basic-directories.txt
+++ b/silent/tests/testdata/vu-basic-directories.txt
@@ -1,0 +1,54 @@
+dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+pr-created expected.json
+
+dependabot update -f input-2.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'updated \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+pr-updated expected.json
+
+-- manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" }
+}
+
+-- expected.json --
+{
+  "dependency-a": { "version": "1.2.5" }
+}
+
+-- dependency-a --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  source:
+    directories:
+      - "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+
+-- input-2.yml --
+job:
+  package-manager: "silent"
+  source:
+    directories:
+      - "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  dependencies:
+    - dependency-a
+  updating-a-pull-request: true
+  existing-pull-requests:
+    - - dependency-name: dependency-a
+        dependency-version: 1.2.5

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -30,6 +30,10 @@ module Dependabot
           @job = job
           @dependency_snapshot = dependency_snapshot
           @error_handler = error_handler
+
+          if job.source.directory.nil? && job.source.directories.count == 1
+            job.source.directory = job.source.directories.first
+          end
         end
 
         def perform

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -31,9 +31,9 @@ module Dependabot
           @dependency_snapshot = dependency_snapshot
           @error_handler = error_handler
 
-          if job.source.directory.nil? && job.source.directories.count == 1
-            job.source.directory = job.source.directories.first
-          end
+          return unless job.source.directory.nil? && job.source.directories.count == 1
+
+          job.source.directory = job.source.directories.first
         end
 
         def perform

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -28,9 +28,9 @@ module Dependabot
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = []
 
-          if job.source.directory.nil? && job.source.directories.count == 1
-            job.source.directory = job.source.directories.first
-          end
+          return unless job.source.directory.nil? && job.source.directories.count == 1
+
+          job.source.directory = job.source.directories.first
         end
 
         def perform

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -27,6 +27,10 @@ module Dependabot
           @error_handler = error_handler
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = []
+
+          if job.source.directory.nil? && job.source.directories.count == 1
+            job.source.directory = job.source.directories.first
+          end
         end
 
         def perform


### PR DESCRIPTION
Some of our multi-dir changes leaked into non-grouped updates, the result is job definitions that have `directories: ["/"]`set rather than `directory: "/"`.

In the long run this is what we want anyway, so I've added a really easy fix in the non-grouped operations to handle this case.
