### PR TITLE
swap language when closing group refresh PR to be less specific

### DIFF
--- a/silent/tests/testdata/vu-group-update-not-possible.txt
+++ b/silent/tests/testdata/vu-group-update-not-possible.txt
@@ -1,0 +1,99 @@
+# For a group rebase, if all dependencies are up-to-date Dependabot will close the PR
+
+dependabot update -f input-up-to-date.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+! stdout record_update_job_error
+stdout -count=1 close_pull_request
+stdout -count=1 mark_as_processed
+
+# Same test as above, but all dependencies errored
+
+! dependabot update -f input-errored.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stdout -count=2 record_update_job_error
+stdout -count=1 close_pull_request
+stdout -count=1 mark_as_processed
+
+-- up-to-date/manifest.json --
+{
+  "dependency-a": { "version": "1.2.3" },
+  "dependency-b": { "version": "1.2.3" }
+}
+
+-- dependency-a.json --
+{
+  "versions": [
+    { "version": "1.2.3" }
+  ]
+}
+
+-- dependency-b.json --
+{
+  "versions": [
+    { "version": "1.2.3" }
+  ]
+}
+
+-- input-up-to-date.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/up-to-date"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  dependency-groups:
+    - name: all-group
+      rules:
+        patterns:
+         - "*"
+  dependencies:
+    - dependency-a
+    - dependency-b
+  updating-a-pull-request: true
+  dependency-group-to-refresh: all-group
+  existing-group-pull-requests:
+    - dependency-group-name: all-group
+      dependencies:
+        - dependency-name: dependency-a
+          dependency-version: 1.2.3
+        - dependency-name: dependency-b
+          dependency-version: 1.2.3
+
+-- errors/manifest.json --
+{
+  "dependency-c": { "version": "1.2.3" },
+  "dependency-d": { "version": "1.2.3" }
+}
+
+-- dependency-c --
+THIS IS NOT JSON
+
+-- dependency-d --
+THIS IS NOT JSON
+
+-- input-errored.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/errors"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  dependency-groups:
+    - name: all-group
+      rules:
+        patterns:
+         - "*"
+  dependencies:
+    - dependency-c
+    - dependency-d
+  updating-a-pull-request: true
+  dependency-group-to-refresh: all-group
+  existing-group-pull-requests:
+    - dependency-group-name: all-group
+      dependencies:
+        - dependency-name: dependency-c
+          dependency-version: 2.0.0
+        - dependency-name: dependency-d
+          dependency-version: 2.0.0

--- a/updater/lib/dependabot/updater/group_update_refreshing.rb
+++ b/updater/lib/dependabot/updater/group_update_refreshing.rb
@@ -16,8 +16,8 @@ module Dependabot
         if dependency_change.updated_dependencies.any?
           upsert_pull_request(dependency_change, group)
         else
-          Dependabot.logger.info("Dependencies are up to date, closing existing Pull Request")
-          close_pull_request(reason: :up_to_date, group: group)
+          Dependabot.logger.info("No updated dependencies, closing existing Pull Request")
+          close_pull_request(reason: :update_no_longer_possible, group: group)
         end
       rescue StandardError => e
         error_handler.handle_job_error(error: e, dependency_group: dependency_snapshot.job_group)

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "closes the pull request" do
-      expect(mock_service).to receive(:close_pull_request).with(["dummy-pkg-b"], :up_to_date)
+      expect(mock_service).to receive(:close_pull_request).with(["dummy-pkg-b"], :update_no_longer_possible)
 
       group_update_all.perform
     end
@@ -166,7 +166,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "considers the dependencies in the other PRs as handled, and closes the duplicate PR" do
-      expect(mock_service).to receive(:close_pull_request).with(["dummy-pkg-b"], :up_to_date)
+      expect(mock_service).to receive(:close_pull_request).with(["dummy-pkg-b"], :update_no_longer_possible)
 
       group_update_all.perform
 


### PR DESCRIPTION
When there's a grouped PR and Dependabot rebases it, but all the dependencies are up to date because a developer went and manually bumped them, Dependabot will close the PR with the message:

> Looks like these dependencies are up-to-date now, so this is no longer needed

The problem is at this point in the code we don't necessarily know _**why**_ there are no updated dependencies. It could be that they were all up to date, but also could be they all errored, perhaps all ignored, or some other reason.

In lieu of tracking why each dependency failed to update, this PR switches the Dependabot message in this scenario to:

> Looks like these dependencies are no longer updatable, so this is no longer needed.

This better captures the reason why the PR was closed.