### PR TITLE
Avoid instantiating a dependency with nil requirements

### DIFF
--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -241,6 +241,7 @@ module Dependabot
             .reject { |dep| dep.name == dependency_name }
             .any? do |dep|
               next true if existing_pull_request([dep])
+              next false if dep.previous_requirements.nil?
 
               original_peer_dep = ::Dependabot::Dependency.new(
                 name: dep.name,


### PR DESCRIPTION
We are seeing sorbet runtime exceptions caused by attempting to instantiate a dependency with nil requirements, when an array of hashes is expected. This is happening during a check that uses a dependency's `previous_requirements`, which may be nil, as the `requirements` when instantiating a new dependency.

https://github.com/dependabot/dependabot-core/blob/795dafedf31666de6e91b078b799fd7f2517478b/updater/lib/dependabot/updater/operations/update_all_versions.rb#L245-L250

This PR fixes this by bailing if `previous_requirements` is nil.

Fixes #9215 