### PR TITLE
proof of concept reading groups directory from dependabot.yml

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -229,7 +229,7 @@ module Dependabot
           type: type,
           content: content,
           symlink_target: symlink_target,
-          support_file: in_submodule?(path)
+          support_file: in_submodule?(path) || filename.to_s.match?(".github/dependabot.ya?ml")
         )
       end
 

--- a/silent/lib/dependabot/silent/file_fetcher.rb
+++ b/silent/lib/dependabot/silent/file_fetcher.rb
@@ -7,7 +7,11 @@ require "dependabot/file_fetchers/base"
 module SilentPackageManager
   class FileFetcher < Dependabot::FileFetchers::Base
     def fetch_files
-      [manifest].compact
+      [
+        manifest,
+        fetch_file_if_present(".github/dependabot.yml"),
+        fetch_file_if_present(".github/dependabot.yaml")
+      ].compact
     end
 
     private

--- a/silent/tests/testdata/vu-group-experiment.txt
+++ b/silent/tests/testdata/vu-group-experiment.txt
@@ -1,0 +1,57 @@
+dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \), dependency-b \( from 2.2.3 to 2.2.5 \)'
+stdout -count=1 create_pull_request
+pr-created expected.json
+
+-- manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" },
+  "dependency-b": { "version": "2.2.3" }
+}
+
+-- expected.json --
+{
+  "dependency-a": { "version": "1.2.5" },
+  "dependency-b": { "version": "2.2.5" }
+}
+
+-- dependency-a --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- dependency-b --
+{
+  "versions": [
+    "2.2.3",
+    "2.2.4",
+    "2.2.5"
+  ]
+}
+
+-- .github/dependabot.yml --
+version: 2
+updates:
+  - package-ecosystem: "silent"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      all:
+        patterns:
+          - "*"
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  grouped-update: true

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -91,7 +91,7 @@ module Dependabot
     attr_reader :vendor_dependencies
 
     sig { returns(T::Array[T.untyped]) }
-    attr_reader :dependency_groups
+    attr_accessor :dependency_groups
 
     sig { returns(T.nilable(String)) }
     attr_reader :dependency_group_to_refresh


### PR DESCRIPTION
This is very quick, just jammed the code in update_files_command.rb.

Known issues:
- When a directory is specified, fetch_files_if_present won't find dependabot.yml because it's relative to the directory. But since all ecosystems are cloned now, this should be pretty trivial, the file is right there!
- Once that issue ☝️ is fixed, this will break all of the smoke tests because it will find the dependabot.yml in that repo.