### PR TITLE
Run the prepare tag step on pull_request_review

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Prepare tag
         run: echo "DEPENDABOT_UPDATER_VERSION=${{ github.sha }}" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
 
       - name: Prepare tag (forks)
         run: |


### PR DESCRIPTION
Follow up to https://github.com/dependabot/dependabot-core/pull/8885

It looks like sentry is receiving the default `development` value for new releases

![Screenshot 2024-02-22 at 12 57 00 PM](https://github.com/dependabot/dependabot-core/assets/12107187/023813ae-5b93-4340-971a-9fa89c49700c)

I think it's because the "prepare tag" and "prepare tag (fork)" steps are both getting skipped and that's where we add the tag to the GITHUB_ENV.

![Screenshot 2024-02-22 at 12 55 33 PM](https://github.com/dependabot/dependabot-core/assets/12107187/d6621a80-0ce5-4b3d-a6dd-5394d1c9cc8f)

We are missing the case where the workflow was triggered by a pull request review, so I fixed that here. I'm not sure if we should also include the `workflow_dispatch` event as well since we sometimes use that for maintainer PRs too. It would fail for forks but then they would try the "prepare tag (forks)" step and succeed. Maybe there's another way to tell if a PR is from a fork?