### PR TITLE
remove redundant parsing of original files

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -21,19 +21,13 @@ module Dependabot
       # can be used for PR creation.
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/PerceivedComplexity
       def compile_all_dependency_changes_for(group)
         prepare_workspace
 
         group_changes = Dependabot::Updater::DependencyGroupChangeBatch.new(
           initial_dependency_files: dependency_snapshot.dependency_files
         )
-        # TODO: add directory to the dependencies to avoid reparsing?
-        job_directory = Pathname.new(job.source.directory).cleanpath
-        original_dependency_files = dependency_snapshot.dependency_files.select do |f|
-          Pathname.new(f.directory).cleanpath == job_directory
-        end
-        original_dependencies = dependency_file_parser(original_dependency_files).parse
+        original_dependencies = dependency_snapshot.dependencies
 
         group.dependencies.each do |dependency|
           if dependency_snapshot.handled_dependencies.include?(dependency.name)
@@ -93,7 +87,6 @@ module Dependabot
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/PerceivedComplexity
 
       def dependency_file_parser(dependency_files)
         Dependabot::FileParsers.for_package_manager(job.package_manager).new(


### PR DESCRIPTION
In #8963 I made DependencySnapshot aware of multiple directories, so we can remove this TODO now.

This should speed up all grouped updates a small amount because it was re-parsing the files an extra time for each group.

Now we can simply do `dependency_snapshot.dependencies` which will return what DependencySnapshot parsed at the beginning of the job run.