### PR TITLE
handle ungrouped security updates with multi-dir version updates

### DIFF
--- a/silent/tests/testdata/su-multidir-not-grouped.txt
+++ b/silent/tests/testdata/su-multidir-not-grouped.txt
@@ -1,9 +1,12 @@
 dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
-stdout -count=1 'create_pull_request'
-stderr -count=1 'created \| dependency-a \( from 1.2.3 to 1.2.4 \)'
-pr-created frontend/expected-1.json
+stdout -count=2 'create_pull_request'
+stderr -count=2 'created \| dependency-a \( from 1.2.3 to 1.2.4 \)'
+pr-created frontend/expected.json
+pr-created backend/expected.json
 
 # Testing multi-directory configuration without a group.
+# Since it's impossible to tell which directory dependency-a should be
+# updated in, it should update in all directories.
 
 -- frontend/manifest.json --
 {
@@ -11,15 +14,25 @@ pr-created frontend/expected-1.json
   "dependency-b": { "version": "1.2.3" }
 }
 
--- frontend/expected-1.json --
+-- backend/manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" }
+}
+
+-- utilities/manifest.json --
+{
+  "unrelated": { "version": "1.0.0" }
+}
+
+-- frontend/expected.json --
 {
   "dependency-a": { "version": "1.2.4" },
   "dependency-b": { "version": "1.2.3" }
 }
 
--- backend/manifest.json --
+-- backend/expected.json --
 {
-  "dependency-a": { "version": "1.2.3" }
+  "dependency-a": { "version": "1.2.4" }
 }
 
 -- dependency-a --
@@ -39,6 +52,7 @@ job:
   source:
     directories:
       - "/frontend"
+      - "/utilities"
       - "/backend"
     provider: example
     hostname: example.com

--- a/silent/tests/testdata/su-multidir-not-grouped.txt
+++ b/silent/tests/testdata/su-multidir-not-grouped.txt
@@ -1,0 +1,53 @@
+dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stdout -count=1 'create_pull_request'
+stderr -count=1 'created \| dependency-a \( from 1.2.3 to 1.2.4 \)'
+pr-created frontend/expected-1.json
+
+# Testing multi-directory configuration without a group.
+
+-- frontend/manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" },
+  "dependency-b": { "version": "1.2.3" }
+}
+
+-- frontend/expected-1.json --
+{
+  "dependency-a": { "version": "1.2.4" },
+  "dependency-b": { "version": "1.2.3" }
+}
+
+-- backend/manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" }
+}
+
+-- dependency-a --
+{
+  "versions": [
+    "1.2.3",
+    "1.2.4",
+    "1.2.5"
+  ]
+}
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  dependencies:
+      - dependency-a
+  source:
+    directories:
+      - "/frontend"
+      - "/backend"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  security-advisories:
+    - dependency-name: dependency-a
+      affected-versions:
+        - < 1.2.4
+      patched-versions: []
+      unaffected-versions: []
+  security-updates-only: true

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -20,7 +20,7 @@ module Dependabot
       class GroupUpdateAllVersions
         include GroupUpdateCreation
 
-        def self.applies_to?(job:)
+        def self.applies_to?(job:) # rubocop:disable Metrics/PerceivedComplexity
           return false if job.updating_a_pull_request?
           if Dependabot::Experiments.enabled?(:grouped_security_updates_disabled) && job.security_updates_only?
             return false
@@ -29,6 +29,7 @@ module Dependabot
           if job.security_updates_only?
             return true if job.dependencies.count > 1
             return true if job.dependency_groups&.any? { |group| group["applies-to"] == "security-updates" }
+            return true if job.source.directories && job.source.directories.count > 1
 
             return false
           end


### PR DESCRIPTION
If multi-directory version updates is enabled, but grouped security updates is not, then the API sends kind of an edge-casey job to the Updater.

This test passes, but it updated `frontend` and not `backend`, it really doesn't know which dependency to look at and seems to just pick the first one.

It should probably update both in individual PRs.