### PR TITLE
Add `require 'sorbet-runtime'` where missing

### DIFF
--- a/common/lib/dependabot/clients/bitbucket_with_retries.rb
+++ b/common/lib/dependabot/clients/bitbucket_with_retries.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require_relative "bitbucket"
 
 module Dependabot

--- a/nuget/lib/dependabot/nuget/file_fetcher/import_paths_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher/import_paths_finder.rb
@@ -3,6 +3,7 @@
 
 require "nokogiri"
 require "pathname"
+require "sorbet-runtime"
 
 require "dependabot/nuget/file_fetcher"
 

--- a/nuget/lib/dependabot/nuget/file_fetcher/sln_project_paths_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher/sln_project_paths_finder.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "sorbet-runtime"
+
 require "dependabot/nuget/file_fetcher"
 
 module Dependabot

--- a/nuget/lib/dependabot/nuget/file_parser/dotnet_tools_json_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/dotnet_tools_json_parser.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/nuget/file_parser"

--- a/nuget/lib/dependabot/nuget/file_parser/global_json_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/global_json_parser.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/nuget/file_parser"

--- a/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/nuget/file_parser"

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/nuget/file_parser"

--- a/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/nuget/file_fetcher/import_paths_finder"
 require "dependabot/nuget/file_parser"
 

--- a/nuget/lib/dependabot/nuget/file_updater/property_value_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater/property_value_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "sorbet-runtime"
 
 require "dependabot/dependency_file"
 require "dependabot/nuget/file_updater"

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -1,6 +1,8 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/version"
 
 # Terraform pre-release versions use 1.0.1-rc1 syntax, which Gem::Version

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/dependency_group"
 
 # This class implements our strategy for keeping track of and matching dependency

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "base64"
+require "sorbet-runtime"
+
 require "dependabot/file_parsers"
 
 # This class describes the dependencies obtained from a project at a specific commit SHA

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "sorbet-runtime"
 require "wildcard_matcher"
 
 require "dependabot/config/ignore_condition"

--- a/updater/lib/dependabot/setup.rb
+++ b/updater/lib/dependabot/setup.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sentry-ruby"
+require "sorbet-runtime"
 
 require "dependabot/environment"
 require "dependabot/logger"


### PR DESCRIPTION
`require "sorbet-runtime"` is required to enable runtime checks. Found using the following:

```
grep --files-without-match "require \"sorbet-runtime\"" (grep --files-with-matches "# typed: strict" --include "*.rb" --recursive)
```