### PR TITLE
report the current version as latest if nothing can be found

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -17,7 +17,8 @@ module Dependabot
         # No need to find latest version for transitive dependencies unless they have a vulnerability.
         return dependency.version if !dependency.top_level? && !vulnerable?
 
-        @latest_version = latest_version_details&.fetch(:version)
+        # if no update sources have the requisite package, then we can only assume that the current version is correct
+        @latest_version = latest_version_details&.fetch(:version) || dependency.version
       end
 
       def latest_resolvable_version

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
     "https://api.nuget.org/v3-flatcontainer/#{name.downcase}/#{version}/#{name.downcase}.nuspec"
   end
 
+  def registration_index_url(name)
+    "https://api.nuget.org/v3/registration5-gz-semver2/#{name.downcase}/index.json"
+  end
+
   describe "up_to_date?" do
     subject(:up_to_date?) { checker.up_to_date? }
 
@@ -102,6 +106,17 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         .and_return(version: "dummy_version")
 
       expect(checker.latest_version).to eq("dummy_version")
+    end
+
+    context "the package could not be found on any source" do
+      before do
+        stub_request(:get, registration_index_url("microsoft.extensions.dependencymodel"))
+          .to_return(status: 404)
+      end
+
+      it "reports the current version" do
+        expect(checker.latest_version).to eq("1.1.1")
+      end
     end
   end
 


### PR DESCRIPTION
When checking for updated packages, it's possible that none of the queried sources has that package.  The result is that `UpdateChecker.latest_version` can be `nil` which leads to all sorts of problems.

The fix is to report the currently installed package version as latest if nothing could be found.  This situation was found where a user is running dependabot on their repo with only their own private NuGet feed, specifically so they could always be up-to-date with their internal organization.  During this update process, the dependency `Newtonsoft.Json` version `13.0.3` was found, but since that's a public package, it wasn't found on their private feed.  The result was `undefined method 'fetch' for nil:NilClass`.  That is obviously incorrect, so in the instance where the package could not be found, it is simply reported as being up-to-date so no other action is attempted.

Fixes #9233