### PR TITLE
fix pub build not using lockfile

### DIFF
--- a/pub/helpers/build
+++ b/pub/helpers/build
@@ -10,7 +10,7 @@ if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
 fi
 
 # Retrieve the dependencies
-dart pub upgrade -C "$DEPENDABOT_NATIVE_HELPERS_PATH/pub/helpers"
+dart pub get -C "$DEPENDABOT_NATIVE_HELPERS_PATH/pub/helpers"
 
 # Compile the helpers
 dart compile exe "$DEPENDABOT_NATIVE_HELPERS_PATH/pub/helpers/bin/dependency_services.dart" -o "$DEPENDABOT_NATIVE_HELPERS_PATH/pub/dependency_services"


### PR DESCRIPTION
We suddenly started getting pub image failures.

<details>

<summary>logs</summary>

```
#10 11.17 /opt/dart/pub-cache/git/pub-a42800e5a2f539dd5d86fdc3a6f3beefc971c753/lib/src/command/lish.dart:43:57: Error: The argument type 'String?' can't be assigned to the parameter type 'String' because 'String?' is nullable and 'String' isn't.
#10 11.17         return validateAndNormalizeHostedUrl(argResults.option('server'));
#10 11.17                                                         ^
#10 11.17 /opt/dart/pub-cache/git/pub-a42800e5a2f539dd5d86fdc3a6f3beefc971c753/lib/src/command/uploader.dart:26:42: Error: The argument type 'String?' can't be assigned to the parameter type 'String' because 'String?' is nullable and 'String' isn't.
#10 11.17   Uri get server => Uri.parse(argResults.option('server'));
#10 11.17                                          ^
#10 11.17 /opt/dart/pub-cache/git/pub-a42800e5a2f539dd5d86fdc3a6f3beefc971c753/lib/src/command_runner.dart:46:38: Error: A value of type 'String?' can't be returned from a function with return type 'String' because 'String?' is nullable and 'String' isn't.
#10 11.17   String get directory => argResults.option('directory');
#10 11.17                                      ^
#10 11.17 /opt/dart/pub-cache/git/pub-a42800e5a2f539dd5d86fdc3a6f3beefc971c753/lib/src/pub_embeddable_command.dart:60:38: Error: A value of type 'String?' can't be returned from a function with return type 'String' because 'String?' is nullable and 'String' isn't.
#10 11.17   String get directory => argResults.option('directory');
#10 11.17                                      ^
#10 11.17 Error: AOT compilation failed
#10 11.17 Generating AOT kernel dill failed!
#10 ERROR: process "/bin/bash -o pipefail -c bash /opt/pub/helpers/build" did not complete successfully: exit code: 64
```

</details>

To fix this I switched to `pub get` which uses the lockfile, unlike `pub upgrade` which bumps dependencies when it runs. 

We should be relying on Dependabot to bump our dependencies! :dependabot: 