### PR TITLE
allow interactive debugging of tests in the updater

### DIFF
--- a/script/ci-test-updater
+++ b/script/ci-test-updater
@@ -16,6 +16,7 @@ done
 # other ecosystems with -v into the updater image we can still run those tests.
 script/build bundler
 docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
+  -it \
   --pull never \
   --env VCR \
   --rm \


### PR DESCRIPTION
This allows you to add `binding.irb` or `debugger` to the code in order to debug updater tests.