### PR TITLE
Maven: Handle Malformed expressions or Invalid values present in properties section of the pom.xml file

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -49,7 +49,7 @@ module Dependabot
             end
 
           # and value is an expression
-          if node && node.content.strip.start_with?("${")
+          if node && /\$\{(?<expression>.+)\}/.match(node.content.strip)
             return extract_value_from_expression(
               expression: node.content.strip,
               property_name: property_name,

--- a/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe Dependabot::Maven::FileParser::PropertyValueFinder do
         let(:property_name) { "orika.version" }
         its([:value]) { is_expected.to eq("1.2.7") }
       end
+
+      context "and malformed expression should be treated as regular value." do
+        let(:base_pom_fixture_name) { "property_pom_duplicate_tags.xml" }
+        let(:property_name) { "lombok.version" }
+        its([:value]) { is_expected.to eq("${lombok.version") }
+      end
     end
 
     context "when the property is declared in a parent pom" do

--- a/maven/spec/fixtures/poms/property_pom_duplicate_tags.xml
+++ b/maven/spec/fixtures/poms/property_pom_duplicate_tags.xml
@@ -16,6 +16,7 @@
     <dozer.version>6.5.0</dozer.version>
     <dozer.version>${dozer.version}</dozer.version>
     <orika.version>${jmh.version}</orika.version>
+    <lombok.version>${lombok.version</lombok.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Problem:
How to handle the Malformed expression?

Solution provided : 
As per the maven documentation, properties can contain any values. So if it is an expression then we should treat it as an expression and find the value of it, else we need to treat that as regular value.

Property value can accept
1. Expression ${exp}
2. Booleans
3. Version numbers in any format
4. Date Time formats and etc.

Ref : 
https://maven.apache.org/pom.html#Properties
https://maven.apache.org/guides/introduction/introduction-to-the-pom.html