### PR TITLE
improve update-not-possible logging

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -68,7 +68,11 @@ module Dependabot
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
-          versions_array.reject(&:prerelease?)
+          filtered = versions_array.reject(&:prerelease?)
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
+          end
+          filtered
         end
 
         def filter_ignored_versions(versions_array)
@@ -76,6 +80,10 @@ module Dependabot
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
             raise AllVersionsIgnored
+          end
+
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} ignored versions")
           end
 
           filtered

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -10,11 +10,14 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/bundler/update_checker/latest_version_finder/" \
         "dependency_source"
+require "sorbet-runtime"
 
 module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
+        extend T::Sig
+
         def initialize(dependency:, dependency_files:, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,
                        security_advisories:, options:)
@@ -65,6 +68,7 @@ module Dependabot
           relevant_versions.min
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
@@ -75,6 +79,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_ignored_versions(versions_array)
           filtered = versions_array
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -4,12 +4,15 @@
 require "dependabot/registry_client"
 require "dependabot/bundler/native_helpers"
 require "dependabot/bundler/helpers"
+require "sorbet-runtime"
 
 module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
         class DependencySource
+          extend T::Sig
+
           require_relative "../shared_bundler_helpers"
           include SharedBundlerHelpers
 
@@ -33,7 +36,7 @@ module Dependabot
 
           # The latest version details for the dependency from a registry
           #
-          # @return [Array<Gem::Version>]
+          sig { returns(T::Array[Gem::Version]) }
           def versions
             return rubygems_versions if dependency.name == "bundler"
             return rubygems_versions unless gemfile

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -55,7 +55,10 @@ module Dependabot
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
-          versions_array.reject(&:prerelease?)
+          filtered = versions_array.reject(&:prerelease?)
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
+          end
         end
 
         def filter_ignored_versions(versions_array)
@@ -63,6 +66,10 @@ module Dependabot
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
             raise Dependabot::AllVersionsIgnored
+          end
+
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} ignored versions")
           end
 
           filtered

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -5,11 +5,14 @@ require "excon"
 require "dependabot/cargo/update_checker"
 require "dependabot/update_checkers/version_filters"
 require "dependabot/registry_client"
+require "sorbet-runtime"
 
 module Dependabot
   module Cargo
     class UpdateChecker
       class LatestVersionFinder
+        extend T::Sig
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -52,6 +55,7 @@ module Dependabot
           versions.min
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
@@ -59,8 +63,10 @@ module Dependabot
           if versions_array.count > filtered.count
             Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
           end
+          filtered
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_ignored_versions(versions_array)
           filtered = versions_array
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -9,11 +9,20 @@ module Dependabot
       extend T::Sig
 
       sig do
-        params(
-          versions_array: T::Array[T.any(Gem::Version, T::Hash[Symbol, Gem::Version])],
-          security_advisories: T::Array[SecurityAdvisory]
-        )
-          .returns(T::Array[T.any(Gem::Version, T::Hash[Symbol, Gem::Version])])
+        # Tricky generics explanation:
+        # There's a type T that is either a Gem::Version or a Hash with a :version key
+        # The method returns an array of T
+        # So whichever is provided as input, the output will be an array of the same type.
+        type_parameters(:T)
+          .params(
+            versions_array: T::Array[
+              T.any(
+                T.all(T.type_parameter(:T), Gem::Version),
+                T.all(T.type_parameter(:T), T::Hash[Symbol, Gem::Version])
+              )],
+            security_advisories: T::Array[SecurityAdvisory]
+          )
+          .returns(T::Array[T.type_parameter(:T)])
       end
       def self.filter_vulnerable_versions(versions_array, security_advisories)
         versions_array.reject do |v|

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -13,6 +13,7 @@ module Dependabot
         # There's a type T that is either a Gem::Version or a Hash with a :version key
         # The method returns an array of T
         # So whichever is provided as input, the output will be an array of the same type.
+        # https://sorbet.org/docs/generics#placing-bounds-on-generic-methods
         type_parameters(:T)
           .params(
             versions_array: T::Array[

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -139,7 +139,11 @@ module Dependabot
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
-          versions_array.reject(&:prerelease?)
+          filtered = versions_array.reject(&:prerelease?)
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
+          end
+          filtered
         end
 
         def filter_lower_versions(versions_array)
@@ -154,6 +158,10 @@ module Dependabot
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
             raise AllVersionsIgnored
+          end
+
+          if versions_array.count > filtered.count
+            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} ignored versions")
           end
 
           filtered

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -9,11 +9,14 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/requirement"
 require "dependabot/go_modules/resolvability_errors"
+require "sorbet-runtime"
 
 module Dependabot
   module GoModules
     class UpdateChecker
       class LatestVersionFinder
+        extend T::Sig
+
         RESOLVABILITY_ERROR_REGEXES = [
           # Package url/proxy doesn't include any redirect meta tags
           /no go-import meta tags/,
@@ -136,6 +139,7 @@ module Dependabot
           end
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_prerelease_versions(versions_array)
           return versions_array if wants_prerelease?
 
@@ -153,6 +157,7 @@ module Dependabot
             .select { |version| version > dependency.numeric_version }
         end
 
+        sig { params(versions_array: T::Array[Gem::Version]).returns(T::Array[Gem::Version]) }
         def filter_ignored_versions(versions_array)
           filtered = versions_array
                      .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -9,11 +9,14 @@ require "dependabot/gradle/update_checker"
 require "dependabot/gradle/version"
 require "dependabot/gradle/requirement"
 require "dependabot/maven/utils/auth_headers_finder"
+require "sorbet-runtime"
 
 module Dependabot
   module Gradle
     class UpdateChecker
       class VersionFinder
+        extend T::Sig
+
         KOTLIN_PLUGIN_REPO_PREFIX = "org.jetbrains.kotlin"
         TYPE_SUFFICES = %w(jre android java native_mt agp).freeze
 
@@ -76,6 +79,7 @@ module Dependabot
         attr_reader :dependency, :dependency_files, :credentials,
                     :ignored_versions, :forbidden_urls, :security_advisories
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_prereleases(possible_versions)
           return possible_versions if wants_prerelease?
 
@@ -86,6 +90,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_date_based_versions(possible_versions)
           return possible_versions if wants_date_based_version?
 
@@ -96,6 +101,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_version_types(possible_versions)
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
@@ -105,6 +111,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_ignored_versions(possible_versions)
           filtered = possible_versions
 
@@ -128,6 +135,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_lower_versions(possible_versions)
           return possible_versions unless dependency.numeric_version
 

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -106,7 +106,7 @@ module Dependabot
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
             diff = possible_versions.count - filtered.count
-            Dependabot.logger.info("Filtered out #{diff} versions not matching the type")
+            Dependabot.logger.info("Filtered out #{diff} versions with a different classifier")
           end
           filtered
         end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -79,19 +79,30 @@ module Dependabot
         def filter_prereleases(possible_versions)
           return possible_versions if wants_prerelease?
 
-          possible_versions.reject { |v| v.fetch(:version).prerelease? }
+          filtered = possible_versions.reject { |v| v.fetch(:version).prerelease? }
+          if possible_versions.count > filtered.count
+            Dependabot.logger.info("Filtered out #{possible_versions.count - filtered.count} pre-release versions")
+          end
+          filtered
         end
 
         def filter_date_based_versions(possible_versions)
           return possible_versions if wants_date_based_version?
 
-          possible_versions
-            .reject { |v| v.fetch(:version) > version_class.new(1900) }
+          filtered = possible_versions.reject { |v| v.fetch(:version) > version_class.new(1900) }
+          if possible_versions.count > filtered.count
+            Dependabot.logger.info("Filtered out #{possible_versions.count - filtered.count} date-based versions")
+          end
+          filtered
         end
 
         def filter_version_types(possible_versions)
-          possible_versions
-            .select { |v| matches_dependency_version_type?(v.fetch(:version)) }
+          filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
+          if possible_versions.count > filtered.count
+            diff = possible_versions.count - filtered.count
+            Dependabot.logger.info("Filtered out #{diff} versions not matching the type")
+          end
+          filtered
         end
 
         def filter_ignored_versions(possible_versions)
@@ -107,6 +118,11 @@ module Dependabot
           if @raise_on_ignored && filter_lower_versions(filtered).empty? &&
              filter_lower_versions(possible_versions).any?
             raise AllVersionsIgnored
+          end
+
+          if possible_versions.count > filtered.count
+            diff = possible_versions.count - filtered.count
+            Dependabot.logger.info("Filtered out #{diff} ignored versions")
           end
 
           filtered

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -106,7 +106,8 @@ module Dependabot
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
             diff = possible_versions.count - filtered.count
-            Dependabot.logger.info("Filtered out #{diff} versions with a different classifier")
+            classifier = dependency.version.split(/[.\-]/).last
+            Dependabot.logger.info("Filtered out #{diff} non-#{classifier} classifier versions")
           end
           filtered
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -108,7 +108,8 @@ module Dependabot
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
             diff = possible_versions.count - filtered.count
-            Dependabot.logger.info("Filtered out #{diff} versions with a different classifier")
+            classifier = dependency.version.split(/[.\-]/).last
+            Dependabot.logger.info("Filtered out #{diff} non-#{classifier} classifier versions")
           end
           filtered
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -9,11 +9,14 @@ require "dependabot/maven/version"
 require "dependabot/maven/requirement"
 require "dependabot/maven/utils/auth_headers_finder"
 require "dependabot/registry_client"
+require "sorbet-runtime"
 
 module Dependabot
   module Maven
     class UpdateChecker
       class VersionFinder
+        extend T::Sig
+
         TYPE_SUFFICES = %w(jre android java native_mt agp).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
@@ -54,6 +57,7 @@ module Dependabot
           possible_versions.find { |v| released?(v.fetch(:version)) }
         end
 
+        sig { returns(T::Array[T.untyped]) }
         def versions
           version_details =
             repositories.map do |repository_details|
@@ -77,6 +81,7 @@ module Dependabot
         attr_reader :dependency, :dependency_files, :credentials,
                     :ignored_versions, :forbidden_urls, :security_advisories
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_prereleases(possible_versions)
           return possible_versions if wants_prerelease?
 
@@ -87,6 +92,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_date_based_versions(possible_versions)
           return possible_versions if wants_date_based_version?
 
@@ -97,6 +103,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_version_types(possible_versions)
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
@@ -106,6 +113,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_ignored_versions(possible_versions)
           filtered = possible_versions
 
@@ -129,6 +137,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_lower_versions(possible_versions)
           return possible_versions unless dependency.numeric_version
 

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -108,7 +108,7 @@ module Dependabot
           filtered = possible_versions.select { |v| matches_dependency_version_type?(v.fetch(:version)) }
           if possible_versions.count > filtered.count
             diff = possible_versions.count - filtered.count
-            Dependabot.logger.info("Filtered out #{diff} versions that don't match the version type")
+            Dependabot.logger.info("Filtered out #{diff} versions with a different classifier")
           end
           filtered
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -120,6 +120,11 @@ module Dependabot
             raise AllVersionsIgnored
           end
 
+          if versions_array.count > filtered.count
+            diff = versions_array.count - filtered.count
+            Dependabot.logger.info("Filtered out #{diff} ignored versions")
+          end
+
           filtered
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -9,10 +9,14 @@ require "dependabot/npm_and_yarn/version"
 require "dependabot/npm_and_yarn/requirement"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require "sorbet-runtime"
+
 module Dependabot
   module NpmAndYarn
     class UpdateChecker
       class LatestVersionFinder
+        extend T::Sig
+
         class RegistryError < StandardError
           attr_reader :status
 
@@ -111,6 +115,7 @@ module Dependabot
           !npm_details&.fetch("dist-tags", nil).nil?
         end
 
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_ignored_versions(versions_array)
           filtered = versions_array.reject do |v, _|
             ignore_requirements.any? { |r| r.satisfied_by?(v) }
@@ -128,6 +133,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_out_of_range_versions(versions_array)
           reqs = dependency.requirements.filter_map do |r|
             NpmAndYarn::Requirement.requirements_array(r.fetch(:requirement))
@@ -137,6 +143,7 @@ module Dependabot
             .select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }
         end
 
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_lower_versions(versions_array)
           return versions_array unless dependency.numeric_version
 

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -110,10 +110,14 @@ module Dependabot
         end
 
         def filter_prereleases(possible_versions)
-          possible_versions.reject do |d|
+          filtered = possible_versions.reject do |d|
             version = d.fetch(:version)
             version.prerelease? && !related_to_current_pre?(version)
           end
+          if possible_versions.count > filtered.count
+            Dependabot.logger.info("Filtered out #{possible_versions.count - filtered.count} pre-release versions")
+          end
+          filtered
         end
 
         def filter_ignored_versions(possible_versions)
@@ -129,6 +133,10 @@ module Dependabot
           if @raise_on_ignored && filter_lower_versions(filtered).empty? &&
              filter_lower_versions(possible_versions).any?
             raise AllVersionsIgnored
+          end
+
+          if possible_versions.count > filtered.count
+            Dependabot.logger.info("Filtered out #{possible_versions.count - filtered.count} ignored versions")
           end
 
           filtered

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -6,11 +6,14 @@ require "dependabot/nuget/requirement"
 require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/version_filters"
 require "dependabot/nuget/nuget_client"
+require "sorbet-runtime"
 
 module Dependabot
   module Nuget
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class VersionFinder
+        extend T::Sig
+
         require_relative "compatibility_checker"
         require_relative "repository_finder"
 
@@ -109,6 +112,7 @@ module Dependabot
           )
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_prereleases(possible_versions)
           filtered = possible_versions.reject do |d|
             version = d.fetch(:version)
@@ -120,6 +124,7 @@ module Dependabot
           filtered
         end
 
+        sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_ignored_versions(possible_versions)
           filtered = possible_versions
 

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -109,9 +109,9 @@ module Dependabot
           return versions_array if wants_prerelease?
 
           filtered = versions_array.reject(&:prerelease?)
-          if versions_array.count > filtered.count
-            Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
-          end
+          return unless versions_array.count > filtered.count
+
+          Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
         end
 
         def filter_ignored_versions(versions_array)
@@ -120,6 +120,7 @@ module Dependabot
           if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
             raise Dependabot::AllVersionsIgnored
           end
+
           if versions_array.count > filtered.count
             Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} ignored versions")
           end

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -94,7 +94,7 @@ module Dependabot
         end
 
         sig do
-          params(versions_array: T::Array[T.untyped], python_version: T.nilable(Version))
+          params(versions_array: T::Array[T.untyped], python_version: T.nilable(T.any(String, Version)))
             .returns(T::Array[T.untyped])
         end
         def filter_unsupported_versions(versions_array, python_version)

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -94,7 +94,7 @@ module Dependabot
         end
 
         sig do
-          params(versions_array: T::Array[T.untyped], python_version: T.nilable(Gem::Requirement))
+          params(versions_array: T::Array[T.untyped], python_version: T.nilable(Version))
             .returns(T::Array[T.untyped])
         end
         def filter_unsupported_versions(versions_array, python_version)


### PR DESCRIPTION
When doing an update, you might get an update_not_possible error with the following logs:

```
updater | Latest version is 1.0.0
updater | Requirements to unlock update_not_possible
updater | Requirements update strategy bump_versions
updater | No update possible for my-dependency 1.0.0
```

One of the reasons this can happen is that all versions were filtered out while trying to update a specific dependency. 

This PR aims to improve the logging for ecosystems to give users a hint of why the update is not possible:

```
updater | Latest version is 1.0.0
updater | Requirements to unlock update_not_possible
updater | Requirements update strategy bump_versions
updater | Filtered out 156 unsupported Python 3.11 versions
updater | Filtered out 12 pre-release versions
updater | Filtered out 256 ignored versions
updater | No update possible for my-dependency 1.0.0
```
