### PR TITLE
don't fail completely if package version cannot be parsed

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -408,10 +408,6 @@ module Dependabot
                 version = dependency_version(package_node, file)
                 next unless name && version
 
-                version = Version.new(version)
-                existing_version = package_versions[name]
-                next if existing_version && existing_version > version
-
                 package_versions[name] = version
               end
             end

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -135,6 +135,70 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
       end
     end
 
+    describe "dependencies from Directory.Packages.props" do
+      let(:parser) do
+        described_class.new(dependency_files: dependency_files, credentials: credentials,
+                            repo_contents_path: "/test/repo")
+      end
+      let(:project_file) do
+        Dependabot::DependencyFile.new(
+          name: "project.csproj",
+          content:
+            <<~XML
+              <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                  <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                  <PackageReference Include="Some.Package" />
+                  <PackageReference Include="Some.Other.Package" />
+                </ItemGroup>
+              </Project>
+            XML
+        )
+      end
+      let(:dependency_set) { parser.dependency_set(project_file: project_file) }
+      let(:dependency_files) do
+        [
+          project_file,
+          Dependabot::DependencyFile.new(
+            name: "Directory.Packages.props",
+            content:
+              <<~XML
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageVersion Include="Some.Package" Version="$(SomePropertyThatIsNotResolvable)" />
+                    <PackageVersion Include="Some.Other.Package" Version="4.5.6" />
+                  </ItemGroup>
+                </Project>
+              XML
+          )
+        ]
+      end
+
+      subject(:dependencies) { dependency_set.dependencies }
+
+      before do
+        stub_search_results_with_versions_v3("some.package", ["1.2.3"])
+        stub_search_results_with_versions_v3("some.other.package", ["4.5.6"])
+      end
+
+      it "returns the correct information" do
+        expect(dependencies.length).to eq(2)
+
+        expect(dependencies[0]).to be_a(Dependabot::Dependency)
+        expect(dependencies[0].name).to eq("Some.Package")
+        expect(dependencies[0].version).to eq("$SomePropertyThatIsNotResolvable")
+
+        expect(dependencies[1]).to be_a(Dependabot::Dependency)
+        expect(dependencies[1].name).to eq("Some.Other.Package")
+        expect(dependencies[1].version).to eq("4.5.6")
+      end
+    end
+
     describe "the top_level dependencies" do
       let(:dependencies) { dependency_set.dependencies }
       subject(:top_level_dependencies) { dependencies.select(&:top_level?) }


### PR DESCRIPTION
If a package version property can't be expanded, silly things happen like querying NuGet for `$SomePackageVersion`.  This PR is 2 related fixes rolled into one.

1. Pre-filter package versions by passing them through `Version.parse()`.  If that fails, there's nothing meaningful that can be done, so we can quit early and, more importantly, cleanly.  Package versions that failed to parse are elevated to warnings.
2. Don't assume package versions in `Directory.Packages.props` are a version number; they might be a variable expansion.  Currently this PR just removes the `Version` requirement to allow the raw string to pass through, but I've filed #9151 to track future work.  The raw string pass-through will prevent a bunch of crashes if a variable is used in the property field.

This should fix the most egregious errors of #8490.