### PR TITLE
build(deps): bump corepack to 0.26.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.24.1
+ARG COREPACK_VERSION=0.25.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.15.2 

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.26.0
+ARG COREPACK_VERSION=0.24.1
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.15.2 

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.25.0
+ARG COREPACK_VERSION=0.26.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.15.2 

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.24.0
+ARG COREPACK_VERSION=0.26.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.15.2 


### PR DESCRIPTION
See https://github.com/nodejs/corepack/releases for release notes

The only change that might break some things is https://github.com/nodejs/corepack/pull/375 but just like corepack, we should not support EOL node versions anyways 