### PR TITLE
update all packages with dependencies on the target package when possible

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -171,24 +171,6 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
-        public async Task NoChange_WhenPackageHasVersionConstraint()
-        {
-            // Dependency package has version constraint
-            await TestNoChangeforProject("AWSSDK.Core", "3.3.21.19", "3.7.300.20",
-                projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="AWSSDK.S3" Version="3.3.17.3" />
-                    <PackageReference Include="AWSSDK.Core" Version="3.3.21.19" />
-                  </ItemGroup>
-                </Project>
-                """);
-        }
-
-        [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForPackageReferenceInclude_Windows()
         {
             // update Newtonsoft.Json from 9.0.1 to 13.0.1
@@ -2552,6 +2534,36 @@ public partial class UpdateWorkerTests
                     </Project>
                     """
             );
+        }
+
+        [Fact]
+        public async Task UpdatingPackageAlsoUpdatesAnythingWithADependencyOnTheUpdatedPackage()
+        {
+            // updating SpecFlow from 3.3.30 requires that SpecFlow.Tools.MsBuild.Generation also be updated
+            await TestUpdateForProject("SpecFlow", "3.3.30", "3.4.3",
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="SpecFlow" Version="3.3.30" />
+                        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="SpecFlow" Version="3.4.3" />
+                        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.4.3" />
+                      </ItemGroup>
+                    </Project>
+                    """
+                );
         }
     }
 }


### PR DESCRIPTION
This came from a failed update seen in a log file.

The packages `SpecFlow` and `SpecFlow.Tools.MsBuild.Generation` are tightly intertwined with the latter having a hard dependency on the former and attempting to update just `SpecFlow` will result in package incoherencies.  The correct behavior would be to also pull the second package forward.

This is a nasty problem because we have to generate all possible update paths (e.g., the updated version of `SpecFlow` crossed with all updated versions of `SpecFlow.Tools.MsBuild.Generation` and any other packages that generated the same warning) and try them all by running through a call to `dotnet restore` to see if it generated any `NU1608` warnings.  A call to the full `restore` command is necessary because the reported package incompatibilities could be several layers deep.

I've tried to factor the code in a way that we can make targeted improvements to the package resolution.  One possible future improvement I've called out in the code: we could potentially do a quick top-level check between any two packages and if they're incompatible, remove all occurrences of them from the update matrix before even trying.  Another future possibility is to pre-filter out any packages that are incompatible with the project's target framework.