### PR TITLE
chore(python): target latest python versions 3.12.3, 3.11.9

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,7 @@
 # This list must match the versions specified in
 # python/lib/dependabot/python/language_version_manager.rb: PRE_INSTALLED_PYTHON_VERSIONS
-ARG PY_3_12=3.12.2
-ARG PY_3_11=3.11.8
+ARG PY_3_12=3.12.3
+ARG PY_3_11=3.11.9
 ARG PY_3_10=3.10.13
 ARG PY_3_9=3.9.18
 ARG PY_3_8=3.8.18

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -9,8 +9,8 @@ module Dependabot
     class LanguageVersionManager
       # This list must match the versions specified at the top of `python/Dockerfile`
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.12.2
-        3.11.8
+        3.12.3
+        3.11.9
         3.10.13
         3.9.18
         3.8.18


### PR DESCRIPTION
Currently when I use dependabot with python 3.12.3 it says:
```py
Dependabot detected the following Python requirement for your project: '^3.12.3'.

Currently, the following Python versions are supported in Dependabot: 3.12.*, 3.11.*, 3.10.*, 3.9.*, 3.8.*.
```

This enables dependabot for python 3.12.3 and 3.11.9