### PR TITLE
Allow a role to be assumed before checking Docker images in AWS ECR

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -156,6 +156,16 @@ unless ENV["LOCAL_AZURE_ACCESS_TOKEN"].to_s.strip.empty?
   }
 end
 
+unless ENV["LOCAL_ECR_REGISTRY"].to_s.strip.empty?
+  $options[:credentials] << {
+    "type" => "docker_registry",
+    "registry" => ENV["LOCAL_ECR_REGISTRY"],
+    "username" => ENV["AWS_ACCESS_KEY_ID"],
+    "password" => ENV["AWS_SECRET_ACCESS_KEY"],
+    "session_token" => ENV["AWS_SESSION_TOKEN"]
+  }
+end
+
 unless ENV["LOCAL_CONFIG_VARIABLES"].to_s.strip.empty?
   # For example:
   # "[{\"type\":\"npm_registry\",\"registry\":\

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -157,13 +157,15 @@ unless ENV["LOCAL_AZURE_ACCESS_TOKEN"].to_s.strip.empty?
 end
 
 unless ENV["LOCAL_ECR_REGISTRY"].to_s.strip.empty?
-  $options[:credentials] << {
+  ecr_credentials = {
     "type" => "docker_registry",
     "registry" => ENV["LOCAL_ECR_REGISTRY"],
     "username" => ENV["AWS_ACCESS_KEY_ID"],
     "password" => ENV["AWS_SECRET_ACCESS_KEY"],
     "session_token" => ENV["AWS_SESSION_TOKEN"]
   }
+  ecr_credentials["role_arn"] = ENV["AWS_ROLE_ARN"] if ENV["AWS_ROLE_ARN"]
+  $options[:credentials] << ecr_credentials
 end
 
 unless ENV["LOCAL_CONFIG_VARIABLES"].to_s.strip.empty?

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -466,6 +466,8 @@ Dependabot::SimpleInstrumentor.subscribe do |*args|
   end
 end
 
+$options[:credentials].collect! { |creds| Dependabot::Credential.new(creds) }
+
 $source = Dependabot::Source.new(
   provider: $options[:provider],
   repo: $repo_name,

--- a/docker/lib/dependabot/docker/metadata_finder.rb
+++ b/docker/lib/dependabot/docker/metadata_finder.rb
@@ -17,6 +17,8 @@ module Dependabot
         return unless new_source && new_source[:registry] && new_source[:tag]
 
         image_ref = "#{new_source[:registry]}/#{dependency.name}:#{new_source[:tag]}"
+        docker_creds = Utils::CredentialsFinder.new(credentials).credentials_for_registry(new_source[:registry])
+        SharedHelpers.run_shell_command("regctl registry login #{new_source[:registry]} --user #{docker_creds["username"]} --pass #{docker_creds["password"]}")
         image_details_output = SharedHelpers.run_shell_command("regctl image inspect #{image_ref}")
         image_details = JSON.parse(image_details_output)
         image_source = image_details.dig("config", "Labels", "org.opencontainers.image.source")

--- a/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
+++ b/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
         end
       end
 
-      context "with as AKID as the username" do
+      context "with an AKID as the username" do
         let(:credentials) do
           [Dependabot::Credential.new({
             "type" => "docker_registry",


### PR DESCRIPTION
This is to resolve #6152

Very much a work-in-progress. I've tested this code with:
* An ECR repository that gives read permissions to the user via a resource policy
* A user with an identity policy to read the ECR repository
(both of the existing use-cases)

And a new use case:
* A user with permission to assume a role which has an identity policy to read the ECR repository

I still have a few challenges:
* Writing the tests to verify this behaviour
* Documenting how to use this feature
  * Mostly "which repo has the user-facing docs that need updating?"
* Understanding how the Credentials Proxy gets used from the Docker package updater
  * And if this change affects it

Any advice or guidance on these would be greatly appreciated!

I spotted a bug with `bin/dry-run` when credentials get set: they're not converted to `Dependabot::Credential`s. A follow-up to #8967?
I also saw that `regctl` assumes it's already logged in, which isn't always true.