### PR TITLE
Request gzip'ed responses from rubygems API

### DIFF
--- a/bundler/lib/dependabot/bundler/metadata_finder.rb
+++ b/bundler/lib/dependabot/bundler/metadata_finder.rb
@@ -142,7 +142,7 @@ module Dependabot
         response =
           Dependabot::RegistryClient.get(
             url: "#{registry_url}api/v1/gems/#{dependency.name}.json",
-            headers: registry_auth_headers
+            headers: registry_auth_headers.merge({ "Accept-Encoding" => "gzip" })
           )
         return @rubygems_api_response = {} if response.status >= 400
 

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -93,7 +93,8 @@ module Dependabot
             @rubygems_versions ||=
               begin
                 response = Dependabot::RegistryClient.get(
-                  url: dependency_rubygems_uri
+                  url: dependency_rubygems_uri,
+                  headers: { "Accept-Encoding" => "gzip" }
                 )
 
                 JSON.parse(response.body)

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -191,7 +191,8 @@ module Dependabot
               next false unless uri.scheme&.match?(/https?/o)
 
               Dependabot::RegistryClient.get(
-                url: uri.to_s
+                url: uri.to_s,
+                headers: { "Accept-Encoding" => "gzip" }
               ).status == 200
             rescue Excon::Error::Socket, Excon::Error::Timeout
               false

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -200,7 +200,8 @@ module Dependabot
           return false unless details[:ruby_version]
 
           versions = Dependabot::RegistryClient.get(
-            url: "https://rubygems.org/api/v1/versions/#{dependency.name}.json"
+            url: "https://rubygems.org/api/v1/versions/#{dependency.name}.json",
+            headers: { "Accept-Encoding" => "gzip" }
           )
 
           # Give the benefit of the doubt if something goes wrong fetching


### PR DESCRIPTION
I noticed that we're spending a lot of time making requests to rubygems, fair game, but I also noticed that we're requesting uncompressed JSON blobs, and JSON tends to compress relatively well. I'm seeing a modest performance improvement in local testing on a small-ish repo. Benchmarking network requests is always a little tricky, but I think it's fair to assume this certainly wouldn't hurt performance.

Excon is kind enough to handle the decompression for us.