### PR TITLE
Table doesn't properly end for multi-directory GSU

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -479,7 +479,7 @@ module Dependabot
                 "`#{dep.humanized_version}`"
               ]
             end
-            msg += "\n\n#{table([header] + rows)}"
+            msg += "\n\n#{table([header] + rows)}\n"
           else
             # Handle directories with fewer updates without creating a table.
             dependency_links_in_directory = dependency_links_for_directory(directory)
@@ -491,10 +491,10 @@ module Dependabot
                    end
           end
 
-          msg += "\n\n"
+          msg += "\n"
         end
 
-        msg.strip + "\n"
+        msg
       end
       # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -491,10 +491,10 @@ module Dependabot
                    end
           end
 
-          msg += "\n"
+          msg += "\n\n"
         end
 
-        msg
+        msg.strip + "\n"
       end
       # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -455,7 +455,7 @@ module Dependabot
         msg
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       sig { returns(String) }
       def multi_directory_group_intro
         msg = ""
@@ -469,31 +469,34 @@ module Dependabot
           msg += "Bumps the #{T.must(dependency_group).name} group " \
                  "with #{update_count} update#{update_count > 1 ? 's' : ''} in the #{directory} directory:"
 
-          msg += if update_count >= 5
-                   header = %w(Package From To)
-                   rows = dependencies_in_directory.map do |dep|
-                     [
-                       dependency_link(dep),
-                       "`#{dep.humanized_previous_version}`",
-                       "`#{dep.humanized_version}`"
-                     ]
+          if update_count >= 5
+            # Create a table for directories with 5 or more updates.
+            header = %w(Package From To)
+            rows = dependencies_in_directory.map do |dep|
+              [
+                dependency_link(dep),
+                "`#{dep.humanized_previous_version}`",
+                "`#{dep.humanized_version}`"
+              ]
+            end
+            msg += "\n\n#{table([header] + rows)}"
+          else
+            # Handle directories with fewer updates without creating a table.
+            dependency_links_in_directory = dependency_links_for_directory(directory)
+            msg += if update_count > 1
+                     " #{T.must(T.must(dependency_links_in_directory)[0..-2]).join(', ')}" \
+                       " and #{T.must(dependency_links_in_directory)[-1]}."
+                   else
+                     " #{T.must(dependency_links_in_directory).first}."
                    end
-                   "\n\n#{table([header] + rows)}"
-                 elsif update_count > 1
-                   dependency_links_in_directory = dependency_links_for_directory(directory)
-                   " #{T.must(T.must(dependency_links_in_directory)[0..-2]).join(', ')}" \
-                     " and #{T.must(dependency_links_in_directory)[-1]}."
-                 else
-                   dependency_links_in_directory = dependency_links_for_directory(directory)
-                   " #{T.must(dependency_links_in_directory).first}."
-                 end
+          end
 
           msg += "\n"
         end
 
         msg
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
       sig { returns(String) }
       def group_intro

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -455,7 +455,7 @@ module Dependabot
         msg
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
       sig { returns(String) }
       def multi_directory_group_intro
         msg = ""
@@ -469,34 +469,31 @@ module Dependabot
           msg += "Bumps the #{T.must(dependency_group).name} group " \
                  "with #{update_count} update#{update_count > 1 ? 's' : ''} in the #{directory} directory:"
 
-          if update_count >= 5
-            # Create a table for directories with 5 or more updates.
-            header = %w(Package From To)
-            rows = dependencies_in_directory.map do |dep|
-              [
-                dependency_link(dep),
-                "`#{dep.humanized_previous_version}`",
-                "`#{dep.humanized_version}`"
-              ]
-            end
-            msg += "\n\n#{table([header] + rows)}\n"
-          else
-            # Handle directories with fewer updates without creating a table.
-            dependency_links_in_directory = dependency_links_for_directory(directory)
-            msg += if update_count > 1
-                     " #{T.must(T.must(dependency_links_in_directory)[0..-2]).join(', ')}" \
-                       " and #{T.must(dependency_links_in_directory)[-1]}."
-                   else
-                     " #{T.must(dependency_links_in_directory).first}."
+          msg += if update_count >= 5
+                   header = %w(Package From To)
+                   rows = dependencies_in_directory.map do |dep|
+                     [
+                       dependency_link(dep),
+                       "`#{dep.humanized_previous_version}`",
+                       "`#{dep.humanized_version}`"
+                     ]
                    end
-          end
+                   "\n\n#{table([header] + rows)}\n"
+                 elsif update_count > 1
+                   dependency_links_in_directory = dependency_links_for_directory(directory)
+                   " #{T.must(T.must(dependency_links_in_directory)[0..-2]).join(', ')}" \
+                     " and #{T.must(dependency_links_in_directory)[-1]}."
+                 else
+                   dependency_links_in_directory = dependency_links_for_directory(directory)
+                   " #{T.must(dependency_links_in_directory).first}."
+                 end
 
           msg += "\n"
         end
 
         msg
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
 
       sig { returns(String) }
       def group_intro

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2650,7 +2650,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with a table for one directory and no table for the other" do
+        context "with table for one directory and no table for the other" do
           let(:dependencies2) do
             (1..5).map do |index|
               Dependabot::Dependency.new(
@@ -2696,6 +2696,72 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                                           "| Package | From | To |\n" \
                                           "| --- | --- | --- |\n" \
                                           "| [business2]")
+          end
+        end
+
+        context "with table for one directory come first and no table for the other" do
+          let(:dependencies1) do
+            (1..5).map do |index|
+              Dependabot::Dependency.new(
+                name: "business#{index + 1}",
+                version: "#{index + 1}.5.0",
+                previous_version: "#{index + 1}.4.0",
+                package_manager: "dummy",
+                requirements: [],
+                previous_requirements: [],
+                metadata: { directory: "/foo" }
+              )
+            end
+          end
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: [],
+              metadata: { directory: "/bar" }
+            )
+          end
+          let(:dependencies) { dependencies1 + [dependency] + [dependency2] }
+
+          before do
+            json_header = { "Content-Type" => "application/json" }
+
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+})
+              .to_return(status: 200, body: fixture("github", "business_repo.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/})
+              .to_return(status: 200, body: fixture("github", "business_files.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/releases\?per_page=100})
+              .to_return(status: 200, body: fixture("github", "business_releases.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/CHANGELOG\.md\?ref=master})
+              .to_return(status: 200, body: fixture("github", "changelog_contents.json"), headers: json_header)
+            stub_request(:get, %r{https://rubygems\.org/api/v1/gems/.+\.json})
+              .to_return(status: 200, body: fixture("ruby", "rubygems_response_statesman.json"))
+            stub_request(:get, %r{https://github\.com/gocardless/.+\.git/info/refs\?service=git-upload-pack})
+              .to_return(
+                status: 200,
+                body: fixture("git", "upload_packs", "no_tags"),
+                headers: {
+                  "content-type" => "application/x-git-upload-pack-advertisement"
+                }
+              )
+          end
+
+          it "has the correct message" do
+            expected_message = "Bumps the go_modules group with 6 updates in the /foo directory:\n\n" \
+                               "| Package | From | To |\n" \
+                               "| --- | --- | --- |\n" \
+                               "| [business2](https://github.com/gocardless/business2) | `2.4.0` | `2.5.0` |\n" \
+                               "| [business3](https://github.com/gocardless/business3) | `3.4.0` | `3.5.0` |\n" \
+                               "| [business4](https://github.com/gocardless/business4) | `4.4.0` | `4.5.0` |\n" \
+                               "| [business5](https://github.com/gocardless/business5) | `5.4.0` | `5.5.0` |\n" \
+                               "| [business6](https://github.com/gocardless/business6) | `6.4.0` | `6.5.0` |\n" \
+                               "| [business](https://github.com/gocardless/business) | `1.4.0` | `1.5.0` |\n\n" \
+                               "Bumps the go_modules group with 1 update in the /bar directory: [business2](https://github.com/gocardless/business2)."
+
+            expect(pr_message).to include(expected_message)
           end
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -953,6 +953,46 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         it { is_expected.to eq("Bump the go_modules group across 2 directories with 2 updates") }
       end
+
+      context "with more then 5 dependencies" do
+        subject(:message) { builder.message }
+        let(:metadata) { { directory: "/foo" } }
+        let(:bar_dependencies) do
+          (1..5).map do |index|
+            Dependabot::Dependency.new(
+              name: "business#{index + 1}",
+              version: "#{index + 1}.5.0",
+              previous_version: "#{index + 1}.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: [],
+              metadata: { directory: "/bar" }
+            )
+          end
+        end
+        let(:dependencies) { bar_dependencies + [dependency] }
+
+        pr_message = "Bumps the go_modules group with 1 update in the /foo directory: " \
+                     "[business](https://github.com/gocardless/business).\n" \
+                     "Bumps the go_modules group with 5 updates in the /bar directory:\n\n" \
+                     "| Package | From | To |\n" \
+                     "| --- | --- | --- |\n" \
+                     "| [business2](https://github.com/gocardless/business2) | `2.4.0` | `2.5.0` |\n" \
+                     "| [business3](https://github.com/gocardless/business3) | `3.4.0` | `3.5.0` |\n" \
+                     "| [business4](https://github.com/gocardless/business4) | `4.4.0` | `4.5.0` |\n" \
+                     "| [business5](https://github.com/gocardless/business5) | `5.4.0` | `5.5.0` |\n" \
+                     "| [business6](https://github.com/gocardless/business6) | `6.4.0` | `6.5.0` |\n\n"
+
+        its(:pr_name) { should eq("Bump the go_modules group across 2 directories with 6 updates") }
+        it "contains the expected substring" do
+          expect(pr_message).to include("Bumps the go_modules group with 1 update in the /foo directory: " \
+                                        "[business](https://github.com/gocardless/business).\n" \
+                                        "Bumps the go_modules group with 5 updates in the /bar directory:\n\n" \
+                                        "| Package | From | To |\n" \
+                                        "| --- | --- | --- |\n" \
+                                        "| [business2]")
+        end
+      end
     end
   end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2650,7 +2650,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five dependencies in one directory and less then 5 in another" do
+        context "with a table for one directory and no table for the other" do
           let(:dependencies2) do
             (1..5).map do |index|
               Dependabot::Dependency.new(

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2698,6 +2698,81 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                                           "| [business2]")
           end
         end
+
+        context "with a table for both directories" do
+          let(:dependencies1) do
+            (1..5).map do |index|
+              Dependabot::Dependency.new(
+                name: "business#{index + 1}",
+                version: "#{index + 1}.5.0",
+                previous_version: "#{index + 1}.4.0",
+                package_manager: "dummy",
+                requirements: [],
+                previous_requirements: [],
+                metadata: { directory: "/foo" }
+              )
+            end
+          end
+          let(:dependencies2) do
+            (1..5).map do |index|
+              Dependabot::Dependency.new(
+                name: "business#{index + 1}",
+                version: "#{index + 1}.5.0",
+                previous_version: "#{index + 1}.4.0",
+                package_manager: "dummy",
+                requirements: [],
+                previous_requirements: [],
+                metadata: { directory: "/bar" }
+              )
+            end
+          end
+          let(:dependencies) { dependencies1 + dependencies2 + [dependency] }
+
+          before do
+            json_header = { "Content-Type" => "application/json" }
+
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+})
+              .to_return(status: 200, body: fixture("github", "business_repo.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/})
+              .to_return(status: 200, body: fixture("github", "business_files.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/releases\?per_page=100})
+              .to_return(status: 200, body: fixture("github", "business_releases.json"), headers: json_header)
+            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/CHANGELOG\.md\?ref=master})
+              .to_return(status: 200, body: fixture("github", "changelog_contents.json"), headers: json_header)
+            stub_request(:get, %r{https://rubygems\.org/api/v1/gems/.+\.json})
+              .to_return(status: 200, body: fixture("ruby", "rubygems_response_statesman.json"))
+            stub_request(:get, %r{https://github\.com/gocardless/.+\.git/info/refs\?service=git-upload-pack})
+              .to_return(
+                status: 200,
+                body: fixture("git", "upload_packs", "no_tags"),
+                headers: {
+                  "content-type" => "application/x-git-upload-pack-advertisement"
+                }
+              )
+          end
+
+          it "has the correct message" do
+            expected_message = "Bumps the go_modules group with 6 updates in the /foo directory:\n\n" \
+                               "| Package | From | To |\n" \
+                               "| --- | --- | --- |\n" \
+                               "| [business2](https://github.com/gocardless/business2) | `2.4.0` | `2.5.0` |\n" \
+                               "| [business3](https://github.com/gocardless/business3) | `3.4.0` | `3.5.0` |\n" \
+                               "| [business4](https://github.com/gocardless/business4) | `4.4.0` | `4.5.0` |\n" \
+                               "| [business5](https://github.com/gocardless/business5) | `5.4.0` | `5.5.0` |\n" \
+                               "| [business6](https://github.com/gocardless/business6) | `6.4.0` | `6.5.0` |\n" \
+                               "| [business](https://github.com/gocardless/business) | `1.4.0` | `1.5.0` |\n\n" \
+                               "Bumps the go_modules group with 5 updates in the /bar directory:\n\n" \
+                               "| Package | From | To |\n" \
+                               "| --- | --- | --- |\n" \
+                               "| [business2](https://github.com/gocardless/business2) | `2.4.0` | `2.5.0` |\n" \
+                               "| [business3](https://github.com/gocardless/business3) | `3.4.0` | `3.5.0` |\n" \
+                               "| [business4](https://github.com/gocardless/business4) | `4.4.0` | `4.5.0` |\n" \
+                               "| [business5](https://github.com/gocardless/business5) | `5.4.0` | `5.5.0` |\n" \
+                               "| [business6](https://github.com/gocardless/business6) | `6.4.0` | `6.5.0`"
+
+            expect(pr_message).to include(expected_message)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## Context

example: https://github.com/dsp-testing/dependabot-gsu-multi-directory-tests/pull/19

![Screenshot 2024-02-09 at 5 20 39 PM](https://github.com/github/dependabot-updates/assets/12107187/0d471a3f-e88f-4d56-848f-e8e40f16e86c)

## Expected 
The backend directory has >5 dependency updates so it should be a table
The frontend directory only has 3 updates so it should not be a table, and should not be inside of other table

## Fix
The original code was attempting to add a table inside another table when there were 5 or more updates, regardless of the total number of updates in other directories. This made the /frontend updates appear nested incorrectly.

Solution: The fix separates the logic for handling 5 or more updates distinctly from cases with fewer updates. By ensuring that the condition for creating a table is only met for directories with 5 or more updates, we avoid unintended nesting or formatting issues for directories like /frontend with fewer updates.