### PR TITLE
make dependency file not found message more specific

### DIFF
--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -959,7 +959,9 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
     it "raises a Dependabot::DependencyFileNotFound error" do
       expect { file_fetcher_instance.files }
         .to raise_error(Dependabot::DependencyFileNotFound) do |error|
-          expect(error.file_name).to eq("<anything>.(cs|vb|fs)proj")
+          expect(error.directory).to eq("/")
+          expect(error.file_name).to eq("*.(sln|csproj|vbproj|fsproj|proj)")
+          expect(error.message).to eq("Unable to find `*.sln`, `*.(cs|vb|fs)proj`, or `*.proj` in directory `/`")
         end
     end
   end


### PR DESCRIPTION
When an appropriate NuGet dependency file could not be found, return a more specific error message.  This also explicitly limits project files to the extensions `.csproj`, `.vbproj`, and `.fsproj`.  The earlier mechanism would allow other things like `.sfproj`, but the C# updater tool doesn't allow that, so we're tighter on what we'll accept/scan.