### PR TITLE
allow packages.config update when project file doesn't list assembly version

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -66,6 +66,62 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task UpdateSingleDependencyInPackagesConfig_ReferenceHasNoAssemblyVersion()
+        {
+            // update Newtonsoft.Json from 7.0.1 to 13.0.1
+            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+                // existing
+                projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="packages.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Newtonsoft.Json">
+                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+                packagesConfigContents: """
+                <packages>
+                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                </packages>
+                """,
+                // expected
+                expectedProjectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="packages.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+                expectedPackagesConfigContents: """
+                <?xml version="1.0" encoding="utf-8"?>
+                <packages>
+                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+                </packages>
+                """);
+        }
+
+        [Fact]
         public async Task UpdateSingleDependencyInPackagesConfigButNotToLatest()
         {
             // update Newtonsoft.Json from 7.0.1 to 9.0.1, purposefully not updating all the way to the newest


### PR DESCRIPTION
When updating in a `packages.config` scenario, the `.csproj` doesn't have to list the assembly version.  This modifies the check to allow either `Include="Some.Dependency"` _or_ `Include="Some.Dependency, Version=1.2.3.4, ...."`.