### PR TITLE
Fix README image header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <h1 align="center">
-
     <picture>
         <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg">
         <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg">


### PR DESCRIPTION
The block of HTML code that displays a picture header at the top of
the README file is indented with 4 spaces after an empty line.

GitHub Markdown sees that as a code block (see [Indented code
blocks](https://github.github.com/gfm/#indented-code-blocks) in the
GitHub Flavored Markdown Spec).

Removing the blank line should fix it as the HTML code won't be seen as
a code block anymore and will instead be unescaped and inserted as [raw HTML](https://github.github.com/gfm/#raw-html).
