### PR TITLE
Revert "Fix CodeCommit 'fetch_repo_contents' strict type enforcement from Aws::CodeCommit::Types::GetFolderOutput to Seahorse::Client::Response"

### DIFF
--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -82,10 +82,7 @@ module Dependabot
           repo: String, commit: T.nilable(String),
           path: T.nilable(String)
         )
-          # See PR 9344: should .returns(Seahorse::Client::Response)
-          # but it not extend Delegator, unblocking until shim or
-          # another fix is implemented
-          .returns(T.untyped)
+          .returns(Aws::CodeCommit::Types::GetFolderOutput)
       end
       def fetch_repo_contents(repo, commit = nil, path = nil)
         actual_path = path


### PR DESCRIPTION
Reverts dependabot/dependabot-core#9334