### PR TITLE
use MSBuild-evaluated property values for TFM

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -25,11 +25,14 @@ public partial class DiscoveryWorkerTests
                           <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
                           <package id="NuGet.Server" version="2.11.2" targetFramework="net46" />
                           <package id="RouteMagic" version="1.3" targetFramework="net46" />
-                          <package id="WebActivatorEx" version="2.1.0" targetFramework="net46"></package>
+                          <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
                         </packages>
                         """),
                     ("myproj.csproj", """
                         <Project>
+                          <PropertyGroup>
+                            <TargetFramework>net46</TargetFramework>
+                          </PropertyGroup>
                         </Project>
                         """)
                 ],
@@ -40,16 +43,21 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
+                            Properties = [
+                                new("TargetFramework", "net46", "myproj.csproj"),
+                            ],
+                            TargetFrameworks = ["net46"],
                             Dependencies = [
-                                new("Microsoft.CodeDom.Providers.DotNetCompilerPlatform", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("Microsoft.Net.Compilers", "1.0.1", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("Microsoft.Web.Infrastructure", "1.0.0.0", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("Microsoft.Web.Xdt", "2.1.1", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("Newtonsoft.Json", "8.0.3", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("NuGet.Core", "2.11.1", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("NuGet.Server", "2.11.2", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("RouteMagic", "1.3", DependencyType.PackagesConfig, TargetFrameworks: []),
-                                new("WebActivatorEx", "2.1.0", DependencyType.PackagesConfig, TargetFrameworks: []),
+                                new("Microsoft.NETFramework.ReferenceAssemblies", "1.0.3", DependencyType.Unknown, TargetFrameworks: ["net46"], IsTransitive: true),
+                                new("Microsoft.CodeDom.Providers.DotNetCompilerPlatform", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Microsoft.Net.Compilers", "1.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Microsoft.Web.Infrastructure", "1.0.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Microsoft.Web.Xdt", "2.1.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Newtonsoft.Json", "8.0.3", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("NuGet.Core", "2.11.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("NuGet.Server", "2.11.2", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("RouteMagic", "1.3", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("WebActivatorEx", "2.1.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
                             ],
                         }
                     ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -376,5 +376,30 @@ public partial class DiscoveryWorkerTests
                     ],
                 });
         }
+
+        [Fact]
+
+        public async Task NoDependenciesReturnedIfNoTargetFrameworkCanBeResolved()
+        {
+            await TestDiscoveryAsync(
+                workspacePath: "",
+                files: [
+                    ("myproj.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>$(SomeCommonTfmThatCannotBeResolved)</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="1.2.3" />
+                          </ItemGroup>
+                        </Project>
+                        """)
+                ],
+                expectedResult: new()
+                {
+                    FilePath = "",
+                    Projects = []
+                });
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
@@ -167,7 +167,7 @@ namespace NuGetUpdater.Core.Test.Utilities
 
         private static async Task<string[]> LoadBuildFilesFromTemp(TemporaryDirectory temporaryDirectory, string relativeProjectPath)
         {
-            var buildFiles = await MSBuildHelper.LoadBuildFilesAsync(temporaryDirectory.DirectoryPath, $"{temporaryDirectory.DirectoryPath}/{relativeProjectPath}");
+            var (buildFiles, _tfms) = await MSBuildHelper.LoadBuildFilesAndTargetFrameworksAsync(temporaryDirectory.DirectoryPath, $"{temporaryDirectory.DirectoryPath}/{relativeProjectPath}");
             var buildFilePaths = buildFiles.Select(f => f.RelativePath.NormalizePathToUnix()).ToArray();
             return buildFilePaths;
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -9,86 +9,87 @@ internal static class SdkProjectDiscovery
     public static async Task<ImmutableArray<ProjectDiscoveryResult>> DiscoverAsync(string repoRootPath, string workspacePath, string projectPath, Logger logger)
     {
         // Determine which targets and props files contribute to the build.
-        var buildFiles = await MSBuildHelper.LoadBuildFilesAsync(repoRootPath, projectPath, includeSdkPropsAndTargets: true);
+        var (buildFiles, projectTargetFrameworks) = await MSBuildHelper.LoadBuildFilesAndTargetFrameworksAsync(repoRootPath, projectPath);
+        var tfms = projectTargetFrameworks.Order().ToImmutableArray();
 
         // Get all the dependencies which are directly referenced from the project file or indirectly referenced from
         // targets and props files.
         var topLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles);
 
         var results = ImmutableArray.CreateBuilder<ProjectDiscoveryResult>();
-        foreach (var buildFile in buildFiles)
+        if (tfms.Length > 0)
         {
-            // Only include build files that exist beneath the RepoRootPath.
-            if (buildFile.IsOutsideBasePath)
+            foreach (var buildFile in buildFiles)
             {
-                continue;
-            }
-
-            // The build file dependencies have the correct DependencyType and the TopLevelDependencies have the evaluated version.
-            // Combine them to have the set of dependencies that are directly referenced from the build file.
-            var fileDependencies = BuildFile.GetDependencies(buildFile)
-                .ToDictionary(d => d.Name, StringComparer.OrdinalIgnoreCase);
-            var sdkDependencies = fileDependencies.Values
-                .Where(d => d.Type == DependencyType.MSBuildSdk)
-                .ToImmutableArray();
-            var indirectDependencies = topLevelDependencies
-                .Where(d => !fileDependencies.ContainsKey(d.Name))
-                .ToImmutableArray();
-            var directDependencies = topLevelDependencies
-                .Where(d => fileDependencies.ContainsKey(d.Name))
-                .Select(d =>
+                // Only include build files that exist beneath the RepoRootPath.
+                if (buildFile.IsOutsideBasePath)
                 {
-                    var dependency = fileDependencies[d.Name];
-                    return d with
+                    continue;
+                }
+
+                // The build file dependencies have the correct DependencyType and the TopLevelDependencies have the evaluated version.
+                // Combine them to have the set of dependencies that are directly referenced from the build file.
+                var fileDependencies = BuildFile.GetDependencies(buildFile)
+                    .ToDictionary(d => d.Name, StringComparer.OrdinalIgnoreCase);
+                var sdkDependencies = fileDependencies.Values
+                    .Where(d => d.Type == DependencyType.MSBuildSdk)
+                    .ToImmutableArray();
+                var indirectDependencies = topLevelDependencies
+                    .Where(d => !fileDependencies.ContainsKey(d.Name))
+                    .ToImmutableArray();
+                var directDependencies = topLevelDependencies
+                    .Where(d => fileDependencies.ContainsKey(d.Name))
+                    .Select(d =>
                     {
-                        Type = dependency.Type,
-                        IsDirect = true
-                    };
-                }).ToImmutableArray();
+                        var dependency = fileDependencies[d.Name];
+                        return d with
+                        {
+                            Type = dependency.Type,
+                            IsDirect = true
+                        };
+                    }).ToImmutableArray();
 
-            if (buildFile.GetFileType() == ProjectBuildFileType.Project)
-            {
-                // Collect information that is specific to the project file.
-                var tfms = MSBuildHelper.GetTargetFrameworkMonikers(buildFiles)
-                    .OrderBy(tfm => tfm)
-                    .ToImmutableArray();
-                var properties = MSBuildHelper.GetProperties(buildFiles).Values
-                    .Where(p => !p.SourceFilePath.StartsWith(".."))
-                    .OrderBy(p => p.Name)
-                    .ToImmutableArray();
-                var referencedProjectPaths = MSBuildHelper.GetProjectPathsFromProject(projectPath)
-                    .Select(path => Path.GetRelativePath(workspacePath, path))
-                    .OrderBy(p => p)
-                    .ToImmutableArray();
-
-                // Get the complete set of dependencies including transitive dependencies.
-                var dependencies = indirectDependencies.Concat(directDependencies).ToImmutableArray();
-                dependencies = dependencies
-                    .Select(d => d with { TargetFrameworks = tfms })
-                    .ToImmutableArray();
-                var transitiveDependencies = await GetTransitiveDependencies(repoRootPath, projectPath, tfms, dependencies, logger);
-                ImmutableArray<Dependency> allDependencies = dependencies.Concat(transitiveDependencies).Concat(sdkDependencies)
-                    .OrderBy(d => d.Name)
-                    .ToImmutableArray();
-
-                results.Add(new()
+                if (buildFile.GetFileType() == ProjectBuildFileType.Project)
                 {
-                    FilePath = Path.GetRelativePath(workspacePath, buildFile.Path),
-                    Properties = properties,
-                    TargetFrameworks = tfms,
-                    ReferencedProjectPaths = referencedProjectPaths,
-                    Dependencies = allDependencies,
-                });
-            }
-            else
-            {
-                results.Add(new()
-                {
-                    FilePath = Path.GetRelativePath(workspacePath, buildFile.Path),
-                    Dependencies = directDependencies.Concat(sdkDependencies)
+                    // Collect information that is specific to the project file.
+                    var properties = MSBuildHelper.GetProperties(buildFiles).Values
+                        .Where(p => !p.SourceFilePath.StartsWith(".."))
+                        .OrderBy(p => p.Name)
+                        .ToImmutableArray();
+                    var referencedProjectPaths = MSBuildHelper.GetProjectPathsFromProject(projectPath)
+                        .Select(path => Path.GetRelativePath(workspacePath, path))
+                        .OrderBy(p => p)
+                        .ToImmutableArray();
+
+                    // Get the complete set of dependencies including transitive dependencies.
+                    var dependencies = indirectDependencies.Concat(directDependencies).ToImmutableArray();
+                    dependencies = dependencies
+                        .Select(d => d with { TargetFrameworks = tfms })
+                        .ToImmutableArray();
+                    var transitiveDependencies = await GetTransitiveDependencies(repoRootPath, projectPath, tfms, dependencies, logger);
+                    ImmutableArray<Dependency> allDependencies = dependencies.Concat(transitiveDependencies).Concat(sdkDependencies)
                         .OrderBy(d => d.Name)
-                        .ToImmutableArray(),
-                });
+                        .ToImmutableArray();
+
+                    results.Add(new()
+                    {
+                        FilePath = Path.GetRelativePath(workspacePath, buildFile.Path),
+                        Properties = properties,
+                        TargetFrameworks = tfms,
+                        ReferencedProjectPaths = referencedProjectPaths,
+                        Dependencies = allDependencies,
+                    });
+                }
+                else
+                {
+                    results.Add(new()
+                    {
+                        FilePath = Path.GetRelativePath(workspacePath, buildFile.Path),
+                        Dependencies = directDependencies.Concat(sdkDependencies)
+                            .OrderBy(d => d.Name)
+                            .ToImmutableArray(),
+                    });
+                }
             }
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -20,8 +20,7 @@ internal static class SdkPackageUpdater
         // SDK-style project, modify the XML directly
         logger.Log("  Running for SDK-style project");
 
-        var buildFiles = await MSBuildHelper.LoadBuildFilesAsync(repoRootPath, projectPath);
-        var tfms = MSBuildHelper.GetTargetFrameworkMonikers(buildFiles);
+        var (buildFiles, tfms) = await MSBuildHelper.LoadBuildFilesAndTargetFrameworksAsync(repoRootPath, projectPath);
 
         // Get the set of all top-level dependencies in the current project
         var topLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles).ToArray();
@@ -226,10 +225,10 @@ internal static class SdkPackageUpdater
         logger.Log($"    Adding [{dependencyName}/{newDependencyVersion}] as a top-level package reference.");
 
         // see https://learn.microsoft.com/nuget/consume-packages/install-use-packages-dotnet-cli
-        var (exitCode, _, _) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
+        var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
         if (exitCode != 0)
         {
-            logger.Log($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.");
+            logger.Log($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
         }
     }
 

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -701,9 +701,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
 
       it "does not return the `.csproj` with an unresolvable TFM" do
         expect(dependencies.length).to eq(0)
-        expect(Dependabot.logger).to have_received(:warn).with(
-          "Excluding project file 'my.csproj' due to unresolvable target framework"
-        )
       end
     end
 


### PR DESCRIPTION
Previously we'd manually parse each build file's XML and extract the `TargetFramework`, etc. properties.  This could lead to thinking a project supported a TFM when it really didn't.  The solution is to use the MSBuild-evaluated value as the project file is loaded.