### PR TITLE
Check credentials for required properties

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -217,7 +217,7 @@ module Dependabot
 
         def credentials_repository_details
           credentials
-            .select { |cred| cred["type"] == "maven_repository" }
+            .select { |cred| cred["type"] == "maven_repository" && cred["url"] }
             .map do |cred|
               {
                 "url" => cred.fetch("url").gsub(%r{/+$}, ""),

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -45,12 +45,13 @@ module Dependabot
 
       attr_reader :resolved_url, :credentials
 
+      # rubocop:disable Metrics/PerceivedComplexity
       def url_for_relevant_cred
         resolved_url_host = URI(resolved_url).host
 
         credential_matching_url =
           credentials
-          .select { |cred| cred["type"] == "npm_registry" }
+          .select { |cred| cred["type"] == "npm_registry" && cred["registry"] }
           .sort_by { |cred| cred["registry"].length }
           .find do |details|
             next true if resolved_url_host == details["registry"]
@@ -70,6 +71,7 @@ module Dependabot
         reg = credential_matching_url["registry"]
         resolved_url.gsub(/#{Regexp.quote(reg)}.*/, "") + reg
       end
+      # rubocop:enable Metrics/PerceivedComplexity
     end
   end
 end

--- a/python/lib/dependabot/python/authed_url_builder.rb
+++ b/python/lib/dependabot/python/authed_url_builder.rb
@@ -6,7 +6,7 @@ module Dependabot
     class AuthedUrlBuilder
       def self.authed_url(credential:)
         token = credential.fetch("token", nil)
-        url = credential.fetch("index-url")
+        url = credential.fetch("index-url", nil)
         return url unless token
 
         basic_auth_details =

--- a/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
@@ -52,7 +52,7 @@ module Dependabot
             base_url = source["url"].sub(/\${.*}@/, "")
 
             source_cred = credentials
-                          .select { |cred| cred["type"] == "python_index" }
+                          .select { |cred| cred["type"] == "python_index" && cred["index-url"] }
                           .find { |c| c["index-url"].sub(/\${.*}@/, "") == base_url }
 
             return nil if source_cred.nil?


### PR DESCRIPTION
This is the equivalent of #9011 for `nuget_feed`, applied to `maven_repository`, `npm_registry`, and `python_index`.