### PR TITLE
automatically download the latest Go when needed

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -21,7 +21,8 @@ COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # See https://go.dev/doc/toolchain#select
 # By specifying go1.20.10, we use 1.20.10 for any go.mod with go directive <= 1.20.
-# In the file_parser, GOTOOLCHAIN=local is set otherwise, which uses the latest version above.
+# In the file_parser, GOTOOLCHAIN=local+auto is set otherwise, which uses the latest version above
+# or downloads the correct version if it's later than the version installed.
 ENV GOTOOLCHAIN="go1.20.10"
 # This pre-installs go 1.20 so that each job doesn't have to do it.
 RUN go version

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -33,7 +33,7 @@ module Dependabot
 
       private
 
-      # set GOTOOLCHAIN=local if go version >= 1.21
+      # set GOTOOLCHAIN=local+auto if go version >= 1.21
       sig { void }
       def set_gotoolchain_env
         go_directive = go_mod&.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first
@@ -41,7 +41,7 @@ module Dependabot
 
         go_version = Dependabot::GoModules::Version.new(go_directive)
         ENV["GOTOOLCHAIN"] = if go_version >= "1.21"
-                               "local"
+                               "local+auto"
                              else
                                ENV.fetch("GO_LEGACY")
                              end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe Dependabot::GoModules::FileParser do
       context "with a go.mod that has go 1.21 but no toolchain" do
         let(:go_mod_fixture_name) { "go_1_21_no_toolchain.mod" }
 
-        it "sets GOTOOLCHAIN=local" do
+        it "sets GOTOOLCHAIN=local+auto" do
           parser.parse
 
-          expect(ENV.fetch("GOTOOLCHAIN", nil)).to eq("local")
+          expect(ENV.fetch("GOTOOLCHAIN", nil)).to eq("local+auto")
         end
       end
     end


### PR DESCRIPTION
In #8044 I said:

> Additionally, some customers have aggressive firewalls set on their Actions runners, and so it's not a great idea to have the Go tooling automatically download versions of the Go toolchain.

But I was overlooking that GHES customers don't run on the latest updater. They're often frozen on a slightly older version. So naturally when the next version of Go comes out and they update, Dependabot is broken for them and they have no recourse.

This puts back the auto-download behavior built into Go.