### PR TITLE
Update how we record Bundler versions

### DIFF
--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -30,9 +30,9 @@ module Dependabot
         return "unknown" unless lockfile
 
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
-          matches[:version]
+          matches[:version].to_i
         else
-          "1"
+          "unknown"
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -32,7 +32,7 @@ module Dependabot
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
           matches[:version].to_i.to_s
         else
-          "unknown"
+          "unspecified"
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -30,7 +30,7 @@ module Dependabot
         return "unknown" unless lockfile
 
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
-          matches[:version].to_i
+          matches[:version].to_i.to_s
         else
           "unknown"
         end

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Dependabot::Bundler::Helpers do
       expect(described_method(no_lockfile)).to eql("unknown")
     end
 
-    it "is unknown if there is no bundled with string" do
-      expect(described_method(lockfile_bundled_with_missing)).to eql("unknown")
+    it "is unspecified if there is no bundled with string" do
+      expect(described_method(lockfile_bundled_with_missing)).to eql("unspecified")
     end
 
     it "is 1 if it was bundled with a v1.x version" do

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe Dependabot::Bundler::Helpers do
       expect(described_method(no_lockfile)).to eql("unknown")
     end
 
-    it "is 1 if there is no bundled with string" do
-      expect(described_method(lockfile_bundled_with_missing)).to eql("1")
+    it "is unknown if there is no bundled with string" do
+      expect(described_method(lockfile_bundled_with_missing)).to eql("unknown")
     end
 
     it "is 1 if it was bundled with a v1.x version" do
@@ -88,7 +88,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
       expect(described_method(lockfile_bundled_with_v2)).to eql("2")
     end
 
-    it "is 1 if it was bundled with a future version" do
+    it "reports the version if it was bundled with a future version" do
       expect(described_method(lockfile_bundled_with_future_version)).to eql("3")
     end
   end


### PR DESCRIPTION
We rely on this information for metrics, not application logic. I believe we're receiving poor information and making decisions based on it. I'm updating this to see if we're indeed supporting as many Bundler v1 projects as it seems.