### PR TITLE
asynchronously create PRs

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -39,10 +39,11 @@ module Dependabot
                    :record_ecosystem_versions,
                    :increment_metric
 
+    sig { void }
     def wait_for_calls_to_finish
       return unless Experiments.enabled?("threaded_metadata")
 
-      @threads&.each(&:join)
+      @threads.each(&:join)
     end
 
     sig { params(dependency_change: Dependabot::DependencyChange, base_commit_sha: String).void }

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -43,7 +43,7 @@ module Dependabot
           dependency_snapshot: dependency_snapshot
         ).run
 
-        # Wait for all PRs to be created/updated and errors reported
+        # Wait for all PRs to be created
         service.wait_for_calls_to_finish
 
         # Finally, mark the job as processed. The Dependabot::Updater may have

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -43,6 +43,9 @@ module Dependabot
           dependency_snapshot: dependency_snapshot
         ).run
 
+        # Wait for all PRs to be created/updated and errors reported
+        service.wait_for_calls_to_finish
+
         # Finally, mark the job as processed. The Dependabot::Updater may have
         # reported errors to the service, but we always consider the job as
         # successfully processed unless it actually raises.

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Dependabot::UpdateFilesCommand do
                     record_update_job_error: nil,
                     record_update_job_unknown_error: nil,
                     update_dependency_list: nil,
-                    increment_metric: nil)
+                    increment_metric: nil,
+                    wait_for_calls_to_finish: nil)
   end
   let(:job_definition) do
     JSON.parse(fixture("file_fetcher_output/output.json"))


### PR DESCRIPTION
The PR creation process requires gathering a significant amount of metadata which is IO heavy. Rather than wait for that to finish, we can pop that in a thread and continue on with the next updates. 

Testing locally against dependabot-core this lead to a 30% reduction in the job runtime, but it's very dependent on if there's a lot of PRs to create.

The major downside of this is that the logs become more difficult to read because the metadata gathering overlaps with the output for the next dependency, so I've put this behind an experiment and we can enable it on customers that are hitting the timeout.