### PR TITLE
nuget updater command is already space-enabled; allow unsafe execution

### DIFF
--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -113,6 +113,7 @@ module Dependabot
         (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
                                                                 dependency: dependency, is_transitive: is_transitive)
 
+        command = T.must(command)
         puts "running NuGet updater:\n" + command
 
         NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -45,7 +45,7 @@ module Dependabot
 
         puts "running NuGet updater:\n" + command
 
-        output = SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+        output = SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, fingerprint: fingerprint)
         puts output
 
         # Exit code == 0 means that all project frameworks are compatible
@@ -55,17 +55,11 @@ module Dependabot
         false
       end
 
-      # rubocop:disable Metrics/MethodLength
       sig do
-        params(
-          repo_root: String,
-          proj_path: String,
-          dependency: Dependency,
-          is_transitive: T::Boolean,
-          credentials: T::Array[T.untyped]
-        ).void
+        params(repo_root: String, proj_path: String, dependency: Dependency,
+               is_transitive: T::Boolean).returns(T::Array[String])
       end
-      def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)
+      def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency:, is_transitive:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command_parts = [
           exe_path,
@@ -103,14 +97,29 @@ module Dependabot
           "--verbose"
         ].compact.join(" ")
 
+        [command, fingerprint]
+      end
+
+      sig do
+        params(
+          repo_root: String,
+          proj_path: String,
+          dependency: Dependency,
+          is_transitive: T::Boolean,
+          credentials: T::Array[T.untyped]
+        ).void
+      end
+      def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)
+        (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
+                                                                dependency: dependency, is_transitive: is_transitive)
+
         puts "running NuGet updater:\n" + command
 
         NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
-          output = SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+          output = SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, fingerprint: fingerprint)
           puts output
         end
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -106,7 +106,7 @@ module Dependabot
           proj_path: String,
           dependency: Dependency,
           is_transitive: T::Boolean,
-          credentials: T::Array[T.untyped]
+          credentials: T::Array[Dependabot::Credential]
         ).void
       end
       def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -57,7 +57,7 @@ module Dependabot
 
       sig do
         params(repo_root: String, proj_path: String, dependency: Dependency,
-               is_transitive: T::Boolean).returns(T::Array[String])
+               is_transitive: T::Boolean).returns([String, String])
       end
       def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency:, is_transitive:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
@@ -113,7 +113,6 @@ module Dependabot
         (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
                                                                 dependency: dependency, is_transitive: is_transitive)
 
-        command = T.must(command)
         puts "running NuGet updater:\n" + command
 
         NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -8,6 +8,47 @@ require "dependabot/shared_helpers"
 RSpec.describe Dependabot::Nuget::NativeHelpers do
   let(:dependabot_home) { ENV.fetch("DEPENDABOT_HOME", nil) || Dir.home }
 
+  describe "nuget updater command path" do
+    let(:repo_root) { "/path/to/repo" }
+    let(:proj_path) { "/path/to/repo/src/some project/some_project.csproj" }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "Some.Package",
+        version: "1.2.3",
+        previous_version: "1.2.2",
+        requirements: [{ file: "some_project.csproj", requirement: "1.2.3", groups: [], source: nil }],
+        previous_requirements: [{ file: "some_project.csproj", requirement: "1.2.2", groups: [], source: nil }],
+        package_manager: "nuget"
+      )
+    end
+    let(:is_transitive) { false }
+
+    subject(:command) do
+      (command,) = Dependabot::Nuget::NativeHelpers.get_nuget_updater_tool_command(repo_root: repo_root,
+                                                                                   proj_path: proj_path,
+                                                                                   dependency: dependency,
+                                                                                   is_transitive: is_transitive)
+      command = command.gsub(/^.*NuGetUpdater.Cli/, "/path/to/NuGetUpdater.Cli") # normalize path for unit test
+      command
+    end
+
+    it "returns a properly formatted command with spaces on the path" do
+      expect(command).to eq("/path/to/NuGetUpdater.Cli update --repo-root /path/to/repo " \
+                            '--solution-or-project /path/to/repo/src/some\ project/some_project.csproj ' \
+                            "--dependency Some.Package --new-version 1.2.3 --previous-version 1.2.2 " \
+                            "--verbose")
+    end
+
+    it "the tool runs with command line arguments properly interpreted" do
+      # This test will fail if the command line arguments weren't properly interpreted
+      Dependabot::Nuget::NativeHelpers.run_nuget_updater_tool(repo_root: repo_root,
+                                                              proj_path: proj_path,
+                                                              dependency: dependency,
+                                                              is_transitive: is_transitive,
+                                                              credentials: [])
+    end
+  end
+
   describe "#native_csharp_tests" do
     let(:command) do
       [


### PR DESCRIPTION
The NuGet updater is invoked with already-escaped command line options, so we can simply call it with `allow_unsafe_shell_command: true`, otherwise the arguments are double escaped.

Adding that parameter was the real fix, but I also refactored the code a bit to make testing the command line generation easier.

N.b., the helper function `run_shell_command` only takes a string which it tries to escape and that's where the problem arose; we have to pre-escape our strings to allow for a path with spaces in it, etc., and then tell `run_shell_command` that we've already escaped everything.

Fixes #8633