### PR TITLE
output job.json at the start of a run

### DIFF
--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -17,7 +17,7 @@ module Dependabot
     def perform_job # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize
       @base_commit_sha = nil
 
-      Dependabot.logger.info("Job definition: #{File.read(Environment.job_path)}")
+      Dependabot.logger.info("Job definition: #{File.read(Environment.job_path)}") if Environment.job_path
 
       span = ::Dependabot::OpenTelemetry.tracer&.start_span("file_fetcher", kind: :internal)
       span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -17,6 +17,8 @@ module Dependabot
     def perform_job # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize
       @base_commit_sha = nil
 
+      Dependabot.logger.info("Job definition: #{File.read(Environment.job_path)}")
+
       span = ::Dependabot::OpenTelemetry.tracer&.start_span("file_fetcher", kind: :internal)
       span&.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id)
 

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
 
     allow(Dependabot::Environment).to receive(:output_path).and_return(File.join(Dir.mktmpdir, "output.json"))
     allow(Dependabot::Environment).to receive(:job_definition).and_return(job_definition)
+    allow(Dependabot::Environment).to receive(:job_path).and_return(nil)
   end
 
   describe "#perform_job" do


### PR DESCRIPTION
For easier debugging, put the job.json output in the logs immediately during file fetching.