### PR TITLE
Require `typed: strict` for `common`

### DIFF
--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: ../.rubocop.yml
 
-Sorbet/TrueSigil:
+Sorbet/StrictSigil:
   Enabled: true


### PR DESCRIPTION
Now that all of `common` is `typed: strict` this RuboCop rule ensures that going forward all files are required to remain `typed: strict`.