### PR TITLE
fix really long branch names

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -15,10 +15,7 @@ module Dependabot
 
         sig { override.returns(String) }
         def new_branch_name
-          if dependencies.count > 1 && !updating_a_property? && !updating_a_dependency_set?
-            # Fix long branch names by using a digest of the dependencies instead of their names.
-            return sanitize_branch_name(File.join(prefixes, "multi-#{dependency_digest}"))
-          end
+          return short_branch_name if branch_name_might_be_long?
 
           @name ||=
             T.let(
@@ -202,6 +199,17 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
         def requirements_changed?(dependency)
           (dependency.requirements - T.must(dependency.previous_requirements)).any?
+        end
+
+        sig { returns(T::Boolean) }
+        def branch_name_might_be_long?
+          dependencies.count > 1 && !updating_a_property? && !updating_a_dependency_set?
+        end
+
+        sig { returns(String) }
+        def short_branch_name
+          # Fix long branch names by using a digest of the dependencies instead of their names.
+          sanitize_branch_name(File.join(prefixes, "multi-#{dependency_digest}"))
         end
 
         sig { returns(T.nilable(String)) }

--- a/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
         )
       end
 
-      it { is_expected.to eq("dependabot/dummy/business-and-statesman-1.5.0") }
+      it { is_expected.to eq("dependabot/dummy/multi-fc93691fd4") }
 
       context "for a java property update" do
         let(:files) { [pom] }
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
         )
       end
 
-      it { is_expected.to eq("dependabot/dummy/business-and-statesman--removed") }
+      it { is_expected.to eq("dependabot/dummy/multi-068ffedafd") }
     end
 
     context "with a : in the name" do

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         )
       end
 
-      it { is_expected.to eq("dependabot/dummy/business-and-statesman-1.5.0") }
+      it { is_expected.to eq("dependabot/dummy/multi-fc93691fd4") }
 
       context "for a java property update" do
         let(:files) { [pom] }
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         )
       end
 
-      it { is_expected.to eq("dependabot/dummy/business-and-statesman--removed") }
+      it { is_expected.to eq("dependabot/dummy/multi-068ffedafd") }
     end
 
     context "with a : in the name" do


### PR DESCRIPTION
- fixes https://github.com/dependabot/dependabot-core/issues/8565

In some ecosystems, an update to a dependency will result in a multi-dependency PR. In this case our BranchNamer appends all the dependency names to create the branch names. This is causing an excessively long branch names which are within the limits that GitHub allows but can break on Windows since it has a smaller file path limit.

This PR changes the BranchNamer naming strategy for multi-dependency PRs to generate a short digest. The branch names are going to be, for example `dependabot/nuget/multi-068ffedafd`, which is similar to what we use for grouped updates.

I opted to start the name with `multi` to differentiate from `grouped` branches just to make it easier to debug in the future, feel free to bikeshed 😄 