### PR TITLE
don't assume the `Include` attribute is present on a `<ProjectReference>` node

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -74,6 +74,8 @@ module Dependabot
           ref_nodes = proj_refs + proj_files
           ref_nodes.each do |project_reference_node|
             dep_file = get_attribute_value(project_reference_node, "Include")
+            next unless dep_file
+
             full_project_path = full_path(project_file, dep_file)
             full_project_path = full_project_path[1..-1] if full_project_path.start_with?("/")
             full_project_paths = expand_wildcards_in_project_reference_path(full_project_path)

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -47,6 +47,30 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
     stub_search_results_with_versions_v3("system.collections.specialized", versions)
   end
 
+  describe "#downstream_file_references" do
+    subject(:downstream_file_references) { parser.downstream_file_references(project_file: file) }
+
+    context "when there is no `Include` or `Update` attribute on the `<PackageReference>`" do
+      let(:file_body) do
+        <<~XML
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <TargetFramework>net8.0</TargetFramework>
+            </PropertyGroup>
+            <ItemGroup>
+              <ProjectReference Exclude="Not.Used.Here.csproj" />
+              <ProjectReference Include="Some.Other.Project.csproj" />
+            </ItemGroup>
+          </Project>
+        XML
+      end
+
+      it "does not report that dependency" do
+        expect(downstream_file_references).to eq(Set["Some.Other.Project.csproj"])
+      end
+    end
+  end
+
   describe "dependency_set" do
     subject(:dependency_set) { parser.dependency_set(project_file: file) }
 


### PR DESCRIPTION
When parsing project references, we were assuming all of the elements looked like this:

``` xml
...
<ProjectReference Include="path\to\other.csproj" />
...
```

If that `Include` attribute isn't present, then we'll eventually throw with:

```
undefined method `tr' for nil:NilClass

          relative_path = ref_path.tr("\\", "/")
                                  ^^^
```

The fix is to simply skip processing that particular `<ProjectReference>` element if it doesn't have the requisite attribute.  Similar behavior is also present elsewhere in `project_file_parser.rb`, so it's a known pattern that we just missed applying here.

Of all of the current `undefined method '_' for nil:NilClass` errors in NuGet, this is the largest class.