### PR TITLE
fix docker credential type errors

### DIFF
--- a/docker/lib/dependabot/docker/utils/credentials_finder.rb
+++ b/docker/lib/dependabot/docker/utils/credentials_finder.rb
@@ -4,6 +4,7 @@
 require "aws-sdk-ecr"
 require "base64"
 
+require "dependabot/credential"
 require "dependabot/errors"
 
 module Dependabot
@@ -75,7 +76,7 @@ module Dependabot
             ecr_client.get_authorization_token.authorization_data.first.authorization_token
           username, password =
             Base64.decode64(@authorization_tokens[registry_hostname]).split(":")
-          registry_details.merge("username" => username, "password" => password)
+          registry_details.merge(Dependabot::Credential.new({"username" => username, "password" => password}))
         rescue Aws::Errors::MissingCredentialsError,
                Aws::ECR::Errors::UnrecognizedClientException,
                Aws::ECR::Errors::InvalidSignatureException

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
   let(:credentials) do
-    [{
+    [Dependabot::Credential.new({
       "type" => "git_source",
       "host" => "github.com",
       "username" => "x-access-token",
       "password" => "token"
-    }]
+    })]
   end
 
   let(:dependency) do
@@ -1107,17 +1107,17 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       context "with authentication credentials" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "git_source",
             "host" => "github.com",
             "username" => "x-access-token",
             "password" => "token"
-          }, {
+          }), Dependabot::Credential.new({
             "type" => "docker_registry",
             "registry" => "registry-host.io:5000",
             "username" => "grey",
             "password" => "pa55word"
-          }]
+          })]
         end
 
         before do
@@ -1130,15 +1130,15 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
         context "that don't have a username or password" do
           let(:credentials) do
-            [{
+            [Dependabot::Credential.new({
               "type" => "git_source",
               "host" => "github.com",
               "username" => "x-access-token",
               "password" => "token"
-            }, {
+            }), Dependabot::Credential.new({
               "type" => "docker_registry",
               "registry" => "registry-host.io:5000"
-            }]
+            })]
           end
 
           it { is_expected.to eq("17.10") }

--- a/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
+++ b/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
@@ -10,12 +10,12 @@ require "base64"
 RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
   subject(:finder) { described_class.new(credentials) }
   let(:credentials) do
-    [{
+    [Dependabot::Credential.new({
       "type" => "docker_registry",
       "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
       "username" => "grey",
       "password" => "pa55word"
-    }]
+    })]
   end
 
   describe "#credentials_for_registry" do
@@ -30,12 +30,12 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
     context "with a non-AWS registry" do
       let(:registry) { "my.registry.com" }
       let(:credentials) do
-        [{
+        [Dependabot::Credential.new({
           "type" => "docker_registry",
           "registry" => "my.registry.com",
           "username" => "grey",
           "password" => "pa55word"
-        }]
+        })]
       end
 
       it { is_expected.to eq(credentials.first) }
@@ -46,12 +46,12 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
 
       context "with 'AWS' as the username" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "docker_registry",
             "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
             "username" => "AWS",
             "password" => "pa55word"
-          }]
+          })]
         end
 
         it { is_expected.to eq(credentials.first) }
@@ -59,10 +59,10 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
 
       context "without a username or password" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "docker_registry",
             "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com"
-          }]
+          })]
         end
 
         context "and a valid AWS response (via proxying)" do
@@ -75,7 +75,7 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
           end
 
           it "returns details without credentials" do
-            expect(found_credentials).to eq(
+            expect(found_credentials.to_h).to eq(
               "type" => "docker_registry",
               "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com"
             )
@@ -85,12 +85,12 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
 
       context "with as AKID as the username" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "docker_registry",
             "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
             "username" => "AKIAIHYCC4QXL4X2OTCQ",
             "password" => "pa55word"
-          }]
+          })]
         end
 
         context "and an invalid secret key as the password" do
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
           end
 
           it "returns an updated set of credentials" do
-            expect(found_credentials).to eq(
+            expect(found_credentials.to_h).to eq(
               "type" => "docker_registry",
               "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
               "username" => "AWS",
@@ -157,10 +157,10 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
 
       context "using the default credentials provider" do
         let(:credentials) do
-          [{
+          [Dependabot::Credential.new({
             "type" => "docker_registry",
             "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com"
-          }]
+          })]
         end
 
         context "and a valid AWS response" do
@@ -175,7 +175,7 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
           end
 
           it "returns updated, valid credentials" do
-            expect(found_credentials).to eq(
+            expect(found_credentials.to_h).to eq(
               "type" => "docker_registry",
               "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
               "username" => "foo",


### PR DESCRIPTION
The tests didn't catch this since they were still passing in hashes.

Thanks @noorul for https://github.com/dependabot/dependabot-core/pull/9072, I've pulled in your change and fixed up the tests.