### PR TITLE
Handle force push restrictions from repository rules

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -229,7 +229,8 @@ module Dependabot
         if e.message.match?(/protected branch/i) ||
            e.message.match?(/not authorized to push/i) ||
            e.message.include?("must not contain merge commits") ||
-           e.message.match?(/required status check/i)
+           e.message.match?(/required status check/i) ||
+           e.message.match?(/cannot force-push to this branch/i)
           raise BranchProtected
         end
 

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -680,5 +680,18 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
           .to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
       end
     end
+
+    context "when pushing to a branch that does not allow force pushes" do
+      before do
+        stub_request(
+          :patch,
+          "#{watched_repo_url}/git/refs/heads/#{branch_name}"
+        ).to_return(status: 422, body: fixture("github", "force_push_restricted_branch.json"), headers: json_header)
+      end
+
+      it "raises a helpful error" do
+        expect { updater.update } .to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
+      end
+    end
   end
 end

--- a/common/spec/fixtures/github/force_push_restricted_branch.json
+++ b/common/spec/fixtures/github/force_push_restricted_branch.json
@@ -1,0 +1,4 @@
+{
+  "message": "Cannot force-push to this branch",
+  "documentation_url": "https://docs.github.com/rest/git/refs#update-a-reference"
+}


### PR DESCRIPTION
When a force push is rejected from a [Repository Rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) the error that's returned is different, handle that case the same as other force push rejections.