### PR TITLE
when resolving MSBuild properties, don't throw if it can't be resolved

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -2479,5 +2479,23 @@ public partial class UpdateWorkerTests
                 </Project>
                 """);
         }
+
+        [Fact]
+        public async Task NoChange_IfTargetFrameworkCouldNotBeEvaluated()
+        {
+            // Make sure we don't throw if the project's TFM is an unresolvable property
+            await TestNoChangeforProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>$(PropertyThatCannotBeResolved)</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+                );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -82,13 +82,9 @@ internal static partial class MSBuildHelper
         {
             var (resultType, tfms, errorMessage) =
                 GetEvaluatedValue(targetFrameworkValue, propertyInfo, propertiesToIgnore: ["TargetFramework", "TargetFrameworks"]);
-            if (resultType == EvaluationResultType.PropertyIgnored)
+            if (resultType != EvaluationResultType.Success)
             {
                 continue;
-            }
-            else if (resultType != EvaluationResultType.Success)
-            {
-                throw new InvalidDataException(errorMessage);
             }
 
             if (string.IsNullOrEmpty(tfms))


### PR DESCRIPTION
This should allow other potential updates to flow instead of erroring out the whole process.