### PR TITLE
find .nupkg URL without PackageBaseAddress

### DIFF
--- a/nuget/lib/dependabot/nuget/http_response_helpers.rb
+++ b/nuget/lib/dependabot/nuget/http_response_helpers.rb
@@ -1,0 +1,14 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Nuget
+    module HttpResponseHelpers
+      def self.remove_wrapping_zero_width_chars(string)
+        string.force_encoding("UTF-8").encode
+              .gsub(/\A[\u200B-\u200D\uFEFF]/, "")
+              .gsub(/[\u200B-\u200D\uFEFF]\Z/, "")
+      end
+    end
+  end
+end

--- a/nuget/lib/dependabot/nuget/nuget_client.rb
+++ b/nuget/lib/dependabot/nuget/nuget_client.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/nuget/cache_manager"
+require "dependabot/nuget/http_response_helpers"
 require "dependabot/nuget/update_checker/repository_finder"
 require "sorbet-runtime"
 
@@ -162,7 +163,7 @@ module Dependabot
         )
         return unless response.status == 200
 
-        body = remove_wrapping_zero_width_chars(response.body)
+        body = HttpResponseHelpers.remove_wrapping_zero_width_chars(response.body)
         JSON.parse(body)
       end
 
@@ -192,13 +193,6 @@ module Dependabot
         raise if repo_url == Dependabot::Nuget::RepositoryFinder::DEFAULT_REPOSITORY_URL
 
         raise PrivateSourceTimedOut, repo_url
-      end
-
-      sig { params(string: String).returns(String) }
-      private_class_method def self.remove_wrapping_zero_width_chars(string)
-        string.force_encoding("UTF-8").encode
-              .gsub(/\A[\u200B-\u200D\uFEFF]/, "")
-              .gsub(/[\u200B-\u200D\uFEFF]\Z/, "")
       end
     end
   end

--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -73,8 +73,10 @@ module Dependabot
           package_version.casecmp?(v&.[]("version"))
         end
         registration_leaf_url = version_search_result&.[]("@id")
+        return nil unless registration_leaf_url
 
         registration_leaf_response = fetch_url(registration_leaf_url, repository_details)
+        return nil unless registration_leaf_response
         return nil unless registration_leaf_response.status == 200
 
         registration_leaf_response_body =

--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -55,6 +55,7 @@ module Dependabot
         "#{base_url}/#{package_id_downcased}/#{package_version}/#{package_id_downcased}.#{package_version}.nupkg"
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       def self.get_nuget_v3_package_url_from_search(repository_details, package_id, package_version)
         search_url = repository_details[:search_url]
@@ -87,6 +88,7 @@ module Dependabot
         registration_leaf&.[]("packageContent")
       end
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def self.get_nuget_v2_package_url(feed_url, package_id, package_version)
         base_url = feed_url

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
         it "gets the right URL" do
           expect(dependency_urls).to eq(
             [{
-              base_url: "http://localhost:8082/artifactory/api/nuget/v3/nuget-local",
+              base_url: nil,
               registration_url: "http://localhost:8081/artifactory/api/nuget/v3/" \
                                 "dependabot-nuget-local/registration/microsoft.extensions.dependencymodel/index.json",
               repository_url: custom_repo_url,


### PR DESCRIPTION
The NuGet updater uses the `PackageBaseAddress` endpoint to generate URLs to download `.nupkg` packages, but some feed providers don't supply that endpoint.  This is a workaround that allows `PackageBaseAddress` to be missing/`nil` and if it is, it makes a few extra network hops to discover the `.nupkg` download URL.

This PR is also dependent on a separate internal PR that injects authentication to the proper URL endpoints.

Fixes #8887.