### PR TITLE
add more http redirects

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -73,14 +73,17 @@ module Dependabot
             response_block: response_block
           )
 
-          if response.status == 303 || response.status == 307
+          # redirect the HTTP response as appropriate based on documentation here:
+          # https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
+          case response.status
+          when 200
+            package_data.rewind
+            return package_data
+          when 301, 302, 303, 307, 308
             current_redirects += 1
             return nil if current_redirects > max_redirects
 
             current_url = response.headers["Location"]
-          elsif response.status == 200
-            package_data.rewind
-            return package_data
           else
             return nil
           end

--- a/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
@@ -95,11 +95,27 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
     before do
       stub_request(:get, "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg")
         .to_return(
+          status: 301,
+          headers: {
+            "Location" => "https://api.nuget.org/redirect-on-301"
+          },
+          body: "redirecting on 301"
+        )
+      stub_request(:get, "https://api.nuget.org/redirect-on-301")
+        .to_return(
+          status: 302,
+          headers: {
+            "Location" => "https://api.nuget.org/redirect-on-302"
+          },
+          body: "redirecting on 302"
+        )
+      stub_request(:get, "https://api.nuget.org/redirect-on-302")
+        .to_return(
           status: 303,
           headers: {
             "Location" => "https://api.nuget.org/redirect-on-303"
           },
-          body: "not the final contents"
+          body: "redirecting on 303"
         )
       stub_request(:get, "https://api.nuget.org/redirect-on-303")
         .to_return(
@@ -107,9 +123,17 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
           headers: {
             "Location" => "https://api.nuget.org/redirect-on-307"
           },
-          body: "almost final contents"
+          body: "redirecting on 307"
         )
       stub_request(:get, "https://api.nuget.org/redirect-on-307")
+        .to_return(
+          status: 308,
+          headers: {
+            "Location" => "https://api.nuget.org/redirect-on-308"
+          },
+          body: "redirecting on 308"
+        )
+      stub_request(:get, "https://api.nuget.org/redirect-on-308")
         .to_return(
           status: 200,
           body: "the final contents"


### PR DESCRIPTION
When testing NuGet updates against a GitHub package feed, I discovered that there were other types of `30X` redirects that weren't being followed.

This PR follows information found [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections) about various types of `30X` redirects, specifically, `301`, `302`, `303`, `307`, and `308`.  The redirects not covered are the ones where there's not a specific `Location:` header returned that can be followed, e.g., `300` which can specify multiple redirect options, but according to the documentation is rare, and `304` which means a cached version can be used, but our updater won't have a cached version to use.