### PR TITLE
Avoid passing empty strings as versions

### DIFF
--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -224,7 +224,7 @@ module Dependabot
       sig { returns(Dependabot::Dependency) }
       def updated_dependency_without_unlock
         version = latest_resolvable_version_with_no_unlock.to_s
-        previous_version = latest_resolvable_previous_version(version)&.to_s
+        previous_version = latest_resolvable_previous_version(version)
 
         Dependency.new(
           name: dependency.name,

--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -492,6 +492,22 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         its(:name) { is_expected.to eq(dependency.name) }
         its(:requirements) { is_expected.to eq(original_requirements) }
       end
+
+      context "without a previous version" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: nil,
+            requirements: original_requirements,
+            package_manager: "dummy"
+          )
+        end
+
+        describe "the dependency" do
+          subject { updated_dependencies.first }
+          it { is_expected.to be_nil }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
We were previously using safe traversal to call `#to_s` on a nilable string, i.e., we were creating empty strings:

https://github.com/dependabot/dependabot-core/blob/a3dba8f6474160b2f4743a4b43385a735d58fcb9/common/lib/dependabot/update_checkers/base.rb#L227

This has been causing runtime exceptions because the `Dependency` initializer explicitly raises if either `version` or `previous_version` is an empty string.

Fixes #9430 