### PR TITLE
improve robustness of parsing odd-looking version ranges

### DIFF
--- a/nuget/lib/dependabot/nuget/requirement.rb
+++ b/nuget/lib/dependabot/nuget/requirement.rb
@@ -60,6 +60,7 @@ module Dependabot
         convert_wildcard_req(req_string)
       end
 
+      # rubocop:disable Metrics/PerceivedComplexity
       def convert_dotnet_range_to_ruby_range(req_string)
         lower_b, upper_b = req_string.split(",").map(&:strip).map do |bound|
           next convert_range_wildcard_req(bound) if bound.include?("*")
@@ -75,7 +76,8 @@ module Dependabot
           end
 
         upper_b =
-          if [")", "]"].include?(upper_b) then nil
+          if !upper_b then nil
+          elsif [")", "]"].include?(upper_b) then nil
           elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
           else
             "<= #{upper_b.sub(/\s*\]/, '').strip}"
@@ -83,6 +85,7 @@ module Dependabot
 
         [lower_b, upper_b].compact
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def convert_range_wildcard_req(req_string)
         range_end = req_string[-1]

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -419,6 +419,16 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
     end
 
+    context "with an open upper version range specified" do
+      let(:dependency_files) { project_dependency_files("open_upper_version_range") }
+      let(:dependency_version) { "1.1.0" }
+      let(:dependency_requirements) do
+        [{ file: "my.csproj", requirement: "[1.1.0-alpha,", groups: ["dependencies"], source: nil }]
+      end
+
+      its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
+    end
+
     context "with a package that is implicitly referenced", :vcr do
       let(:dependency_files) { project_dependency_files("implicit_reference") }
       let(:dependency_requirements) do

--- a/nuget/spec/fixtures/projects/open_upper_version_range/my.csproj
+++ b/nuget/spec/fixtures/projects/open_upper_version_range/my.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[1.1.0-alpha," />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a package version range was oddly formed then it could eventually lead to

```
undefined method `end_with?' for nil:NilClass

          elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
                       ^^^^^^^^^^
```

The fix is to add another `nil` guard around the result of the string split.  This is done elsewhere in this same method, so it's a valid scenario for it to short-circuit with `nil` instead of assuming we got something as a result of the split.

There are no scenarios where we need to add a `nil` check to the `lower_b` variable; it's already guaranteed to have a value from the stack frame above it.