### PR TITLE
Fix the number of updated directories in a group update

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -233,10 +233,17 @@ module Dependabot
 
       sig { returns(String) }
       def group_pr_name
+        directories_from_dependencies = dependencies.map { |dep| dep.metadata[:directory] }.to_set
+
+        directories_with_updates = source.directories&.filter do |directory|
+          directories_from_dependencies.include?(directory)
+        end
+
         updates = dependencies.map(&:name).uniq.count
 
         if source.directories
-          "bump the #{T.must(dependency_group).name} across #{T.must(source.directories).count} directories " \
+          "bump the #{T.must(dependency_group).name} across #{directories_with_updates.count} "\
+            "#{if directories_with_updates.count > 1 then 'directories' else 'directory' end} "\
             "with #{updates} update#{'s' if updates > 1}"
         else
           "bump the #{T.must(dependency_group).name} group#{pr_name_directory} with #{updates} update#{if updates > 1

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -233,7 +233,7 @@ module Dependabot
 
       sig { returns(String) }
       def group_pr_name
-        directories_from_dependencies = dependencies.map { |dep| dep.metadata[:directory] }.to_set
+        directories_from_dependencies = dependencies.to_set { |dep| dep.metadata[:directory] }
 
         directories_with_updates = source.directories&.filter do |directory|
           directories_from_dependencies.include?(directory)
@@ -242,8 +242,8 @@ module Dependabot
         updates = dependencies.map(&:name).uniq.count
 
         if source.directories
-          "bump the #{T.must(dependency_group).name} across #{directories_with_updates.count} "\
-            "#{if directories_with_updates.count > 1 then 'directories' else 'directory' end} "\
+          "bump the #{T.must(dependency_group).name} across #{T.must(directories_with_updates).count} " \
+            "#{T.must(directories_with_updates).count > 1 ? 'directories' : 'directory'} " \
             "with #{updates} update#{'s' if updates > 1}"
         else
           "bump the #{T.must(dependency_group).name} group#{pr_name_directory} with #{updates} update#{if updates > 1

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       requirements:
         [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [], source: nil }],
       previous_requirements:
-        [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
+        [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }],
+      metadata: metadata
     )
   end
   let(:files) { [gemfile, gemfile_lock] }
@@ -51,6 +52,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   let(:github_redirection_service) { "redirect.github.com" }
   let(:dependency_group) { nil }
   let(:ignore_conditions) { [] }
+  let(:metadata) { {} }
 
   let(:gemfile) do
     Dependabot::DependencyFile.new(
@@ -920,6 +922,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "go_modules group", rules: { patterns: ["*"] })
       end
+      let(:metadata) { { :directory => "/foo" } }
 
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")
@@ -931,9 +934,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
       let(:commits_response) { fixture("github", "commits.json") }
 
-      it { is_expected.to eq("Bump the go_modules group across 2 directories with 1 update") }
+      it { is_expected.to eq("Bump the go_modules group across 1 directory with 1 update") }
 
       context "with two dependencies" do
+        let(:metadata) { { :directory => "/foo" } }
         let(:dependency2) do
           Dependabot::Dependency.new(
             name: "business2",
@@ -941,7 +945,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_version: "1.4.0",
             package_manager: "dummy",
             requirements: [],
-            previous_requirements: []
+            previous_requirements: [],
+            metadata: { :directory => "/bar" }
           )
         end
         let(:dependencies) { [dependency, dependency2] }

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -922,7 +922,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "go_modules group", rules: { patterns: ["*"] })
       end
-      let(:metadata) { { :directory => "/foo" } }
+      let(:metadata) { { directory: "/foo" } }
 
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")
@@ -937,7 +937,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       it { is_expected.to eq("Bump the go_modules group across 1 directory with 1 update") }
 
       context "with two dependencies" do
-        let(:metadata) { { :directory => "/foo" } }
+        let(:metadata) { { directory: "/foo" } }
         let(:dependency2) do
           Dependabot::Dependency.new(
             name: "business2",
@@ -946,7 +946,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             package_manager: "dummy",
             requirements: [],
             previous_requirements: [],
-            metadata: { :directory => "/bar" }
+            metadata: { directory: "/bar" }
           )
         end
         let(:dependencies) { [dependency, dependency2] }


### PR DESCRIPTION
Fix the number of updated directories in a group update.

Previously we were listing the number of directories that Dependabot would try to update instead of the number of directories that were _actually_ updated.

This only affects the PR title and the commit message (since it uses the PR title)