### PR TITLE
Filter out NuGet files where lines were only deleted

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -42,6 +42,8 @@ module Dependabot
           normalized_content = normalize_content(f, updated_content)
           next if normalized_content == f.content
 
+          next if only_deleted_lines?(f.content, normalized_content)
+
           puts "The contents of file [#{f.name}] were updated."
 
           updated_file(file: f, content: normalized_content)
@@ -221,6 +223,14 @@ module Dependabot
         return if project_files.any? || packages_config_files.any?
 
         raise "No project file or packages.config!"
+      end
+
+      sig { params(original_content: T.nilable(String), updated_content: String).returns(T::Boolean) }
+      def only_deleted_lines?(original_content, updated_content)
+        original_lines = original_content&.lines || []
+        updated_lines = updated_content.lines
+
+        original_lines.count > updated_lines.count
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
     subject(:updated_files) { file_updater_instance.updated_dependency_files }
 
     context "with a dirs.proj" do
-      it "does not repeatedly update the same project", focus: true do
+      it "does not repeatedly update the same project" do
         puts dependency_files.map(&:name)
         expect(updated_files.map(&:name)).to match_array([
           "Proj1/Proj1/Proj1.csproj"
@@ -78,6 +78,20 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
             "#{repo_contents_path}/dirs.projMicrosoft.Extensions.DependencyModel" => 1
           }
         )
+      end
+
+      context "that has only deleted lines" do
+        before do
+          allow(File).to receive(:read)
+            .and_call_original
+          allow(File).to receive(:read)
+            .with("#{repo_contents_path}/Proj1/Proj1/Proj1.csproj")
+            .and_return("")
+        end
+
+        it "does not update the project" do
+          expect(updated_files.map(&:name)).to match_array([])
+        end
       end
     end
   end


### PR DESCRIPTION
We've seen behaviour when we attempt to use NuGet to perform an update, where the remote dependency tree is not complete. For example, imagine we have the following dependency tree:

```mermaid
flowchart LR
    MyProject -->|Depends on| A[A 1.0]
    A -->|Depends on|B[B 1.0]
```

If package A version 2.0 is published, and it has a dependency on package B version 2.0, but that package isn't yet published to the NuGet feed, the upgrade will fail. NuGet will give the error `WARNING: Install failed. Rolling back...` and remove the existing dependencies on package A version 1.0 and package B version 1.0. This rollback behaviour of NuGet is not configurable.

To try and catch this, I'm comparing the number of lines in the original content versus the updated content. If the updated content has less lines than the original content, then a package has been removed somewhere and we likely don't want to create a pull request.