### PR TITLE
Cover parts of `go_modules` code with Sorbet

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -38,7 +38,7 @@ module Dependabot
           directory,
           clone_repo_contents
         ) do
-          fetched_files = [T.must(go_mod)]
+          fetched_files = go_mod ? [go_mod] : []
           # Fetch the (optional) go.sum
           fetched_files << T.must(go_sum) if go_sum
           fetched_files

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -11,18 +11,21 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
+      sig { override.params(filenames: T::Array[String]).returns(T::Boolean) }
       def self.required_files_in?(filenames)
         filenames.include?("go.mod")
       end
 
+      sig { override.returns(String) }
       def self.required_files_message
         "Repo must contain a go.mod."
       end
 
+      sig { override.returns(T::Hash[Symbol, T.untyped]) }
       def ecosystem_versions
         {
           package_managers: {
-            "gomod" => go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
+            "gomod" => go_mod.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
           }
         }
       end
@@ -37,23 +40,21 @@ module Dependabot
         ) do
           fetched_files = [go_mod]
           # Fetch the (optional) go.sum
-          fetched_files << go_sum if go_sum
+          fetched_files << T.must(go_sum) if go_sum
           fetched_files
         end
       end
 
       private
 
+      sig { returns(Dependabot::DependencyFile) }
       def go_mod
-        return @go_mod if defined?(@go_mod)
-
-        @go_mod = fetch_file_if_present("go.mod")
+        @go_mod ||= T.let(T.must(fetch_file_if_present("go.mod")), T.nilable(Dependabot::DependencyFile))
       end
 
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def go_sum
-        return @go_sum if defined?(@go_sum)
-
-        @go_sum = fetch_file_if_present("go.sum")
+        @go_sum ||= T.let(fetch_file_if_present("go.sum"), T.nilable(Dependabot::DependencyFile))
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -25,7 +25,7 @@ module Dependabot
       def ecosystem_versions
         {
           package_managers: {
-            "gomod" => go_mod.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
+            "gomod" => go_mod&.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
           }
         }
       end
@@ -38,7 +38,7 @@ module Dependabot
           directory,
           clone_repo_contents
         ) do
-          fetched_files = [go_mod]
+          fetched_files = [T.must(go_mod)]
           # Fetch the (optional) go.sum
           fetched_files << T.must(go_sum) if go_sum
           fetched_files
@@ -47,9 +47,9 @@ module Dependabot
 
       private
 
-      sig { returns(Dependabot::DependencyFile) }
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def go_mod
-        @go_mod ||= T.let(T.must(fetch_file_if_present("go.mod")), T.nilable(Dependabot::DependencyFile))
+        @go_mod ||= T.let(fetch_file_if_present("go.mod"), T.nilable(Dependabot::DependencyFile))
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
+
+require "sorbet-runtime"
 
 require "open3"
 require "dependabot/dependency"
@@ -14,6 +16,9 @@ require "dependabot/go_modules/version"
 module Dependabot
   module GoModules
     class FileParser < Dependabot::FileParsers::Base
+      extend T::Sig
+
+      sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
         set_gotoolchain_env
 
@@ -29,8 +34,9 @@ module Dependabot
       private
 
       # set GOTOOLCHAIN=local if go version >= 1.21
+      sig { void }
       def set_gotoolchain_env
-        go_directive = go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first
+        go_directive = go_mod&.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first
         return ENV["GOTOOLCHAIN"] = ENV.fetch("GO_LEGACY") unless go_directive
 
         go_version = Dependabot::GoModules::Version.new(go_directive)
@@ -41,21 +47,24 @@ module Dependabot
                              end
       end
 
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def go_mod
-        @go_mod ||= get_original_file("go.mod")
+        @go_mod ||= T.let(get_original_file("go.mod"), T.nilable(Dependabot::DependencyFile))
       end
 
+      sig { override.void }
       def check_required_files
         raise "No go.mod!" unless go_mod
       end
 
+      sig { params(details: T::Hash[String, T.untyped]).returns(Dependabot::Dependency) }
       def dependency_from_details(details)
         source = { type: "default", source: details["Path"] }
         version = details["Version"]&.sub(/^v?/, "")
 
         reqs = [{
           requirement: details["Version"],
-          file: go_mod.name,
+          file: go_mod&.name,
           source: source,
           groups: []
         }]
@@ -68,9 +77,10 @@ module Dependabot
         )
       end
 
+      sig { returns(T::Array[T::Hash[String, T.untyped]]) }
       def required_packages
         @required_packages ||=
-          SharedHelpers.in_a_temporary_directory do |path|
+          T.let(SharedHelpers.in_a_temporary_directory do |path|
             # Create a fake empty module for each local module so that
             # `go mod edit` works, even if some modules have been `replace`d with
             # a local module that we don't have access to.
@@ -85,56 +95,63 @@ module Dependabot
 
             stdout, stderr, status = Open3.capture3(command)
             handle_parser_error(path, stderr) unless status.success?
-            JSON.parse(stdout)["Require"] || []
-          end
+            T.let(JSON.parse(stdout)["Require"] || [], T::Array[T::Hash[String, T.untyped]])
+          end, T.nilable(T::Array[T::Hash[String, T.untyped]]))
       end
 
+      sig { returns(T::Hash[String, String]) }
       def local_replacements
         @local_replacements ||=
           # Find all the local replacements, and return them with a stub path
           # we can use in their place. Using generated paths is safer as it
           # means we don't need to worry about references to parent
           # directories, etc.
-          ReplaceStubber.new(repo_contents_path).stub_paths(manifest, go_mod.directory)
+          T.let(ReplaceStubber.new(repo_contents_path).stub_paths(manifest, go_mod&.directory),
+                T.nilable(T::Hash[String, String]))
       end
 
+      sig { returns(T::Hash[String, T.untyped]) }
       def manifest
         @manifest ||=
-          SharedHelpers.in_a_temporary_directory do |path|
-            File.write("go.mod", go_mod.content)
+          T.let(SharedHelpers.in_a_temporary_directory do |path|
+                  File.write("go.mod", go_mod&.content)
 
-            # Parse the go.mod to get a JSON representation of the replace
-            # directives
-            command = "go mod edit -json"
+                  # Parse the go.mod to get a JSON representation of the replace
+                  # directives
+                  command = "go mod edit -json"
 
-            stdout, stderr, status = Open3.capture3(command)
-            handle_parser_error(path, stderr) unless status.success?
+                  stdout, stderr, status = Open3.capture3(command)
+                  handle_parser_error(path, stderr) unless status.success?
 
-            JSON.parse(stdout)
-          end
+                  JSON.parse(stdout)
+                end, T.nilable(T::Hash[String, T.untyped]))
       end
 
+      sig { returns(T.nilable(String)) }
       def go_mod_content
-        local_replacements.reduce(go_mod.content) do |body, (path, stub_path)|
-          body.sub(path, stub_path)
+        local_replacements.reduce(go_mod&.content) do |body, (path, stub_path)|
+          body&.sub(path, stub_path)
         end
       end
 
+      sig { params(path: T.any(Pathname, String), stderr: String).returns(T.noreturn) }
       def handle_parser_error(path, stderr)
         msg = stderr.gsub(path.to_s, "").strip
-        raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)
+        raise Dependabot::DependencyFileNotParseable.new(T.must(go_mod).path, msg)
       end
 
+      sig { params(dep: T::Hash[String, T.untyped]).returns(T::Boolean) }
       def skip_dependency?(dep)
         # Updating replaced dependencies is not supported
         return true if dependency_is_replaced(dep)
 
         path_uri = URI.parse("https://#{dep['Path']}")
-        !path_uri.host.include?(".")
+        !path_uri.host&.include?(".")
       rescue URI::InvalidURIError
         false
       end
 
+      sig { params(details: T::Hash[String, T.untyped]).returns(T::Boolean) }
       def dependency_is_replaced(details)
         # Mark dependency as replaced if the requested dependency has a
         # "replace" directive and that either has the same version, or no

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -95,7 +95,7 @@ module Dependabot
 
             stdout, stderr, status = Open3.capture3(command)
             handle_parser_error(path, stderr) unless status.success?
-            T.let(JSON.parse(stdout)["Require"] || [], T::Array[T::Hash[String, T.untyped]])
+            JSON.parse(stdout)["Require"] || []
           end, T.nilable(T::Array[T::Hash[String, T.untyped]]))
       end
 

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/logger"

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -12,7 +12,9 @@ module Dependabot
   module GoModules
     class FileUpdater
       class GoModUpdater
-        RESOLVABILITY_ERROR_REGEXES = [
+        extend T::Sig
+
+        RESOLVABILITY_ERROR_REGEXES = T.let([
           # The checksum in go.sum does not match the downloaded content
           /verifying .*: checksum mismatch/,
           /go(?: get)?: .*: go.mod has post-v\d+ module path/,
@@ -28,9 +30,9 @@ module Dependabot
           /can't find reason for requirement on/,
           # import path doesn't exist
           /package \S+ is not in GOROOT/
-        ].freeze
+        ].freeze, T::Array[Regexp])
 
-        REPO_RESOLVABILITY_ERROR_REGEXES = [
+        REPO_RESOLVABILITY_ERROR_REGEXES = T.let([
           /fatal: The remote end hung up unexpectedly/,
           /repository '.+' not found/,
           %r{net/http: TLS handshake timeout},
@@ -48,22 +50,32 @@ module Dependabot
           /go(?: get)?: .*: unknown revision/m,
           # Package pointing to a proxy that 404s
           /go(?: get)?: .*: unrecognized import path/m
-        ].freeze
+        ].freeze, T::Array[Regexp])
 
-        MODULE_PATH_MISMATCH_REGEXES = [
+        MODULE_PATH_MISMATCH_REGEXES = T.let([
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?:? .* declares its path as: ([\S]*)/m
-        ].freeze
+        ].freeze, T::Array[Regexp])
 
-        OUT_OF_DISK_REGEXES = [
+        OUT_OF_DISK_REGEXES = T.let([
           %r{input/output error},
           /no space left on device/,
           /Out of diskspace/
-        ].freeze
+        ].freeze, T::Array[Regexp])
 
         GO_MOD_VERSION = /^go 1\.\d+(\.\d+)?$/
 
+        sig do
+          params(
+            dependencies: T::Array[Dependabot::Dependency],
+            dependency_files: T::Array[Dependabot::DependencyFile],
+            credentials: T::Array[Dependabot::Credential],
+            repo_contents_path: T.nilable(String),
+            directory: String,
+            options: T::Hash[Symbol, T.untyped]
+          ).void
+        end
         def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path:,
                        directory:, options:)
           @dependencies = dependencies
@@ -71,31 +83,44 @@ module Dependabot
           @credentials = credentials
           @repo_contents_path = repo_contents_path
           @directory = directory
-          @tidy = options.fetch(:tidy, false)
-          @vendor = options.fetch(:vendor, false)
-          @goprivate = options.fetch(:goprivate)
+          @tidy = T.let(options.fetch(:tidy, false), T::Boolean)
+          @vendor = T.let(options.fetch(:vendor, false), T::Boolean)
+          @goprivate = T.let(options.fetch(:goprivate), T.nilable(String))
         end
 
+        sig { returns(T.nilable(String)) }
         def updated_go_mod_content
           updated_files[:go_mod]
         end
 
+        sig { returns(T.nilable(String)) }
         def updated_go_sum_content
           updated_files[:go_sum]
         end
 
         private
 
+        sig { returns(T::Array[Dependabot::Dependency]) }
         attr_reader :dependencies
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
+
+        sig { returns(T.nilable(String)) }
         attr_reader :repo_contents_path
+
+        sig { returns(String) }
         attr_reader :directory
 
+        sig { returns(T::Hash[Symbol, String]) }
         def updated_files
-          @updated_files ||= update_files
+          @updated_files ||= T.let(update_files, T.nilable(T::Hash[Symbol, String]))
         end
 
+        sig { returns(T::Hash[Symbol, String]) }
         def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
           in_repo_path do
             # During grouped updates, the dependency_files are from a previous dependency
@@ -143,7 +168,7 @@ module Dependabot
             original_go_version = original_go_mod.match(GO_MOD_VERSION)&.to_a&.first
             updated_go_version = updated_go_mod.match(GO_MOD_VERSION)&.to_a&.first
             if original_go_version != updated_go_version
-              go_mod_lines = updated_go_mod.lines
+              go_mod_lines = T.let(updated_go_mod.lines, T::Array[T.nilable(String)])
               go_mod_lines.each_with_index do |line, i|
                 next unless line&.match?(GO_MOD_VERSION)
 
@@ -160,6 +185,7 @@ module Dependabot
           end
         end
 
+        sig { void }
         def run_go_mod_tidy
           return unless tidy?
 
@@ -173,6 +199,7 @@ module Dependabot
           Dependabot.logger.info "Failed to `go mod tidy`: #{stderr}" unless status.success?
         end
 
+        sig { void }
         def run_go_vendor
           return unless vendor?
 
@@ -181,6 +208,7 @@ module Dependabot
           handle_subprocess_error(stderr) unless status.success?
         end
 
+        sig { params(dependencies: T.untyped).void }
         def run_go_get(dependencies = [])
           # `go get` will fail if there are no go files in the directory.
           # For example, if a `//go:build` tag excludes all files when run
@@ -203,9 +231,10 @@ module Dependabot
           _, stderr, status = Open3.capture3(environment, command)
           handle_subprocess_error(stderr) unless status.success?
         ensure
-          FileUtils.rm_f(tmp_go_file)
+          FileUtils.rm_f(T.must(tmp_go_file))
         end
 
+        sig { returns(T::Hash[String, T.untyped]) }
         def parse_manifest
           command = "go mod edit -json"
           stdout, stderr, status = Open3.capture3(environment, command)
@@ -214,12 +243,18 @@ module Dependabot
           JSON.parse(stdout) || {}
         end
 
+        sig do
+          type_parameters(:T)
+            .params(block: T.proc.returns(T.type_parameter(:T)))
+            .returns(T.type_parameter(:T))
+        end
         def in_repo_path(&block)
           SharedHelpers.in_a_temporary_repo_directory(directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials, &block)
           end
         end
 
+        sig { params(stub_paths: T::Array[String]).void }
         def build_module_stubs(stub_paths)
           # Create a fake empty module for each local module so that
           # `go get` works, even if some modules have been `replace`d
@@ -239,12 +274,14 @@ module Dependabot
         # the layout of the filesystem with a structure we can reproduce (i.e.
         # no paths such as ../../../foo), run the Go tooling, then reverse the
         # process afterwards.
+        sig { params(manifest: T::Hash[String, T.untyped]).returns(T::Hash[String, String]) }
         def replace_directive_substitutions(manifest)
           @replace_directive_substitutions ||=
-            Dependabot::GoModules::ReplaceStubber.new(repo_contents_path)
-                                                 .stub_paths(manifest, directory)
+            T.let(Dependabot::GoModules::ReplaceStubber.new(repo_contents_path)
+                                                 .stub_paths(manifest, directory), T.nilable(T::Hash[String, String]))
         end
 
+        sig { params(substitutions: T::Hash[String, String]).void }
         def substitute_all(substitutions)
           body = substitutions.reduce(File.read("go.mod")) do |text, (a, b)|
             text.sub(a, b)
@@ -253,7 +290,8 @@ module Dependabot
           write_go_mod(body)
         end
 
-        def handle_subprocess_error(stderr)
+        sig { params(stderr: String).returns(T.noreturn) }
+        def handle_subprocess_error(stderr) # rubocop:disable Metrics/AbcSize
           stderr = stderr.gsub(Dir.getwd, "")
 
           # Package version doesn't match the module major version
@@ -272,9 +310,9 @@ module Dependabot
 
           path_regex = MODULE_PATH_MISMATCH_REGEXES.find { |r| stderr =~ r }
           if path_regex
-            match = path_regex.match(stderr)
+            match = T.must(path_regex.match(stderr))
             raise Dependabot::GoModulePathMismatch
-              .new(go_mod_path, match[1], match[2])
+              .new(go_mod_path, T.must(match[1]), T.must(match[2]))
           end
 
           out_of_disk_regex = OUT_OF_DISK_REGEXES.find { |r| stderr =~ r }
@@ -288,6 +326,7 @@ module Dependabot
           raise Dependabot::DependabotError, msg
         end
 
+        sig { params(message: String, regex: Regexp).returns(String) }
         def filter_error_message(message:, regex:)
           lines = message.lines.select { |l| regex =~ l }
           return lines.join if lines.any?
@@ -296,24 +335,29 @@ module Dependabot
           message.match(regex).to_s
         end
 
+        sig { returns(String) }
         def go_mod_path
           return "go.mod" if directory == "/"
 
           File.join(directory, "go.mod")
         end
 
+        sig { params(body: Object).void }
         def write_go_mod(body)
           File.write("go.mod", body)
         end
 
+        sig { returns(T::Boolean) }
         def tidy?
           !!@tidy
         end
 
+        sig { returns(T::Boolean) }
         def vendor?
           !!@vendor
         end
 
+        sig { returns(T::Hash[String, T.untyped]) }
         def environment
           { "GOPRIVATE" => @goprivate }
         end

--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -30,7 +30,7 @@ module Dependabot
 
       # Use GoModules::Version rather than Gem::Version to ensure that
       # pre-release versions aren't transformed.
-      sig { params(obj: T.untyped).returns([String, Dependabot::Version]) }
+      sig { params(obj: T.untyped).returns([String, Gem::Version]) }
       def self.parse(obj)
         return ["=", Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 

--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 ################################################################################
@@ -25,11 +25,12 @@ module Dependabot
       quoted = OPS.keys.map { |k| Regexp.quote(k) }.join("|")
       version_pattern = "v?#{Version::VERSION_PATTERN}"
 
-      PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{version_pattern})\\s*".freeze
+      PATTERN_RAW = T.let("\\s*(#{quoted})?\\s*(#{version_pattern})\\s*".freeze, String)
       PATTERN = /\A#{PATTERN_RAW}\z/
 
       # Use GoModules::Version rather than Gem::Version to ensure that
       # pre-release versions aren't transformed.
+      sig { params(obj: T.untyped).returns([String, Dependabot::Version]) }
       def self.parse(obj)
         return ["=", Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
@@ -54,9 +55,12 @@ module Dependabot
         end
       end
 
+      sig do
+        params(requirements: T.nilable(String)).void
+      end
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",").map(&:strip).map do |r|
+          req_string&.split(",")&.map(&:strip)&.map do |r|
             convert_go_constraint_to_ruby_constraint(r.strip)
           end
         end
@@ -66,6 +70,7 @@ module Dependabot
 
       private
 
+      sig { params(req_string: String).returns(T.any(String, T::Array[String])) }
       def convert_go_constraint_to_ruby_constraint(req_string)
         req_string = convert_wildcard_characters(req_string)
 
@@ -80,6 +85,7 @@ module Dependabot
         end
       end
 
+      sig { params(req_string: String).returns(String) }
       def convert_wildcard_characters(req_string)
         if req_string.match?(/^[\dv^>~]/)
           replace_wildcard_in_lower_bound(req_string)
@@ -96,8 +102,9 @@ module Dependabot
         end
       end
 
+      sig { params(req_string: String).returns(String) }
       def replace_wildcard_in_lower_bound(req_string)
-        after_wildcard = false
+        after_wildcard = T.let(false, T::Boolean)
 
         req_string = req_string.gsub(/(?:(?:\.|^)[xX*])(\.[xX*])+/, "") if req_string.start_with?("~")
 
@@ -114,6 +121,7 @@ module Dependabot
         end.join(".")
       end
 
+      sig { params(req_string: String).returns(String) }
       def convert_tilde_req(req_string)
         version = req_string.gsub(/^~/, "")
         parts = version.split(".")
@@ -121,11 +129,13 @@ module Dependabot
         "~> #{parts.join('.')}"
       end
 
+      sig { params(req_string: String).returns(T::Array[String]) }
       def convert_hyphen_req(req_string)
         lower_bound, upper_bound = req_string.split(/\s+-\s+/)
         [">= #{lower_bound}", "<= #{upper_bound}"]
       end
 
+      sig { params(req_string: String).returns(String) }
       def ruby_range(req_string)
         parts = req_string.split(".")
 
@@ -142,6 +152,7 @@ module Dependabot
 
       # NOTE: Dep's caret notation implementation doesn't distinguish between
       # pre and post-1.0.0 requirements (unlike in JS)
+      sig { params(req_string: String).returns(T::Array[String]) }
       def convert_caret_req(req_string)
         version = req_string.gsub(/^\^?v?/, "")
         parts = version.split(".")


### PR DESCRIPTION
This PR adds `strict` Sorbet annotation in some files in `go_modules` and enables Sorbet Runtime.