### PR TITLE
Update corepack to fix new error after pnpm upgrade

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.24.0
+ARG COREPACK_VERSION=0.26.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.15.6

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/peer_disambiguation_v6/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/peer_disambiguation_v6/package.json
@@ -18,7 +18,7 @@
     "eslint": "^8.26.0",
     "typescript": "4.9.5"
   },
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.15.5",
   "engines": {
     "node": ">=16 <17",
     "pnpm": ">=7.17.0"

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/simple/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "{{ name }}",
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.15.5",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
The PNPM bump to v8.15.5 resulted in new Sentry errors; trying to bump corepack to see if it resolves the issues.
```
 ERR_PNPM_UNSUPPORTED_PLATFORM  Unsupported platform for registry.npmjs.org/@swc/core-linux-arm-gnueabihf/1.4.8: wanted {"cpu":["arm"],"os":["linux"],"libc":["any"]} (current: {"os":"linux","cpu":"x64","libc":"glibc"})
```