### PR TITLE
add functionality to ignore comments in .python-version file and fetch minimum Python version successfully

### DIFF
--- a/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
+++ b/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
@@ -83,15 +83,12 @@ module Dependabot
         def python_version_file_version
           return unless python_version_file
 
-          # read the content, split into lines and remove any lines starting with '#'
-          content_lines = python_version_file.content.each_line.reject do |line|
-            line.strip.start_with?('#')
-          end
+          # read the content, split into lines and remove any lines with '#'
+          content_lines = python_version_file.content.each_line.map do |line|
+            line.sub(/#.*$/, " ").strip
+          end.reject(&:empty?)
 
-          # file_version = python_version_file.content.strip
-
-          # join the cleaned lines back into a single string and strip whitesapces
-          file_version = content_lines.join.strip
+          file_version = content_lines.first
           return if file_version&.empty?
           return unless pyenv_versions.include?("#{file_version}\n")
 

--- a/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
+++ b/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
@@ -83,7 +83,15 @@ module Dependabot
         def python_version_file_version
           return unless python_version_file
 
-          file_version = python_version_file.content.strip
+          # read the content, split into lines and remove any lines starting with '#'
+          content_lines = python_version_file.content.each_line.reject do |line|
+            line.strip.start_with?('#')
+          end
+
+          # file_version = python_version_file.content.strip
+
+          # join the cleaned lines back into a single string and strip whitesapces
+          file_version = content_lines.join.strip
           return if file_version&.empty?
           return unless pyenv_versions.include?("#{file_version}\n")
 

--- a/python/spec/dependabot/python/file_parser/python_requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/python_requirement_parser_spec.rb
@@ -53,11 +53,15 @@ RSpec.describe Dependabot::Python::FileParser::PythonRequirementParser do
         it { is_expected.to eq([]) }
       end
 
-      context 'when the file contains comments' do
-        let(:python_version_body) {"# this is a comment\n3.6.2"}
-        it {is_expected.to eq(["3.6.2"])}
+      context "when the file contains comments" do
+        let(:python_version_body) { "# this is a comment\n3.6.2" }
+        it { is_expected.to eq(["3.6.2"]) }
       end
 
+      context "when the file contains inline comments" do
+        let(:python_version_body) { "3.6.2 # this is a comment" }
+        it { is_expected.to eq(["3.6.2"]) }
+      end
     end
 
     context "with a setup.py file" do

--- a/python/spec/dependabot/python/file_parser/python_requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/python_requirement_parser_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Dependabot::Python::FileParser::PythonRequirementParser do
         let(:python_version_body) { "personal-3.6.2\n" }
         it { is_expected.to eq([]) }
       end
+
+      context 'when the file contains comments' do
+        let(:python_version_body) {"# this is a comment\n3.6.2"}
+        it {is_expected.to eq(["3.6.2"])}
+      end
+
     end
 
     context "with a setup.py file" do


### PR DESCRIPTION
Fixes #6650 
Adds functionality to ignore comments in .python-version file, fetches the minimum Python version and unit test it.