### PR TITLE
Resolve some Sorbet errors in Terraform

### DIFF
--- a/terraform/lib/dependabot/terraform/file_fetcher.rb
+++ b/terraform/lib/dependabot/terraform/file_fetcher.rb
@@ -1,7 +1,8 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/terraform/file_selector"
@@ -12,15 +13,15 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
-      include FileSelector
-
       # https://www.terraform.io/docs/language/modules/sources.html#local-paths
       LOCAL_PATH_SOURCE = %r{source\s*=\s*['"](?<path>..?\/[^'"]+)}
 
+      sig { override.params(filenames: T::Array[String]).returns(T::Boolean) }
       def self.required_files_in?(filenames)
         filenames.any? { |f| f.end_with?(".tf", ".hcl") }
       end
 
+      sig { override.returns(String) }
       def self.required_files_message
         "Repo must contain a Terraform configuration file."
       end
@@ -37,22 +38,45 @@ module Dependabot
 
       private
 
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
       def terraform_files
-        @terraform_files ||=
+        @terraform_files ||= T.let(
           repo_contents(raise_errors: false)
           .select { |f| f.type == "file" && f.name.end_with?(".tf") }
-          .map { |f| fetch_file_from_host(f.name) }
+          .map { |f| fetch_file_from_host(f.name) },
+          T.nilable(T::Array[Dependabot::DependencyFile])
+        )
       end
 
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
       def terragrunt_files
-        @terragrunt_files ||=
+        @terragrunt_files ||= T.let(
           repo_contents(raise_errors: false)
           .select { |f| f.type == "file" && terragrunt_file?(f.name) }
-          .map { |f| fetch_file_from_host(f.name) }
+          .map { |f| fetch_file_from_host(f.name) },
+          T.nilable(T::Array[Dependabot::DependencyFile])
+        )
       end
 
+      sig { params(file_name: String).returns(T::Boolean) }
+      def terragrunt_file?(file_name)
+        !lockfile?(file_name) && file_name.end_with?(".hcl")
+      end
+
+      sig { params(filename: String).returns(T::Boolean) }
+      def lockfile?(filename)
+        filename == ".terraform.lock.hcl"
+      end
+
+      sig do
+        params(
+          files: T::Array[Dependabot::DependencyFile],
+          dir: String
+        )
+          .returns(T::Array[Dependabot::DependencyFile])
+      end
       def local_path_module_files(files, dir: ".")
-        terraform_files = []
+        terraform_files = T.let([], T::Array[Dependabot::DependencyFile])
 
         files.each do |file|
           terraform_file_local_module_details(file).each do |path|
@@ -71,19 +95,22 @@ module Dependabot
         terraform_files.tap { |fs| fs.each { |f| f.support_file = true } }
       end
 
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
       def terraform_file_local_module_details(file)
         return [] unless file.name.end_with?(".tf")
-        return [] unless file.content.match?(LOCAL_PATH_SOURCE)
+        return [] unless file.content&.match?(LOCAL_PATH_SOURCE)
 
-        file.content.scan(LOCAL_PATH_SOURCE).flatten.map do |path|
+        T.must(file.content).scan(LOCAL_PATH_SOURCE).flatten.map do |path|
           Pathname.new(path).cleanpath.to_path
         end
       end
 
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def lockfile
-        return @lockfile if defined?(@lockfile)
-
-        @lockfile = fetch_file_if_present(".terraform.lock.hcl")
+        @lockfile ||= T.let(
+          fetch_file_if_present(".terraform.lock.hcl"),
+          T.nilable(Dependabot::DependencyFile)
+        )
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/file_selector.rb
+++ b/terraform/lib/dependabot/terraform/file_selector.rb
@@ -1,25 +1,40 @@
-# typed: false
+# typed: strong
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 module FileSelector
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.returns(T::Array[Dependabot::DependencyFile]) }
+  def dependency_files; end
+
   private
 
+  sig { returns(T::Array[Dependabot::DependencyFile]) }
   def terraform_files
     dependency_files.select { |f| f.name.end_with?(".tf") }
   end
 
+  sig { returns(T::Array[Dependabot::DependencyFile]) }
   def terragrunt_files
     dependency_files.select { |f| terragrunt_file?(f.name) }
   end
 
+  sig { params(file_name: String).returns(T::Boolean) }
   def terragrunt_file?(file_name)
     !lockfile?(file_name) && file_name.end_with?(".hcl")
   end
 
+  sig { params(filename: String).returns(T::Boolean) }
   def lockfile?(filename)
     filename == ".terraform.lock.hcl"
   end
 
+  sig { returns(T.nilable(Dependabot::DependencyFile)) }
   def lockfile
     dependency_files.find { |f| lockfile?(f.name) }
   end


### PR DESCRIPTION
I removed the `FileSelector` mixin from `FileFetcher` as the mixin expects `dependency_files` to be defined. Instead, I extracted the 2 methods that are used in `FileFetcher`.

See [the Sorbet documentation][1] for the advice I followed

[1]: https://sorbet.org/docs/abstract#interfaces-and-the-included-hook