### PR TITLE
Bump Swift version from 5.9 to 5.10

### DIFF
--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -25,7 +25,7 @@ USER dependabot
 
 # https://www.swift.org/download/
 # https://github.com/apple/swift-org-website/blob/main/_data/builds/swift_releases.yml
-ARG SWIFT_VERSION=5.9
+ARG SWIFT_VERSION=5.10
 ARG SWIFT_UBUNTU_VERSION=ubuntu22.04
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VERSION}-aarch64"; fi \


### PR DESCRIPTION
Hello there!

I have encountered an issue:
<img width="913" alt="Screenshot 2024-04-09 at 19 57 58" src="https://github.com/dependabot/dependabot-core/assets/64660122/7b09f0e1-7028-4904-8f4c-ff107b08dad4">

```sh
updater | 2024/04/09 06:19:14 ERROR <job_811965137> error: 'repo': package 'repo' is using Swift tools version 5.10.0 but the installed version is 5.9.0
```

I have found a similar one here:
- #8073

It looks like it's time to update the Swift version:
- https://github.com/apple/swift-org-website/blob/main/_data/builds/swift_releases.yml#L1674