### PR TITLE
run `nuget restore` if the first update operation failed

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1072,6 +1072,72 @@ public partial class UpdateWorkerTests
                 """);
         }
 
+        [Fact]
+        public async Task PackageCanBeUpdatedWhenAnotherInstalledPackageHasBeenDelisted()
+        {
+            // updating one package (Newtonsoft.Json) when another installed package (FSharp.Core/5.0.3-beta.21369.4) has been delisted
+            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+                // existing
+                projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="packages.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+                      <HintPath>packages\FSharp.Core.5.0.3-beta.21369.4\lib\netstandard2.0\FSharp.Core.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+                packagesConfigContents: """
+                <packages>
+                  <package id="FSharp.Core" version="5.0.3-beta.21369.4" targetFramework="net462" />
+                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net462" />
+                </packages>
+                """,
+                // expected
+                expectedProjectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="packages.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+                      <HintPath>packages\FSharp.Core.5.0.3-beta.21369.4\lib\netstandard2.0\FSharp.Core.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+                expectedPackagesConfigContents: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <packages>
+                  <package id="FSharp.Core" version="5.0.3-beta.21369.4" targetFramework="net462" />
+                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+                </packages>
+                """);
+        }
+
         protected static Task TestUpdateForProject(
             string dependencyName,
             string oldVersion,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -48,7 +48,7 @@ internal static class PackagesConfigUpdater
         var packagesDirectory = PathHelper.JoinPath(projectDirectory, packagesSubDirectory);
         Directory.CreateDirectory(packagesDirectory);
 
-        var args = new List<string>
+        var updateArgs = new List<string>
         {
             "update",
             packagesConfigPath,
@@ -61,17 +61,29 @@ internal static class PackagesConfigUpdater
             "-NonInteractive",
         };
 
+        var restoreArgs = new List<string>
+        {
+            "restore",
+            projectPath,
+            "-PackagesDirectory",
+            packagesDirectory,
+            "-NonInteractive",
+        };
+
         logger.Log("    Finding MSBuild...");
         var msbuildDirectory = MSBuildHelper.MSBuildPath;
         if (msbuildDirectory is not null)
         {
-            args.Add("-MSBuildPath");
-            args.Add(msbuildDirectory); // e.g., /usr/share/dotnet/sdk/7.0.203
+            foreach (var args in new[] { updateArgs, restoreArgs })
+            {
+                args.Add("-MSBuildPath");
+                args.Add(msbuildDirectory); // e.g., /usr/share/dotnet/sdk/7.0.203
+            }
         }
 
         using (new WebApplicationTargetsConditionPatcher(projectPath))
         {
-            RunNuget(args, packagesDirectory, logger);
+            RunNuget(updateArgs, restoreArgs, packagesDirectory, logger);
         }
 
         projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);
@@ -84,7 +96,7 @@ internal static class PackagesConfigUpdater
         await projectBuildFile.SaveAsync();
     }
 
-    private static void RunNuget(List<string> args, string packagesDirectory, Logger logger)
+    private static void RunNuget(List<string> updateArgs, List<string> restoreArgs, string packagesDirectory, Logger logger)
     {
         var outputBuilder = new StringBuilder();
         var writer = new StringWriter(outputBuilder);
@@ -97,15 +109,38 @@ internal static class PackagesConfigUpdater
         var currentDir = Environment.CurrentDirectory;
         try
         {
-            logger.Log($"    Running NuGet.exe with args: {string.Join(" ", args)}");
 
             Environment.CurrentDirectory = packagesDirectory;
-            var result = Program.Main(args.ToArray());
+            var retryingAfterRestore = false;
+
+        doRestore:
+            logger.Log($"    Running NuGet.exe with args: {string.Join(" ", updateArgs)}");
+            outputBuilder.Clear();
+            var result = Program.Main(updateArgs.ToArray());
             var fullOutput = outputBuilder.ToString();
             logger.Log($"    Result: {result}");
             logger.Log($"    Output:\n{fullOutput}");
             if (result != 0)
             {
+                // If the `packages.config` file contains a delisted package, the initial `update` operation will fail
+                // with the message listed below.  The solution is to run `nuget.exe restore ...` and retry.
+                if (!retryingAfterRestore &&
+                    fullOutput.Contains("Existing packages must be restored before performing an install or update."))
+                {
+                    logger.Log($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
+                    retryingAfterRestore = true;
+                    outputBuilder.Clear();
+                    var exitCodeAgain = Program.Main(restoreArgs.ToArray());
+                    var restoreOutput = outputBuilder.ToString();
+
+                    if (exitCodeAgain != 0)
+                    {
+                        throw new Exception($"Unable to restore.\nOutput:\n${restoreOutput}\n");
+                    }
+
+                    goto doRestore;
+                }
+
                 throw new Exception(fullOutput);
             }
         }


### PR DESCRIPTION
If attempting to `nuget.exe update ...` a package when one of the other installed packages has been delisted, the operation will fail with:

```
Unable to find package 'Delisted.Package'. Existing packages must be restored before performing an install or update.
```

This PR detects this issue by checking for exit code != 0 and the message listed above (n.b., the updater image and tool is always built and run with the default locale, so this string does not need to be localized), runs `nuget restore ...`, and then retries the update procedure.  This retry is only done once and if it fails the second time, the update process will fail.

Fixes #9108.