### PR TITLE
`requirements_update_strategy` is `String` not `Symbol`

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -1,11 +1,13 @@
 # typed: true
 # frozen_string_literal: true
 
-require "dependabot/update_checkers"
-require "dependabot/update_checkers/base"
 require "dependabot/bundler/file_updater/requirement_replacer"
 require "dependabot/bundler/version"
 require "dependabot/git_commit_checker"
+require "dependabot/requirements_update_strategy"
+require "dependabot/update_checkers"
+require "dependabot/update_checkers/base"
+
 module Dependabot
   module Bundler
     class UpdateChecker < Dependabot::UpdateCheckers::Base
@@ -75,7 +77,7 @@ module Dependabot
 
       def requirements_unlocked_or_can_be?
         return true if requirements_unlocked?
-        return false if requirements_update_strategy == "lockfile_only"
+        return false if requirements_update_strategy == RequirementsUpdateStrategy::LockfileOnly
 
         dependency.specific_requirements
                   .all? do |req|
@@ -95,7 +97,11 @@ module Dependabot
         return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        dependency.version.nil? ? "bump_versions_if_necessary" : "bump_versions"
+        if dependency.version.nil?
+          RequirementsUpdateStrategy::BumpVersionsIfNecessary
+        else
+          RequirementsUpdateStrategy::BumpVersions
+        end
       end
 
       def conflicting_dependencies

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -75,7 +75,7 @@ module Dependabot
 
       def requirements_unlocked_or_can_be?
         return true if requirements_unlocked?
-        return false if requirements_update_strategy == :lockfile_only
+        return false if requirements_update_strategy == "lockfile_only"
 
         dependency.specific_requirements
                   .all? do |req|
@@ -92,10 +92,10 @@ module Dependabot
 
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
-        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+        return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        dependency.version.nil? ? :bump_versions_if_necessary : :bump_versions
+        dependency.version.nil? ? "bump_versions_if_necessary" : "bump_versions"
       end
 
       def conflicting_dependencies

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -1,16 +1,27 @@
 # typed: true
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/bundler/update_checker"
+require "dependabot/requirements_update_strategy"
 
 module Dependabot
   module Bundler
     class UpdateChecker
       class RequirementsUpdater
+        extend T::Sig
+
         class UnfixableRequirement < StandardError; end
 
-        ALLOWED_UPDATE_STRATEGIES =
-          %w(lockfile_only bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = T.let(
+          [
+            RequirementsUpdateStrategy::LockfileOnly,
+            RequirementsUpdateStrategy::BumpVersions,
+            RequirementsUpdateStrategy::BumpVersionsIfNecessary
+          ].freeze,
+          T::Array[Dependabot::RequirementsUpdateStrategy]
+        )
 
         def initialize(requirements:, update_strategy:, updated_source:,
                        latest_version:, latest_resolvable_version:)
@@ -28,7 +39,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == "lockfile_only"
+          return requirements if update_strategy == RequirementsUpdateStrategy::LockfileOnly
 
           requirements.map do |req|
             if req[:file].include?(".gemspec")
@@ -58,9 +69,9 @@ module Dependabot
           return req unless latest_resolvable_version
 
           case update_strategy
-          when "bump_versions"
+          when RequirementsUpdateStrategy::BumpVersions
             update_version_requirement(req)
-          when "bump_versions_if_necessary"
+          when RequirementsUpdateStrategy::BumpVersionsIfNecessary
             update_version_requirement_if_needed(req)
           else raise "Unexpected update strategy: #{update_strategy}"
           end

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -10,7 +10,7 @@ module Dependabot
         class UnfixableRequirement < StandardError; end
 
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
+          %w(lockfile_only bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:, updated_source:,
                        latest_version:, latest_resolvable_version:)
@@ -28,7 +28,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
+          return requirements if update_strategy == "lockfile_only"
 
           requirements.map do |req|
             if req[:file].include?(".gemspec")
@@ -58,9 +58,9 @@ module Dependabot
           return req unless latest_resolvable_version
 
           case update_strategy
-          when :bump_versions
+          when "bump_versions"
             update_version_requirement(req)
-          when :bump_versions_if_necessary
+          when "bump_versions_if_necessary"
             update_version_requirement_if_needed(req)
           else raise "Unexpected update strategy: #{update_strategy}"
           end

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -3,9 +3,11 @@
 
 require "spec_helper"
 require "shared_contexts"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
+
 require "dependabot/bundler/file_updater"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/requirements_update_strategy"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::Bundler::FileUpdater do

--- a/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
@@ -3,9 +3,11 @@
 
 require "spec_helper"
 require "shared_contexts"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
+
 require "dependabot/bundler/update_checker/force_updater"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/requirements_update_strategy"
 
 RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
   include_context "stub rubygems compact index"
@@ -38,7 +40,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
   let(:dependency_name) { "rspec-mocks" }
   let(:current_version) { "3.5.0" }
   let(:target_version) { "3.6.0" }
-  let(:update_strategy) { "bump_versions" }
+  let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
   let(:requirements) do
     [{
       file: "Gemfile",

--- a/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
   let(:dependency_name) { "rspec-mocks" }
   let(:current_version) { "3.5.0" }
   let(:target_version) { "3.6.0" }
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
   let(:requirements) do
     [{
       file: "Gemfile",

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
   let(:gemspec_groups) { [] }
   let(:updated_source) { nil }
 
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
   let(:latest_version) { "1.8.0" }
   let(:latest_resolvable_version) { "1.5.0" }
 
@@ -140,7 +140,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
         end
 
         context "for a library" do
-          let(:update_strategy) { :bump_versions_if_necessary }
+          let(:update_strategy) { "bump_versions_if_necessary" }
 
           context "and the new version satisfies the old requirements" do
             let(:gemfile_requirement_string) { "~> 1.4" }
@@ -508,7 +508,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
     end
 
     context "when lockfile_only configured" do
-      let(:update_strategy) { :lockfile_only }
+      let(:update_strategy) { "lockfile_only" }
 
       it "does not change any requirements" do
         expect(updated_requirements).to eq(requirements)

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+
 require "dependabot/bundler/update_checker/requirements_updater"
+require "dependabot/requirements_update_strategy"
 
 RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
   let(:updater) do
@@ -38,7 +40,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
   let(:gemspec_groups) { [] }
   let(:updated_source) { nil }
 
-  let(:update_strategy) { "bump_versions" }
+  let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
   let(:latest_version) { "1.8.0" }
   let(:latest_resolvable_version) { "1.5.0" }
 
@@ -140,7 +142,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
         end
 
         context "for a library" do
-          let(:update_strategy) { "bump_versions_if_necessary" }
+          let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
 
           context "and the new version satisfies the old requirements" do
             let(:gemfile_requirement_string) { "~> 1.4" }
@@ -508,7 +510,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
     end
 
     context "when lockfile_only configured" do
-      let(:update_strategy) { "lockfile_only" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it "does not change any requirements" do
         expect(updated_requirements).to eq(requirements)

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -3,9 +3,11 @@
 
 require "spec_helper"
 require "shared_contexts"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
+
 require "dependabot/bundler/update_checker"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Bundler::UpdateChecker do
@@ -1488,7 +1490,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: "bump_versions",
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: nil
@@ -1513,7 +1515,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: "bump_versions",
+              update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
               latest_version: "1.13.0",
               latest_resolvable_version: "1.5.0",
               updated_source: nil
@@ -1549,7 +1551,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: "bump_versions",
+              update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
               latest_version: "1.13.0",
               latest_resolvable_version: "1.13.0",
               updated_source: nil
@@ -1606,7 +1608,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: "bump_versions",
+              update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
               latest_version: "1.0.1",
               latest_resolvable_version: "1.0.1",
               updated_source: requirements.first[:source]
@@ -1646,7 +1648,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               expect(requirements_updater)
                 .to receive(:new).with(
                   requirements: requirements,
-                  update_strategy: "bump_versions",
+                  update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
                   latest_version: /^2./,
                   latest_resolvable_version: /^1./,
                   updated_source: requirements.first[:source]
@@ -1684,7 +1686,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: "bump_versions",
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1719,7 +1721,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: "bump_versions_if_necessary",
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary,
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1748,7 +1750,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: "bump_versions_if_necessary",
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary,
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1776,7 +1778,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: "bump_versions_if_necessary",
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary,
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1800,7 +1802,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(true) }
 
       context "and with the lockfile-only requirements update strategy set" do
-        let(:requirements_update_strategy) { "lockfile_only" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
         it { is_expected.to eq(true) }
       end
@@ -1832,7 +1834,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "but with the lockfile-only requirements update strategy set" do
-        let(:requirements_update_strategy) { "lockfile_only" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
         it { is_expected.to eq(false) }
       end

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1488,7 +1488,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: :bump_versions,
+            update_strategy: "bump_versions",
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: nil
@@ -1513,7 +1513,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: :bump_versions,
+              update_strategy: "bump_versions",
               latest_version: "1.13.0",
               latest_resolvable_version: "1.5.0",
               updated_source: nil
@@ -1549,7 +1549,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: :bump_versions,
+              update_strategy: "bump_versions",
               latest_version: "1.13.0",
               latest_resolvable_version: "1.13.0",
               updated_source: nil
@@ -1606,7 +1606,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           expect(requirements_updater)
             .to receive(:new).with(
               requirements: requirements,
-              update_strategy: :bump_versions,
+              update_strategy: "bump_versions",
               latest_version: "1.0.1",
               latest_resolvable_version: "1.0.1",
               updated_source: requirements.first[:source]
@@ -1646,7 +1646,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               expect(requirements_updater)
                 .to receive(:new).with(
                   requirements: requirements,
-                  update_strategy: :bump_versions,
+                  update_strategy: "bump_versions",
                   latest_version: /^2./,
                   latest_resolvable_version: /^1./,
                   updated_source: requirements.first[:source]
@@ -1684,7 +1684,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: :bump_versions,
+            update_strategy: "bump_versions",
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1719,7 +1719,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: :bump_versions_if_necessary,
+            update_strategy: "bump_versions_if_necessary",
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1748,7 +1748,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: :bump_versions_if_necessary,
+            update_strategy: "bump_versions_if_necessary",
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1776,7 +1776,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         expect(requirements_updater)
           .to receive(:new).with(
             requirements: requirements,
-            update_strategy: :bump_versions_if_necessary,
+            update_strategy: "bump_versions_if_necessary",
             latest_version: "1.13.0",
             latest_resolvable_version: "1.13.0",
             updated_source: requirements.first[:source]
@@ -1800,7 +1800,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(true) }
 
       context "and with the lockfile-only requirements update strategy set" do
-        let(:requirements_update_strategy) { :lockfile_only }
+        let(:requirements_update_strategy) { "lockfile_only" }
 
         it { is_expected.to eq(true) }
       end
@@ -1832,7 +1832,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "but with the lockfile-only requirements update strategy set" do
-        let(:requirements_update_strategy) { :lockfile_only }
+        let(:requirements_update_strategy) { "lockfile_only" }
 
         it { is_expected.to eq(false) }
       end

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -77,15 +77,15 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != :lockfile_only
+        requirements_update_strategy != "lockfile_only"
       end
 
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
-        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+        return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? :bump_versions_if_necessary : :bump_versions
+        library? ? "bump_versions_if_necessary" : "bump_versions"
       end
 
       private

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/git_commit_checker"
+require "dependabot/requirements_update_strategy"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 
@@ -77,7 +78,7 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != "lockfile_only"
+        requirements_update_strategy != RequirementsUpdateStrategy::LockfileOnly
       end
 
       def requirements_update_strategy
@@ -85,7 +86,7 @@ module Dependabot
         return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? "bump_versions_if_necessary" : "bump_versions"
+        library? ? RequirementsUpdateStrategy::BumpVersionsIfNecessary : RequirementsUpdateStrategy::BumpVersions
       end
 
       private

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -19,7 +19,7 @@ module Dependabot
 
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-*]+)*/
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
+          %w(lockfile_only bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        target_version:)
@@ -35,7 +35,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
+          return requirements if update_strategy == "lockfile_only"
 
           # NOTE: Order is important here. The FileUpdater needs the updated
           # requirement at index `i` to correspond to the previous requirement
@@ -46,7 +46,7 @@ module Dependabot
             next req if req[:requirement].nil?
 
             # TODO: Add a widen_ranges options
-            if update_strategy == :bump_versions_if_necessary
+            if update_strategy == "bump_versions_if_necessary"
               update_version_requirement_if_needed(req)
             else
               update_version_requirement(req)

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -7,19 +7,30 @@
 # - https://steveklabnik.github.io/semver/semver/index.html                    #
 ################################################################################
 
+require "sorbet-runtime"
+
 require "dependabot/cargo/update_checker"
 require "dependabot/cargo/requirement"
 require "dependabot/cargo/version"
+require "dependabot/requirements_update_strategy"
 
 module Dependabot
   module Cargo
     class UpdateChecker
       class RequirementsUpdater
+        extend T::Sig
+
         class UnfixableRequirement < StandardError; end
 
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-*]+)*/
-        ALLOWED_UPDATE_STRATEGIES =
-          %w(lockfile_only bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = T.let(
+          [
+            RequirementsUpdateStrategy::LockfileOnly,
+            RequirementsUpdateStrategy::BumpVersions,
+            RequirementsUpdateStrategy::BumpVersionsIfNecessary
+          ].freeze,
+          T::Array[Dependabot::RequirementsUpdateStrategy]
+        )
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        target_version:)
@@ -35,7 +46,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == "lockfile_only"
+          return requirements if update_strategy == RequirementsUpdateStrategy::LockfileOnly
 
           # NOTE: Order is important here. The FileUpdater needs the updated
           # requirement at index `i` to correspond to the previous requirement
@@ -45,8 +56,8 @@ module Dependabot
             next req unless target_version
             next req if req[:requirement].nil?
 
-            # TODO: Add a widen_ranges options
-            if update_strategy == "bump_versions_if_necessary"
+            # TODO: Add a RequirementsUpdateStrategy::WidenRanges options
+            if update_strategy == RequirementsUpdateStrategy::BumpVersionsIfNecessary
               update_version_requirement_if_needed(req)
             else
               update_version_requirement(req)

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+
 require "dependabot/cargo/update_checker/requirements_updater"
+require "dependabot/requirements_update_strategy"
 
 RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
   let(:updater) do
@@ -25,7 +27,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
   end
   let(:req_string) { "^1.4.0" }
 
-  let(:update_strategy) { "bump_versions" }
+  let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
   let(:target_version) { "1.5.0" }
 
   describe "#updated_requirements" do
@@ -77,7 +79,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a bump_versions strategy" do
-      let(:update_strategy) { "bump_versions" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
 
       context "when there is a latest version" do
         context "and a full version was previously specified" do
@@ -222,7 +224,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a bump_versions_if_necessary strategy" do
-      let(:update_strategy) { "bump_versions_if_necessary" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
 
       context "when there is no latest version" do
         let(:target_version) { nil }
@@ -366,7 +368,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a lockfile_only strategy" do
-      let(:update_strategy) { "lockfile_only" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it "does not change any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
   end
   let(:req_string) { "^1.4.0" }
 
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
   let(:target_version) { "1.5.0" }
 
   describe "#updated_requirements" do
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a bump_versions strategy" do
-      let(:update_strategy) { :bump_versions }
+      let(:update_strategy) { "bump_versions" }
 
       context "when there is a latest version" do
         context "and a full version was previously specified" do
@@ -222,7 +222,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a bump_versions_if_necessary strategy" do
-      let(:update_strategy) { :bump_versions_if_necessary }
+      let(:update_strategy) { "bump_versions_if_necessary" }
 
       context "when there is no latest version" do
         let(:target_version) { nil }
@@ -366,7 +366,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a lockfile_only strategy" do
-      let(:update_strategy) { :lockfile_only }
+      let(:update_strategy) { "lockfile_only" }
 
       it "does not change any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           requirements: requirements,
           updated_source: nil,
           target_version: "0.1.40",
-          update_strategy: :bump_versions
+          update_strategy: "bump_versions"
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -471,7 +471,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
             requirements: requirements,
             updated_source: nil,
             target_version: "0.1.39",
-            update_strategy: :bump_versions
+            update_strategy: "bump_versions"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -493,7 +493,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { :lockfile_only }
+      let(:requirements_update_strategy) { "lockfile_only" }
 
       it { is_expected.to eq(false) }
     end

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -2,9 +2,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
+
 require "dependabot/cargo/update_checker"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Cargo::UpdateChecker do
@@ -438,7 +440,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           requirements: requirements,
           updated_source: nil,
           target_version: "0.1.40",
-          update_strategy: "bump_versions"
+          update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -471,7 +473,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
             requirements: requirements,
             updated_source: nil,
             target_version: "0.1.39",
-            update_strategy: "bump_versions"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -493,7 +495,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { "lockfile_only" }
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it { is_expected.to eq(false) }
     end

--- a/common/lib/dependabot/requirements_update_strategy.rb
+++ b/common/lib/dependabot/requirements_update_strategy.rb
@@ -1,0 +1,13 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Dependabot
+  class RequirementsUpdateStrategy < T::Enum
+    enums do
+      BumpVersions = new("bump_versions")
+      BumpVersionsIfNecessary = new("bump_versions_if_necessary")
+      LockfileOnly = new("lockfile_only")
+      WidenRanges = new("widen_ranges")
+    end
+  end
+end

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -4,8 +4,9 @@
 require "json"
 require "sorbet-runtime"
 
-require "dependabot/utils"
+require "dependabot/requirements_update_strategy"
 require "dependabot/security_advisory"
+require "dependabot/utils"
 
 module Dependabot
   module UpdateCheckers
@@ -34,7 +35,7 @@ module Dependabot
       sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
       attr_reader :security_advisories
 
-      sig { returns(T.nilable(String)) }
+      sig { returns(T.nilable(Dependabot::RequirementsUpdateStrategy)) }
       attr_reader :requirements_update_strategy
 
       sig { returns(T.nilable(Dependabot::DependencyGroup)) }
@@ -52,7 +53,7 @@ module Dependabot
           ignored_versions: T::Array[String],
           raise_on_ignored: T::Boolean,
           security_advisories: T::Array[Dependabot::SecurityAdvisory],
-          requirements_update_strategy: T.nilable(String),
+          requirements_update_strategy: T.nilable(Dependabot::RequirementsUpdateStrategy),
           dependency_group: T.nilable(Dependabot::DependencyGroup),
           options: T::Hash[Symbol, T.untyped]
         )

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -34,7 +34,7 @@ module Dependabot
       sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
       attr_reader :security_advisories
 
-      sig { returns(T.nilable(T.any(Symbol, String))) }
+      sig { returns(T.nilable(String)) }
       attr_reader :requirements_update_strategy
 
       sig { returns(T.nilable(Dependabot::DependencyGroup)) }
@@ -52,7 +52,7 @@ module Dependabot
           ignored_versions: T::Array[String],
           raise_on_ignored: T::Boolean,
           security_advisories: T::Array[Dependabot::SecurityAdvisory],
-          requirements_update_strategy: T.nilable(T.any(Symbol, String)),
+          requirements_update_strategy: T.nilable(String),
           dependency_group: T.nilable(Dependabot::DependencyGroup),
           options: T::Hash[Symbol, T.untyped]
         )

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -70,15 +70,15 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != :lockfile_only
+        requirements_update_strategy != "lockfile_only"
       end
 
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
-        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+        return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? :widen_ranges : :bump_versions_if_necessary
+        library? ? "widen_ranges" : "bump_versions_if_necessary"
       end
 
       private

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -2,10 +2,12 @@
 # frozen_string_literal: true
 
 require "json"
+
+require "dependabot/errors"
+require "dependabot/requirements_update_strategy"
+require "dependabot/shared_helpers"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/shared_helpers"
-require "dependabot/errors"
 
 module Dependabot
   module Composer
@@ -70,7 +72,7 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != "lockfile_only"
+        requirements_update_strategy != RequirementsUpdateStrategy::LockfileOnly
       end
 
       def requirements_update_strategy
@@ -78,7 +80,7 @@ module Dependabot
         return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? "widen_ranges" : "bump_versions_if_necessary"
+        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersionsIfNecessary
       end
 
       private

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -20,7 +20,7 @@ module Dependabot
         OR_SEPARATOR = /(?<=[a-zA-Z0-9*])[\s,]*\|\|?\s*/
         SEPARATOR = /(?:#{AND_SEPARATOR})|(?:#{OR_SEPARATOR})/
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+          %w(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:,
                        latest_resolvable_version:)
@@ -36,7 +36,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
+          return requirements if update_strategy == "lockfile_only"
           return requirements unless latest_resolvable_version
 
           requirements.map { |req| updated_requirement(req) }
@@ -67,13 +67,13 @@ module Dependabot
           return req if numeric_or_string_reqs.none?
           return updated_alias(req) if req_string.match?(ALIAS_REGEX)
           return req if req_satisfied_by_latest_resolvable?(req_string) &&
-                        update_strategy != :bump_versions
+                        update_strategy != "bump_versions"
 
           new_req =
             case update_strategy
-            when :widen_ranges
+            when "widen_ranges"
               widen_requirement(req, or_separator)
-            when :bump_versions, :bump_versions_if_necessary
+            when "bump_versions", "bump_versions_if_necessary"
               update_requirement_version(req, or_separator)
             end
 

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -6,21 +6,33 @@
 # https://getcomposer.org/doc/articles/versions.md#writing-version-constraints #
 ################################################################################
 
+require "sorbet-runtime"
+
+require "dependabot/composer/requirement"
 require "dependabot/composer/update_checker"
 require "dependabot/composer/version"
-require "dependabot/composer/requirement"
+require "dependabot/requirements_update_strategy"
 
 module Dependabot
   module Composer
     class UpdateChecker
       class RequirementsUpdater
+        extend T::Sig
+
         ALIAS_REGEX = /[a-z0-9\-_\.]*\sas\s+/
         VERSION_REGEX = /(?:#{ALIAS_REGEX})?[0-9]+(?:\.[a-zA-Z0-9*\-]+)*/
         AND_SEPARATOR = /(?<=[a-zA-Z0-9*])(?<!\sas)[\s,]+(?![\s,]*[|-]|as)/
         OR_SEPARATOR = /(?<=[a-zA-Z0-9*])[\s,]*\|\|?\s*/
         SEPARATOR = /(?:#{AND_SEPARATOR})|(?:#{OR_SEPARATOR})/
-        ALLOWED_UPDATE_STRATEGIES =
-          %w(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = T.let(
+          [
+            RequirementsUpdateStrategy::LockfileOnly,
+            RequirementsUpdateStrategy::WidenRanges,
+            RequirementsUpdateStrategy::BumpVersions,
+            RequirementsUpdateStrategy::BumpVersionsIfNecessary
+          ].freeze,
+          T::Array[Dependabot::RequirementsUpdateStrategy]
+        )
 
         def initialize(requirements:, update_strategy:,
                        latest_resolvable_version:)
@@ -36,7 +48,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == "lockfile_only"
+          return requirements if update_strategy == RequirementsUpdateStrategy::LockfileOnly
           return requirements unless latest_resolvable_version
 
           requirements.map { |req| updated_requirement(req) }
@@ -67,13 +79,13 @@ module Dependabot
           return req if numeric_or_string_reqs.none?
           return updated_alias(req) if req_string.match?(ALIAS_REGEX)
           return req if req_satisfied_by_latest_resolvable?(req_string) &&
-                        update_strategy != "bump_versions"
+                        update_strategy != RequirementsUpdateStrategy::BumpVersions
 
           new_req =
             case update_strategy
-            when "widen_ranges"
+            when RequirementsUpdateStrategy::WidenRanges
               widen_requirement(req, or_separator)
-            when "bump_versions", "bump_versions_if_necessary"
+            when RequirementsUpdateStrategy::BumpVersions, RequirementsUpdateStrategy::BumpVersionsIfNecessary
               update_requirement_version(req, or_separator)
             end
 

--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     }
   end
 
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
 
   describe "#updated_requirements" do
     subject { updater.updated_requirements.first }
@@ -39,7 +39,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with bump_versions_if_necessary as the update strategy" do
-      let(:update_strategy) { :bump_versions_if_necessary }
+      let(:update_strategy) { "bump_versions_if_necessary" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with bump_versions as the update strategy" do
-      let(:update_strategy) { :bump_versions }
+      let(:update_strategy) { "bump_versions" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with widen_ranges as the update strategy" do
-      let(:update_strategy) { :widen_ranges }
+      let(:update_strategy) { "widen_ranges" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -708,7 +708,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with lockfile_only as the update strategy" do
-      let(:update_strategy) { :lockfile_only }
+      let(:update_strategy) { "lockfile_only" }
 
       it "does not update any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+
 require "dependabot/composer/update_checker/requirements_updater"
+require "dependabot/requirements_update_strategy"
 
 RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
   let(:updater) do
@@ -23,7 +25,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     }
   end
 
-  let(:update_strategy) { "bump_versions" }
+  let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
 
   describe "#updated_requirements" do
     subject { updater.updated_requirements.first }
@@ -39,7 +41,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with bump_versions_if_necessary as the update strategy" do
-      let(:update_strategy) { "bump_versions_if_necessary" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -260,7 +262,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with bump_versions as the update strategy" do
-      let(:update_strategy) { "bump_versions" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -486,7 +488,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with widen_ranges as the update strategy" do
-      let(:update_strategy) { "widen_ranges" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { "1.5.0" }
@@ -708,7 +710,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
     end
 
     context "with lockfile_only as the update strategy" do
-      let(:update_strategy) { "lockfile_only" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it "does not update any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -826,7 +826,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         .with(
           requirements: dependency_requirements,
           latest_resolvable_version: "1.6.0",
-          update_strategy: :bump_versions_if_necessary
+          update_strategy: "bump_versions_if_necessary"
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -863,7 +863,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           .with(
             requirements: dependency_requirements,
             latest_resolvable_version: "1.5.0",
-            update_strategy: :bump_versions_if_necessary
+            update_strategy: "bump_versions_if_necessary"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -885,7 +885,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { :lockfile_only }
+      let(:requirements_update_strategy) { "lockfile_only" }
 
       it { is_expected.to eq(false) }
     end

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -2,9 +2,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
+
 require "dependabot/composer/update_checker"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Composer::UpdateChecker do
@@ -826,7 +828,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         .with(
           requirements: dependency_requirements,
           latest_resolvable_version: "1.6.0",
-          update_strategy: "bump_versions_if_necessary"
+          update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -863,7 +865,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           .with(
             requirements: dependency_requirements,
             latest_resolvable_version: "1.5.0",
-            update_strategy: "bump_versions_if_necessary"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -885,7 +887,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { "lockfile_only" }
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it { is_expected.to eq(false) }
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -1,11 +1,13 @@
 # typed: true
 # frozen_string_literal: true
 
+require "set"
+
 require "dependabot/git_commit_checker"
+require "dependabot/requirements_update_strategy"
+require "dependabot/shared_helpers"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/shared_helpers"
-require "set"
 
 module Dependabot
   module NpmAndYarn
@@ -104,7 +106,7 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != "lockfile_only"
+        requirements_update_strategy != RequirementsUpdateStrategy::LockfileOnly
       end
 
       def requirements_update_strategy
@@ -112,7 +114,7 @@ module Dependabot
         return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? "widen_ranges" : "bump_versions"
+        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
       end
 
       def conflicting_dependencies

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -104,15 +104,15 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != :lockfile_only
+        requirements_update_strategy != "lockfile_only"
       end
 
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
-        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+        return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? :widen_ranges : :bump_versions
+        library? ? "widen_ranges" : "bump_versions"
       end
 
       def conflicting_dependencies

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -6,9 +6,10 @@
 # https://docs.npmjs.com/misc/semver                                           #
 ################################################################################
 
+require "dependabot/npm_and_yarn/requirement"
 require "dependabot/npm_and_yarn/update_checker"
 require "dependabot/npm_and_yarn/version"
-require "dependabot/npm_and_yarn/requirement"
+require "dependabot/requirements_update_strategy"
 
 module Dependabot
   module NpmAndYarn
@@ -16,7 +17,15 @@ module Dependabot
       class RequirementsUpdater
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
         SEPARATOR = /(?<=[a-zA-Z0-9*])[\s|]+(?![\s|-])/
-        ALLOWED_UPDATE_STRATEGIES = %w(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = T.let(
+          [
+            RequirementsUpdateStrategy::LockfileOnly,
+            RequirementsUpdateStrategy::WidenRanges,
+            RequirementsUpdateStrategy::BumpVersions,
+            RequirementsUpdateStrategy::BumpVersionsIfNecessary
+          ].freeze,
+          T::Array[Dependabot::RequirementsUpdateStrategy]
+        )
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        latest_resolvable_version:)
@@ -33,7 +42,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == "lockfile_only"
+          return requirements if update_strategy == RequirementsUpdateStrategy::LockfileOnly
 
           requirements.map do |req|
             req = req.merge(source: updated_source)
@@ -42,9 +51,9 @@ module Dependabot
             next req if req[:requirement].match?(/^([A-Za-uw-z]|v[^\d])/)
 
             case update_strategy
-            when "widen_ranges" then widen_requirement(req)
-            when "bump_versions" then update_version_requirement(req)
-            when "bump_versions_if_necessary"
+            when RequirementsUpdateStrategy::WidenRanges then widen_requirement(req)
+            when RequirementsUpdateStrategy::BumpVersions then update_version_requirement(req)
+            when RequirementsUpdateStrategy::BumpVersionsIfNecessary
               update_version_requirement_if_needed(req)
             else raise "Unexpected update strategy: #{update_strategy}"
             end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -16,7 +16,7 @@ module Dependabot
       class RequirementsUpdater
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
         SEPARATOR = /(?<=[a-zA-Z0-9*])[\s|]+(?![\s|-])/
-        ALLOWED_UPDATE_STRATEGIES = %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = %w(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        latest_resolvable_version:)
@@ -33,7 +33,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
+          return requirements if update_strategy == "lockfile_only"
 
           requirements.map do |req|
             req = req.merge(source: updated_source)
@@ -42,9 +42,9 @@ module Dependabot
             next req if req[:requirement].match?(/^([A-Za-uw-z]|v[^\d])/)
 
             case update_strategy
-            when :widen_ranges then widen_requirement(req)
-            when :bump_versions then update_version_requirement(req)
-            when :bump_versions_if_necessary
+            when "widen_ranges" then widen_requirement(req)
+            when "bump_versions" then update_version_requirement(req)
+            when "bump_versions_if_necessary"
               update_version_requirement_if_needed(req)
             else raise "Unexpected update strategy: #{update_strategy}"
             end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
   end
   let(:package_json_req_string) { "^1.4.0" }
 
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
   let(:latest_resolvable_version) { "1.5.0" }
   let(:version_class) { Dependabot::NpmAndYarn::Version }
 
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement having its version bumped" do
-      let(:update_strategy) { :bump_versions }
+      let(:update_strategy) { "bump_versions" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement having its version bumped if required" do
-      let(:update_strategy) { :bump_versions_if_necessary }
+      let(:update_strategy) { "bump_versions_if_necessary" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -368,7 +368,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement being widened" do
-      let(:update_strategy) { :widen_ranges }
+      let(:update_strategy) { "widen_ranges" }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -609,7 +609,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement being left alone" do
-      let(:update_strategy) { :lockfile_only }
+      let(:update_strategy) { "lockfile_only" }
 
       it "does not update any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+
 require "dependabot/npm_and_yarn/update_checker/requirements_updater"
+require "dependabot/requirements_update_strategy"
 
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
   let(:updater) do
@@ -26,7 +28,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
   end
   let(:package_json_req_string) { "^1.4.0" }
 
-  let(:update_strategy) { "bump_versions" }
+  let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
   let(:latest_resolvable_version) { "1.5.0" }
   let(:version_class) { Dependabot::NpmAndYarn::Version }
 
@@ -154,7 +156,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement having its version bumped" do
-      let(:update_strategy) { "bump_versions" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -325,7 +327,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement having its version bumped if required" do
-      let(:update_strategy) { "bump_versions_if_necessary" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -368,7 +370,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement being widened" do
-      let(:update_strategy) { "widen_ranges" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
 
       context "when there is a resolvable version" do
         let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
@@ -609,7 +611,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
     end
 
     context "for a requirement being left alone" do
-      let(:update_strategy) { "lockfile_only" }
+      let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it "does not update any requirements" do
         expect(updater.updated_requirements).to eq(requirements)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -871,7 +871,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           requirements: dependency_requirements,
           updated_source: nil,
           latest_resolvable_version: "1.7.0",
-          update_strategy: :bump_versions
+          update_strategy: "bump_versions"
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -905,7 +905,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.2.1",
-            update_strategy: :bump_versions
+            update_strategy: "bump_versions"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -928,7 +928,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           ignored_versions: ignored_versions,
           security_advisories: security_advisories,
-          requirements_update_strategy: :bump_versions_if_necessary
+          requirements_update_strategy: "bump_versions_if_necessary"
         )
       end
 
@@ -939,7 +939,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.7.0",
-            update_strategy: :bump_versions_if_necessary
+            update_strategy: "bump_versions_if_necessary"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -966,7 +966,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.7.0",
-            update_strategy: :widen_ranges
+            update_strategy: "widen_ranges"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -1047,7 +1047,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               ref: "master"
             },
             latest_resolvable_version: "4.0.0",
-            update_strategy: :bump_versions
+            update_strategy: "bump_versions"
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -1081,7 +1081,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 ref: "master"
               },
               latest_resolvable_version: "4.0.0",
-              update_strategy: :bump_versions
+              update_strategy: "bump_versions"
             )
             .and_call_original
           expect(checker.updated_requirements)
@@ -1138,7 +1138,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: nil,
-            update_strategy: :widen_ranges
+            update_strategy: "widen_ranges"
           )
           .and_call_original
 
@@ -1204,7 +1204,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { :lockfile_only }
+      let(:requirements_update_strategy) { "lockfile_only" }
 
       it { is_expected.to eq(false) }
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -2,10 +2,12 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dependabot/dependency"
+
 require "dependabot/dependency_file"
-require "dependabot/npm_and_yarn/update_checker"
+require "dependabot/dependency"
 require "dependabot/npm_and_yarn/metadata_finder"
+require "dependabot/npm_and_yarn/update_checker"
+require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
@@ -871,7 +873,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           requirements: dependency_requirements,
           updated_source: nil,
           latest_resolvable_version: "1.7.0",
-          update_strategy: "bump_versions"
+          update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
         )
         .and_call_original
       expect(checker.updated_requirements)
@@ -905,7 +907,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.2.1",
-            update_strategy: "bump_versions"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -928,7 +930,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           ignored_versions: ignored_versions,
           security_advisories: security_advisories,
-          requirements_update_strategy: "bump_versions_if_necessary"
+          requirements_update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
         )
       end
 
@@ -939,7 +941,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.7.0",
-            update_strategy: "bump_versions_if_necessary"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -966,7 +968,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: "1.7.0",
-            update_strategy: "widen_ranges"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::WidenRanges
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -1047,7 +1049,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               ref: "master"
             },
             latest_resolvable_version: "4.0.0",
-            update_strategy: "bump_versions"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
           )
           .and_call_original
         expect(checker.updated_requirements)
@@ -1081,7 +1083,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 ref: "master"
               },
               latest_resolvable_version: "4.0.0",
-              update_strategy: "bump_versions"
+              update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
             )
             .and_call_original
           expect(checker.updated_requirements)
@@ -1138,7 +1140,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: nil,
             latest_resolvable_version: nil,
-            update_strategy: "widen_ranges"
+            update_strategy: Dependabot::RequirementsUpdateStrategy::WidenRanges
           )
           .and_call_original
 
@@ -1204,7 +1206,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { "lockfile_only" }
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it { is_expected.to eq(false) }
     end

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -335,11 +335,11 @@ module Dependabot
       # strategies.
       def constraint_field_from_update_strategy(requirements_update_strategy)
         case requirements_update_strategy
-        when :widen_ranges
+        when "widen_ranges"
           "constraintWidened"
-        when :bump_versions
+        when "bump_versions"
           "constraintBumped"
-        when :bump_versions_if_necessary
+        when "bump_versions_if_necessary"
           "constraintBumpedIfNeeded"
         end
       end

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -7,8 +7,9 @@ require "digest"
 
 require "dependabot/errors"
 require "dependabot/logger"
-require "dependabot/shared_helpers"
 require "dependabot/pub/requirement"
+require "dependabot/requirements_update_strategy"
+require "dependabot/shared_helpers"
 
 module Dependabot
   module Pub
@@ -335,11 +336,11 @@ module Dependabot
       # strategies.
       def constraint_field_from_update_strategy(requirements_update_strategy)
         case requirements_update_strategy
-        when "widen_ranges"
+        when RequirementsUpdateStrategy::WidenRanges
           "constraintWidened"
-        when "bump_versions"
+        when RequirementsUpdateStrategy::BumpVersions
           "constraintBumped"
-        when "bump_versions_if_necessary"
+        when RequirementsUpdateStrategy::BumpVersionsIfNecessary
           "constraintBumpedIfNeeded"
         end
       end

--- a/pub/lib/dependabot/pub/update_checker.rb
+++ b/pub/lib/dependabot/pub/update_checker.rb
@@ -156,7 +156,7 @@ module Dependabot
 
       def resolve_requirements_update_strategy
         raise "Unexpected requirements_update_strategy #{requirements_update_strategy}" unless
-          [nil, :widen_ranges, :bump_versions, :bump_versions_if_necessary].include? requirements_update_strategy
+          [nil, "widen_ranges", "bump_versions", "bump_versions_if_necessary"].include? requirements_update_strategy
 
         if requirements_update_strategy.nil?
           # Check for a version field in the pubspec.yaml. If it is present
@@ -167,12 +167,12 @@ module Dependabot
           begin
             parsed_pubspec = YAML.safe_load(T.must(pubspec.content), aliases: false)
           rescue ScriptError
-            return :bump_versions
+            return "bump_versions"
           end
           if parsed_pubspec["version"].nil? || parsed_pubspec["publish_to"] == "none"
-            :bump_versions
+            "bump_versions"
           else
-            :widen_ranges
+            "widen_ranges"
           end
         else
           requirements_update_strategy

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions strategy" do
-        let(:requirements_update_strategy) { :bump_versions }
+        let(:requirements_update_strategy) { "bump_versions" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -186,7 +186,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions_if_necessary strategy" do
-        let(:requirements_update_strategy) { :bump_versions_if_necessary }
+        let(:requirements_update_strategy) { "bump_versions_if_necessary" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -203,7 +203,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with widen_ranges strategy" do
-        let(:requirements_update_strategy) { :widen_ranges }
+        let(:requirements_update_strategy) { "widen_ranges" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -308,7 +308,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions strategy" do
-        let(:requirements_update_strategy) { :bump_versions }
+        let(:requirements_update_strategy) { "bump_versions" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -326,7 +326,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions_if_necessary strategy" do
-        let(:requirements_update_strategy) { :bump_versions_if_necessary }
+        let(:requirements_update_strategy) { "bump_versions_if_necessary" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -344,7 +344,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with widen_ranges strategy" do
-        let(:requirements_update_strategy) { :widen_ranges }
+        let(:requirements_update_strategy) { "widen_ranges" }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -704,7 +704,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       ref
     end
     let(:requirements_to_unlock) { :all }
-    let(:requirements_update_strategy) { :bump_versions_if_necessary }
+    let(:requirements_update_strategy) { "bump_versions_if_necessary" }
 
     it "updates to latest git commit" do
       dependency_version # triggers the initial commit.

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -2,10 +2,12 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dependabot/dependency"
-require "dependabot/dependency_file"
-require "dependabot/pub/update_checker"
 require "webrick"
+
+require "dependabot/dependency_file"
+require "dependabot/dependency"
+require "dependabot/pub/update_checker"
+require "dependabot/requirements_update_strategy"
 
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
@@ -169,7 +171,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions strategy" do
-        let(:requirements_update_strategy) { "bump_versions" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -186,7 +188,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions_if_necessary strategy" do
-        let(:requirements_update_strategy) { "bump_versions_if_necessary" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -203,7 +205,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with widen_ranges strategy" do
-        let(:requirements_update_strategy) { "widen_ranges" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -308,7 +310,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions strategy" do
-        let(:requirements_update_strategy) { "bump_versions" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersions }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -326,7 +328,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with bump_versions_if_necessary strategy" do
-        let(:requirements_update_strategy) { "bump_versions_if_necessary" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -344,7 +346,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         end
       end
       context "with widen_ranges strategy" do
-        let(:requirements_update_strategy) { "widen_ranges" }
+        let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
         it "can update" do
           expect(can_update).to be_truthy
           expect(updated_dependencies).to eq [
@@ -704,7 +706,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       ref
     end
     let(:requirements_to_unlock) { :all }
-    let(:requirements_update_strategy) { "bump_versions_if_necessary" }
+    let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary }
 
     it "updates to latest git commit" do
       dependency_version # triggers the initial commit.

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -80,15 +80,15 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != :lockfile_only
+        requirements_update_strategy != "lockfile_only"
       end
 
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
-        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+        return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, check if this is a library or not
-        library? ? :widen_ranges : :bump_versions
+        library? ? "widen_ranges" : "bump_versions"
       end
 
       private

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -5,13 +5,14 @@ require "excon"
 require "toml-rb"
 
 require "dependabot/dependency"
+require "dependabot/errors"
+require "dependabot/python/name_normaliser"
+require "dependabot/python/requirement_parser"
+require "dependabot/python/requirement"
+require "dependabot/registry_client"
+require "dependabot/requirements_update_strategy"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/registry_client"
-require "dependabot/errors"
-require "dependabot/python/requirement"
-require "dependabot/python/requirement_parser"
-require "dependabot/python/name_normaliser"
 
 module Dependabot
   module Python
@@ -80,7 +81,7 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        requirements_update_strategy != "lockfile_only"
+        requirements_update_strategy != RequirementsUpdateStrategy::LockfileOnly
       end
 
       def requirements_update_strategy
@@ -88,7 +89,7 @@ module Dependabot
         return @requirements_update_strategy if @requirements_update_strategy
 
         # Otherwise, check if this is a library or not
-        library? ? "widen_ranges" : "bump_versions"
+        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
       end
 
       private

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -31,7 +31,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
+          return requirements if update_strategy == "lockfile_only"
 
           requirements.map do |req|
             case req[:file]
@@ -89,9 +89,9 @@ module Dependabot
           return update_pyproject_version(req) if req.fetch(:groups).include?("dev-dependencies")
 
           case update_strategy
-          when :widen_ranges then widen_pyproject_requirement(req)
-          when :bump_versions then update_pyproject_version(req)
-          when :bump_versions_if_necessary then update_pyproject_version_if_needed(req)
+          when "widen_ranges" then widen_pyproject_requirement(req)
+          when "bump_versions" then update_pyproject_version(req)
+          when "bump_versions_if_necessary" then update_pyproject_version_if_needed(req)
           else raise "Unexpected update strategy: #{update_strategy}"
           end
         rescue UnfixableRequirement
@@ -190,11 +190,11 @@ module Dependabot
           return req unless req.fetch(:requirement)
 
           case update_strategy
-          when :widen_ranges
+          when "widen_ranges"
             widen_requirement(req)
-          when :bump_versions
+          when "bump_versions"
             update_requirement(req)
-          when :bump_versions_if_necessary
+          when "bump_versions_if_necessary"
             update_requirement_if_needed(req)
           else
             raise "Unexpected update strategy: #{update_strategy}"

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -2,9 +2,10 @@
 # frozen_string_literal: true
 
 require "dependabot/python/requirement_parser"
+require "dependabot/python/requirement"
 require "dependabot/python/update_checker"
 require "dependabot/python/version"
-require "dependabot/python/requirement"
+require "dependabot/requirements_update_strategy"
 
 module Dependabot
   module Python
@@ -31,7 +32,7 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == "lockfile_only"
+          return requirements if update_strategy == RequirementsUpdateStrategy::LockfileOnly
 
           requirements.map do |req|
             case req[:file]
@@ -89,9 +90,9 @@ module Dependabot
           return update_pyproject_version(req) if req.fetch(:groups).include?("dev-dependencies")
 
           case update_strategy
-          when "widen_ranges" then widen_pyproject_requirement(req)
-          when "bump_versions" then update_pyproject_version(req)
-          when "bump_versions_if_necessary" then update_pyproject_version_if_needed(req)
+          when RequirementsUpdateStrategy::WidenRanges then widen_pyproject_requirement(req)
+          when RequirementsUpdateStrategy::BumpVersions then update_pyproject_version(req)
+          when RequirementsUpdateStrategy::BumpVersionsIfNecessary then update_pyproject_version_if_needed(req)
           else raise "Unexpected update strategy: #{update_strategy}"
           end
         rescue UnfixableRequirement
@@ -190,11 +191,11 @@ module Dependabot
           return req unless req.fetch(:requirement)
 
           case update_strategy
-          when "widen_ranges"
+          when RequirementsUpdateStrategy::WidenRanges
             widen_requirement(req)
-          when "bump_versions"
+          when RequirementsUpdateStrategy::BumpVersions
             update_requirement(req)
-          when "bump_versions_if_necessary"
+          when RequirementsUpdateStrategy::BumpVersionsIfNecessary
             update_requirement_if_needed(req)
           else
             raise "Unexpected update strategy: #{update_strategy}"

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
     )
   end
 
-  let(:update_strategy) { :bump_versions }
+  let(:update_strategy) { "bump_versions" }
   let(:requirements) { [requirement_txt_req, setup_py_req, setup_cfg_req].compact }
   let(:requirement_txt_req) do
     {
@@ -150,13 +150,13 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             its([:requirement]) { is_expected.to eq("~=1.5") }
 
             context "with the bump_versions_if_necessary update strategy" do
-              let(:update_strategy) { :bump_versions_if_necessary }
+              let(:update_strategy) { "bump_versions_if_necessary" }
 
               its([:requirement]) { is_expected.to eq("~=1.3") }
             end
 
             context "with the widen_ranges update strategy" do
-              let(:update_strategy) { :widen_ranges }
+              let(:update_strategy) { "widen_ranges" }
 
               its([:requirement]) { is_expected.to eq("~=1.3") }
             end
@@ -168,13 +168,13 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             its([:requirement]) { is_expected.to eq("~=2.1") }
 
             context "with the bump_versions_if_necessary update strategy" do
-              let(:update_strategy) { :bump_versions_if_necessary }
+              let(:update_strategy) { "bump_versions_if_necessary" }
 
               its([:requirement]) { is_expected.to eq("~=2.1") }
             end
 
             context "with the widen_ranges update strategy" do
-              let(:update_strategy) { :widen_ranges }
+              let(:update_strategy) { "widen_ranges" }
 
               its([:requirement]) { is_expected.to eq(">=1.3,<3.0") }
             end
@@ -468,7 +468,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
 
             context "and a ^ requirement was specified" do
               let(:pyproject_req_string) { "^1.3.0" }
-              its([:requirement]) { is_expected.to eq(update_strategy == :bump_versions ? "^1.5.0" : "^1.3.0") }
+              its([:requirement]) { is_expected.to eq(update_strategy == "bump_versions" ? "^1.5.0" : "^1.3.0") }
 
               context "without a lockfile" do
                 let(:has_lockfile) { false }
@@ -507,7 +507,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
       end
 
       context "when asked to widen ranges" do
-        let(:update_strategy) { :widen_ranges }
+        let(:update_strategy) { "widen_ranges" }
 
         context "when there is no resolvable version" do
           let(:latest_resolvable_version) { nil }
@@ -652,7 +652,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
       end
 
       context "when asked to not change requirements" do
-        let(:update_strategy) { :lockfile_only }
+        let(:update_strategy) { "lockfile_only" }
 
         it "does not update any requirements" do
           expect(updated_requirements).to eq(requirements)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
       subject { updated_requirements.find { |r| r[:file] == "pyproject.toml" } }
       let(:pyproject_req_string) { "*" }
 
-      %i(bump_versions bump_versions_if_necessary).each do |update_strategy|
+      %w(bump_versions bump_versions_if_necessary).each do |update_strategy|
         context "when asked to #{update_strategy}" do
           let(:update_strategy) { update_strategy }
 

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -772,7 +772,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { :lockfile_only }
+      let(:requirements_update_strategy) { "lockfile_only" }
 
       it { is_expected.to eq(false) }
     end

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -2,9 +2,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dependabot/dependency"
+
 require "dependabot/dependency_file"
+require "dependabot/dependency"
 require "dependabot/python/update_checker"
+require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Python::UpdateChecker do
@@ -772,7 +774,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
     it { is_expected.to eq(true) }
 
     context "with the lockfile-only requirements update strategy set" do
-      let(:requirements_update_strategy) { "lockfile_only" }
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it { is_expected.to eq(false) }
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,13 +1,15 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "dependabot/credential"
+require "wildcard_matcher"
+
 require "dependabot/config/ignore_condition"
 require "dependabot/config/update_config"
+require "dependabot/credential"
 require "dependabot/dependency_group_engine"
 require "dependabot/experiments"
+require "dependabot/requirements_update_strategy"
 require "dependabot/source"
-require "wildcard_matcher"
 
 # Describes a single Dependabot workload within the GitHub-integrated Service
 #
@@ -72,7 +74,7 @@ module Dependabot
     sig { returns(String) }
     attr_reader :package_manager
 
-    sig { returns(T.nilable(String)) }
+    sig { returns(T.nilable(Dependabot::RequirementsUpdateStrategy)) }
     attr_reader :requirements_update_strategy
 
     sig { returns(T::Array[T.untyped]) }
@@ -154,7 +156,7 @@ module Dependabot
 
       @requirements_update_strategy   = T.let(build_update_strategy(
                                                 **attributes.slice(:requirements_update_strategy, :lockfile_only)
-                                              ), T.nilable(String))
+                                              ), T.nilable(Dependabot::RequirementsUpdateStrategy))
 
       @security_advisories            = T.let(attributes.fetch(:security_advisories), T::Array[T.untyped])
       @security_updates_only          = T.let(attributes.fetch(:security_updates_only), T::Boolean)
@@ -414,12 +416,18 @@ module Dependabot
     end
 
     sig do
-      params(requirements_update_strategy: T.nilable(String), lockfile_only: T::Boolean).returns(T.nilable(String))
+      params(
+        requirements_update_strategy: T.nilable(String),
+        lockfile_only: T::Boolean
+      )
+        .returns(T.nilable(Dependabot::RequirementsUpdateStrategy))
     end
     def build_update_strategy(requirements_update_strategy:, lockfile_only:)
-      return requirements_update_strategy unless requirements_update_strategy.nil?
+      unless requirements_update_strategy.nil?
+        return RequirementsUpdateStrategy.deserialize(requirements_update_strategy)
+      end
 
-      lockfile_only ? "lockfile_only" : nil
+      lockfile_only ? RequirementsUpdateStrategy::LockfileOnly : nil
     end
 
     sig { params(source_details: T::Hash[String, T.untyped]).returns(Dependabot::Source) }

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -290,7 +290,7 @@ module Dependabot
         return unless checker.respond_to?(:requirements_update_strategy)
 
         Dependabot.logger.info(
-          "Requirements update strategy #{checker.requirements_update_strategy}"
+          "Requirements update strategy #{checker.requirements_update_strategy&.serialize}"
         )
       end
 

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -195,7 +195,7 @@ module Dependabot
           return unless checker.respond_to?(:requirements_update_strategy)
 
           Dependabot.logger.info(
-            "Requirements update strategy #{checker.requirements_update_strategy}"
+            "Requirements update strategy #{checker.requirements_update_strategy&.serialize}"
           )
         end
 

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -190,7 +190,7 @@ module Dependabot
           return unless checker.respond_to?(:requirements_update_strategy)
 
           Dependabot.logger.info(
-            "Requirements update strategy #{checker.requirements_update_strategy}"
+            "Requirements update strategy #{checker.requirements_update_strategy&.serialize}"
           )
         end
 

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -195,7 +195,7 @@ module Dependabot
           return unless checker.respond_to?(:requirements_update_strategy)
 
           Dependabot.logger.info(
-            "Requirements update strategy #{checker.requirements_update_strategy}"
+            "Requirements update strategy #{checker.requirements_update_strategy&.serialize}"
           )
         end
 

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -230,7 +230,7 @@ module Dependabot
           return unless checker.respond_to?(:requirements_update_strategy)
 
           Dependabot.logger.info(
-            "Requirements update strategy #{checker.requirements_update_strategy}"
+            "Requirements update strategy #{checker.requirements_update_strategy&.serialize}"
           )
         end
 

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Dependabot::Job do
   let(:dependencies) { nil }
   let(:security_advisories) { [] }
   let(:package_manager) { "bundler" }
-  let("lockfile_only") { false }
+  let(:lockfile_only) { false }
   let(:security_updates_only) { false }
   let(:allowed_updates) do
     [
@@ -142,10 +142,10 @@ RSpec.describe Dependabot::Job do
   end
 
   context "when lockfile_only is passed as true" do
-    let("lockfile_only") { true }
+    let(:lockfile_only) { true }
 
     it "infers a lockfile_only requirements_update_strategy" do
-      expect(subject.requirements_update_strategy).to eq("lockfile_only")
+      expect(subject.requirements_update_strategy).to eq(Dependabot::RequirementsUpdateStrategy::LockfileOnly)
     end
   end
 

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Dependabot::Job do
   let(:dependencies) { nil }
   let(:security_advisories) { [] }
   let(:package_manager) { "bundler" }
-  let(:lockfile_only) { false }
+  let("lockfile_only") { false }
   let(:security_updates_only) { false }
   let(:allowed_updates) do
     [
@@ -142,7 +142,7 @@ RSpec.describe Dependabot::Job do
   end
 
   context "when lockfile_only is passed as true" do
-    let(:lockfile_only) { true }
+    let("lockfile_only") { true }
 
     it "infers a lockfile_only requirements_update_strategy" do
       expect(subject.requirements_update_strategy).to eq("lockfile_only")

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Dependabot::Updater do
 
     context "when the checker has an requirements update strategy" do
       it "logs the update requirements and strategy" do
-        stub_update_checker(requirements_update_strategy: "bump_versions")
+        stub_update_checker(requirements_update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions)
 
         job = build_job
         service = build_service

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Dependabot::Updater do
 
     context "when the checker has an requirements update strategy" do
       it "logs the update requirements and strategy" do
-        stub_update_checker(requirements_update_strategy: :bump_versions)
+        stub_update_checker(requirements_update_strategy: "bump_versions")
 
         job = build_job
         service = build_service


### PR DESCRIPTION
From an example stack trace

```
Parameter 'requirements_update_strategy': Expected type T.nilable(Symbol), got type String with value "widen_ranges"
Caller: /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:135
Definition: /home/dependabot/common/lib/dependabot/update_checkers/base.rb:61
```