### PR TITLE
`package_version` may be nil

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/nuspec_fetcher.rb
@@ -18,7 +18,7 @@ module Dependabot
         params(
           dependency_urls: T::Array[T::Hash[Symbol, String]],
           package_id: String,
-          package_version: String
+          package_version: T.nilable(String)
         )
           .returns(T.nilable(Nokogiri::XML::Document))
       end


### PR DESCRIPTION
Updates type signature to accommodate the possibility of a nil `package_version` argument in `NuspecFetcher::fetch_nuspec`.