### PR TITLE
Avoid comparison with nil version

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -270,6 +270,8 @@ module Dependabot
         def types_update_available?
           return false if types_package.nil?
 
+          return false if latest_types_package_version.nil?
+
           return false unless latest_allowable_version.backwards_compatible_with?(latest_types_package_version)
 
           return false unless version_class.correct?(types_package.version)


### PR DESCRIPTION
We are seeing sorbet runtime exceptions when checking if the corresponding types package for a dependency should be updated due to passing a nil version to [`#backwards_compatible_with?`](https://github.com/dependabot/dependabot-core/blob/0661469a58981018312249c24306fa34bf08d8fa/npm_and_yarn/lib/dependabot/npm_and_yarn/version.rb#L75-L76):

https://github.com/dependabot/dependabot-core/blob/0661469a58981018312249c24306fa34bf08d8fa/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb#L273

This PR addresses this by returning early if the latest types package version is nil.

Fixes #9241