### PR TITLE
Fix hardcoded amd64 arch for git-shim

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,5 +1,7 @@
 FROM docker.io/library/ubuntu:22.04
 
+ARG TARGETARCH
+
 LABEL org.opencontainers.image.source="https://github.com/dependabot/dependabot-core"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -72,7 +74,7 @@ ENV DEPENDABOT=true
 ENV GIT_LFS_SKIP_SMUDGE=1
 
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
-ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
+ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-${TARGETARCH}.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
 COPY --chown=dependabot:dependabot omnibus omnibus


### PR DESCRIPTION
Adds `TARGETARCH` argument similar to updater images to prevent having `amd64` binary of `git-shim` when building arm image