### PR TITLE
Minor: Proper path for bunlder native helpers

### DIFF
--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -88,7 +88,7 @@ module Dependabot
       sig { returns(String) }
       def self.native_helpers_root
         helpers_root = ENV.fetch("DEPENDABOT_NATIVE_HELPERS_PATH", nil)
-        return File.join(helpers_root, "bundler") unless helpers_root.nil?
+        return File.join(helpers_root, "bundler", "helpers") unless helpers_root.nil?
 
         File.expand_path("../../../helpers", __dir__)
       end


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-script?tab=readme-ov-file#native-helpers it is recommanded to install native helpers with:

![Screenshot_2024-03-04_22-50-30](https://github.com/dependabot/dependabot-core/assets/1866809/e8db1943-4660-40b4-9780-f6d3c9b7396f)

So if you do a loop with all package manger you would expect bundler helpers to be in `$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/helpers`

But currently expected path is ``$DEPENDABOT_NATIVE_HELPERS_PATH/bundler` which isn't consistent
