### PR TITLE
use built-in file downloader to get `.nupkg`

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -111,7 +111,9 @@ module Dependabot
         current_redirects = 0
 
         loop do
-          connection = Excon.new(current_url, persistent: true)
+          # `omit_default_port` is required so that ":80" and ":443" aren't added to the URL because some authenticated
+          # NuGet feeds calculate auth tokens based on the URL and this changes the calculation via the proxy
+          connection = Excon.new(current_url, persistent: true, omit_default_port: true)
 
           package_data = StringIO.new
           response_block = lambda do |chunk, _remaining_bytes, _total_bytes|

--- a/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nupkg_fetcher.rb
@@ -111,27 +111,13 @@ module Dependabot
         current_redirects = 0
 
         loop do
-          # `omit_default_port` is required so that ":80" and ":443" aren't added to the URL because some authenticated
-          # NuGet feeds calculate auth tokens based on the URL and this changes the calculation via the proxy
-          connection = Excon.new(current_url, persistent: true, omit_default_port: true)
-
-          package_data = StringIO.new
-          response_block = lambda do |chunk, _remaining_bytes, _total_bytes|
-            package_data.write(chunk)
-          end
-
-          response = connection.request(
-            method: :get,
-            headers: auth_header,
-            response_block: response_block
-          )
+          response = fetch_url_with_auth(current_url, auth_header)
 
           # redirect the HTTP response as appropriate based on documentation here:
           # https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
           case response.status
           when 200
-            package_data.rewind
-            return package_data
+            return response.body
           when 301, 302, 303, 307, 308
             current_redirects += 1
             return nil if current_redirects > max_redirects
@@ -144,10 +130,14 @@ module Dependabot
       end
 
       def self.fetch_url(url, repository_details)
+        fetch_url_with_auth(url, repository_details.fetch(:auth_header))
+      end
+
+      def self.fetch_url_with_auth(url, auth_header)
         cache = CacheManager.cache("nupkg_fetcher_cache")
         cache[url] ||= Dependabot::RegistryClient.get(
           url: url,
-          headers: repository_details.fetch(:auth_header)
+          headers: auth_header
         )
 
         cache[url]

--- a/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/nupkg_fetcher_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Dependabot::Nuget::NupkgFetcher do
     end
 
     it "fetches the nupkg after multiple redirects" do
-      expect(nupkg_buffer.string).to eq("the final contents")
+      expect(nupkg_buffer.to_s).to eq("the final contents")
     end
   end
 end


### PR DESCRIPTION
Some authenticated NuGet feeds (e.g., AWS CodeArtifact) handle `.nupkg` downloads with a `307` redirect with a signed URL and that redirect (from the response header `Location: <redirected-url>`) must be used _exactly_ for it to work, otherwise it's reported as a signing failure.  The fix is to use the built-in file downloader (`RegistryClient.get`) because it sets `omit_default_port: true` to prevent `:443` from getting appended to the host.

I couldn't find a meaningful way to test this since there's no way to see if the port was manually specified or if it was inferred.  I did, however, run a manual test with an AWS CodeArtifact NuGet feed.