### PR TITLE
Prevent `NoMethodError` in group update creation

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -340,6 +340,7 @@ module Dependabot
       end
 
       def deduce_updated_dependency(dependency, original_dependency)
+        return nil if dependency.nil? || original_dependency.nil?
         return nil if original_dependency.version == dependency.version
 
         Dependabot.logger.info(

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -231,4 +231,30 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       group_update_all.perform
     end
   end
+
+  describe "#deduce_updated_dependency" do
+    let(:job_definition) do
+      job_definition_fixture("bundler/version_updates/group_update_refresh_dependencies_changed")
+    end
+
+    let(:dependency_files) do
+      original_bundler_files
+    end
+
+    before do
+      stub_rubygems_calls
+    end
+
+    it "returns nil if dependency is nil" do
+      dependency = nil
+      original_dependency = dependency_snapshot.dependencies.first
+      expect(group_update_all.deduce_updated_dependency(dependency, original_dependency)).to eq(nil)
+    end
+
+    it "returns nil if original_dependency is nil" do
+      dependency = dependency_snapshot.dependencies.first
+      original_dependency = nil
+      expect(group_update_all.deduce_updated_dependency(dependency, original_dependency)).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
We are seeing runtime exceptions due to calling a method on an argument that may be nil. This change properly handles nil arguments.