### PR TITLE
bundler: lazy parsing of lockfiles

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -359,14 +359,15 @@ module Dependabot
         @latest_version_finder ||= {}
         @latest_version_finder[remove_git_source] ||=
           begin
-            prepared_dependency_files = prepared_dependency_files(
+            file_preparer = file_preparer(
               remove_git_source: remove_git_source,
               unlock_requirement: true
             )
 
             LatestVersionFinder.new(
               dependency: dependency,
-              dependency_files: prepared_dependency_files,
+              dependency_files: dependency_files,
+              file_preparer: file_preparer,
               repo_contents_path: repo_contents_path,
               credentials: credentials,
               ignored_versions: ignored_versions,
@@ -377,15 +378,14 @@ module Dependabot
           end
       end
 
-      def prepared_dependency_files(remove_git_source:, unlock_requirement:,
-                                    latest_allowable_version: nil)
+      def file_preparer(remove_git_source:, unlock_requirement:, latest_allowable_version: nil)
         FilePreparer.new(
           dependency: dependency,
           dependency_files: dependency_files,
           remove_git_source: remove_git_source,
           unlock_requirement: unlock_requirement,
           latest_allowable_version: latest_allowable_version
-        ).prepared_dependency_files
+        )
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -18,11 +18,12 @@ module Dependabot
       class LatestVersionFinder
         extend T::Sig
 
-        def initialize(dependency:, dependency_files:, repo_contents_path: nil,
+        def initialize(dependency:, dependency_files:, file_preparer: nil, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,
                        security_advisories:, options:)
           @dependency          = dependency
           @dependency_files    = dependency_files
+          @file_preparer       = file_preparer
           @repo_contents_path  = repo_contents_path
           @credentials         = credentials
           @ignored_versions    = ignored_versions
@@ -43,6 +44,7 @@ module Dependabot
 
         attr_reader :dependency
         attr_reader :dependency_files
+        attr_reader :file_preparer
         attr_reader :repo_contents_path
         attr_reader :credentials
         attr_reader :ignored_versions
@@ -123,6 +125,7 @@ module Dependabot
           @dependency_source ||= DependencySource.new(
             dependency: dependency,
             dependency_files: dependency_files,
+            file_preparer: file_preparer,
             credentials: credentials,
             options: options
           )
@@ -134,11 +137,6 @@ module Dependabot
 
         def requirement_class
           dependency.requirement_class
-        end
-
-        def gemfile
-          dependency_files.find { |f| f.name == "Gemfile" } ||
-            dependency_files.find { |f| f.name == "gems.rb" }
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -22,19 +22,22 @@ module Dependabot
           OTHER = "other"
 
           attr_reader :dependency
-          attr_reader :dependency_files
+          attr_reader :unprepared_dependency_files
+          attr_reader :file_preparer
           attr_reader :repo_contents_path
           attr_reader :credentials
           attr_reader :options
 
           def initialize(dependency:,
                          dependency_files:,
+                         file_preparer: nil,
                          credentials:,
                          options:)
-            @dependency          = dependency
-            @dependency_files    = dependency_files
-            @credentials         = credentials
-            @options             = options
+            @dependency                     = dependency
+            @unprepared_dependency_files    = dependency_files
+            @file_preparer                  = file_preparer
+            @credentials                    = credentials
+            @options                        = options
           end
 
           # The latest version details for the dependency from a registry
@@ -143,6 +146,12 @@ module Dependabot
                 }
               )
             end
+          end
+
+          def dependency_files
+            return unprepared_dependency_files if file_preparer.nil?
+
+            @dependency_files ||= file_preparer.prepared_dependency_files
           end
 
           def gemfile


### PR DESCRIPTION
The FilePreparer parses the lockfile looking for gemspec versions which incurs a significant cost (10+ seconds) when parsing large lockfiles, so an update with no changes can spend upwards of 30 minutes parsing the lockfiles.

If the dependency in question is a rubygems source, it doesn't even use the prepared_dependency_files. 

So by passing down the FilePreparer instance we can avoid parsing the lockfile in many cases, saving significant time. 

I considered removing `dependency_files` as a parameter completely to LatestVersionFinder, but the version_resolver seems to want to pass in prepared and unprepared files at times. So left that alone for now to keep things simple.