### PR TITLE
bundler: avoid repeat lockfile parsing with caching

### DIFF
--- a/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
+++ b/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
+++ b/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "digest"
+require "digest/sha2"
 require "bundler/lockfile_parser"
 
 module Dependabot
@@ -12,7 +13,7 @@ module Dependabot
 
       sig { params(lockfile_content: String).returns(::Bundler::LockfileParser) }
       def self.parse(lockfile_content)
-        lockfile_hash = Digest::SHA256.hexdigest(lockfile_content)
+        lockfile_hash = Digest::SHA2.hexdigest(lockfile_content)
         @cache ||= T.let({}, T.nilable(T::Hash[String, ::Bundler::LockfileParser]))
         return T.must(@cache[lockfile_hash]) if @cache.key?(lockfile_hash)
 

--- a/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
+++ b/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
@@ -14,7 +14,7 @@ module Dependabot
       def self.parse(lockfile_content)
         lockfile_hash = Digest::SHA256.hexdigest(lockfile_content)
         @cache ||= T.let({}, T.nilable(T::Hash[String, ::Bundler::LockfileParser]))
-        return @cache[lockfile_hash] if @cache.key?(lockfile_hash)
+        return T.must(@cache[lockfile_hash]) if @cache.key?(lockfile_hash)
 
         @cache[lockfile_hash] = ::Bundler::LockfileParser.new(lockfile_content)
       end

--- a/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
+++ b/bundler/lib/dependabot/bundler/cached_lockfile_parser.rb
@@ -1,0 +1,23 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "digest"
+require "bundler/lockfile_parser"
+
+module Dependabot
+  module Bundler
+    class CachedLockfileParser
+      extend T::Sig
+
+      sig { params(lockfile_content: String).returns(::Bundler::LockfileParser) }
+      def self.parse(lockfile_content)
+        lockfile_hash = Digest::SHA256.hexdigest(lockfile_content)
+        @cache ||= T.let({}, T.nilable(T::Hash[String, ::Bundler::LockfileParser]))
+        return @cache[lockfile_hash] if @cache.key?(lockfile_hash)
+
+        @cache[lockfile_hash] = ::Bundler::LockfileParser.new(lockfile_content)
+      end
+    end
+  end
+end

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/bundler/file_updater/lockfile_updater"
+require "dependabot/bundler/cached_lockfile_parser"
 require "dependabot/errors"
 
 module Dependabot
@@ -162,8 +163,7 @@ module Dependabot
 
       def fetch_path_gemspec_paths
         if lockfile
-          parsed_lockfile = ::Bundler::LockfileParser
-                            .new(sanitized_lockfile_content)
+          parsed_lockfile = CachedLockfileParser.parse(sanitized_lockfile_content)
           parsed_lockfile.specs
                          .select { |s| s.source.instance_of?(::Bundler::Source::Path) }
                          .map { |s| s.source.path }.uniq

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -8,6 +8,7 @@ require "dependabot/bundler/file_updater/lockfile_updater"
 require "dependabot/bundler/native_helpers"
 require "dependabot/bundler/helpers"
 require "dependabot/bundler/version"
+require "dependabot/bundler/cached_lockfile_parser"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 
@@ -255,8 +256,7 @@ module Dependabot
       end
 
       def parsed_lockfile
-        @parsed_lockfile ||=
-          ::Bundler::LockfileParser.new(sanitized_lockfile_content)
+        CachedLockfileParser.parse(sanitized_lockfile_content)
       end
 
       def production_dep_names

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -256,7 +256,7 @@ module Dependabot
       end
 
       def parsed_lockfile
-        CachedLockfileParser.parse(sanitized_lockfile_content)
+        @parsed_lockfile ||= CachedLockfileParser.parse(sanitized_lockfile_content)
       end
 
       def production_dep_names

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -6,6 +6,7 @@ require "bundler"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/bundler/file_updater"
+require "dependabot/bundler/cached_lockfile_parser"
 require "dependabot/bundler/native_helpers"
 require "dependabot/bundler/helpers"
 
@@ -216,8 +217,8 @@ module Dependabot
                                        .dependency_name || File.basename(path, ".gemspec")
 
           gemspec_specs =
-            ::Bundler::LockfileParser.new(sanitized_lockfile_body).specs
-                                     .select { |s| s.name == gem_name && gemspec_sources.include?(s.source.class) }
+            CachedLockfileParser.parse(sanitized_lockfile_body).specs
+                                .select { |s| s.name == gem_name && gemspec_sources.include?(s.source.class) }
 
           gemspec_specs.first&.version || "0.0.1"
         end

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -268,8 +268,8 @@ module Dependabot
           return "0.0.1" unless lockfile
 
           gemspec_specs =
-            ::Bundler::LockfileParser.new(sanitized_lockfile_content).specs
-                                     .select { |s| gemspec_sources.include?(s.source.class) }
+            CachedLockfileParser.parse(sanitized_lockfile_content).specs
+                                .select { |s| gemspec_sources.include?(s.source.class) }
 
           gem_name =
             FileUpdater::GemspecDependencyNameFinder

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/dependency_file"
 require "dependabot/bundler/update_checker"
+require "dependabot/bundler/cached_lockfile_parser"
 require "dependabot/bundler/file_updater/gemspec_sanitizer"
 require "dependabot/bundler/file_updater/git_pin_replacer"
 require "dependabot/bundler/file_updater/git_source_remover"


### PR DESCRIPTION
The bundler ecosystem repeatedly parsed the customer's lockfile during file fetching, file parsing, and file updating.

To speed things up I've introduced a cache which will return the pre-parsed lockfile.