### PR TITLE
Prevent comparison of Integer with String in group update creation

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -240,6 +240,7 @@ module Dependabot
       # then it should not be in the group, but be an individual PR, or in another group that fits it.
       # SemVer Grouping rules have to be applied after we have a checker, because we need to know the latest version.
       # Other rules are applied earlier in the process.
+      # rubocop:disable Metrics/AbcSize
       def semver_rules_allow_grouping?(group, dependency, checker)
         # There are no group rules defined, so this dependency can be included in the group.
         return true unless group.rules["update-types"]
@@ -255,6 +256,9 @@ module Dependabot
         # Not every version class implements .major, .minor, .patch so we calculate it here from the segments
         latest = semver_segments(latest_version)
         current = semver_segments(version)
+        # Ensure that semver components are of the same type and can be compared with each other.
+        return false unless %i(major minor patch).all? { |k| current[k].instance_of?(latest[k].class) }
+
         return group.rules["update-types"].include?("major") if latest[:major] > current[:major]
         return group.rules["update-types"].include?("minor") if latest[:minor] > current[:minor]
         return group.rules["update-types"].include?("patch") if latest[:patch] > current[:patch]
@@ -262,6 +266,7 @@ module Dependabot
         # some ecosystems don't do semver exactly, so anything lower gets individual for now
         false
       end
+      # rubocop:enable Metrics/AbcSize
 
       def semver_segments(version)
         {

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -257,4 +257,166 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       expect(group_update_all.deduce_updated_dependency(dependency, original_dependency)).to eq(nil)
     end
   end
+
+  describe "#semver_rules_allow_grouping?" do
+    let(:job_definition) do
+      job_definition_fixture("bundler/version_updates/group_update_refresh_versions_changed")
+    end
+
+    let(:dependency_files) do
+      original_bundler_files
+    end
+
+    let(:update_types) do
+      []
+    end
+
+    let(:group) do
+      instance_double("Dependabot::DependencyGroup", rules: { "update-types" => update_types })
+    end
+
+    let(:dependency) do
+      instance_double("Dependabot::Dependency", version: current_version)
+    end
+
+    let(:checker) do
+      instance_double("Dependabot::UpdateCheckers::Base", latest_version: latest_version)
+    end
+
+    before do
+      stub_rubygems_calls
+    end
+
+    context "when major version component of current and latest versions are not comparable" do
+      let(:current_version) { "X.2.3" }
+      let(:latest_version) { "1.2.3" }
+
+      it "returns false" do
+        expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+      end
+    end
+
+    context "when minor version component of current and latest versions are not comparable" do
+      let(:current_version) { "1.X.3" }
+      let(:latest_version) { "1.2.3" }
+
+      it "returns false" do
+        expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+      end
+    end
+
+    context "when patch version component of current and latest versions are not comparable" do
+      let(:current_version) { "1.2.X" }
+      let(:latest_version) { "1.2.3" }
+
+      it "returns false" do
+        expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+      end
+    end
+
+    context "when latest major version > current major version" do
+      let(:current_version) { "1.2.3" }
+      let(:latest_version) { "2.0.0" }
+
+      context "when group update-types includes major version" do
+        let(:update_types) do
+          ["major"]
+        end
+
+        it "returns true" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(true)
+        end
+      end
+
+      context "when group update-types includes minor version" do
+        let(:update_types) do
+          ["minor"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+
+      context "when group update-types includes patch version" do
+        let(:update_types) do
+          ["patch"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+    end
+
+    context "when latest minor version > current minor version" do
+      let(:current_version) { "1.2.3" }
+      let(:latest_version) { "1.3.0" }
+
+      context "when group update-types includes major version" do
+        let(:update_types) do
+          ["major"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+
+      context "when group update-types includes minor version" do
+        let(:update_types) do
+          ["minor"]
+        end
+
+        it "returns true" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(true)
+        end
+      end
+
+      context "when group update-types includes patch version" do
+        let(:update_types) do
+          ["patch"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+    end
+
+    context "when latest patch version > current patch version" do
+      let(:current_version) { "1.2.3" }
+      let(:latest_version) { "1.2.4" }
+
+      context "when group update-types includes major version" do
+        let(:update_types) do
+          ["major"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+
+      context "when group update-types includes minor version" do
+        let(:update_types) do
+          ["minor"]
+        end
+
+        it "returns false" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(false)
+        end
+      end
+
+      context "when group update-types includes patch version" do
+        let(:update_types) do
+          ["patch"]
+        end
+
+        it "returns true" do
+          expect(group_update_all.semver_rules_allow_grouping?(group, dependency, checker)).to eq(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
We are seeing runtime exceptions due to comparing the semver components of two versions of a dependency when the components are not of the same type.

I considered two approaches:
1. Coerce the semver components of both versions to integers before comparing
2. Skip the comparison unless the semver components of both versions are of the same type

This is updater code so it's supposed to be ecosystem agnostic. Since each ecosystem brings its own version class (which inherits from `Gem::Version` and whose major/minor/patch components could be a number of different things), I opted to avoid making assumptions about the version instances. Instead, if two instances of an ecosystem's version class have major/minor/patch components of different types, we avoid the comparison altogether.