### PR TITLE
Support Poetry non-package mode

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -160,7 +160,9 @@ module Dependabot
         end
 
         def missing_poetry_keys
-          %w(name version description authors).reject { |key| poetry_root.key?(key) }
+          package_mode = poetry_root.fetch("package-mode", true)
+          required_keys = package_mode ? %w(name version description authors) : []
+          required_keys.reject { |key| poetry_root.key?(key) }
         end
 
         def using_pep621?

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -121,6 +121,14 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
           expect(dependency_names).to include("pytest")
         end
       end
+
+      context "with non-package mode" do
+        let(:pyproject_fixture_name) { "poetry_non_package_mode.toml" }
+
+        it "parses correctly with no metadata" do
+          expect { parser.dependency_set }.to_not raise_error
+        end
+      end
     end
 
     context "with a lockfile" do

--- a/python/spec/fixtures/pyproject_files/poetry_non_package_mode.toml
+++ b/python/spec/fixtures/pyproject_files/poetry_non_package_mode.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.6 || ^3.7"
+geopy = "^1.13"
+Pillow = "^5.1"
+requests = "^2.18"
+
+[tool.poetry.dev-dependencies]
+black = "^18.5"
+flake8 = "^3.5"
+flake8-comprehensions = "^1.4"
+httmock = "^1.2"
+hypothesis = "^3.56"
+mypy = "^0.600"
+pytest = "^3.5"
+pytest-cov = "^2.5"
+pytest-mock = "^1.9"
+pytest-sugar = "^0.9"
+pytest-random-order = "^0.7"
+tox = "^3.0"


### PR DESCRIPTION
Starting with version 1.8, Poetry has a non-package mode for projects using Poetry not for building and publishing packages but only for dependency management. `name`, `version`, `description` and `authors` fields are optional in non-package mode.