### PR TITLE
Add `recurse_submodules_when_cloning` to `cargo`

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -57,6 +57,10 @@ module Dependabot
 
       private
 
+      def recurse_submodules_when_cloning?
+        true
+      end
+
       def fetch_path_dependency_and_workspace_files(files = nil)
         fetched_files = files || [cargo_toml]
 


### PR DESCRIPTION
I work with a lot of Rust projects that use path-based dependencies from submodules. These projects have been structured that way for a long time, and Dependabot updates have been enabled and working for a long time. Recently, I've noticed that _some_ of those projects have started encountering the same situation described by #8428. Using `bin/dry-run.rb`, I found that even for my projects that are currently getting updates, I get dependency resolution errors. Adding the `recurse_submodules_when_cloning` implementation enables `bin/dry-run.rb` to consistently succeed.

The errors that I have seen in `bin/dry-run.rb` actually come in two flavors, and I cannot explain the difference in the projects where I see the second form.

Error 1:
```
[dependabot-core-dev] ~ $ LOCAL_GITHUB_ACCESS_TOKEN=<token> bin/dry-run.rb cargo myorg/myproject
=> cloning into /home/dependabot/tmp/myorg/myproject
 => handled error whilst fetching dependencies: path_dependencies_not_reachable {:dependencies=>["my_submodule/Cargo.toml"]}
```

Error 2:
```
[dependabot-core-dev] ~ $ LOCAL_GITHUB_ACCESS_TOKEN=<token> bin/dry-run.rb cargo myorg/myproject
=> cloning into /home/dependabot/tmp/myorg/myproject
🎈 Ecosystem Versions log: {:package_managers=>{"cargo"=>"default"}}
=> parsing dependency files
=> updating 12 dependencies: my_submodule, anyhow, base64, clap, env_logger, futures, log, reqwest, serde_json, time, tokio, uuid

=== my_submodule (0.1.0)
 => checking for updates 1/12
 => latest available version is
 => latest allowed version is 0.1.0
 => requirements to unlock: update_not_possible
 => requirements update strategy: bump_versions
    (no update possible 🙅‍♀️)

=== anyhow (1.0.68)
 => checking for updates 2/12
🌍 --> GET https://crates.io/api/v1/crates/anyhow
🌍 <-- 200 https://crates.io/api/v1/crates/anyhow
 => latest available version is 1.0.80
/home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:153:in `run_cargo_command': error: failed to get `my_submodule` as a dependency of package `myproject v0.1.0 (dependabot_tmp_dir)` (Dependabot::SharedHelpers::HelperSubprocessFailed)

Caused by:
  failed to load source for dependency `my_submodule`

Caused by:
  Unable to update dependabot_tmp_dir/my_submodule

Caused by:
  failed to read `dependabot_tmp_dir/my_submodule/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:137:in `run_cargo_update_command'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:47:in `block (2 levels) in fetch_latest_resolvable_version'
        from /home/dependabot/common/lib/dependabot/shared_helpers.rb:265:in `with_git_configured'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:272:in `bind_call'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:272:in `validate_call'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:193:in `block in create_validator_slow'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:46:in `block in fetch_latest_resolvable_version'
        from /home/dependabot/common/lib/dependabot/shared_helpers.rb:81:in `block in in_a_temporary_directory'
        from /home/dependabot/common/lib/dependabot/shared_helpers.rb:81:in `chdir'
        from /home/dependabot/common/lib/dependabot/shared_helpers.rb:81:in `in_a_temporary_directory'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:272:in `bind_call'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/call_validation.rb:272:in `validate_call'
        from /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/sorbet-runtime-0.5.11193/lib/types/private/methods/_methods.rb:272:in `block in _on_method_added'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:43:in `fetch_latest_resolvable_version'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb:33:in `latest_resolvable_version'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker.rb:220:in `fetch_latest_resolvable_version'
        from /home/dependabot/cargo/lib/dependabot/cargo/update_checker.rb:42:in `latest_resolvable_version'
        from bin/dry-run.rb:658:in `block in <main>'
        from bin/dry-run.rb:620:in `each'
        from bin/dry-run.rb:620:in `<main>'
```

While I can't explain the difference, adding `recurse_submodules_when_cloning` fixes both.

I also don't understand why this only recently seems to have become a problem, and only in some projects and not others. From what I have seen, this should be failing consistently and should have never worked in the first place. Unfortunately, I only have private repos where things are working, so I can't share a working example. I created a pair of public repos to demonstrate one of the failure cases (it encounters error 1 from above):

https://github.com/mweber15/dependabot-test-shell

Submodule: https://github.com/mweber15/dependabot-test-submodule

Dependabot attempting to create a PR but failing: https://github.com/mweber15/dependabot-test-shell/security/dependabot/1

```
updater | 2024/03/01 17:14:47 ERROR <job_794727072> Error during file fetching; aborting: The following path based dependencies could not be retrieved: dependabot-test-submodule/Cargo.toml
updater | 2024/03/01 17:14:48 INFO <job_794727072> Finished job processing
updater | 2024/03/01 17:14:48 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +---------------------------------+
updater | |             Errors              |
updater | +---------------------------------+
updater | | path_dependencies_not_reachable |
updater | +---------------------------------+
```
