### PR TITLE
remove unused boolean from input of tests

### DIFF
--- a/silent/tests/testdata/su-group-default-rebase-multidir.txt
+++ b/silent/tests/testdata/su-group-default-rebase-multidir.txt
@@ -83,4 +83,3 @@ job:
       unaffected-versions: []
   security-updates-only: true
   updating-a-pull-request: true
-  grouped-update: true

--- a/silent/tests/testdata/su-group-rebase-default.txt
+++ b/silent/tests/testdata/su-group-rebase-default.txt
@@ -59,4 +59,3 @@ job:
       unaffected-versions: []
   security-updates-only: true
   updating-a-pull-request: true
-  grouped-update: true

--- a/silent/tests/testdata/su-group-type.txt
+++ b/silent/tests/testdata/su-group-type.txt
@@ -82,7 +82,6 @@ job:
       patched-versions: []
       unaffected-versions: []
   security-updates-only: true
-  grouped-update: true
   dependency-groups:
     - name: dev
       applies-to: security-updates

--- a/silent/tests/testdata/vu-group-all.txt
+++ b/silent/tests/testdata/vu-group-all.txt
@@ -45,7 +45,6 @@ job:
     hostname: example.com
     api-endpoint: https://example.com/api/v3
     repo: dependabot/smoke-tests
-  grouped-update: true
   dependency-groups:
     - name: first
       rules:
@@ -70,7 +69,6 @@ job:
     - dependency-a
     - dependency-b
   updating-a-pull-request: true
-  grouped-update: true
   dependency-group-to-refresh: first
   existing-group-pull-requests:
     - dependency-group-name: first

--- a/silent/tests/testdata/vu-group-exclude-patterns.txt
+++ b/silent/tests/testdata/vu-group-exclude-patterns.txt
@@ -60,7 +60,6 @@ job:
     hostname: example.com
     api-endpoint: https://example.com/api/v3
     repo: dependabot/smoke-tests
-  grouped-update: true
   dependency-groups:
     - name: exclude
       rules:

--- a/silent/tests/testdata/vu-group-incidental.txt
+++ b/silent/tests/testdata/vu-group-incidental.txt
@@ -45,7 +45,6 @@ job:
     hostname: example.com
     api-endpoint: https://example.com/api/v3
     repo: dependabot/smoke-tests
-  grouped-update: true
   dependency-groups:
     - name: first
       rules:


### PR DESCRIPTION
The grouped-update flag was never hooked up fully, we don't use it. Removing from the input of the tests to avoid confusion.