### PR TITLE
Only use credentials that have `registry` key when building `.npmrc`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -224,6 +224,8 @@ module Dependabot
         def credential_lines_for_npmrc
           lines = []
           registry_credentials.each do |cred|
+            next unless cred["registry"]
+
             registry = cred.fetch("registry")
 
             lines += registry_scopes(registry) if registry_scopes(registry)


### PR DESCRIPTION
It looks like #9159 and https://github.com/dependabot/cli/pull/290 were only partial fixes. We are still seeing these stack traces:

```
Error processing ... (KeyError)
key not found: "registry"
/usr/local/lib/ruby/3.1.0/forwardable.rb:238:in `fetch'
/usr/local/lib/ruby/3.1.0/forwardable.rb:238:in `fetch'
/home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb:227:in `block in credential_lines_for_npmrc'
