### PR TITLE
Add handling for nil `source_url` in `IssueLinker` when generating PR text

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
@@ -21,10 +21,10 @@ module Dependabot
           /\[(?<tag>(?:\#|GH-)?\d+)\]\(\)/i
         ].freeze, T::Array[Regexp])
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_reader :source_url
 
-        sig { params(source_url: String).void }
+        sig { params(source_url: T.nilable(String)).void }
         def initialize(source_url:)
           @source_url = source_url
         end
@@ -46,9 +46,18 @@ module Dependabot
                      .match("#{REPO_REGEX}#{TAG_REGEX}")
                      &.named_captures
                      &.fetch("repo", nil)
-              source = repo ? "https://github.com/#{repo}" : source_url
 
-              "[#{repo ? (repo + tag) : tag}](#{source}/issues/#{number})"
+              source = if repo
+                         "https://github.com/#{repo}"
+                       elsif source_url
+                         source_url
+                       end
+
+              if source
+                "[#{repo ? (repo + tag) : tag}](#{source}/issues/#{number})"
+              else
+                issue_link
+              end
             end
           end
         end


### PR DESCRIPTION
We are seeing sorbet runtime exceptions when generating issue links during PR creation because a method is returning a nil `source_url` where a string is expected.

The exceptions are coming from `IssueLinker`:

https://github.com/dependabot/dependabot-core/blob/795dafedf31666de6e91b078b799fd7f2517478b/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb#L49

`IssueLinker` [expects a non-nil `source_url`](https://github.com/dependabot/dependabot-core/blob/795dafedf31666de6e91b078b799fd7f2517478b/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb#L27-L30) in its initializer, so internally it expects `source_url` to be a non-nil string.

`IssueLinker` is [instantiated by `MetadataPresenter`](https://github.com/dependabot/dependabot-core/blob/6357b576ca6c5061d7423273dfd2489b58363c58/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb#L241-L243) using the latter's `source_url`, which is actually [`def_delegate`d](https://github.com/dependabot/dependabot-core/blob/795dafedf31666de6e91b078b799fd7f2517478b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb#L29-L39) to `MetadataFinders::Base`'s `source_url`, which [may return nil](https://github.com/dependabot/dependabot-core/blob/795dafedf31666de6e91b078b799fd7f2517478b/common/lib/dependabot/metadata_finders/base.rb#L38-L45).

The best way to resolve this isn't totally obvious. I am posing a strawman in this PR and welcome alternatives. I have updated the signature of the `source_url` initializer argument and attr_reader in `IssueLinker` to match that of `MetadataFinders::Base#source_url`, i.e., to `T.nilable(String)`, and in `IssueLinker#link_issues`, the method from which these runtime exceptions are originating, I have added handling to return the original link text without a markdown link if a valid source cannot be determined.

Closes #9217
Closes #9221