### PR TITLE
Fix: Bundler: ruby version fetched from .ruby-version for jruby

### DIFF
--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -14,7 +14,7 @@ module BundlerDefinitionRubyVersionPatch
           file_content.strip
         end
       Bundler::RubyVersion.new(ruby_version, nil, nil, nil) if ruby_version
-    rescue SystemCallError
+    rescue SystemCallError, Gem::Requirement::BadRequirementError
       # .ruby-version doesn't exist, fallback to the Ruby Dependabot runs
     end
   end

--- a/bundler/helpers/v2/spec/ruby_version_spec.rb
+++ b/bundler/helpers/v2/spec/ruby_version_spec.rb
@@ -37,4 +37,19 @@ RSpec.describe BundlerDefinitionRubyVersionPatch do
       expect(spec.version).to eq("2.0.1")
     end
   end
+
+  context 'with jruby' do
+    it "doesnt fail" do
+      in_tmp_folder do
+        # replace file content
+        File.write(".ruby-version", "jruby-9.3.8.0")
+        definition = Bundler::Definition.build("Gemfile", "Gemfile.lock", gems: ["statesman"])
+        definition.resolve_remotely!
+        specs = definition.resolve["statesman"]
+        expect(specs.size).to eq(1)
+        spec = specs.first
+        expect(spec.version).to eq("7.2.0")
+      end
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/commit/935ab99a13cbc29184d92c3e91fa5dbf508c4ac1 some logic was added to read ruby version from .ruby-version but it fails for jruby projects

I added a rescue for this case, fallbacking on dependabot ruby version

cc @etiennebarrie 