### PR TITLE
Surface out of disk/memory error message for easier visibility

### DIFF
--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -162,6 +162,10 @@ module Dependabot
       sig { params(args: String, kwargs: T.any(T::Boolean, String)).returns(String) }
       def run_shell_command(*args, **kwargs)
         Dir.chdir(path) { T.unsafe(SharedHelpers).run_shell_command(*args, **kwargs) }
+      rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+        raise Dependabot::OutOfDisk, e.message if e.message.end_with?("No space left on device")
+        raise Dependabot::OutOfDisk, e.message if e.message.end_with?("Out of diskspace")
+        raise Dependabot::OutOfMemory, e.message if e.message.end_with?("MemoryError")
       end
 
       sig { params(message: String).void }

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -162,10 +162,6 @@ module Dependabot
       sig { params(args: String, kwargs: T.any(T::Boolean, String)).returns(String) }
       def run_shell_command(*args, **kwargs)
         Dir.chdir(path) { T.unsafe(SharedHelpers).run_shell_command(*args, **kwargs) }
-      rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-        raise Dependabot::OutOfDisk, e.message if e.message.end_with?("No space left on device")
-        raise Dependabot::OutOfDisk, e.message if e.message.end_with?("Out of diskspace")
-        raise Dependabot::OutOfMemory, e.message if e.message.end_with?("MemoryError")
       end
 
       sig { params(message: String).void }

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -268,6 +268,26 @@ RSpec.describe Dependabot::SharedHelpers do
           .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
+
+    context "when the subprocess exits with out of disk error" do
+      let(:command) { File.join(spec_root, "helpers/test/error_bash disk") }
+      it "raises a HelperSubprocessFailed out of disk error" do
+        expect { run_shell_command }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+            expect(error.message).to include("No space left on device")
+          end
+      end
+
+      context "when the subprocess exits with out of memory error" do
+        let(:command) { File.join(spec_root, "helpers/test/error_bash memory") }
+        it "raises a HelperSubprocessFailed out of memory error" do
+          expect { run_shell_command }
+            .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+              expect(error.message).to include("MemoryError")
+            end
+        end
+      end
+    end
   end
 
   describe ".escape_command" do

--- a/common/spec/helpers/test/error_bash
+++ b/common/spec/helpers/test/error_bash
@@ -2,4 +2,10 @@
 
 set -e
 
+if [ "$1" = "disk" ]; then
+  echo "No space left on device" >&2
+elif [ "$1" = "memory" ]; then
+  echo "MemoryError" >&2
+fi
+
 exit 1

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -58,7 +58,8 @@ module Dependabot
 
         OUT_OF_DISK_REGEXES = [
           %r{input/output error},
-          /no space left on device/
+          /no space left on device/,
+          /Out of diskspace/
         ].freeze
 
         GO_MOD_VERSION = /^go 1\.\d+(\.\d+)?$/

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -962,6 +962,17 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           expect(error.message).to include("info/attributes: no space left on device")
         end
       end
+
+      it "detects 'Out of diskspace'" do
+        stderr = <<~ERROR
+          rsc.io/sampler imports
+          write fatal: sha1 file '/home/dependabot/dependabot-updater/repo/.git/index.lock' write error. Out of diskspace
+        ERROR
+
+        expect { updater.send(:handle_subprocess_error, stderr) }.to raise_error(Dependabot::OutOfDisk) do |error|
+          expect(error.message).to include("write error. Out of diskspace")
+        end
+      end
     end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -23,9 +23,9 @@ module Dependabot
               args: [Dir.pwd]
             )
           rescue SharedHelpers::HelperSubprocessFailed => e
-            raise Dependabot::OutOfDisk if e.message.end_with?("No space left on device")
-            raise Dependabot::OutOfDisk if e.message.end_with?("Out of diskspace")
-            raise Dependabot::OutOfMemory if e.message.end_with?("MemoryError")
+            raise Dependabot::OutOfDisk, e.message if e.message.end_with?("No space left on device")
+            raise Dependabot::OutOfDisk, e.message if e.message.end_with?("Out of diskspace")
+            raise Dependabot::OutOfMemory, e.message if e.message.end_with?("MemoryError")
 
             raise Dependabot::DependencyFileNotParseable, @dependency_file.path
           end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -22,7 +22,11 @@ module Dependabot
               function: "yarn:parseLockfile",
               args: [Dir.pwd]
             )
-          rescue SharedHelpers::HelperSubprocessFailed
+          rescue SharedHelpers::HelperSubprocessFailed => e
+            raise Dependabot::OutOfDisk if e.message.end_with?("No space left on device")
+            raise Dependabot::OutOfDisk if e.message.end_with?("write error. Out of diskspace")
+            raise Dependabot::OutOfMemory if e.message.end_with?("MemoryError")
+
             raise Dependabot::DependencyFileNotParseable, @dependency_file.path
           end
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -24,7 +24,7 @@ module Dependabot
             )
           rescue SharedHelpers::HelperSubprocessFailed => e
             raise Dependabot::OutOfDisk if e.message.end_with?("No space left on device")
-            raise Dependabot::OutOfDisk if e.message.end_with?("write error. Out of diskspace")
+            raise Dependabot::OutOfDisk if e.message.end_with?("Out of diskspace")
             raise Dependabot::OutOfMemory if e.message.end_with?("MemoryError")
 
             raise Dependabot::DependencyFileNotParseable, @dependency_file.path

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
               expect(error.message).to eq("Out of diskspace")
             end
         end
+
+        it "raises a OutOfMemory error" do
+          expect { dependencies }
+            .to raise_error(Dependabot::OutOfMemory) do |error|
+              expect(error.message).to eq("MemoryError")
+            end
+        end
+
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
             end
         end
       end
+
+      context "that contain out of disk/memory error" do
+        let(:dependency_files) { project_dependency_files("yarn/broken_lockfile") }
+
+        it "raises a OutOfDisk error" do
+          expect { dependencies }
+            .to raise_error(Dependabot::OutOfDisk) do |error|
+              expect(error.message).to eq("Out of diskspace")
+            end
+        end
+      end
     end
 
     context "for pnpm lockfiles" do


### PR DESCRIPTION
## Context

These currently end up in the `unknown_error category` so this provides easier visibility to the user.

- Added out of disk error message to the go module updater.
- Added out of disk/memory error message to the yarn file parser.