### PR TITLE
don't allow `global.json` from repo to affect MSBuild discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -231,7 +231,7 @@ internal static class SdkPackageUpdater
         logger.Log($"    Adding [{dependencyName}/{newDependencyVersion}] as a top-level package reference.");
 
         // see https://learn.microsoft.com/nuget/consume-packages/install-use-packages-dotnet-cli
-        var (exitCode, _, _) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}");
+        var (exitCode, _, _) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
         if (exitCode != 0)
         {
             logger.Log($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -41,9 +41,29 @@ internal static partial class MSBuildHelper
         // Ensure MSBuild types are registered before calling a method that loads the types
         if (!IsMSBuildRegistered)
         {
-            var defaultInstance = MSBuildLocator.QueryVisualStudioInstances().First();
-            MSBuildPath = defaultInstance.MSBuildPath;
-            MSBuildLocator.RegisterInstance(defaultInstance);
+            var globalJsonPath = "global.json";
+            var tempGlobalJsonPath = globalJsonPath + Guid.NewGuid().ToString();
+            var globalJsonExists = File.Exists(globalJsonPath);
+            try
+            {
+                if (globalJsonExists)
+                {
+                    Console.WriteLine("Temporarily removing `global.json` for MSBuild detection.");
+                    File.Move(globalJsonPath, tempGlobalJsonPath);
+                }
+
+                var defaultInstance = MSBuildLocator.QueryVisualStudioInstances().First();
+                MSBuildPath = defaultInstance.MSBuildPath;
+                MSBuildLocator.RegisterInstance(defaultInstance);
+            }
+            finally
+            {
+                if (globalJsonExists)
+                {
+                    Console.WriteLine("Restoring `global.json` after MSBuild detection.");
+                    File.Move(tempGlobalJsonPath, globalJsonPath);
+                }
+            }
         }
     }
 
@@ -311,7 +331,7 @@ internal static partial class MSBuildHelper
         try
         {
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"");
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"", workingDirectory: tempDirectory.FullName);
 
             // NU1608: Detected package version outside of dependency constraint
 
@@ -451,7 +471,7 @@ internal static partial class MSBuildHelper
         {
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
 
-            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"build \"{tempProjectPath}\" /t:_ReportDependencies");
+            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"build \"{tempProjectPath}\" /t:_ReportDependencies", workingDirectory: tempDirectory.FullName);
 
             if (exitCode == 0)
             {


### PR DESCRIPTION
When the C# tool is invoked to process updates, the repo's root is set as the working directory.  It's common practice for a repo to contain a `global.json` file that specifies the .NET SDK to use, but when the C# tool is launched, it picks up that `global.json` file and tries to use that SDK version when locating MSBuild and if the SDK version specified in the file doesn't match what's installed in the updater (or it's not upgradable via `"rollForward": "latestMinor"` or similar), then an exception is thrown.  The updater (currently) has SDK 8.0.202, but it's not uncommon for repos in the wild to use 3, 5, 6, or 7; this is what causes the failure.

The desired behavior is that the updater uses the version of MSBuild that's installed in the updater and to accomplish this, the user's `global.json` is temporarily renamed so that it won't be picked up by the MSBuild locator.  Once MSBuild has been located and loaded, `global.json` is restored and the rest of the update proceeds as desired.

N.b., a common scenario is that the updater has version 8.0.202 of the SDK installed, but a repo's `global.json` specifies the last LTS like 6.0.100.  We _could_ fix this scenario by installing the major SDK versions in the updater, but installing all of the past and present versions would make the updater image >6GB and it still wouldn't work in all situations.  It's not uncommon for a repo to specify a newer SDK than the updater, includidng preview releases, etc.  It would be a never ending task to try and keep everything updated, but by doing it this way, we only have to do some creative file handling once.

Another possibility is to install the required SDK when the updater starts.  That method is probably no easier or difficult than what's happening in this PR, but the downside is that any repo that requires a different SDK will incur a large network and compute hit; each SDK installer is >200MB in size and takes 30s - 1m to install.

There is the possibility that some future version of the .NET SDK will change how MSBuild resolves imports and dependencies, but that would be such a major breaking change that we'd have to revisit the behavior anyway.

The nature of the fix is:

1. Temporarily displace `global.json` when trying to locate and load MSBuild.
2. When running the `dotnet` CLI against a temporary project (used quite frequently), ensure the working directory is properly set.

Fixes #9287