### PR TITLE
Prevent attempt to create empty commit

### DIFF
--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -26,7 +26,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def changed?
-        changes.any? || !changed_files.empty?
+        changes.any? || !changed_files(ignored_mode: "no").empty?
       end
 
       sig { override.returns(String) }
@@ -53,7 +53,7 @@ module Dependabot
           .returns(T.nilable(T::Array[Dependabot::Workspace::ChangeAttempt]))
       end
       def store_change(memo = nil)
-        return nil if changed_files.empty?
+        return nil if changed_files(ignored_mode: "no").empty?
 
         debug("store_change - before: #{current_commit}")
         sha, diff = commit(memo)

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -210,8 +210,22 @@ RSpec.describe Dependabot::Workspace::Git do
       end
     end
 
+    context "when there are changes to ignored files" do
+      # See: common/spec/fixtures/projects/simple/.gitignore
+
+      it "returns nil and doesn't add any changes to the workspace" do
+        workspace.change { `echo "ignore me" >> ignored-file.txt` }
+        workspace.store_change("modify ignored file")
+        workspace.change { `mkdir -p ignored-dir && echo "ignore me" >> ignored-dir/file.txt` }
+        workspace.store_change("modify file in ignored directory")
+
+        expect(workspace).not_to be_changed
+        expect(workspace.changes).to be_empty
+      end
+    end
+
     context "when there are changes to store" do
-      it "captures the stores the changes correctly" do
+      it "stores the changes correctly" do
         workspace.change("timecop") do
           `echo 'gem "timecop", "~> 0.9.6", group: :test' >> Gemfile`
         end


### PR DESCRIPTION
Previously `Dependabot::Workspace::Git#store_change` would attempt to create a git commit if there were changes to ignored files, which would cause `git commit` to return a non-zero status and fail the job. As of this change, the method returns early if there are no changes (to un-ignored files) to commit.

Fixes: https://github.com/dependabot/dependabot-core/issues/9060