### PR TITLE
always recurse submodules when cloning

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -354,11 +354,6 @@ module Dependabot
         end
       end
 
-      sig { returns(T::Boolean) }
-      def recurse_submodules_when_cloning?
-        false
-      end
-
       sig do
         returns(
           T.any(
@@ -789,11 +784,7 @@ module Dependabot
 
           clone_options = StringIO.new
           clone_options << "--no-tags --depth 1"
-          clone_options << if recurse_submodules_when_cloning?
-                             " --recurse-submodules --shallow-submodules"
-                           else
-                             " --no-recurse-submodules"
-                           end
+          clone_options << " --recurse-submodules --shallow-submodules"
           clone_options << " --branch #{source.branch} --single-branch" if source.branch
 
           submodule_cloning_failed = false
@@ -805,7 +796,7 @@ module Dependabot
               CMD
             )
 
-            @submodules = find_submodules(path) if recurse_submodules_when_cloning?
+            @submodules = find_submodules(path)
           rescue SharedHelpers::HelperSubprocessFailed => e
             if GIT_RETRYABLE_ERRORS.any? { |error| error.match?(e.message) } && retries < 5
               retries += 1
@@ -835,20 +826,20 @@ module Dependabot
             Dir.chdir(path) do
               fetch_options = StringIO.new
               fetch_options << "--depth 1"
-              fetch_options << if recurse_submodules_when_cloning? && !submodule_cloning_failed
-                                 " --recurse-submodules=on-demand"
-                               else
+              fetch_options << if submodule_cloning_failed
                                  " --no-recurse-submodules"
+                               else
+                                 " --recurse-submodules=on-demand"
                                end
               # Need to fetch the commit due to the --depth 1 above.
               SharedHelpers.run_shell_command("git fetch #{fetch_options.string} origin #{source.commit}")
 
               reset_options = StringIO.new
               reset_options << "--hard"
-              reset_options << if recurse_submodules_when_cloning? && !submodule_cloning_failed
-                                 " --recurse-submodules"
-                               else
+              reset_options << if submodule_cloning_failed
                                  " --no-recurse-submodules"
+                               else
+                                 " --recurse-submodules"
                                end
               # Set HEAD to this commit so later calls so git reset HEAD will work.
               SharedHelpers.run_shell_command("git reset #{reset_options.string} #{source.commit}")

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -771,7 +771,6 @@ module Dependabot
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/BlockLength
-      # rubocop:disable Metrics/CyclomaticComplexity
       sig { params(target_directory: T.nilable(String)).returns(String) }
       def _clone_repo_contents(target_directory:)
         SharedHelpers.with_git_configured(credentials: credentials) do
@@ -853,7 +852,6 @@ module Dependabot
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/BlockLength
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       sig { params(str: String).returns(String) }
       def decode_binary_string(str)

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1722,7 +1722,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
         end
       end
 
-      context "when #recurse_submodules_when_cloning? returns true" do
+      context "when there's a submodule" do
         let(:child_class) do
           Class.new(described_class) do
             def self.required_files_in?(filenames)
@@ -1737,10 +1737,6 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
             def fetch_files
               [fetch_file_from_host("go.mod")]
-            end
-
-            def recurse_submodules_when_cloning?
-              true
             end
           end
         end

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1659,7 +1659,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
             )
 
           expect { subject }.to_not raise_error
-          expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).twice
+          expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).thrice
           expect(file_fetcher_instance).to have_received(:sleep).once
         end
 
@@ -1706,19 +1706,19 @@ RSpec.describe Dependabot::FileFetchers::Base do
     after { FileUtils.rm_rf(repo_contents_path) }
 
     describe "#clone_repo_contents" do
-      it "does not clone submodules by default" do
+      it "clones submodules by default" do
         file_fetcher_instance.clone_repo_contents
 
-        expect(`ls -1 #{submodule_contents_path}`.split).to_not include("go.mod")
+        expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
       end
 
       context "with a source commit" do
         let(:source_commit) { "5c7e92a4860382fd31336872f0fe79a848669c4d" }
 
-        it "does not fetch/reset submodules by default" do
+        it "fetches/reset submodules by default" do
           file_fetcher_instance.clone_repo_contents
 
-          expect(`ls -1 #{submodule_contents_path}`.split).to_not include("go.mod")
+          expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
         end
       end
 

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -55,10 +55,6 @@ module Dependabot
 
         @go_sum = fetch_file_if_present("go.sum")
       end
-
-      def recurse_submodules_when_cloning?
-        true
-      end
     end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -87,10 +87,6 @@ module Dependabot
 
       private
 
-      def recurse_submodules_when_cloning?
-        true
-      end
-
       def npm_files
         fetched_npm_files = []
         fetched_npm_files << package_lock if package_lock && !skip_package_lock?


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/8933 we made all ecosystems clone rather than fetching single files. 

Similarly this PR enables recurse submodules for all ecosystems to fix some path dependency issues. The only downside would be an increase in out of disk errors but we can onboard to Actions beta now which increases the amount of disk available.

Fixes #8428
Fixes #9198
Fixes #7201
Fixes #9193
Fixes #7916

Supersedes:
- #7078
- #9181
- #8807