### PR TITLE
handle _all_ instances of `global.json` when initializing MSBuild

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestBase.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Test
+{
+    public abstract class TestBase
+    {
+        protected TestBase()
+        {
+            MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, Environment.CurrentDirectory);
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
@@ -1,16 +1,9 @@
-using System.Collections.Generic;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
 
-public class PackagesConfigUpdaterTests
+public class PackagesConfigUpdaterTests : TestBase
 {
-    public PackagesConfigUpdaterTests()
-    {
-        MSBuildHelper.RegisterMSBuild();
-    }
-
     [Theory]
     [MemberData(nameof(PackagesDirectoryPathTestData))]
     public void PathToPackagesDirectoryCanBeDetermined(string projectContents, string dependencyName, string dependencyVersion, string expectedPackagesDirectoryPath)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -10,7 +10,7 @@ namespace NuGetUpdater.Core.Test.Update;
 using TestFile = (string Path, string Content);
 using TestProject = (string Path, string Content, Guid ProjectId);
 
-public abstract class UpdateWorkerTestBase
+public abstract class UpdateWorkerTestBase : TestBase
 {
     protected static Task TestNoChange(
         string dependencyName,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DirsProj.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DirsProj.cs
@@ -10,11 +10,6 @@ public partial class UpdateWorkerTests
 {
     public class DirsProj : UpdateWorkerTestBase
     {
-        public DirsProj()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Fact]
         public async Task UpdateSingleDependencyInDirsProj()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
@@ -8,11 +8,6 @@ public partial class UpdateWorkerTests
 {
     public class DotNetTools : UpdateWorkerTestBase
     {
-        public DotNetTools()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Fact]
         public async Task NoChangeWhenDotNetToolsJsonNotFound()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
@@ -8,11 +8,6 @@ public partial class UpdateWorkerTests
 {
     public class GlobalJson : UpdateWorkerTestBase
     {
-        public GlobalJson()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Fact]
         public async Task NoChangeWhenGlobalJsonNotFound()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
@@ -8,11 +8,6 @@ public partial class UpdateWorkerTests
 {
     public class Mixed : UpdateWorkerTestBase
     {
-        public Mixed()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Fact]
         public async Task ForPackagesProject_UpdatePackageReference_InBuildProps()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -9,11 +9,6 @@ public partial class UpdateWorkerTests
 {
     public class PackagesConfig : UpdateWorkerTestBase
     {
-        public PackagesConfig()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfig()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -8,11 +8,6 @@ public partial class UpdateWorkerTests
 {
     public class Sdk : UpdateWorkerTestBase
     {
-        public Sdk()
-        {
-            MSBuildHelper.RegisterMSBuild();
-        }
-
         [Theory]
         [InlineData("net472")]
         [InlineData("netstandard2.0")]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -6,13 +6,8 @@ namespace NuGetUpdater.Core.Test.Utilities;
 
 using TestFile = (string Path, string Content);
 
-public class MSBuildHelperTests
+public class MSBuildHelperTests : TestBase
 {
-    public MSBuildHelperTests()
-    {
-        MSBuildHelper.RegisterMSBuild();
-    }
-
     [Fact]
     public void GetRootedValue_FindsValue()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -26,7 +26,7 @@ public partial class DiscoveryWorker
 
     public async Task RunAsync(string repoRootPath, string workspacePath, string outputPath)
     {
-        MSBuildHelper.RegisterMSBuild();
+        MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, repoRootPath);
 
         // When running under unit tests, the workspace path may not be rooted.
         if (!Path.IsPathRooted(workspacePath) || !Directory.Exists(workspacePath))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -12,7 +12,7 @@ public class UpdaterWorker
 
     public async Task RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
     {
-        MSBuildHelper.RegisterMSBuild();
+        MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, repoRootPath);
 
         if (!Path.IsPathRooted(workspacePath) || !File.Exists(workspacePath))
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -34,6 +34,25 @@ internal static class PathHelper
     public static string GetFullPathFromRelative(string rootPath, string relativePath)
         => Path.GetFullPath(JoinPath(rootPath, relativePath.NormalizePathToUnix()));
 
+    public static string[] GetAllDirectoriesToRoot(string initialDirectoryPath, string rootDirectoryPath)
+    {
+        var candidatePaths = new List<string>();
+        var rootDirectory = new DirectoryInfo(rootDirectoryPath);
+        var candidateDirectory = new DirectoryInfo(initialDirectoryPath);
+        while (candidateDirectory.FullName != rootDirectory.FullName)
+        {
+            candidatePaths.Add(candidateDirectory.FullName);
+            candidateDirectory = candidateDirectory.Parent;
+            if (candidateDirectory is null)
+            {
+                break;
+            }
+        }
+
+        candidatePaths.Add(rootDirectoryPath);
+        return candidatePaths.ToArray();
+    }
+
     /// <summary>
     /// Check in every directory from <paramref name="initialPath"/> up to <paramref name="rootPath"/> for the file specified in <paramref name="fileName"/>.
     /// </summary>
@@ -45,21 +64,7 @@ internal static class PathHelper
             initialPath = Path.GetDirectoryName(initialPath)!;
         }
 
-        var candidatePaths = new List<string>();
-        var rootDirectory = new DirectoryInfo(rootPath);
-        var candidateDirectory = new DirectoryInfo(initialPath);
-        while (candidateDirectory.FullName != rootDirectory.FullName)
-        {
-            candidatePaths.Add(candidateDirectory.FullName);
-            candidateDirectory = candidateDirectory.Parent;
-            if (candidateDirectory is null)
-            {
-                break;
-            }
-        }
-
-        candidatePaths.Add(rootPath);
-
+        var candidatePaths = GetAllDirectoriesToRoot(initialPath, rootPath);
         foreach (var candidatePath in candidatePaths)
         {
             try


### PR DESCRIPTION
Previously we had to temporarily displace a `global.json` file to allow MSBuild discovery to work.  This process would fail, however, if the updater tool was launched in a subdirectory and `global.json` was at the root.

The fix is to explicitly search for _all_ copies of `global.json`, starting from the current directory and progressing to the root and temporarily displace them.

Fixes #9249.