### PR TITLE
support group configs specifically for security updates or version updates

### DIFF
--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -28,12 +28,12 @@ module Dependabot
     sig do
       params(
         name: String,
-        applies_to: T.nilable(String),
-        rules: T::Hash[String, T.untyped]
+        rules: T::Hash[String, T.untyped],
+        applies_to: T.nilable(String)
       )
         .void
     end
-    def initialize(name:, applies_to:, rules:)
+    def initialize(name:, rules:, applies_to: "version-updates")
       @name = name
       # For backwards compatibility, if no applies_to is provided, default to "version-updates"
       @applies_to = T.let(applies_to || "version-updates", String)

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -22,15 +22,21 @@ module Dependabot
     sig { returns(T::Array[Dependabot::Dependency]) }
     attr_reader :dependencies
 
+    sig { returns(String) }
+    attr_reader :applies_to
+
     sig do
       params(
         name: String,
+        applies_to: T.nilable(String),
         rules: T::Hash[String, T.untyped]
       )
         .void
     end
-    def initialize(name:, rules:)
+    def initialize(name:, applies_to:, rules:)
       @name = name
+      # For backwards compatibility, if no applies_to is provided, default to "version-updates"
+      @applies_to = T.let(applies_to || "version-updates", String)
       @rules = rules
       @dependencies = T.let([], T::Array[Dependabot::Dependency])
     end

--- a/silent/tests/testdata/su-group-pattern.txt
+++ b/silent/tests/testdata/su-group-pattern.txt
@@ -83,6 +83,7 @@ job:
   security-updates-only: true
   dependency-groups:
     - name: related
+      applies-to: "security-updates"
       rules:
         patterns:
           - "related-*"

--- a/silent/tests/testdata/su-group-semver.txt
+++ b/silent/tests/testdata/su-group-semver.txt
@@ -83,6 +83,7 @@ job:
   security-updates-only: true
   dependency-groups:
     - name: dev
+      applies-to: security-updates
       rules:
         update-types:
           - minor

--- a/silent/tests/testdata/su-group-type.txt
+++ b/silent/tests/testdata/su-group-type.txt
@@ -85,8 +85,10 @@ job:
   grouped-update: true
   dependency-groups:
     - name: dev
+      applies-to: security-updates
       rules:
         dependency-type: development
     - name: prod
+      applies-to: security-updates
       rules:
         dependency-type: production


### PR DESCRIPTION
This adds support for property `applies-to` which allows developers to specify that the group configuration should apply to only version updates, or only security updates.

For backward compatibility, if `applies-to` is not set then it applies only to version updates.
