### PR TITLE
Strict type `Dependabot::MetadataFinders::Base::ChangelogFinder`

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "excon"
@@ -9,9 +9,11 @@ require "dependabot/clients/gitlab_with_retries"
 require "dependabot/clients/bitbucket_with_retries"
 require "dependabot/shared_helpers"
 require "dependabot/metadata_finders/base"
+
 module Dependabot
   module MetadataFinders
     class Base
+      # rubocop:disable Metrics/ClassLength
       class ChangelogFinder
         extend T::Sig
 
@@ -19,24 +21,49 @@ module Dependabot
         require_relative "commits_finder"
 
         # Earlier entries are preferred
-        CHANGELOG_NAMES = %w(
-          changelog news changes history release whatsnew releases
-        ).freeze
+        CHANGELOG_NAMES = T.let(
+          %w(changelog news changes history release whatsnew releases).freeze,
+          T::Array[String]
+        )
 
-        attr_reader :source, :dependency, :credentials, :suggested_changelog_url
+        sig { returns(T.nilable(Dependabot::Source)) }
+        attr_reader :source
 
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :suggested_changelog_url
+
+        sig do
+          params(
+            source: T.nilable(Dependabot::Source),
+            dependency: Dependabot::Dependency,
+            credentials: T::Array[Dependabot::Credential],
+            suggested_changelog_url: T.nilable(String)
+          )
+            .void
+        end
         def initialize(source:, dependency:, credentials:,
                        suggested_changelog_url: nil)
           @source = source
           @dependency = dependency
           @credentials = credentials
           @suggested_changelog_url = suggested_changelog_url
+
+          @new_version = T.let(nil, T.nilable(String))
+          @changelog_from_suggested_url = T.let(nil, T.untyped)
         end
 
+        sig { returns(T.nilable(String)) }
         def changelog_url
           changelog&.html_url
         end
 
+        sig { returns(T.nilable(String)) }
         def changelog_text
           return unless full_changelog_text
 
@@ -46,19 +73,25 @@ module Dependabot
           ).pruned_text
         end
 
+        sig { returns(T.nilable(String)) }
         def upgrade_guide_url
           upgrade_guide&.html_url
         end
 
+        sig { returns(T.nilable(String)) }
         def upgrade_guide_text
           return unless upgrade_guide
 
-          @upgrade_guide_text ||= fetch_file_text(upgrade_guide)
+          @upgrade_guide_text ||= T.let(
+            fetch_file_text(upgrade_guide),
+            T.nilable(String)
+          )
         end
 
         private
 
         # rubocop:disable Metrics/PerceivedComplexity
+        sig { returns(T.untyped) }
         def changelog
           return unless changelog_from_suggested_url || source
           return if git_source? && !ref_changed?
@@ -66,13 +99,13 @@ module Dependabot
 
           # If there is a changelog, and it includes the new version, return it
           if new_version && default_branch_changelog &&
-             fetch_file_text(default_branch_changelog)&.include?(new_version)
+             fetch_file_text(default_branch_changelog)&.include?(T.must(new_version))
             return default_branch_changelog
           end
 
           # Otherwise, look for a changelog at the tag for this version
           if new_version && relevant_tag_changelog &&
-             fetch_file_text(relevant_tag_changelog)&.include?(new_version)
+             fetch_file_text(relevant_tag_changelog)&.include?(T.must(new_version))
             return relevant_tag_changelog
           end
 
@@ -81,8 +114,9 @@ module Dependabot
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
+        sig { returns(T.nilable(Sawyer::Resource)) }
         def changelog_from_suggested_url
-          return @changelog_from_suggested_url if defined?(@changelog_from_suggested_url)
+          return @changelog_from_suggested_url unless @changelog_from_suggested_url.nil?
           return unless suggested_changelog_url
 
           # TODO: Support other providers
@@ -90,29 +124,40 @@ module Dependabot
           return unless suggested_source&.provider == "github"
 
           opts = { path: suggested_source&.directory, ref: suggested_source&.branch }.compact
-          suggested_source_client = github_client_for_source(suggested_source)
-          tmp_files = suggested_source_client.contents(suggested_source&.repo, opts)
+          suggested_source_client = github_client_for_source(T.must(suggested_source))
+          tmp_files = T.unsafe(suggested_source_client).contents(suggested_source&.repo, opts)
 
-          filename = suggested_changelog_url.split("/").last.split("#").first
+          filename = T.must(T.must(suggested_changelog_url).split("/").last).split("#").first
           @changelog_from_suggested_url =
             tmp_files.find { |f| f.name == filename }
         rescue Octokit::NotFound, Octokit::UnavailableForLegalReasons
           @changelog_from_suggested_url = nil
         end
 
+        sig { returns(T.nilable(T.any(OpenStruct, Sawyer::Resource))) }
         def default_branch_changelog
           return unless source
 
-          @default_branch_changelog ||= changelog_from_ref(nil)
+          @default_branch_changelog ||=
+            T.let(
+              changelog_from_ref(nil),
+              T.nilable(T.any(OpenStruct, Sawyer::Resource))
+            )
         end
 
+        sig { returns(T.nilable(T.any(OpenStruct, Sawyer::Resource))) }
         def relevant_tag_changelog
           return unless source
           return unless tag_for_new_version
 
-          @relevant_tag_changelog ||= changelog_from_ref(tag_for_new_version)
+          @relevant_tag_changelog ||=
+            T.let(
+              changelog_from_ref(tag_for_new_version),
+              T.nilable(T.any(OpenStruct, Sawyer::Resource))
+            )
         end
 
+        sig { params(ref: T.nilable(String)).returns(T.nilable(T.any(OpenStruct, Sawyer::Resource))) }
         def changelog_from_ref(ref)
           files =
             dependency_file_list(ref)
@@ -125,6 +170,7 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
+        sig { params(files: T::Array[T.untyped]).returns(T.untyped) }
         def select_best_changelog(files)
           CHANGELOG_NAMES.each do |name|
             candidates = files.select { |f| f.name =~ /#{name}/i }
@@ -150,15 +196,20 @@ module Dependabot
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
+        sig { returns(T.nilable(String)) }
         def tag_for_new_version
           @tag_for_new_version ||=
-            CommitsFinder.new(
-              dependency: dependency,
-              source: source,
-              credentials: credentials
-            ).new_tag
+            T.let(
+              CommitsFinder.new(
+                dependency: dependency,
+                source: source,
+                credentials: credentials
+              ).new_tag,
+              T.nilable(String)
+            )
         end
 
+        sig { returns(T.nilable(String)) }
         def full_changelog_text
           return unless changelog
 
@@ -167,7 +218,7 @@ module Dependabot
 
         sig { params(file: T.untyped).returns(T.nilable(String)) }
         def fetch_file_text(file)
-          @file_text ||= {}
+          @file_text ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
 
           unless @file_text.key?(file.download_url)
             file_source = T.must(Source.from_url(file.html_url))
@@ -187,12 +238,14 @@ module Dependabot
           @file_text[file.download_url].rstrip
         end
 
+        sig { params(file_source: Dependabot::Source, file: T.untyped).returns(String) }
         def fetch_github_file(file_source, file)
           # Hitting the download URL directly causes encoding problems
-          raw_content = github_client_for_source(file_source).get(file.url).content
+          raw_content = T.unsafe(github_client_for_source(file_source)).get(file.url).content
           Base64.decode64(raw_content).force_encoding("UTF-8").encode
         end
 
+        sig { params(file: T.untyped).returns(String) }
         def fetch_gitlab_file(file)
           Excon.get(
             file.download_url,
@@ -201,16 +254,19 @@ module Dependabot
           ).body.force_encoding("UTF-8").encode
         end
 
+        sig { params(file: T.untyped).returns(String) }
         def fetch_bitbucket_file(file)
-          bitbucket_client.get(file.download_url).body
-                          .force_encoding("UTF-8").encode
+          T.unsafe(bitbucket_client).get(file.download_url).body
+           .force_encoding("UTF-8").encode
         end
 
+        sig { params(file: T.untyped).returns(String) }
         def fetch_azure_file(file)
           azure_client.get(file.download_url).body
                       .force_encoding("UTF-8").encode
         end
 
+        sig { returns(T.untyped) }
         def upgrade_guide
           return unless source
 
@@ -225,49 +281,55 @@ module Dependabot
             .max_by(&:size)
         end
 
+        sig { params(ref: T.nilable(String)).returns(T.untyped) }
         def dependency_file_list(ref = nil)
-          @dependency_file_list ||= {}
+          @dependency_file_list ||= T.let({}, T.nilable(T::Hash[T.nilable(String), T.untyped]))
           @dependency_file_list[ref] ||= fetch_dependency_file_list(ref)
         end
 
+        sig { params(ref: T.nilable(String)).returns(T::Array[T.untyped,]) }
         def fetch_dependency_file_list(ref)
-          case source.provider
+          case T.must(source).provider
           when "github" then fetch_github_file_list(ref)
           when "bitbucket" then fetch_bitbucket_file_list
           when "gitlab" then fetch_gitlab_file_list
           when "azure" then fetch_azure_file_list
           when "codecommit" then [] # TODO: Fetch Files from Codecommit
-          else raise "Unexpected repo provider '#{source.provider}'"
+          else raise "Unexpected repo provider '#{T.must(source).provider}'"
           end
         end
 
+        # rubocop:disable Metrics/AbcSize
+        sig { params(ref: T.nilable(String)).returns(T::Array[T.untyped]) }
         def fetch_github_file_list(ref)
           files = []
 
-          if source.directory
-            opts = { path: source.directory, ref: ref }.compact
-            tmp_files = github_client.contents(source.repo, opts)
+          if T.must(source).directory
+            opts = { path: T.must(source).directory, ref: ref }.compact
+            tmp_files = T.unsafe(github_client).contents(T.must(source).repo, opts)
             files += tmp_files if tmp_files.is_a?(Array)
           end
 
           opts = { ref: ref }.compact
-          files += github_client.contents(source.repo, opts)
+          files += T.unsafe(github_client).contents(T.must(source).repo, opts)
 
           files.uniq.each do |f|
             next unless f.type == "dir" && f.name.match?(/docs?/o)
 
             opts = { path: f.path, ref: ref }.compact
-            files += github_client.contents(source.repo, opts)
+            files += T.unsafe(github_client).contents(T.must(source).repo, opts)
           end
 
           files
         rescue Octokit::NotFound, Octokit::UnavailableForLegalReasons
           []
         end
+        # rubocop:enable Metrics/AbcSize
 
+        sig { returns(T.untyped) }
         def fetch_bitbucket_file_list
           branch = default_bitbucket_branch
-          bitbucket_client.fetch_repo_contents(source.repo).map do |file|
+          T.unsafe(bitbucket_client).fetch_repo_contents(T.must(source).repo).map do |file|
             type = case file.fetch("type")
                    when "commit_file" then "file"
                    when "commit_directory" then "dir"
@@ -277,8 +339,8 @@ module Dependabot
               name: file.fetch("path").split("/").last,
               type: type,
               size: file.fetch("size", 100),
-              html_url: "#{source.url}/src/#{branch}/#{file['path']}",
-              download_url: "#{source.url}/raw/#{branch}/#{file['path']}"
+              html_url: "#{T.must(source).url}/src/#{branch}/#{file['path']}",
+              download_url: "#{T.must(source).url}/raw/#{branch}/#{file['path']}"
             )
           end
         rescue Dependabot::Clients::Bitbucket::NotFound,
@@ -287,9 +349,10 @@ module Dependabot
           []
         end
 
+        sig { returns(T.untyped) }
         def fetch_gitlab_file_list
           branch = default_gitlab_branch
-          gitlab_client.repo_tree(source.repo).map do |file|
+          T.unsafe(gitlab_client).repo_tree(T.must(source).repo).map do |file|
             type = case file.type
                    when "blob" then "file"
                    when "tree" then "dir"
@@ -299,14 +362,15 @@ module Dependabot
               name: file.name,
               type: type,
               size: 100, # GitLab doesn't return file size
-              html_url: "#{source.url}/blob/#{branch}/#{file.path}",
-              download_url: "#{source.url}/raw/#{branch}/#{file.path}"
+              html_url: "#{T.must(source).url}/blob/#{branch}/#{file.path}",
+              download_url: "#{T.must(source).url}/raw/#{branch}/#{file.path}"
             )
           end
         rescue Gitlab::Error::NotFound
           []
         end
 
+        sig { returns(T.untyped) }
         def fetch_azure_file_list
           azure_client.fetch_repo_contents.map do |entry|
             type = case entry.fetch("gitObjectType")
@@ -320,7 +384,7 @@ module Dependabot
               type: type,
               size: entry.fetch("size"),
               path: entry.fetch("relativePath"),
-              html_url: "#{source.url}?path=/#{entry.fetch('relativePath')}",
+              html_url: "#{T.must(source).url}?path=/#{entry.fetch('relativePath')}",
               download_url: entry.fetch("url")
             )
           end
@@ -330,20 +394,23 @@ module Dependabot
           []
         end
 
+        sig { returns(T.nilable(String)) }
         def new_version
-          return @new_version if defined?(@new_version)
+          return @new_version unless @new_version.nil?
 
           new_version = git_source? && new_ref ? new_ref : dependency.version
           @new_version = new_version&.gsub(/^v/, "")
         end
 
+        sig { returns(T.nilable(String)) }
         def previous_ref
-          previous_refs = dependency.previous_requirements.filter_map do |r|
+          previous_refs = dependency.previous_requirements&.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.uniq
-          previous_refs.first if previous_refs.count == 1
+          end&.uniq
+          previous_refs&.first if previous_refs&.count == 1
         end
 
+        sig { returns(T.nilable(String)) }
         def new_ref
           new_refs = dependency.requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
@@ -351,12 +418,14 @@ module Dependabot
           new_refs.first if new_refs.count == 1
         end
 
+        sig { returns(T::Boolean) }
         def ref_changed?
           # We could go from multiple previous refs (nil) to a single new ref
           previous_ref != new_ref
         end
 
         # TODO: Refactor me so that Composer doesn't need to be special cased
+        sig { returns(T::Boolean) }
         def git_source?
           # Special case Composer, which uses git as a source but handles tags
           # internally
@@ -369,51 +438,77 @@ module Dependabot
           sources.all? { |s| s[:type] == "git" || s["type"] == "git" }
         end
 
+        sig { returns(T::Boolean) }
         def major_version_upgrade?
           return false unless dependency.version&.match?(/^\d/)
           return false unless dependency.previous_version&.match?(/^\d/)
 
-          dependency.version.split(".").first.to_i -
-            dependency.previous_version.split(".").first.to_i >= 1
+          T.must(dependency.version).split(".").first.to_i -
+            T.must(dependency.previous_version).split(".").first.to_i >= 1
         end
 
+        sig { returns(Dependabot::Clients::GitlabWithRetries) }
         def gitlab_client
-          @gitlab_client ||= Dependabot::Clients::GitlabWithRetries
-                             .for_gitlab_dot_com(credentials: credentials)
+          @gitlab_client ||=
+            T.let(
+              Dependabot::Clients::GitlabWithRetries.for_gitlab_dot_com(credentials: credentials),
+              T.nilable(Dependabot::Clients::GitlabWithRetries)
+            )
         end
 
+        sig { returns(Dependabot::Clients::GithubWithRetries) }
         def github_client
-          @github_client ||= Dependabot::Clients::GithubWithRetries
-                             .for_source(source: source, credentials: credentials)
+          @github_client ||=
+            T.let(
+              Dependabot::Clients::GithubWithRetries.for_source(source: source, credentials: credentials),
+              T.nilable(Dependabot::Clients::GithubWithRetries)
+            )
         end
 
+        sig { returns(Dependabot::Clients::Azure) }
         def azure_client
-          @azure_client ||= Dependabot::Clients::Azure
-                            .for_source(source: source, credentials: credentials)
+          @azure_client ||=
+            T.let(
+              Dependabot::Clients::Azure.for_source(source: source, credentials: credentials),
+              T.nilable(Dependabot::Clients::Azure)
+            )
         end
 
+        sig { params(client_source: Dependabot::Source).returns(Dependabot::Clients::GithubWithRetries) }
         def github_client_for_source(client_source)
           return github_client if client_source == source
 
-          Dependabot::Clients::GithubWithRetries
-            .for_source(source: client_source, credentials: credentials)
+          Dependabot::Clients::GithubWithRetries.for_source(source: client_source, credentials: credentials)
         end
 
+        sig { returns(Dependabot::Clients::BitbucketWithRetries) }
         def bitbucket_client
-          @bitbucket_client ||= Dependabot::Clients::BitbucketWithRetries
-                                .for_bitbucket_dot_org(credentials: credentials)
+          @bitbucket_client ||=
+            T.let(
+              Dependabot::Clients::BitbucketWithRetries.for_bitbucket_dot_org(credentials: credentials),
+              T.nilable(Dependabot::Clients::BitbucketWithRetries)
+            )
         end
 
+        sig { returns(String) }
         def default_bitbucket_branch
           @default_bitbucket_branch ||=
-            bitbucket_client.fetch_default_branch(source.repo)
+            T.let(
+              T.unsafe(bitbucket_client).fetch_default_branch(T.must(source).repo),
+              T.nilable(String)
+            )
         end
 
+        sig { returns(String) }
         def default_gitlab_branch
           @default_gitlab_branch ||=
-            gitlab_client.fetch_default_branch(source.repo)
+            T.let(
+              gitlab_client.fetch_default_branch(T.must(source).repo),
+              T.nilable(String)
+            )
         end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end


### PR DESCRIPTION
This has a lot of:
- `T.unsafe` because the source platform clients (GitHub, Azure DevOps, etc.) all use `method_missing` to inject credentials or handle retries. Rewriting them is going to be difficult 😖
- `OpenStruct` and `Sawyer::Resource` return types, again because of source platform clients
- `T.untyped` response types because of (you guessed it!) source platform clients