### PR TITLE
📏 Standardize Error Keys

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -7,6 +7,17 @@ require "dependabot/utils"
 module Dependabot
   extend T::Sig
 
+  module ErrorAttributes
+    BACKTRACE        = "error-backtrace"
+    CLASS            = "error-class"
+    DETAILS          = "error-details"
+    MESSAGE          = "error-message"
+    DEPENDENCIES     = "job-dependencies"
+    DEPENDENCY_GROUP = "job-dependency-group"
+    JOB_ID           = "job-id"
+    PACKAGE_MANAGER  = "package-manager"
+  end
+
   # rubocop:disable Metrics/MethodLength
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.fetcher_error_details(error)

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -8,14 +8,14 @@ module Dependabot
   extend T::Sig
 
   module ErrorAttributes
-    BACKTRACE        = "error-backtrace"
-    CLASS            = "error-class"
-    DETAILS          = "error-details"
-    MESSAGE          = "error-message"
-    DEPENDENCIES     = "job-dependencies"
-    DEPENDENCY_GROUP = "job-dependency-group"
-    JOB_ID           = "job-id"
-    PACKAGE_MANAGER  = "package-manager"
+    BACKTRACE         = "error-backtrace"
+    CLASS             = "error-class"
+    DETAILS           = "error-details"
+    MESSAGE           = "error-message"
+    DEPENDENCIES      = "job-dependencies"
+    DEPENDENCY_GROUPS = "job-dependency-groups"
+    JOB_ID            = "job-id"
+    PACKAGE_MANAGER   = "package-manager"
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -11,6 +11,7 @@ module Dependabot
     BACKTRACE         = "error-backtrace"
     CLASS             = "error-class"
     DETAILS           = "error-details"
+    FINGERPRINT       = "fingerprint"
     MESSAGE           = "error-message"
     DEPENDENCIES      = "job-dependencies"
     DEPENDENCY_GROUPS = "job-dependency-groups"

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -64,7 +64,7 @@ module Dependabot
         ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
         ErrorAttributes::JOB_ID => job.id,
         ErrorAttributes::DEPENDENCIES => job.dependencies,
-        ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
+        ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
       }.compact
       service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)
       service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/api_client"
+require "dependabot/errors"
 require "dependabot/service"
 require "dependabot/logger"
 require "dependabot/logger/formats"
@@ -57,13 +58,13 @@ module Dependabot
 
     def handle_unknown_error(err)
       error_details = {
-        "error-class" => err.class.to_s,
-        "error-message" => err.message,
-        "error-backtrace" => err.backtrace.join("\n"),
-        "package-manager" => job.package_manager,
-        "job-id" => job.id,
-        "job-dependencies" => job.dependencies,
-        "job-dependency-group" => job.dependency_groups
+        ErrorAttributes::CLASS => err.class.to_s,
+        ErrorAttributes::MESSAGE => err.message,
+        ErrorAttributes::BACKTRACE => err.backtrace.join("\n"),
+        ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
+        ErrorAttributes::JOB_ID => job.id,
+        ErrorAttributes::DEPENDENCIES => job.dependencies,
+        ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
       }.compact
       service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)
       service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -63,7 +63,7 @@ module Dependabot
         "package-manager" => job.package_manager,
         "job-id" => job.id,
         "job-dependencies" => job.dependencies,
-        "job-dependency_group" => job.dependency_groups
+        "job-dependency-group" => job.dependency_groups
       }.compact
       service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)
       service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -61,6 +61,7 @@ module Dependabot
         ErrorAttributes::CLASS => err.class.to_s,
         ErrorAttributes::MESSAGE => err.message,
         ErrorAttributes::BACKTRACE => err.backtrace.join("\n"),
+        ErrorAttributes::FINGERPRINT => err.respond_to?(:sentry_context) ? err.sentry_context[:fingerprint] : nil,
         ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
         ErrorAttributes::JOB_ID => job.id,
         ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -3,6 +3,7 @@
 
 require "base64"
 require "dependabot/base_command"
+require "dependabot/errors"
 require "dependabot/opentelemetry"
 require "dependabot/updater"
 require "octokit"
@@ -173,13 +174,13 @@ module Dependabot
         log_error(error)
 
         unknown_error_details = {
-          "error-class" => error.class.to_s,
-          "error-message" => error.message,
-          "error-backtrace" => error.backtrace.join("\n"),
-          "package-manager" => job.package_manager,
-          "job-id" => job.id,
-          "job-dependencies" => job.dependencies,
-          "job-dependency-group" => job.dependency_groups
+          ErrorAttributes::CLASS => error.class.to_s,
+          ErrorAttributes::MESSAGE => error.message,
+          ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+          ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
+          ErrorAttributes::JOB_ID => job.id,
+          ErrorAttributes::DEPENDENCIES => job.dependencies,
+          ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
         }.compact
 
         error_details = {

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -180,7 +180,7 @@ module Dependabot
           ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
           ErrorAttributes::JOB_ID => job.id,
           ErrorAttributes::DEPENDENCIES => job.dependencies,
-          ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
+          ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
         }.compact
 
         error_details = {

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -177,6 +177,7 @@ module Dependabot
           ErrorAttributes::CLASS => error.class.to_s,
           ErrorAttributes::MESSAGE => error.message,
           ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+          ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? error.sentry_context[:fingerprint] : nil,
           ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
           ErrorAttributes::JOB_ID => job.id,
           ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -179,7 +179,7 @@ module Dependabot
           "package-manager" => job.package_manager,
           "job-id" => job.id,
           "job-dependencies" => job.dependencies,
-          "job-dependency_group" => job.dependency_groups
+          "job-dependency-group" => job.dependency_groups
         }.compact
 
         error_details = {

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -109,7 +109,7 @@ module Dependabot
         ErrorAttributes::CLASS => error.class.to_s,
         ErrorAttributes::MESSAGE => error.message,
         ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? error.sentry_context[:fingerprint] : nil,
+        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.unsafe(error).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -112,7 +112,7 @@ module Dependabot
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
-        ErrorAttributes::DEPENDENCY_GROUP => dependency_group&.name || job&.dependency_groups
+        ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
     end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -109,6 +109,7 @@ module Dependabot
         ErrorAttributes::CLASS => error.class.to_s,
         ErrorAttributes::MESSAGE => error.message,
         ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
+        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? error.sentry_context[:fingerprint] : nil,
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 require "terminal-table"
 
 require "dependabot/api_client"
+require "dependabot/errors"
 require "dependabot/opentelemetry"
 
 # This class provides an output adapter for the Dependabot Service which manages
@@ -105,13 +106,13 @@ module Dependabot
       return unless Experiments.enabled?(:record_update_job_unknown_error)
 
       error_details = {
-        "error-class" => error.class.to_s,
-        "error-message" => error.message,
-        "error-backtrace" => error.backtrace&.join("\n"),
-        "package-manager" => job&.package_manager,
-        "job-id" => job&.id,
-        "job-dependencies" => dependency&.name || job&.dependencies,
-        "job-dependency-group" => dependency_group&.name || job&.dependency_groups
+        ErrorAttributes::CLASS => error.class.to_s,
+        ErrorAttributes::MESSAGE => error.message,
+        ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
+        ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
+        ErrorAttributes::JOB_ID => job&.id,
+        ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
+        ErrorAttributes::DEPENDENCY_GROUP => dependency_group&.name || job&.dependency_groups
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
     end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -89,7 +89,7 @@ module Dependabot
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
-            ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
+            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
           }.compact
 
           service.capture_exception(error: error, job: job)

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -4,6 +4,7 @@
 require "base64"
 require "dependabot/base_command"
 require "dependabot/dependency_snapshot"
+require "dependabot/errors"
 require "dependabot/opentelemetry"
 require "dependabot/updater"
 
@@ -82,13 +83,13 @@ module Dependabot
           Dependabot.logger.error error.message
           error.backtrace.each { |line| Dependabot.logger.error line }
           unknown_error_details = {
-            "error-class" => error.class.to_s,
-            "error-message" => error.message,
-            "error-backtrace" => error.backtrace.join("\n"),
-            "package-manager" => job.package_manager,
-            "job-id" => job.id,
-            "job-dependencies" => job.dependencies,
-            "job-dependency-group" => job.dependency_groups
+            ErrorAttributes::CLASS => error.class.to_s,
+            ErrorAttributes::MESSAGE => error.message,
+            ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+            ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
+            ErrorAttributes::JOB_ID => job.id,
+            ErrorAttributes::DEPENDENCIES => job.dependencies,
+            ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
           }.compact
 
           service.capture_exception(error: error, job: job)

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -64,7 +64,7 @@ module Dependabot
       Environment.job_definition["base_commit_sha"]
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Layout/LineLength
     def handle_parser_error(error)
       # This happens if the repo gets removed after a job gets kicked off.
       # The service will handle the removal without any prompt from the updater,
@@ -86,6 +86,7 @@ module Dependabot
             ErrorAttributes::CLASS => error.class.to_s,
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? error.sentry_context[:fingerprint] : nil,
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
@@ -114,6 +115,6 @@ module Dependabot
         error_details: error_details[:"error-detail"]
       )
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Layout/LineLength
   end
 end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -88,7 +88,7 @@ module Dependabot
             "package-manager" => job.package_manager,
             "job-id" => job.id,
             "job-dependencies" => job.dependencies,
-            "job-dependency_group" => job.dependency_groups
+            "job-dependency-group" => job.dependency_groups
           }.compact
 
           service.capture_exception(error: error, job: job)

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -160,7 +160,7 @@ module Dependabot
           "package-manager" => job.package_manager,
           "job-id" => job.id,
           "job-dependencies" => job.dependencies,
-          "job-dependency_group" => job.dependency_groups
+          "job-dependency-group" => job.dependency_groups
         }.compact
 
         service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -154,13 +154,13 @@ module Dependabot
 
       def log_unknown_error_with_backtrace(error)
         error_details = {
-          "error-class" => error.class.to_s,
-          "error-message" => error.message,
-          "error-backtrace" => error.backtrace.join("\n"),
-          "package-manager" => job.package_manager,
-          "job-id" => job.id,
-          "job-dependencies" => job.dependencies,
-          "job-dependency-group" => job.dependency_groups
+          ErrorAttributes::CLASS => error.class.to_s,
+          ErrorAttributes::MESSAGE => error.message,
+          ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+          ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
+          ErrorAttributes::JOB_ID => job.id,
+          ErrorAttributes::DEPENDENCIES => job.dependencies,
+          ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
         }.compact
 
         service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -157,6 +157,7 @@ module Dependabot
           ErrorAttributes::CLASS => error.class.to_s,
           ErrorAttributes::MESSAGE => error.message,
           ErrorAttributes::BACKTRACE => error.backtrace.join("\n"),
+          ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? error.sentry_context[:fingerprint] : nil,
           ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
           ErrorAttributes::JOB_ID => job.id,
           ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -160,7 +160,7 @@ module Dependabot
           ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
           ErrorAttributes::JOB_ID => job.id,
           ErrorAttributes::DEPENDENCIES => job.dependencies,
-          ErrorAttributes::DEPENDENCY_GROUP => job.dependency_groups
+          ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
         }.compact
 
         service.increment_metric("updater.update_job_unknown_error", tags: {

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -3,6 +3,7 @@
 
 require "spec_helper"
 require "dependabot/file_fetcher_command"
+require "dependabot/errors"
 require "tmpdir"
 
 require "support/dummy_package_manager/dummy"
@@ -139,12 +140,12 @@ RSpec.describe Dependabot::FileFetcherCommand do
         expect(api_client).to receive(:record_update_job_error).with(
           error_type: "file_fetcher_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "my_branch",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "my_branch",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
         expect(api_client).to receive(:record_update_job_unknown_error)
@@ -157,12 +158,12 @@ RSpec.describe Dependabot::FileFetcherCommand do
         expect(api_client).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "my_branch",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "my_branch",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)
@@ -182,12 +183,12 @@ RSpec.describe Dependabot::FileFetcherCommand do
         expect(api_client).to receive(:record_update_job_error).with(
           error_type: "file_fetcher_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "my_branch",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "my_branch",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             "error-class" => "StandardError",
             "package-manager" => "bundler",
             "job-id" => "123123",
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
         expect(api_client).to receive(:record_update_job_unknown_error)
@@ -187,7 +187,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             "error-class" => "StandardError",
             "package-manager" => "bundler",
             "job-id" => "123123",
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
         expect(api_client).to receive(:record_update_job_unknown_error)
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Dependabot::Service do
           error_details: hash_including(
             Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
             Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => "all-the-things"
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => "all-the-things"
           )
         )
     end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -302,8 +302,8 @@ RSpec.describe Dependabot::Service do
         .with(
           error_type: "unknown_error",
           error_details: hash_including(
-            "error-message" => "Something went wrong",
-            "error-class" => "Dependabot::DependabotError"
+            Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError"
           )
         )
     end
@@ -317,10 +317,10 @@ RSpec.describe Dependabot::Service do
         .with(
           error_type: "unknown_error",
           error_details: hash_including(
-            "error-class" => "Dependabot::DependabotError",
-            "error-message" => "Something went wrong",
-            "job-id" => job.id,
-            "package-manager" => job.package_manager
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError",
+            Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
+            Dependabot::ErrorAttributes::JOB_ID => job.id,
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => job.package_manager
           )
         )
     end
@@ -334,9 +334,9 @@ RSpec.describe Dependabot::Service do
         .with(
           error_type: "unknown_error",
           error_details: hash_including(
-            "error-message" => "Something went wrong",
-            "error-class" => "Dependabot::DependabotError",
-            "job-dependencies" => "lodash"
+            Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError",
+            Dependabot::ErrorAttributes::DEPENDENCIES => "lodash"
           )
         )
     end
@@ -351,9 +351,9 @@ RSpec.describe Dependabot::Service do
         .with(
           error_type: "unknown_error",
           error_details: hash_including(
-            "error-message" => "Something went wrong",
-            "error-class" => "Dependabot::DependabotError",
-            "job-dependency-group" => "all-the-things"
+            Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => "all-the-things"
           )
         )
     end

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             "error-class" => "StandardError",
             "package-manager" => "bundler",
             "job-id" => "123123",
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             "error-class" => "StandardError",
             "package-manager" => "bundler",
             "job-id" => "123123",
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             "error-class" => "StandardError",
             "package-manager" => "bundler",
             "job-id" => "123123",
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -130,12 +130,12 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         expect(service).to receive(:record_update_job_error).with(
           error_type: "update_files_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "hell",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "hell",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 
@@ -147,12 +147,12 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         expect(service).to receive(:record_update_job_unknown_error).with(
           error_type: "update_files_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "hell",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "hell",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 
@@ -171,12 +171,12 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         expect(service).to receive(:record_update_job_error).with(
           error_type: "update_files_error",
           error_details: {
-            "error-backtrace" => an_instance_of(String),
-            "error-message" => "hell",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+            Dependabot::ErrorAttributes::MESSAGE => "hell",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 
 require "dependabot/dependency"
 require "dependabot/dependency_group"
+require "dependabot/errors"
 require "dependabot/job"
 require "dependabot/service"
 require "dependabot/shared_helpers"
@@ -82,13 +83,13 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
         expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
           error_details: {
-            "error-backtrace" => "bees.rb:5:in `buzz`",
-            "error-message" => "There are bees everywhere",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependencies" => [],
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => "bees.rb:5:in `buzz`",
+            Dependabot::ErrorAttributes::MESSAGE => "There are bees everywhere",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCIES => [],
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 
@@ -180,13 +181,13 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
         expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
           error_details: {
-            "error-backtrace" => "****** ERROR 8335 -- 101",
-            "error-message" => "the kernal is full of bees",
-            "error-class" => "Dependabot::SharedHelpers::HelperSubprocessFailed",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependencies" => [],
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => "****** ERROR 8335 -- 101",
+            Dependabot::ErrorAttributes::MESSAGE => "the kernal is full of bees",
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCIES => [],
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 
@@ -327,13 +328,13 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
         expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
           error_details: {
-            "error-backtrace" => "bees.rb:5:in `buzz`",
-            "error-message" => "There are bees everywhere",
-            "error-class" => "StandardError",
-            "package-manager" => "bundler",
-            "job-id" => "123123",
-            "job-dependencies" => [],
-            "job-dependency-group" => []
+            Dependabot::ErrorAttributes::BACKTRACE => "bees.rb:5:in `buzz`",
+            Dependabot::ErrorAttributes::MESSAGE => "There are bees everywhere",
+            Dependabot::ErrorAttributes::CLASS => "StandardError",
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+            Dependabot::ErrorAttributes::JOB_ID => "123123",
+            Dependabot::ErrorAttributes::DEPENDENCIES => [],
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
           }
         )
 

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             "package-manager" => "bundler",
             "job-id" => "123123",
             "job-dependencies" => [],
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 
@@ -186,7 +186,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             "package-manager" => "bundler",
             "job-id" => "123123",
             "job-dependencies" => [],
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 
@@ -333,7 +333,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             "package-manager" => "bundler",
             "job-id" => "123123",
             "job-dependencies" => [],
-            "job-dependency_group" => []
+            "job-dependency-group" => []
           }
         )
 

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -184,6 +184,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             Dependabot::ErrorAttributes::BACKTRACE => "****** ERROR 8335 -- 101",
             Dependabot::ErrorAttributes::MESSAGE => "the kernal is full of bees",
             Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+            Dependabot::ErrorAttributes::FINGERPRINT => anything,
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCIES => [],

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCIES => [],
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 
@@ -187,7 +187,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCIES => [],
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 
@@ -334,7 +334,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCIES => [],
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
           }
         )
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1818,6 +1818,7 @@ RSpec.describe Dependabot::Updater do
                 Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
                 Dependabot::ErrorAttributes::MESSAGE => "Potentially sensitive log content goes here",
                 Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+                Dependabot::ErrorAttributes::FINGERPRINT => anything,
                 Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
                 Dependabot::ErrorAttributes::JOB_ID => "1",
                 Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1815,12 +1815,12 @@ RSpec.describe Dependabot::Updater do
             .with(
               error_type: "unknown_error",
               error_details: {
-                "error-backtrace" => an_instance_of(String),
-                "error-message" => "Potentially sensitive log content goes here",
-                "error-class" => "Dependabot::SharedHelpers::HelperSubprocessFailed",
-                "package-manager" => "bundler",
-                "job-id" => "1",
-                "job-dependency-group" => []
+                Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
+                Dependabot::ErrorAttributes::MESSAGE => "Potentially sensitive log content goes here",
+                Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+                Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
+                Dependabot::ErrorAttributes::JOB_ID => "1",
+                Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
               }
             )
           updater.run

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1820,7 +1820,7 @@ RSpec.describe Dependabot::Updater do
                 "error-class" => "Dependabot::SharedHelpers::HelperSubprocessFailed",
                 "package-manager" => "bundler",
                 "job-id" => "1",
-                "job-dependency_group" => []
+                "job-dependency-group" => []
               }
             )
           updater.run

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1820,7 +1820,7 @@ RSpec.describe Dependabot::Updater do
                 Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
                 Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
                 Dependabot::ErrorAttributes::JOB_ID => "1",
-                Dependabot::ErrorAttributes::DEPENDENCY_GROUP => []
+                Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
               }
             )
           updater.run


### PR DESCRIPTION
We're using a mix of dashes and underscores, which I find confusing. I've introduced some failures trying to get these right, so I'm making all string keys dasherized.