### PR TITLE
replace credentials with dummy creds

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -372,8 +372,9 @@ module Dependabot
         end
 
         def sanitize_yarnrc_content(content)
-          # Replace all "${...}" and ${...} occurrences with empty strings
-          content.gsub(/\"\$\{.*?\}\"/, '""').gsub(/\$\{.*?\}/, '""')
+          # Replace all "${...}" and ${...} occurrences with dummy strings. We use
+          # dummy strings instead of empty strings to prevent issues with npmAlwaysAuth
+          content.gsub(/"\$\{.*?}"/, '"DUMMYCREDS"').gsub(/\$\{.*?}/, '"DUMMYCREDS"')
         end
 
         def clean_npmrc_in_path(yarn_lock)


### PR DESCRIPTION
Customers are setting `npmAlwaysAuth` in their `.yarmrc.yml` which due to our sanitation results in `No authentication configured for request`, even if they set a fallback value with `${TOKEN:-fallback}` because we clear out the entire thing.

This works around that by setting a default value ourselves.

For the life of me I cannot reproduce this issue locally, but it should be completely harmless assuming all the tests pass.