### PR TITLE
Switch to official GitHub action for managing app tokens

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app_id: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Improve security by switching to the official GitHub action for managing app tokens. More [details](https://github.com/tibdex/github-app-token/issues/99#issuecomment-1787602874).

The default scope is limited to only this repo per the [docs](https://github.com/actions/create-github-app-token?tab=readme-ov-file#repositories):

> If owner and repositories are empty, access will be scoped to only the current repository.

See also:
* https://github.com/dependabot/fetch-metadata/pull/504