### PR TITLE
Use the project's version of a dependency to determine transitive or not

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -73,9 +73,12 @@ module Dependabot
           next unless repo_contents_path
 
           checked_key = "#{project_file.name}-#{dependency.name}#{dependency.version}"
-          unless checked_files.include?(checked_key)
-            call_nuget_updater_tool(dependency, proj_path, !project_dependency.top_level?)
-          end
+          should_run = !checked_files.include?(checked_key)
+
+          # Run the updater for top-level dependencies and vulnerable transitive dependencies
+          should_run &&= project_dependency.top_level? || dependency.metadata[:vulnerable]
+
+          call_nuget_updater_tool(dependency, proj_path, !project_dependency.top_level?) if should_run
 
           checked_files.add(checked_key)
           # We need to check the downstream references even though we're already evaluated the file

--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -100,7 +100,8 @@ module Dependabot
           requirements: updated_requirements,
           previous_version: dependency.version,
           previous_requirements: dependency.requirements,
-          package_manager: dependency.package_manager
+          package_manager: dependency.package_manager,
+          metadata: { vulnerable: vulnerable? }
         )
         updated_dependencies = [updated_dependency]
         updated_dependencies += DependencyFinder.new(


### PR DESCRIPTION
Currently the NuGet updater uses the workspace version of a dependency when determining whether it is transitive or not. However, when updating multiple project files, whether it is transitive or not is based on the dependency as that project sees it. This change has the file_updater locate the dependency from the project being processed and using its `.top_level?` to determine whether it is transitive.