### PR TITLE
Treat pep-621 deps as prod if no requirement_type is specified

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -98,7 +98,7 @@ module Dependabot
                   requirement: dep["requirement"],
                   file: Pathname.new(dep["file"]).cleanpath.to_path,
                   source: nil,
-                  groups: [dep["requirement_type"]]
+                  groups: [dep["requirement_type"]].compact
                 }],
                 package_manager: "pip"
               )

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 require "dependabot/dependency_file"
-require "dependabot/python/file_parser/pyproject_files_parser"
+require "dependabot/python"
 
 RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
   let(:parser) { described_class.new(dependency_files: files) }
@@ -288,10 +288,11 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
           [{
             requirement: "==0.3.0",
             file: "pyproject.toml",
-            groups: [nil],
+            groups: [],
             source: nil
           }]
         )
+        expect(dependency.production?).to be_truthy
       end
     end
 


### PR DESCRIPTION
When the Python native requirement parser is unable to determine a `requirement_type`, we previously would include a `nil` value in the requirements group attribute, which in turn would cause our production check to determine that groups are present and no `default` or `install_requires` group is present, so this must be a dev dependency.

However, when no groups can be determined I think it's safer to assume all dependencies as production dependencies instead, as demonstrated by the test that I've updated, where the dependency in question is specified as such:

```toml
[build-system]
requires = ["flit_core >=3.2,<4"]
build-backend = "flit_core.buildapi"

[project]
name = "pkgtest"
authors = [{name = "Sample", email = "sample.project@example.org"}]
license = {file = "LICENSE"}
classifiers = ["License :: OSI Approved :: MIT License"]
dynamic = ["version", "description"]
dependencies = [
   "ansys-templates==0.3.0",
]
```

From my understanding, `ansys-templates` should not be considered a development dependency in this case.