### PR TITLE
Actions: allow less precise semver updates

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -133,6 +133,13 @@ module Dependabot
     end
 
     sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    def local_ref_for_latest_version_lower_precision
+      allowed_refs = local_tag_for_pinned_sha ? allowed_version_tags : allowed_version_refs
+
+      max_local_tag_for_lower_precision(allowed_refs)
+    end
+
+    sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
     def local_tag_for_latest_version
       max_local_tag(allowed_version_tags)
     end
@@ -239,6 +246,11 @@ module Dependabot
     end
 
     sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    def max_local_tag_for_lower_precision(tags)
+      max_local_tag(select_lower_precision(tags))
+    end
+
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
     def max_local_tag(tags)
       max_version_tag = tags.max_by { |t| version_from_tag(t) }
 
@@ -251,6 +263,14 @@ module Dependabot
       current_precision = precision(T.must(dependency.version))
 
       tags.select { |tag| precision(scan_version(tag.name)) == current_precision }
+    end
+
+    # Find the latest version with a lower precision as the pinned version.
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T::Array[Dependabot::GitRef]) }
+    def select_lower_precision(tags)
+      current_precision = precision(T.must(dependency.version))
+
+      tags.select { |tag| precision(scan_version(tag.name)) <= current_precision }
     end
 
     sig { params(version: String).returns(Integer) }

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1174,6 +1174,146 @@ RSpec.describe Dependabot::GitCommitChecker do
 
         it { is_expected.to match(latest_minor_tag) }
       end
+
+      context "when pinned to a patch" do
+        let(:version) { "7.0.0" }
+
+        let(:latest_minor_tag) do
+          {
+            commit_sha: "831e6cd560cc8688a4967c5766e4215afbd196d9",
+            tag: "v10.6",
+            tag_sha: anything,
+            version: anything
+          }
+        end
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
+  describe "#local_ref_for_latest_version_lower_precision" do
+    subject { checker.local_ref_for_latest_version_lower_precision }
+    let(:repo_url) { "https://github.com/gocardless/business.git" }
+    let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+    before do
+      stub_request(:get, service_pack_url)
+        .to_return(
+          status: 200,
+          body: fixture("git", "upload_packs", upload_pack_fixture),
+          headers: {
+            "content-type" => "application/x-git-upload-pack-advertisement"
+          }
+        )
+    end
+
+    context "with no tags, nor version branches" do
+      let(:upload_pack_fixture) { "no_tags" }
+      it { is_expected.to be_nil }
+    end
+
+    context "with no version tags nor version branches" do
+      let(:upload_pack_fixture) { "no_versions" }
+      it { is_expected.to be_nil }
+    end
+
+    context "with version tags, and some version branches not matching pinned schema" do
+      let(:upload_pack_fixture) { "actions-checkout" }
+      let(:version) { "1.1.1" }
+
+      let(:source) do
+        {
+          type: "git",
+          url: "https://github.com/gocardless/business",
+          branch: "master",
+          ref: "v#{version}"
+        }
+      end
+
+      let(:latest_patch) do
+        {
+          commit_sha: "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f",
+          tag: "v2.3.4",
+          tag_sha: anything,
+          version: anything
+        }
+      end
+
+      it { is_expected.to match(latest_patch) }
+    end
+
+    context "with a version branch higher than the latest version tag, and pinned to the commit sha of a version tag" do
+      let(:upload_pack_fixture) { "actions-checkout-2022-12-01" }
+      let(:version) { "1.1.0" }
+
+      let(:source) do
+        {
+          type: "git",
+          url: "https://github.com/gocardless/business",
+          branch: "master",
+          ref: "0b496e91ec7ae4428c3ed2eeb4c3a40df431f2cc"
+        }
+      end
+
+      let(:latest_patch) do
+        {
+          commit_sha: "93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8",
+          tag: "v3.1.0",
+          tag_sha: anything,
+          version: anything
+        }
+      end
+
+      it { is_expected.to match(latest_patch) }
+    end
+
+    context "with tags for minor versions and branches for major versions" do
+      let(:upload_pack_fixture) { "run-vcpkg" }
+
+      context "when pinned to a major" do
+        let(:version) { "7" }
+
+        let(:latest_major_branch) do
+          {
+            commit_sha: "831e6cd560cc8688a4967c5766e4215afbd196d9",
+            tag: "v10",
+            tag_sha: anything,
+            version: anything
+          }
+        end
+
+        it { is_expected.to match(latest_major_branch) }
+      end
+
+      context "when pinned to a minor" do
+        let(:version) { "7.0" }
+
+        let(:latest_minor_tag) do
+          {
+            commit_sha: "831e6cd560cc8688a4967c5766e4215afbd196d9",
+            tag: "v10.6",
+            tag_sha: anything,
+            version: anything
+          }
+        end
+
+        it { is_expected.to match(latest_minor_tag) }
+      end
+
+      context "when pinned to a patch" do
+        let(:version) { "7.0.0" }
+
+        let(:latest_minor_tag) do
+          {
+            commit_sha: "831e6cd560cc8688a4967c5766e4215afbd196d9",
+            tag: "v10.6",
+            tag_sha: anything,
+            version: anything
+          }
+        end
+
+        it { is_expected.to match(latest_minor_tag) }
+      end
     end
   end
 

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -165,7 +165,10 @@ module Dependabot
         @latest_version_tag ||= begin
           return git_commit_checker.local_tag_for_latest_version if dependency.version.nil?
 
-          git_commit_checker.local_ref_for_latest_version_matching_existing_precision
+          ref = git_commit_checker.local_ref_for_latest_version_matching_existing_precision
+          return ref if ref && ref.fetch(:version) > current_version
+
+          git_commit_checker.local_ref_for_latest_version_lower_precision
         end
       end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -331,6 +331,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "v7" }
         it { is_expected.to eq(Dependabot::GithubActions::Version.new("10")) }
       end
+
+      context "using the minor version" do
+        let(:reference) { "v7.0" }
+        it { is_expected.to eq(Dependabot::GithubActions::Version.new("10.5")) }
+      end
+
+      context "using a patch version" do
+        let(:reference) { "v7.0.0" }
+        it { is_expected.to eq(Dependabot::GithubActions::Version.new("10.5")) }
+      end
     end
 
     context "given a dependency with a tag reference and a branch similar to the tag" do


### PR DESCRIPTION
If an Action is pinned to v3.5, and a v4 and v4.1.0 are released, Dependabot won't bump the Action.

This is because it tries to match the same precision. So v3.5 is precision 2, v4 is precision 1, v4.1.0 is precision 3.

It makes sense to not allow a v4 -> v4.1.0 bump because in the Action world, v4 and v4.1.0 SHOULD be pointed to the same commit.

However in the case above, v3.5 -> v4 does make sense, but we'd prefer a v4.X if available.

So this code will prefer a matching precision, but if one doesn't exist it will become less precise.
