### PR TITLE
bundler: avoid reparsing same gemspec

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -75,7 +75,9 @@ module Dependabot
         dependencies
       end
 
-      def gemspec_dependencies
+      def gemspec_dependencies # rubocop:disable Metrics/PerceivedComplexity
+        return @gemspec_dependencies if defined?(@gemspec_dependencies)
+
         queue = Queue.new
 
         SharedHelpers.in_a_temporary_repo_directory(base_directory, repo_contents_path) do
@@ -108,7 +110,7 @@ module Dependabot
 
         dependency_set = DependencySet.new
         dependency_set << queue.pop(true) while queue.size.positive?
-        dependency_set
+        @gemspec_dependencies ||= dependency_set
       end
 
       def lockfile_dependencies


### PR DESCRIPTION
This is a slight performance improvement that will help with grouped updates. 

I noticed in a flamegraph that `gemspec_dependencies` is called multiple times for each call of `parse`, so memoizing the call improves the performance.