### PR TITLE
Set `Style/AccessorGrouping` to `separated`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -227,7 +227,7 @@ Performance/UnfreezeString:
 Performance/UriDefaultParser:
   Enabled: true
 Style/AccessorGrouping:
-  Enabled: false
+  EnforcedStyle: 'separated'
 Style/ArgumentsForwarding:
   Enabled: true
 Style/ArrayCoercion:

--- a/bundler/helpers/v1/lib/functions/conflicting_dependency_resolver.rb
+++ b/bundler/helpers/v1/lib/functions/conflicting_dependency_resolver.rb
@@ -34,7 +34,9 @@ module Functions
 
     private
 
-    attr_reader :dependency_name, :target_version, :lockfile_name
+    attr_reader :dependency_name
+    attr_reader :target_version
+    attr_reader :lockfile_name
 
     def parent_specs
       version = Gem::Version.new(target_version)

--- a/bundler/helpers/v1/lib/functions/dependency_source.rb
+++ b/bundler/helpers/v1/lib/functions/dependency_source.rb
@@ -3,7 +3,8 @@
 
 module Functions
   class DependencySource
-    attr_reader :gemfile_name, :dependency_name
+    attr_reader :gemfile_name
+    attr_reader :dependency_name
 
     RUBYGEMS = "rubygems"
     PRIVATE_REGISTRY = "private"

--- a/bundler/helpers/v1/lib/functions/force_updater.rb
+++ b/bundler/helpers/v1/lib/functions/force_updater.rb
@@ -56,9 +56,12 @@ module Functions
 
     private
 
-    attr_reader :dependency_name, :target_version, :gemfile_name,
-                :lockfile_name, :credentials,
-                :update_multiple_dependencies
+    attr_reader :dependency_name
+    attr_reader :target_version
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
+    attr_reader :credentials
+    attr_reader :update_multiple_dependencies
     alias update_multiple_dependencies? update_multiple_dependencies
 
     def new_dependencies_to_unlock_from(error:, already_unlocked:)

--- a/bundler/helpers/v1/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v1/lib/functions/lockfile_updater.rb
@@ -25,7 +25,9 @@ module Functions
 
     private
 
-    attr_reader :gemfile_name, :lockfile_name, :dependencies
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
+    attr_reader :dependencies
 
     def generate_lockfile # rubocop:disable Metrics/PerceivedComplexity
       dependencies_to_unlock = dependencies.map { |d| d.fetch("name") }

--- a/bundler/helpers/v1/lib/functions/version_resolver.rb
+++ b/bundler/helpers/v1/lib/functions/version_resolver.rb
@@ -5,8 +5,10 @@ module Functions
   class VersionResolver
     GEM_NOT_FOUND_ERROR_REGEX = /locked to (?<name>[^\s]+) \(/
 
-    attr_reader :dependency_name, :dependency_requirements,
-                :gemfile_name, :lockfile_name
+    attr_reader :dependency_name
+    attr_reader :dependency_requirements
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
 
     def initialize(dependency_name:, dependency_requirements:,
                    gemfile_name:, lockfile_name:)

--- a/bundler/helpers/v2/lib/functions/conflicting_dependency_resolver.rb
+++ b/bundler/helpers/v2/lib/functions/conflicting_dependency_resolver.rb
@@ -32,7 +32,9 @@ module Functions
 
     private
 
-    attr_reader :dependency_name, :target_version, :lockfile_name
+    attr_reader :dependency_name
+    attr_reader :target_version
+    attr_reader :lockfile_name
 
     def parent_specs
       version = Gem::Version.new(target_version)

--- a/bundler/helpers/v2/lib/functions/dependency_source.rb
+++ b/bundler/helpers/v2/lib/functions/dependency_source.rb
@@ -3,7 +3,8 @@
 
 module Functions
   class DependencySource
-    attr_reader :gemfile_name, :dependency_name
+    attr_reader :gemfile_name
+    attr_reader :dependency_name
 
     RUBYGEMS = "rubygems"
     PRIVATE_REGISTRY = "private"

--- a/bundler/helpers/v2/lib/functions/force_updater.rb
+++ b/bundler/helpers/v2/lib/functions/force_updater.rb
@@ -57,9 +57,12 @@ module Functions
 
     private
 
-    attr_reader :dependency_name, :target_version, :gemfile_name,
-                :lockfile_name, :credentials,
-                :update_multiple_dependencies
+    attr_reader :dependency_name
+    attr_reader :target_version
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
+    attr_reader :credentials
+    attr_reader :update_multiple_dependencies
     alias update_multiple_dependencies? update_multiple_dependencies
 
     def extra_top_level_deps(specs)

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -26,7 +26,9 @@ module Functions
 
     private
 
-    attr_reader :gemfile_name, :lockfile_name, :dependencies
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
+    attr_reader :dependencies
 
     def generate_lockfile # rubocop:disable Metrics/PerceivedComplexity
       dependencies_to_unlock = dependencies.map { |d| d.fetch("name") }

--- a/bundler/helpers/v2/lib/functions/version_resolver.rb
+++ b/bundler/helpers/v2/lib/functions/version_resolver.rb
@@ -5,8 +5,10 @@ module Functions
   class VersionResolver
     GEM_NOT_FOUND_ERROR_REGEX = /locked to (?<name>[^\s]+) \(/
 
-    attr_reader :dependency_name, :dependency_requirements,
-                :gemfile_name, :lockfile_name
+    attr_reader :dependency_name
+    attr_reader :dependency_requirements
+    attr_reader :gemfile_name
+    attr_reader :lockfile_name
 
     def initialize(dependency_name:, dependency_requirements:,
                    gemfile_name:, lockfile_name:)

--- a/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
@@ -38,7 +38,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :gemfile
+        attr_reader :dependencies
+        attr_reader :gemfile
 
         def replace_gemfile_version_requirement(dependency, file, content)
           return content unless requirement_changed?(file, dependency)

--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_updater.rb
@@ -28,7 +28,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :gemspec
+        attr_reader :dependencies
+        attr_reader :gemspec
 
         def replace_gemspec_version_requirement(gemspec, dependency, content)
           return content unless requirement_changed?(gemspec, dependency)

--- a/bundler/lib/dependabot/bundler/file_updater/git_pin_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/git_pin_replacer.rb
@@ -8,7 +8,8 @@ module Dependabot
   module Bundler
     class FileUpdater
       class GitPinReplacer
-        attr_reader :dependency, :new_pin
+        attr_reader :dependency
+        attr_reader :new_pin
 
         def initialize(dependency:, new_pin:)
           @dependency = dependency
@@ -27,7 +28,8 @@ module Dependabot
 
         class Rewriter < Parser::TreeRewriter
           PIN_KEYS = %i(ref tag).freeze
-          attr_reader :dependency, :new_pin
+          attr_reader :dependency
+          attr_reader :new_pin
 
           def initialize(dependency:, new_pin:)
             @dependency = dependency

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -54,8 +54,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :repo_contents_path,
-                    :credentials, :options
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
+        attr_reader :options
 
         def build_updated_lockfile
           base_dir = dependency_files.first.directory

--- a/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
@@ -8,8 +8,10 @@ module Dependabot
   module Bundler
     class FileUpdater
       class RequirementReplacer
-        attr_reader :dependency, :file_type, :updated_requirement,
-                    :previous_requirement
+        attr_reader :dependency
+        attr_reader :file_type
+        attr_reader :updated_requirement
+        attr_reader :previous_requirement
 
         def initialize(dependency:, file_type:, updated_requirement:,
                        previous_requirement: nil, insert_if_bare: false)
@@ -115,7 +117,9 @@ module Dependabot
 
           private
 
-          attr_reader :dependency, :file_type, :updated_requirement
+          attr_reader :dependency
+          attr_reader :file_type
+          attr_reader :updated_requirement
 
           def insert_if_bare?
             @insert_if_bare

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -102,8 +102,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :dependency, :replacement_git_pin,
-                    :latest_allowable_version
+        attr_reader :dependency_files
+        attr_reader :dependency
+        attr_reader :replacement_git_pin
+        attr_reader :latest_allowable_version
 
         def remove_git_source?
           @remove_git_source

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -38,9 +38,13 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :repo_contents_path,
-                    :credentials, :target_version, :requirements_update_strategy,
-                    :options
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
+        attr_reader :target_version
+        attr_reader :requirements_update_strategy
+        attr_reader :options
 
         def update_multiple_dependencies?
           @update_multiple_dependencies

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -41,9 +41,13 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :repo_contents_path,
-                    :credentials, :ignored_versions, :security_advisories,
-                    :options
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
+        attr_reader :options
 
         def fetch_latest_version_details
           return dependency_source.latest_git_version_details if dependency_source.git?

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -21,8 +21,11 @@ module Dependabot
           GIT = "git"
           OTHER = "other"
 
-          attr_reader :dependency, :dependency_files, :repo_contents_path,
-                      :credentials, :options
+          attr_reader :dependency
+          attr_reader :dependency_files
+          attr_reader :repo_contents_path
+          attr_reader :credentials
+          attr_reader :options
 
           def initialize(dependency:,
                          dependency_files:,

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -54,9 +54,11 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :updated_source,
-                    :latest_version, :latest_resolvable_version,
-                    :update_strategy
+        attr_reader :requirements
+        attr_reader :updated_source
+        attr_reader :latest_version
+        attr_reader :latest_resolvable_version
+        attr_reader :update_strategy
 
         def check_update_strategy
           return if ALLOWED_UPDATE_STRATEGIES.include?(update_strategy)

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -41,7 +41,9 @@ module Dependabot
           Bundler::Fetcher::FallbackError
         ).freeze
 
-        attr_reader :dependency_files, :repo_contents_path, :credentials
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
 
         #########################
         # Bundler context setup #

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -53,10 +53,14 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :unprepared_dependency_files,
-                    :repo_contents_path, :credentials, :ignored_versions,
-                    :replacement_git_pin, :latest_allowable_version,
-                    :options
+        attr_reader :dependency
+        attr_reader :unprepared_dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :replacement_git_pin
+        attr_reader :latest_allowable_version
+        attr_reader :options
 
         def remove_git_source?
           @remove_git_source

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -50,7 +50,9 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         # Currently, there will only be a single updated dependency
         def dependency

--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -38,7 +38,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :manifest
+        attr_reader :dependencies
+        attr_reader :manifest
 
         def requirement_changed?(file, dependency)
           changed_requirements =

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -39,8 +39,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :dependency, :replacement_git_pin,
-                    :latest_allowable_version
+        attr_reader :dependency_files
+        attr_reader :dependency
+        attr_reader :replacement_git_pin
+        attr_reader :latest_allowable_version
 
         def unlock_requirement?
           @unlock_requirement

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -34,8 +34,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def fetch_latest_version
           versions = available_versions

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -67,8 +67,10 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :updated_source, :update_strategy,
-                    :target_version
+        attr_reader :requirements
+        attr_reader :updated_source
+        attr_reader :update_strategy
+        attr_reader :target_version
 
         def check_update_strategy
           return if ALLOWED_UPDATE_STRATEGIES.include?(update_strategy)

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -35,8 +35,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials,
-                    :prepared_dependency_files, :original_dependency_files
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :prepared_dependency_files
+        attr_reader :original_dependency_files
 
         def fetch_latest_resolvable_version
           base_directory = prepared_dependency_files.first.directory

--- a/composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb
+++ b/composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb
@@ -35,7 +35,9 @@ module Dependabot
 
         private
 
-        attr_reader :path, :lockfile, :directory
+        attr_reader :path
+        attr_reader :lockfile
+        attr_reader :directory
 
         def details_from_lockfile
           keys = FileParser::DEPENDENCY_GROUP_KEYS

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -58,8 +58,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :credentials,
-                    :composer_platform_extensions
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :composer_platform_extensions
 
         def generate_updated_lockfile_content
           base_directory = dependency_files.first.directory

--- a/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
@@ -38,7 +38,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :manifest
+        attr_reader :dependencies
+        attr_reader :manifest
 
         def new_requirements(dependency)
           dependency.requirements.select { |r| r[:file] == manifest.name }

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -34,8 +34,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def fetch_latest_version
           versions = available_versions

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -56,8 +56,9 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :update_strategy,
-                    :latest_resolvable_version
+        attr_reader :requirements
+        attr_reader :update_strategy
+        attr_reader :latest_resolvable_version
 
         def check_update_strategy
           return if ALLOWED_UPDATE_STRATEGIES.include?(update_strategy)

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -57,9 +57,12 @@ module Dependabot
 
         private
 
-        attr_reader :credentials, :dependency, :dependency_files,
-                    :requirements_to_unlock, :latest_allowable_version,
-                    :composer_platform_extensions
+        attr_reader :credentials
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :requirements_to_unlock
+        attr_reader :latest_allowable_version
+        attr_reader :composer_platform_extensions
 
         def fetch_latest_resolvable_version
           version = fetch_latest_resolvable_version_string

--- a/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
+++ b/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
@@ -32,7 +32,8 @@ module Dependabot
 
         private
 
-        attr_reader :elm_json_file, :dependencies
+        attr_reader :elm_json_file
+        attr_reader :dependencies
 
         def requirement_changed?(file, dependency)
           changed_requirements =

--- a/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
+++ b/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
@@ -66,7 +66,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files
+        attr_reader :dependency
+        attr_reader :dependency_files
 
         def fetch_latest_resolvable_version(unlock_requirement)
           changed_deps = install_metadata

--- a/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
+++ b/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
@@ -38,7 +38,8 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :latest_resolvable_version
+        attr_reader :requirements
+        attr_reader :latest_resolvable_version
 
         def update_requirement(old_req, new_version)
           if requirement_class.new(old_req).satisfied_by?(new_version)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -86,8 +86,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :credentials, :repo_contents_path,
-                    :directory
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
+        attr_reader :directory
 
         def updated_files
           @updated_files ||= update_files

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -56,7 +56,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials, :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def fetch_latest_version
           candidate_versions = available_versions

--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -48,7 +48,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :target_dependency_file
+        attr_reader :dependency_files
+        attr_reader :target_dependency_file
 
         def inherited_repository_urls(dependency_file)
           return [] unless dependency_file

--- a/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
@@ -59,8 +59,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :target_version, :source_url, :ignored_versions
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :target_version
+        attr_reader :source_url
+        attr_reader :ignored_versions
 
         def dependencies_to_update
           @dependencies_to_update ||=

--- a/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
@@ -44,8 +44,10 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :latest_version, :source_url,
-                    :properties_to_update
+        attr_reader :requirements
+        attr_reader :latest_version
+        attr_reader :source_url
+        attr_reader :properties_to_update
 
         def update_requirement(req_string)
           if req_string.include?("+")

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -76,8 +76,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :forbidden_urls, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :forbidden_urls
+        attr_reader :security_advisories
 
         sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_prereleases(possible_versions)

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -41,7 +41,9 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def dependency
           # For now, we'll only ever be updating a single dep for Elixir

--- a/hex/lib/dependabot/hex/file_updater/mixfile_git_pin_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_git_pin_updater.rb
@@ -26,8 +26,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_name, :mixfile_content,
-                    :previous_pin, :updated_pin
+        attr_reader :dependency_name
+        attr_reader :mixfile_content
+        attr_reader :previous_pin
+        attr_reader :updated_pin
 
         def update_pin(content)
           requirement_line_regex =

--- a/hex/lib/dependabot/hex/file_updater/mixfile_requirement_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_requirement_updater.rb
@@ -28,8 +28,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_name, :mixfile_content,
-                    :previous_requirement, :updated_requirement
+        attr_reader :dependency_name
+        attr_reader :mixfile_content
+        attr_reader :previous_requirement
+        attr_reader :updated_requirement
 
         def insert_if_bare?
           !@insert_if_bare.nil?

--- a/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
@@ -40,7 +40,8 @@ module Dependabot
 
         private
 
-        attr_reader :mixfile, :dependencies
+        attr_reader :mixfile
+        attr_reader :dependencies
 
         def requirement_changed?(file, dependency)
           changed_requirements =

--- a/hex/lib/dependabot/hex/update_checker/file_preparer.rb
+++ b/hex/lib/dependabot/hex/update_checker/file_preparer.rb
@@ -41,8 +41,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :dependency, :replacement_git_pin,
-                    :latest_allowable_version
+        attr_reader :dependency_files
+        attr_reader :dependency
+        attr_reader :replacement_git_pin
+        attr_reader :latest_allowable_version
 
         def unlock_requirement?
           @unlock_requirement

--- a/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
+++ b/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
@@ -32,7 +32,9 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :latest_resolvable_version, :updated_source
+        attr_reader :requirements
+        attr_reader :latest_resolvable_version
+        attr_reader :updated_source
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/AbcSize
         def updated_mixfile_requirement(req)

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -27,8 +27,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials,
-                    :original_dependency_files, :prepared_dependency_files
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :original_dependency_files
+        attr_reader :prepared_dependency_files
 
         def fetch_latest_resolvable_version
           latest_resolvable_version =

--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -15,7 +15,9 @@ module Dependabot
              <plugin>.*?(?:<plugin>.*?</plugin>.*)?</plugin>|<extension>.*?</extension>|
              <path>.*?</path>}mx
 
-        attr_reader :dependency, :declaring_requirement, :dependency_files
+        attr_reader :dependency
+        attr_reader :declaring_requirement
+        attr_reader :dependency_files
 
         def initialize(dependency:, dependency_files:, declaring_requirement:)
           @dependency            = dependency

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -60,8 +60,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :target_version,
-                    :source_url, :credentials, :ignored_versions
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :target_version
+        attr_reader :source_url
+        attr_reader :credentials
+        attr_reader :ignored_versions
 
         def dependencies_using_property
           @dependencies_using_property ||=

--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -44,8 +44,10 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :latest_version, :source_url,
-                    :properties_to_update
+        attr_reader :requirements
+        attr_reader :latest_version
+        attr_reader :source_url
+        attr_reader :properties_to_update
 
         def update_requirement(req_string)
           if req_string.include?(".+")

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -78,8 +78,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :forbidden_urls, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :forbidden_urls
+        attr_reader :security_advisories
 
         sig { params(possible_versions: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
         def filter_prereleases(possible_versions)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
@@ -37,7 +37,8 @@ module Dependabot
 
       private
 
-      attr_reader :dependency_files, :updated_dependencies
+      attr_reader :dependency_files
+      attr_reader :updated_dependencies
 
       def fetch_paths_requiring_update_check
         # if only a root lockfile exists, it tracks all dependencies

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder.rb
@@ -32,8 +32,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_name, :path, :package_lock, :yarn_lock,
-                    :directory
+        attr_reader :dependency_name
+        attr_reader :path
+        attr_reader :package_lock
+        attr_reader :yarn_lock
+        attr_reader :directory
 
         def details_from_yarn_lock
           path_starts = FileFetcher::PATH_DEPENDENCY_STARTS

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -33,7 +33,10 @@ module Dependabot
 
         private
 
-        attr_reader :lockfile, :dependencies, :dependency_files, :credentials
+        attr_reader :lockfile
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         UNREACHABLE_GIT = /fatal: repository '(?<url>.*)' not found/
         FORBIDDEN_GIT = /fatal: Authentication failed for '(?<url>.*)'/

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -61,7 +61,9 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :credentials, :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :dependencies
 
         def build_npmrc_content_from_lockfile
           return unless yarn_lock || package_lock || shrinkwrap

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
@@ -20,7 +20,8 @@ module Dependabot
 
         private
 
-        attr_reader :package_json, :dependencies
+        attr_reader :package_json
+        attr_reader :dependencies
 
         def updated_package_json_content
           dependencies.reduce(package_json.content.dup) do |content, dep|

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -32,7 +32,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :repo_contents_path, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
 
         IRRESOLVABLE_PACKAGE = "ERR_PNPM_NO_MATCHING_VERSION"
         INVALID_REQUIREMENT = "ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -39,7 +39,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :dependency_files, :repo_contents_path, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
 
         UNREACHABLE_GIT = /ls-remote --tags --heads (?<url>.*)/
         TIMEOUT_FETCHING_PACKAGE = %r{(?<url>.+)/(?<package>[^/]+): ETIMEDOUT}

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -43,7 +43,8 @@ module Dependabot
 
       private
 
-      attr_reader :resolved_url, :credentials
+      attr_reader :resolved_url
+      attr_reader :credentials
 
       # rubocop:disable Metrics/PerceivedComplexity
       def url_for_relevant_cred

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
@@ -33,7 +33,8 @@ module Dependabot
 
       private
 
-      attr_reader :dependency_files, :updated_dependencies
+      attr_reader :dependency_files
+      attr_reader :updated_dependencies
 
       def lockfile_dependencies(lockfile)
         @lockfile_dependencies ||= {}

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
@@ -65,7 +65,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :credentials
+        attr_reader :dependency_files
+        attr_reader :credentials
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/dependency_files_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/dependency_files_builder.rb
@@ -79,7 +79,9 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def write_lockfiles
           yarn_locks.each do |f|

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -108,8 +108,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials, :dependency_files,
-                    :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def valid_npm_details?
           !npm_details&.fetch("dist-tags", nil).nil?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb
@@ -23,7 +23,9 @@ module Dependabot
 
         private
 
-        attr_reader :package_json_file, :credentials, :dependency_files
+        attr_reader :package_json_file
+        attr_reader :credentials
+        attr_reader :dependency_files
 
         def package_json_may_be_for_library?
           return false unless project_name

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -61,7 +61,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials, :npmrc_file, :yarnrc_file, :yarnrc_yml_file
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :npmrc_file
+        attr_reader :yarnrc_file
+        attr_reader :yarnrc_yml_file
 
         def explicit_registry_from_rc(dependency_name)
           if dependency_name.start_with?("@") && dependency_name.include?("/")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -62,8 +62,10 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :updated_source, :update_strategy,
-                    :latest_resolvable_version
+        attr_reader :requirements
+        attr_reader :updated_source
+        attr_reader :update_strategy
+        attr_reader :latest_resolvable_version
 
         def check_update_strategy
           return if ALLOWED_UPDATE_STRATEGIES.include?(update_strategy)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -53,8 +53,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials, :dependency_files,
-                    :ignored_versions, :latest_allowable_version, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :ignored_versions
+        attr_reader :latest_allowable_version
+        attr_reader :repo_contents_path
 
         def update_subdependency_in_lockfile(lockfile)
           lockfile_name = Pathname.new(lockfile.name).basename.to_s

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -154,8 +154,12 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :credentials, :dependency_files,
-                    :latest_allowable_version, :repo_contents_path, :dependency_group
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :latest_allowable_version
+        attr_reader :repo_contents_path
+        attr_reader :dependency_group
 
         def latest_version_finder(dep)
           @latest_version_finder[dep] ||=

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -100,7 +100,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :credentials
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def explain_fix_unavailable(validation_result, dependency)
           case validation_result

--- a/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/compatibility_checker.rb
@@ -39,7 +39,9 @@ module Dependabot
 
       private
 
-      attr_reader :dependency_urls, :dependency, :tfm_finder
+      attr_reader :dependency_urls
+      attr_reader :dependency
+      attr_reader :tfm_finder
 
       def pure_development_dependency?(nuspec_xml)
         contents = nuspec_xml.at_xpath("package/metadata/developmentDependency")&.content&.strip

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -104,7 +104,10 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
 
         def updated_requirements(dep, target_version_details)
           @updated_requirements ||= {}

--- a/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
@@ -75,8 +75,13 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :target_version,
-                    :source_details, :credentials, :ignored_versions, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :target_version
+        attr_reader :source_details
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :repo_contents_path
 
         def process_updated_peer_dependencies(dependency, dependencies)
           DependencyFinder.new(

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -56,7 +56,9 @@ module Dependabot
 
       private
 
-      attr_reader :dependency, :credentials, :config_files
+      attr_reader :dependency
+      attr_reader :credentials
+      attr_reader :config_files
 
       def find_dependency_urls
         @find_dependency_urls ||=

--- a/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/tfm_finder.rb
@@ -31,7 +31,9 @@ module Dependabot
 
       private
 
-      attr_reader :dependency_files, :credentials, :repo_contents_path
+      attr_reader :dependency_files
+      attr_reader :credentials
+      attr_reader :repo_contents_path
 
       def project_file_tfms(dependency)
         project_files_with_dependency(dependency).flat_map do |file|

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -30,7 +30,9 @@ module Dependabot
         NATIVE_COMPILATION_ERROR =
           "pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1"
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def initialize(dependencies:, dependency_files:, credentials:)
           @dependencies = dependencies

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -21,7 +21,10 @@ module Dependabot
 
         DEPENDENCY_TYPES = %w(packages dev-packages).freeze
 
-        attr_reader :dependencies, :dependency_files, :credentials, :repo_contents_path
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
 
         def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path:)
           @dependencies = dependencies

--- a/python/lib/dependabot/python/file_updater/pipfile_manifest_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_manifest_updater.rb
@@ -31,7 +31,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :manifest
+        attr_reader :dependencies
+        attr_reader :manifest
 
         def update_requirements(content:, dependency:)
           updated_content = content.dup

--- a/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
@@ -41,7 +41,8 @@ module Dependabot
 
         private
 
-        attr_reader :pipfile_content, :lockfile
+        attr_reader :pipfile_content
+        attr_reader :lockfile
 
         def pipfile_sources
           @pipfile_sources ||= TomlRB.parse(pipfile_content).fetch("source", [])

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -19,7 +19,9 @@ module Dependabot
       class PoetryFileUpdater
         require_relative "pyproject_preparer"
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def initialize(dependencies:, dependency_files:, credentials:)
           @dependencies = dependencies

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -103,7 +103,8 @@ module Dependabot
 
         private
 
-        attr_reader :pyproject_content, :lockfile
+        attr_reader :pyproject_content
+        attr_reader :lockfile
 
         def locked_details(dep_name)
           parsed_lockfile.fetch("package")

--- a/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
@@ -12,7 +12,9 @@ module Dependabot
       class RequirementFileUpdater
         require_relative "requirement_replacer"
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :dependencies
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def initialize(dependencies:, dependency_files:, credentials:)
           @dependencies = dependencies

--- a/python/lib/dependabot/python/file_updater/requirement_replacer.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_replacer.rb
@@ -38,8 +38,11 @@ module Dependabot
 
         private
 
-        attr_reader :content, :dependency_name, :old_requirement,
-                    :new_requirement, :new_hash_version
+        attr_reader :content
+        attr_reader :dependency_name
+        attr_reader :old_requirement
+        attr_reader :new_requirement
+        attr_reader :new_hash_version
 
         def update_hashes?
           !new_hash_version.nil?

--- a/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
+++ b/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
@@ -31,7 +31,8 @@ module Dependabot
 
         private
 
-        attr_reader :setup_file, :setup_cfg
+        attr_reader :setup_file
+        attr_reader :setup_cfg
 
         def include_pbr?
           setup_requires_array.any? { |d| d.start_with?("pbr") }

--- a/python/lib/dependabot/python/pipenv_runner.rb
+++ b/python/lib/dependabot/python/pipenv_runner.rb
@@ -41,7 +41,9 @@ module Dependabot
 
       private
 
-      attr_reader :dependency, :lockfile, :language_version_manager
+      attr_reader :dependency
+      attr_reader :lockfile
+      attr_reader :language_version_manager
 
       def fetch_version_from_parsed_lockfile(updated_lockfile)
         deps = updated_lockfile[lockfile_section] || {}

--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -40,7 +40,8 @@ module Dependabot
 
         private
 
-        attr_reader :dependency_files, :credentials
+        attr_reader :dependency_files
+        attr_reader :credentials
 
         def main_index_url
           url =

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -49,8 +49,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def fetch_latest_version(python_version:)
           versions = available_versions

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -33,7 +33,10 @@ module Dependabot
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"
         ERROR_REGEX = /(?<=ERROR\:\W).*$/
 
-        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
 
         def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -37,8 +37,11 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :security_advisories
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
 
         def latest_version_finder
           @latest_version_finder ||= LatestVersionFinder.new(

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -32,7 +32,10 @@ module Dependabot
 
         PIPENV_RANGE_WARNING = /Warning:\sPython\s[<>].* was not found/
 
-        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
 
         def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -38,7 +38,10 @@ module Dependabot
           \s+check\syour\sgit\sconfiguration
         /mx
 
-        attr_reader :dependency, :dependency_files, :credentials, :repo_contents_path
+        attr_reader :dependency
+        attr_reader :dependency_files
+        attr_reader :credentials
+        attr_reader :repo_contents_path
 
         def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
           @dependency               = dependency

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -16,8 +16,10 @@ module Dependabot
 
         class UnfixableRequirement < StandardError; end
 
-        attr_reader :requirements, :update_strategy, :has_lockfile,
-                    :latest_resolvable_version
+        attr_reader :requirements
+        attr_reader :update_strategy
+        attr_reader :has_lockfile
+        attr_reader :latest_resolvable_version
 
         def initialize(requirements:, update_strategy:, has_lockfile:,
                        latest_resolvable_version:)

--- a/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
@@ -75,7 +75,9 @@ module Dependabot
           "#{uri.host}#{uri.path}".delete_prefix("www.").delete_suffix(".git")
         end
 
-        attr_reader :dependency_files, :repo_contents_path, :credentials
+        attr_reader :dependency_files
+        attr_reader :repo_contents_path
+        attr_reader :credentials
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -41,7 +41,8 @@ module Dependabot
 
         private
 
-        attr_reader :manifest, :source
+        attr_reader :manifest
+        attr_reader :source
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_updater/lockfile_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater/lockfile_updater.rb
@@ -51,7 +51,11 @@ module Dependabot
           Dependabot.logger.info("Lockfile failed to be updated due to error:\n#{e.message}")
         end
 
-        attr_reader :dependency, :manifest, :repo_contents_path, :credentials, :target_version
+        attr_reader :dependency
+        attr_reader :manifest
+        attr_reader :repo_contents_path
+        attr_reader :credentials
+        attr_reader :target_version
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_updater/manifest_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater/manifest_updater.rb
@@ -31,7 +31,9 @@ module Dependabot
 
         private
 
-        attr_reader :content, :old_requirements, :new_requirements
+        attr_reader :content
+        attr_reader :old_requirements
+        attr_reader :new_requirements
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
+++ b/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
@@ -22,7 +22,10 @@ module Dependabot
 
         private
 
-        attr_reader :content, :declaration, :old_requirement, :new_requirement
+        attr_reader :content
+        attr_reader :declaration
+        attr_reader :old_requirement
+        attr_reader :new_requirement
       end
     end
   end

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -150,7 +150,9 @@ module Dependabot
         declaration.include?("..<")
       end
 
-      attr_reader :min, :max, :requirement
+      attr_reader :min
+      attr_reader :max
+      attr_reader :requirement
 
       def unquote(declaration)
         declaration[1..-2]

--- a/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
+++ b/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
@@ -25,7 +25,8 @@ module Dependabot
 
         private
 
-        attr_reader :requirements, :target_version
+        attr_reader :requirements
+        attr_reader :target_version
       end
     end
   end

--- a/swift/lib/dependabot/swift/update_checker/version_resolver.rb
+++ b/swift/lib/dependabot/swift/update_checker/version_resolver.rb
@@ -52,7 +52,11 @@ module Dependabot
           )
         end
 
-        attr_reader :dependency, :manifest, :lockfile, :repo_contents_path, :credentials
+        attr_reader :dependency
+        attr_reader :manifest
+        attr_reader :lockfile
+        attr_reader :repo_contents_path
+        attr_reader :credentials
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -134,7 +134,8 @@ module Dependabot
 
       private
 
-      attr_reader :hostname, :tokens
+      attr_reader :hostname
+      attr_reader :tokens
 
       def version_class
         Version

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -81,7 +81,9 @@ module Dependabot
 
       private
 
-      attr_reader :requirements, :latest_version, :tag_for_latest_version
+      attr_reader :requirements
+      attr_reader :latest_version
+      attr_reader :tag_for_latest_version
 
       def update_git_requirement(req)
         return req unless req.dig(:source, :ref)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -63,6 +63,9 @@ module Dependabot
 
     private
 
-    attr_reader :service, :job, :dependency_snapshot, :error_handler
+    attr_reader :service
+    attr_reader :job
+    attr_reader :dependency_snapshot
+    attr_reader :error_handler
   end
 end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -118,7 +118,8 @@ module Dependabot
 
       private
 
-      attr_reader :service, :job
+      attr_reader :service
+      attr_reader :job
 
       # This method accepts an error class and returns an appropriate `error_details` hash
       # to be reported to the backend service.

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -57,11 +57,11 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :group
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
+        attr_reader :group
 
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -54,11 +54,11 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :created_pull_requests
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
+        attr_reader :created_pull_requests
 
         def check_and_create_pr_with_error_handling(dependency)
           check_and_create_pull_request(dependency)

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -75,10 +75,10 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
 
         def run_grouped_dependency_updates # rubocop:disable Metrics/AbcSize
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -106,10 +106,10 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
 
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -45,10 +45,10 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
 
         def dependencies
           dependency_snapshot.job_dependencies

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -46,11 +46,11 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :created_pull_requests
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
+        attr_reader :created_pull_requests
 
         def dependencies
           dependency_snapshot.job_dependencies

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -41,11 +41,11 @@ module Dependabot
 
         private
 
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler,
-                    :created_pull_requests
+        attr_reader :job
+        attr_reader :service
+        attr_reader :dependency_snapshot
+        attr_reader :error_handler
+        attr_reader :created_pull_requests
 
         def dependencies
           if dependency_snapshot.dependencies.any? && dependency_snapshot.allowed_dependencies.none?


### PR DESCRIPTION
While we've been doing the Sorbet migration, we've had to separate out all of our attribute accessors so we can add `sig`s to them. For example:

```ruby
class Foo
  attr_reader :bar, :bax, :baz
end
```

has become

```ruby
class Foo
  attr_reader :bar
  attr_reader :bax
  attr_reader :baz
end
```

This change enables the RuboCop `Style/AccessorGrouping` rule and sets it to `separated` so we don't have to do this change manually.

Check out [the RuboCop documentation][1] for more information.

[1]: https://docs.rubocop.org/rubocop/cops_style.html#styleaccessorgrouping