### PR TITLE
Check for nil `Dependency#previous_requirements` before passing to `T.must`

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -238,6 +238,8 @@ module Dependabot
 
     sig { returns(T.nilable(String)) }
     def previous_ref
+      return nil if previous_requirements.nil?
+
       previous_refs = T.must(previous_requirements).filter_map do |r|
         r.dig(:source, "ref") || r.dig(:source, :ref)
       end.uniq


### PR DESCRIPTION
`Dependency#previous_requirements` may be nil, so handle nil case before passing to `T.must`, which may cause a runtime exception.

Closes #9325 