### PR TITLE
ensure nupkg zip entry contains a tfm before adding to the list

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -83,7 +83,10 @@ module Dependabot
 
             lib_file_entries.each do |entry|
               _, tfm = entry.name.split("/").first(2)
-              tfms << tfm
+
+              # some zip compressors create empty directory entries (in this case `lib/`) which can cause the string
+              # split to return `nil`, so we have to explicitly guard against that
+              tfms << tfm if tfm
             end
           end
 


### PR DESCRIPTION
When determining the target frameworks that a package supports, we first check the `.nuspec` file.  If that doesn't list anything then we open the `.nupkg` as a zip file and find all subdirectories under the `lib/` directory.  Some zip compressors create empty entry objects for each directory which could cause the string split to return `nil` eventually resorting in:

```
ArgumentError
comparison of NilClass with String failed
```

The fix is to exlucde these `nil` entries.  This was a large class of failures in the telemetry.