### PR TITLE
Fix Duplicate Dependencies Showing in PR summary table

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -518,7 +518,7 @@ module Dependabot
       def group_intro
         update_count = dependencies.map(&:name).uniq.count
         # Ensure dependencies are unique by name
-unique_dependencies = dependencies.uniq(&:name)
+        unique_dependencies = dependencies.uniq(&:name)
 
         msg = "Bumps the #{T.must(dependency_group).name} group#{pr_name_directory} " \
               "with #{update_count} update#{update_count > 1 ? 's' : ''}:"

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -518,7 +518,7 @@ module Dependabot
       def group_intro
         update_count = dependencies.map(&:name).uniq.count
         # Ensure dependencies are unique by name
-        unique_dependencies = dependencies.uniq { |dep| [dep.name] }
+unique_dependencies = dependencies.uniq(&:name)
 
         msg = "Bumps the #{T.must(dependency_group).name} group#{pr_name_directory} " \
               "with #{update_count} update#{update_count > 1 ? 's' : ''}:"

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -517,13 +517,15 @@ module Dependabot
       sig { returns(String) }
       def group_intro
         update_count = dependencies.map(&:name).uniq.count
+        # Ensure dependencies are unique by name
+        unique_dependencies = dependencies.uniq { |dep| [dep.name] }
 
         msg = "Bumps the #{T.must(dependency_group).name} group#{pr_name_directory} " \
               "with #{update_count} update#{update_count > 1 ? 's' : ''}:"
 
         msg += if update_count >= 5
                  header = %w(Package From To)
-                 rows = dependencies.map do |dep|
+                 rows = unique_dependencies.map do |dep|
                    [
                      dependency_link(dep),
                      "`#{dep.humanized_previous_version}`",

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -516,9 +516,9 @@ module Dependabot
 
       sig { returns(String) }
       def group_intro
-        update_count = dependencies.map(&:name).uniq.count
-        # Ensure dependencies are unique by name
-        unique_dependencies = dependencies.uniq(&:name)
+        # Ensure dependencies are unique by name, from and to versions
+        unique_dependencies = dependencies.uniq { |dep| [dep.name, dep.previous_version, dep.version] }
+        update_count = unique_dependencies.count
 
         msg = "Bumps the #{T.must(dependency_group).name} group#{pr_name_directory} " \
               "with #{update_count} update#{update_count > 1 ? 's' : ''}:"

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2422,7 +2422,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five or more dependencies with same name, different to and from versions" do
+        context "with five or more dependencies with some duplicates" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2477,7 +2477,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             Dependabot::Dependency.new(
               name: "business6",
               version: "0.5.4",
-              previous_version: "0.4.1",
+              previous_version: "0.4.2",
               package_manager: "dummy",
               requirements: [],
               previous_requirements: []
@@ -2542,7 +2542,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
           it "has the correct message" do
             expect(pr_message).to start_with(
-              "Bumps the all-the-things group with 8 updates:\n\n" \
+              "Bumps the all-the-things group with 7 updates:\n\n" \
               "| Package | From | To |\n" \
               "| --- | --- | --- |\n" \
               "| [business](https://github.com/gocardless/business) | `1.4.0` | `1.5.0` |\n" \
@@ -2551,7 +2551,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "| [business4](https://github.com/gocardless/business4) | `2.1.0` | `2.1.1` |\n" \
               "| [business5](https://github.com/gocardless/business5) | `0.16.2` | `0.17.0` |\n" \
               "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `0.5.4` |\n" \
-              "| [business6](https://github.com/gocardless/business6) | `0.4.1` | `0.5.4` |\n" \
               "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `1.5.0` |\n\n" \
               "Updates `business` from 1.4.0 to 1.5.0"
             )

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2352,18 +2352,20 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
           let(:dependency6) do
             Dependabot::Dependency.new(
-              name: "business5",
-              version: "0.17.0",
-              previous_version: "0.16.2",
+              name: "business6",
+              version: "0.5.4",
+              previous_version: "0.4.2",
               package_manager: "dummy",
               requirements: [],
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5, dependency6] }
+          let(:dependencies) do
+            [dependency, dependency2, dependency3, dependency4, dependency5, dependency5, dependency6]
+          end
 
           before do
-            (2..5).each do |i|
+            (2..6).each do |i|
               repo_url = "https://api.github.com/repos/gocardless/business#{i}"
 
               stub_request(:get, repo_url)
@@ -2406,14 +2408,15 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
           it "has the correct message" do
             expect(pr_message).to start_with(
-              "Bumps the all-the-things group with 5 updates:\n\n" \
+              "Bumps the all-the-things group with 6 updates:\n\n" \
               "| Package | From | To |\n" \
               "| --- | --- | --- |\n" \
               "| [business](https://github.com/gocardless/business) | `1.4.0` | `1.5.0` |\n" \
               "| [business2](https://github.com/gocardless/business2) | `1.7.0` | `1.8.0` |\n" \
               "| [business3](https://github.com/gocardless/business3) | `1.4.0` | `1.5.0` |\n" \
               "| [business4](https://github.com/gocardless/business4) | `2.1.0` | `2.1.1` |\n" \
-              "| [business5](https://github.com/gocardless/business5) | `0.16.2` | `0.17.0` |\n\n" \
+              "| [business5](https://github.com/gocardless/business5) | `0.16.2` | `0.17.0` |\n" \
+              "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `0.5.4` |\n\n" \
               "Updates `business` from 1.4.0 to 1.5.0"
             )
           end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2101,7 +2101,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with three dependencies", :vcr do
+        context "with three dependencies" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2210,7 +2210,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five or more dependencies", :vcr do
+        context "with five or more dependencies" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2309,7 +2309,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five or more dependencies with same name", :vcr do
+        context "with five or more dependencies with same name" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2422,7 +2422,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five or more dependencies with same name, different to and from versions", :vcr do
+        context "with five or more dependencies with same name, different to and from versions" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2558,7 +2558,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with ignore conditions", :vcr do
+        context "with ignore conditions" do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2664,7 +2664,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "without ignore conditions", :vcr do
+        context "without ignore conditions" do
           let(:dependency1) do
             Dependabot::Dependency.new(
               name: "business2",
@@ -2752,7 +2752,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
       end
 
-      context "for a multi-directory dependency group", :vcr do
+      context "for a multi-directory dependency group" do
         let(:source) do
           Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directories: ["/foo", "/bar"])
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2422,7 +2422,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
-        context "with five or more dependencies with same name, differet to and from versions", :vcr do
+        context "with five or more dependencies with same name, different to and from versions", :vcr do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business2",

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2084,7 +2084,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           let(:dependency2) do
             Dependabot::Dependency.new(
               name: "business",
-              version: "1.6.0",
+              version: "1.5.0",
               previous_version: "1.4.0",
               package_manager: "dummy",
               requirements: [],
@@ -2417,6 +2417,142 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "| [business4](https://github.com/gocardless/business4) | `2.1.0` | `2.1.1` |\n" \
               "| [business5](https://github.com/gocardless/business5) | `0.16.2` | `0.17.0` |\n" \
               "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `0.5.4` |\n\n" \
+              "Updates `business` from 1.4.0 to 1.5.0"
+            )
+          end
+        end
+
+        context "with five or more dependencies with same name, differet to and from versions", :vcr do
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.8.0",
+              previous_version: "1.7.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency3) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency4) do
+            Dependabot::Dependency.new(
+              name: "business4",
+              version: "2.1.1",
+              previous_version: "2.1.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency5) do
+            Dependabot::Dependency.new(
+              name: "business5",
+              version: "0.17.0",
+              previous_version: "0.16.2",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency6) do
+            Dependabot::Dependency.new(
+              name: "business6",
+              version: "0.5.4",
+              previous_version: "0.4.2",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency7) do
+            Dependabot::Dependency.new(
+              name: "business6",
+              version: "0.5.4",
+              previous_version: "0.4.1",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency8) do
+            Dependabot::Dependency.new(
+              name: "business6",
+              version: "1.5.0",
+              previous_version: "0.4.2",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) do
+            [dependency, dependency2, dependency3, dependency4, dependency5, dependency5, dependency6, dependency7,
+             dependency8]
+          end
+
+          before do
+            (2..6).each do |i|
+              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
+
+              stub_request(:get, repo_url)
+                .to_return(status: 200,
+                           body: fixture("github", "business_repo.json"),
+                           headers: json_header)
+              stub_request(:get, "#{repo_url}/contents/")
+                .to_return(status: 200,
+                           body: fixture("github", "business_files.json"),
+                           headers: json_header)
+              stub_request(:get, "#{repo_url}/releases?per_page=100")
+                .to_return(status: 200,
+                           body: fixture("github", "business_releases.json"),
+                           headers: json_header)
+              stub_request(:get, "https://api.github.com/repos/gocardless/" \
+                                 "business#{i}/contents/CHANGELOG.md?ref=master")
+                .to_return(status: 200,
+                           body: fixture("github", "changelog_contents.json"),
+                           headers: json_header)
+              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
+                .to_return(
+                  status: 200,
+                  body: fixture("ruby", "rubygems_response_statesman.json")
+                )
+
+              service_pack_url =
+                "https://github.com/gocardless/business#{i}.git/info/refs" \
+                "?service=git-upload-pack"
+
+              stub_request(:get, service_pack_url)
+                .to_return(
+                  status: 200,
+                  body: fixture("git", "upload_packs", "no_tags"),
+                  headers: {
+                    "content-type" => "application/x-git-upload-pack-advertisement"
+                  }
+                )
+            end
+          end
+
+          it "has the correct message" do
+            expect(pr_message).to start_with(
+              "Bumps the all-the-things group with 8 updates:\n\n" \
+              "| Package | From | To |\n" \
+              "| --- | --- | --- |\n" \
+              "| [business](https://github.com/gocardless/business) | `1.4.0` | `1.5.0` |\n" \
+              "| [business2](https://github.com/gocardless/business2) | `1.7.0` | `1.8.0` |\n" \
+              "| [business3](https://github.com/gocardless/business3) | `1.4.0` | `1.5.0` |\n" \
+              "| [business4](https://github.com/gocardless/business4) | `2.1.0` | `2.1.1` |\n" \
+              "| [business5](https://github.com/gocardless/business5) | `0.16.2` | `0.17.0` |\n" \
+              "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `0.5.4` |\n" \
+              "| [business6](https://github.com/gocardless/business6) | `0.4.1` | `0.5.4` |\n" \
+              "| [business6](https://github.com/gocardless/business6) | `0.4.2` | `1.5.0` |\n\n" \
               "Updates `business` from 1.4.0 to 1.5.0"
             )
           end


### PR DESCRIPTION
## Context

This PR resolves the issue of duplicated entries in the group update PR's summary table by ensuring that only unique dependencies are considered in the message builder. These are then displayed in the PR summary table.

Fixes: https://github.com/dependabot/dependabot-core/issues/7695