### PR TITLE
Ensure stackprof is only required once

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ PATH
       parser (>= 2.5, < 4.0)
       psych (~> 5.0)
       sorbet-runtime (~> 0.5.11178)
+      stackprof (~> 0.2.16)
       toml-rb (>= 1.1.2, < 3.0)
 
 PATH
@@ -393,7 +394,6 @@ DEPENDENCIES
   rubocop-rspec (~> 2.27.1)
   rubocop-sorbet (~> 0.7.3)
   sorbet (= 0.5.11288)
-  stackprof (~> 0.2.16)
   tapioca (= 0.12.0)
   turbo_tests (~> 2.2.0)
   vcr (~> 6.1)

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "psych", "~> 5.0"
   spec.add_dependency "sorbet-runtime", "~> 0.5.11178"
+  spec.add_dependency "stackprof", "~> 0.2.16"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
   spec.add_development_dependency "debug", "~> 1.8.0"
@@ -54,7 +55,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.19.0"
   spec.add_development_dependency "rubocop-rspec", "~> 2.27.1"
   spec.add_development_dependency "rubocop-sorbet", "~> 0.7.3"
-  spec.add_development_dependency "stackprof", "~> 0.2.16"
   spec.add_development_dependency "turbo_tests", "~> 2.2.0"
   spec.add_development_dependency "vcr", "~> 6.1"
   spec.add_development_dependency "webmock", "~> 3.18"

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -36,7 +36,6 @@ gem "sentry-ruby", "~> 5.16"
 gem "terminal-table", "~> 3.0.2"
 
 gem "flamegraph", "~> 0.9.5"
-gem "stackprof", "~> 0.2.16"
 
 group :test do
   common_gemspec = File.expand_path("../common/dependabot-common.gemspec", __dir__)

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -31,6 +31,7 @@ PATH
       parser (>= 2.5, < 4.0)
       psych (~> 5.0)
       sorbet-runtime (~> 0.5.11178)
+      stackprof (~> 0.2.16)
       toml-rb (>= 1.1.2, < 3.0)
 
 PATH
@@ -409,7 +410,6 @@ DEPENDENCIES
   rubocop-sorbet (~> 0.7.3)
   sentry-opentelemetry (~> 5.16)
   sentry-ruby (~> 5.16)
-  stackprof (~> 0.2.16)
   terminal-table (~> 3.0.2)
   turbo_tests (~> 2.2.0)
   vcr (~> 6.1)


### PR DESCRIPTION
This is currently giving Bundler a hard time when trying to create updates for updater. Since we already depended on Stackprof as a development dependency in dependabot-core, I've just upgraded that to be a runtime dependency and all should be good.