### PR TITLE
use safe navigation through resolvable version

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -45,9 +45,8 @@ module Dependabot
       def updated_requirements
         RequirementsUpdater.new(
           requirements: dependency.requirements,
-          latest_version: preferred_resolvable_version_details.fetch(:version)&.to_s,
-          source_details: preferred_resolvable_version_details
-                          &.slice(:nuspec_url, :repo_url, :source_url)
+          latest_version: preferred_resolvable_version_details&.fetch(:version, nil)&.to_s,
+          source_details: preferred_resolvable_version_details&.slice(:nuspec_url, :repo_url, :source_url)
         ).updated_requirements
       end
 

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -269,12 +269,13 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
 
     context "with a security vulnerability" do
       let(:target_version) { "2.0.0" }
+      let(:vulnerable_versions) { ["< 2.0.0"] }
       let(:security_advisories) do
         [
           Dependabot::SecurityAdvisory.new(
             dependency_name: dependency_name,
             package_manager: "nuget",
-            vulnerable_versions: ["< 2.0.0"]
+            vulnerable_versions: vulnerable_versions
           )
         ]
       end
@@ -311,6 +312,40 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
             }
           }]
         )
+      end
+
+      context "the security vulnerability excludes all compatible packages" do
+        let(:target_version) { "1.1.1" }
+        let(:vulnerable_versions) { ["< 999.999.999"] } # it's all bad
+        subject(:updated_requirement_version) { updated_requirements[0].fetch(:requirement) }
+
+        before do
+          # only vulnerable versions are returned
+          stub_request(:get, registration_index_url(dependency_name))
+            .to_return(
+              status: 200,
+              body: {
+                items: [
+                  items: [
+                    {
+                      catalogEntry: {
+                        version: "1.1.1" # the currently installed version, but it's vulnerable
+                      }
+                    },
+                    {
+                      catalogEntry: {
+                        version: "3.0.0" # newer version, but it's still vulnerable
+                      }
+                    }
+                  ]
+                ]
+              }.to_json
+            )
+        end
+
+        it "reports the currently installed version" do
+          expect(updated_requirement_version).to eq(target_version)
+        end
       end
     end
   end


### PR DESCRIPTION
When trying to update a vulnerable package, it's possible that no non-vulnerable compatible package can be found.  In this instance it was leading to another case of this:

```
undefined method `fetch' for nil:NilClass

          latest_version: preferred_resolvable_version_details.fetch(:version)&.to_s,
                                                              ^^^^^^
```

The fix is to use the safe navigation operator (`&.`) to allow `nil` to propagate all the way up.  This behavior is expected and allowed in this case because further along the modified line is another safe navigation (`&.to_s`) and on the next line is yet another (`&.slice(...`).

The `nil` propagation in this case flows into `requirements_updater.rb` where it's explicitly allowed, both in the [initializer](https://github.com/dependabot/dependabot-core/blob/971d0915d9c42845675c3e8ba3f45a9d9eb3e72f/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb#L19) and in the [`updated_requirements`](https://github.com/dependabot/dependabot-core/blob/971d0915d9c42845675c3e8ba3f45a9d9eb3e72f/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb#L25) property.

The end result is that attempting an update in this case results in `security_update_not_possible`.

The scenario that surfaced this issue and that influenced the unit test was a project targeting `netstandard1.0` referencing `SharpCompress` version `0.23.0`, but all versions of that package `< 0.29` are considered vulnerable.  There _are_ newer versions, but not any that can be targeted by a `netstandard1.0` project and aren't still vulnerable.