### PR TITLE
Handle more branch protection errors

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -213,17 +213,20 @@ module Dependabot
         )
       end
 
-      BRANCH_PROTECTION_ERROR_MESSAGES = [
-        /protected branch/i,
-        /not authorized to push/i,
-        /must not contain merge commits/i,
-        /required status check/i,
-        /cannot force-push to this branch/i,
-        /pull request for this branch has been added to a merge queue/i,
-        # Unverified commits can be present when PR contains commits from other authors
-        /commits must have verified signatures/i,
-        /changes must be made through a pull request/i,
-      ]
+      BRANCH_PROTECTION_ERROR_MESSAGES = T.let(
+        [
+          /protected branch/i,
+          /not authorized to push/i,
+          /must not contain merge commits/i,
+          /required status check/i,
+          /cannot force-push to this branch/i,
+          /pull request for this branch has been added to a merge queue/i,
+          # Unverified commits can be present when PR contains commits from other authors
+          /commits must have verified signatures/i,
+          /changes must be made through a pull request/i,
+        ],
+        T::Array[Regexp]
+      )
 
       sig { params(commit: T.untyped).returns(T.untyped) }
       def update_branch(commit)

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -224,9 +224,9 @@ module Dependabot
           # Unverified commits can be present when PR contains commits from other authors
           /commits must have verified signatures/i,
           /changes must be made through a pull request/i
-        ],
+        ].freeze,
         T::Array[Regexp]
-      ).freeze
+      )
 
       sig { params(commit: T.untyped).returns(T.untyped) }
       def update_branch(commit)

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -223,10 +223,10 @@ module Dependabot
           /pull request for this branch has been added to a merge queue/i,
           # Unverified commits can be present when PR contains commits from other authors
           /commits must have verified signatures/i,
-          /changes must be made through a pull request/i,
+          /changes must be made through a pull request/i
         ],
         T::Array[Regexp]
-      )
+      ).freeze
 
       sig { params(commit: T.untyped).returns(T.untyped) }
       def update_branch(commit)

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -230,7 +230,11 @@ module Dependabot
            e.message.match?(/not authorized to push/i) ||
            e.message.include?("must not contain merge commits") ||
            e.message.match?(/required status check/i) ||
-           e.message.match?(/cannot force-push to this branch/i)
+           e.message.match?(/cannot force-push to this branch/i) ||
+           e.message.match?(/pull request for this branch has been added to a merge queue/i) ||
+           # Unverified commits can be present when PR contains commits from other authors
+           e.message.match?(/commits must have verified signatures/i) ||
+           e.message.match?(/changes must be made through a pull request/i)
           raise BranchProtected
         end
 

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -241,7 +241,7 @@ module Dependabot
         return nil if e.message.match?(/Reference does not exist/i)
         return nil if e.message.match?(/Reference cannot be updated/i)
 
-        raise BranchProtected if BRANCH_PROTECTION_ERROR_MESSAGES.any? { |msg| e.message.match?(msg) }
+        raise BranchProtected, e.message if BRANCH_PROTECTION_ERROR_MESSAGES.any? { |msg| e.message.match?(msg) }
 
         raise
       end


### PR DESCRIPTION
As a follow-up to #9439, I noticed a couple more exceptions around branch protection rules, which I've listed here.

I am not sure that adding a new test for each permutation of this error is of a lot of value, but open to feedback on this