### PR TITLE
Record Sorbet errors with OpenTelemetry

### DIFF
--- a/updater/lib/dependabot/sorbet/runtime.rb
+++ b/updater/lib/dependabot/sorbet/runtime.rb
@@ -16,6 +16,7 @@ module Dependabot
           error.set_backtrace(caller.dup)
 
           ::Sentry.capture_exception(error)
+          ::Dependabot::OpenTelemetry.record_exception(error: error)
         end
       end
     end


### PR DESCRIPTION
Sorbet errors are currently sent to Sentry. This change also sends them via OpenTelemetry.