### PR TITLE
use boolean for clearer signal of a grouped update

### DIFF
--- a/common/lib/dependabot/credential.rb
+++ b/common/lib/dependabot/credential.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "forwardable"
 require "sorbet-runtime"
 
 module Dependabot

--- a/silent/tests/testdata/su-group-default-multidir.txt
+++ b/silent/tests/testdata/su-group-default-multidir.txt
@@ -82,3 +82,4 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
+  grouped-update: true

--- a/silent/tests/testdata/su-group-default-onedir.txt
+++ b/silent/tests/testdata/su-group-default-onedir.txt
@@ -55,3 +55,4 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
+  grouped-update: true

--- a/silent/tests/testdata/su-group-default.txt
+++ b/silent/tests/testdata/su-group-default.txt
@@ -58,4 +58,4 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
-
+  grouped-update: true

--- a/silent/tests/testdata/su-group-pattern.txt
+++ b/silent/tests/testdata/su-group-pattern.txt
@@ -86,3 +86,4 @@ job:
       rules:
         patterns:
           - "related-*"
+  grouped-update: true

--- a/silent/tests/testdata/su-group-semver.txt
+++ b/silent/tests/testdata/su-group-semver.txt
@@ -87,3 +87,4 @@ job:
         update-types:
           - minor
           - patch
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-failure.txt
+++ b/silent/tests/testdata/vu-group-failure.txt
@@ -41,3 +41,4 @@ job:
         # specifically not using semver rules (update-types) for this test
         patterns:
          - "*"
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-individual.txt
+++ b/silent/tests/testdata/vu-group-individual.txt
@@ -67,3 +67,4 @@ job:
         patterns:
           - "dependency-a"
           - "dependency-b"
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-overlap.txt
+++ b/silent/tests/testdata/vu-group-overlap.txt
@@ -51,4 +51,4 @@ job:
       rules:
         patterns:
           - "*"
-
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-semver-error.txt
+++ b/silent/tests/testdata/vu-group-semver-error.txt
@@ -65,3 +65,4 @@ job:
         update-types:
           - minor
           - patch
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-semver-git.txt
+++ b/silent/tests/testdata/vu-group-semver-git.txt
@@ -53,3 +53,4 @@ job:
         update-types:
           - minor
           - patch
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-semver-ignore-major.txt
+++ b/silent/tests/testdata/vu-group-semver-ignore-major.txt
@@ -61,3 +61,4 @@ job:
       rules:
         update-types:
           - patch
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-semver.txt
+++ b/silent/tests/testdata/vu-group-semver.txt
@@ -67,3 +67,4 @@ job:
         update-types:
           - minor
           - patch
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-type.txt
+++ b/silent/tests/testdata/vu-group-type.txt
@@ -92,3 +92,4 @@ job:
     - name: prod
       rules:
         dependency-type: "production"
+  grouped-update: true

--- a/silent/tests/testdata/vu-group-unmatched.txt
+++ b/silent/tests/testdata/vu-group-unmatched.txt
@@ -31,3 +31,4 @@ job:
       rules:
         patterns:
           - "dependency-c"
+  grouped-update: true

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -24,11 +24,8 @@ module Dependabot
 
     sig { params(job: Dependabot::Job).returns(Dependabot::DependencyGroupEngine) }
     def self.from_job_config(job:)
-      if job.security_updates_only? && job.source.directories && job.dependency_groups.empty?
-        # The indication that this should be a grouped update is:
-        # - We're using the DependencyGroupEngine which means this is a grouped update
-        # - This is a security update and there are multiple dependencies passed in
-        # Since there are no groups, the default behavior is to group all dependencies, so create a fake group.
+      if job.security_updates_only? && job.grouped_update? && job.dependency_groups.empty?
+        # For security updates, the default behavior is to group all dependencies, so create a fake group.
         job.dependency_groups << {
           "name" => "#{job.package_manager} group",
           "rules" => { "patterns" => ["*"] }

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -43,6 +43,7 @@ module Dependabot
       update_subdependencies
       updating_a_pull_request
       vendor_dependencies
+      grouped_update
       dependency_groups
       dependency_group_to_refresh
       repo_private
@@ -168,6 +169,7 @@ module Dependabot
       # We will need to do a pass updating the CLI and smoke tests before this is possible,
       # so let's consider it optional for now. If we get a nil value, let's force it to be
       # an array.
+      @grouped_update                 = T.let(attributes.fetch(:grouped_update, false), T::Boolean)
       @dependency_groups              = T.let(attributes.fetch(:dependency_groups, []) || [], T::Array[T.untyped])
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
@@ -200,6 +202,11 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     def repo_owner
       source.organization
+    end
+
+    sig { returns(T::Boolean) }
+    def grouped_update?
+      @grouped_update
     end
 
     sig { returns(T::Boolean) }

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -25,9 +25,8 @@ module Dependabot
           if Dependabot::Experiments.enabled?(:grouped_security_updates_disabled) && job.security_updates_only?
             return false
           end
-          return false if job.source.directory && job.security_updates_only?
 
-          job.dependency_groups&.any?
+          job.grouped_update?
         end
 
         def self.tag_name

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -37,7 +37,7 @@ module Dependabot
           end
           return false if job.source.directory && job.security_updates_only?
 
-          job.updating_a_pull_request?
+          job.updating_a_pull_request? && job.grouped_update?
         end
 
         def self.tag_name

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
                       source: source,
                       security_updates_only?: true,
                       updating_a_pull_request?: false,
+                      grouped_update?: true,
                       dependency_group_to_refresh: nil)
     end
 

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Dependabot::DependencySnapshot do
                     source: source,
                     dependency_groups: dependency_groups,
                     allowed_update?: true,
+                    grouped_update?: false,
                     dependency_group_to_refresh: nil,
                     dependencies: nil,
                     experiments: { large_hadron_collider: true })
@@ -152,6 +153,7 @@ RSpec.describe Dependabot::DependencySnapshot do
                         dependency_groups: dependency_groups,
                         dependencies: ["dummy-pkg-a"],
                         allowed_update?: false,
+                        grouped_update?: true,
                         dependency_group_to_refresh: nil,
                         experiments: { large_hadron_collider: true })
       end

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             source: source,
                             security_updates_only?: false,
                             updating_a_pull_request?: false,
+                            grouped_update?: false,
                             dependencies: [],
                             dependency_groups: [],
                             is_a?: true)
@@ -46,8 +47,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             source: source,
                             security_updates_only?: false,
                             updating_a_pull_request?: false,
-                            dependencies: [],
-                            dependency_groups: [anything],
+                            grouped_update?: true,
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).to be(Dependabot::Updater::Operations::GroupUpdateAllVersions)
@@ -65,6 +65,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             dependencies: [anything],
                             dependency_group_to_refresh: anything,
                             dependency_groups: [anything],
+                            grouped_update?: true,
                             is_a?: true)
 
       expect(described_class.class_for(job: job))
@@ -93,6 +94,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             updating_a_pull_request?: false,
                             dependencies: [anything],
                             dependency_groups: [],
+                            grouped_update?: false,
                             source: Dependabot::Source.new(provider: "github", repo: "gocardless/bump"),
                             is_a?: true)
 
@@ -106,9 +108,8 @@ RSpec.describe Dependabot::Updater::Operations do
       job = instance_double(Dependabot::Job,
                             source: source,
                             security_updates_only?: true,
+                            grouped_update?: true,
                             updating_a_pull_request?: false,
-                            dependencies: [anything, anything],
-                            dependency_groups: [anything],
                             is_a?: true)
 
       expect(described_class.class_for(job: job))
@@ -122,8 +123,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             source: source,
                             security_updates_only?: true,
                             updating_a_pull_request?: false,
-                            dependencies: [anything, anything],
-                            dependency_groups: [anything],
+                            grouped_update?: true,
                             is_a?: true)
 
       expect(described_class.class_for(job: job))
@@ -138,6 +138,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             updating_a_pull_request?: false,
                             dependencies: [anything, anything],
                             dependency_groups: [anything],
+                            grouped_update?: false,
                             is_a?: true)
 
       expect(described_class.class_for(job: job))
@@ -154,6 +155,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             dependencies: [anything, anything],
                             dependency_group_to_refresh: anything,
                             dependency_groups: [anything],
+                            grouped_update?: true,
                             is_a?: true)
 
       expect(described_class.class_for(job: job))


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/8963 I am running into a problem where using `directory` and `directories` is not a clear enough signal that this is supposed to be a grouped update, so switching to the `grouped-update` boolean.
