### PR TITLE
allow updating package without assemblies from `packages.config`

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
@@ -19,6 +19,11 @@
 
   <ItemGroup>
     <Compile Include="$(NuGetSourceLocation)\src\NuGet.Core\NuGet.Packaging\**\*.cs" />
+    <!--
+    The `PackageFolderReader.GetFiles()` method is case-sensitive which doesn't work for some scenarios so this
+    directory contains a copy of that file with that method with a case-insensitive patch.
+    -->
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Core\NuGet.Packaging\PackageFolderReader.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/PackageFolderReader.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/PackageFolderReader.cs
@@ -1,0 +1,270 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+
+namespace NuGet.Packaging
+{
+    /// <summary>
+    /// Reads an unzipped nupkg folder.
+    /// </summary>
+    public class PackageFolderReader : PackageReaderBase
+    {
+        private readonly DirectoryInfo _root;
+
+        /// <summary>
+        /// Package folder reader
+        /// </summary>
+        public PackageFolderReader(string folderPath)
+            : this(folderPath, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Package folder reader
+        /// </summary>
+        /// <param name="folder">root directory of an extracted nupkg</param>
+        public PackageFolderReader(DirectoryInfo folder)
+            : this(folder, DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Package folder reader
+        /// </summary>
+        /// <param name="folderPath">root directory of an extracted nupkg</param>
+        /// <param name="frameworkProvider">framework mappings</param>
+        /// <param name="compatibilityProvider">framework compatibility provider</param>
+        public PackageFolderReader(string folderPath, IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
+            : this(new DirectoryInfo(folderPath), frameworkProvider, compatibilityProvider)
+        {
+        }
+
+        /// <summary>
+        /// Package folder reader
+        /// </summary>
+        /// <param name="folder">root directory of an extracted nupkg</param>
+        /// <param name="frameworkProvider">framework mappings</param>
+        /// <param name="compatibilityProvider">framework compatibility provider</param>
+        public PackageFolderReader(DirectoryInfo folder, IFrameworkNameProvider frameworkProvider, IFrameworkCompatibilityProvider compatibilityProvider)
+            : base(frameworkProvider, compatibilityProvider)
+        {
+            _root = folder;
+        }
+
+        public override string GetNuspecFile()
+        {
+            // This needs to be explicitly case insensitive in order to work on XPlat, since GetFiles is normally case sensitive on non-Windows
+            var nuspecFiles = _root.GetFiles("*.*", SearchOption.TopDirectoryOnly).Where(f => f.Name.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)).ToArray();
+
+            if (nuspecFiles.Length == 0)
+            {
+                var message = new StringBuilder();
+                message.Append(Strings.Error_MissingNuspecFile);
+                message.AppendFormat(CultureInfo.CurrentCulture, Strings.Message_Path, _root.FullName);
+                throw new PackagingException(NuGetLogCode.NU5037, message.ToString());
+            }
+            else if (nuspecFiles.Length > 1)
+            {
+                throw new PackagingException(Strings.MultipleNuspecFiles);
+            }
+
+            return nuspecFiles[0].FullName;
+        }
+
+        /// <summary>
+        /// Opens a local file in read only mode.
+        /// </summary>
+        public override Stream GetStream(string path)
+        {
+            return GetFile(path).OpenRead();
+        }
+
+        private FileInfo GetFile(string path)
+        {
+            var file = new FileInfo(Path.Combine(_root.FullName, path));
+
+            if (!file.FullName.StartsWith(_root.FullName, StringComparison.OrdinalIgnoreCase))
+            {
+                // the given path does not appear under the folder root
+                throw new FileNotFoundException(path);
+            }
+
+            return file;
+        }
+
+        public override IEnumerable<string> GetFiles()
+        {
+            // Read all files starting at the root.
+            return GetFiles(folder: null);
+        }
+
+        public override IEnumerable<string> GetFiles(string folder)
+        {
+            // Default to retrieve files and throwing if the root
+            // directory is not found.
+            var getFiles = true;
+            var searchFolder = new DirectoryInfo(_root.FullName);
+
+            if (!string.IsNullOrEmpty(folder))
+            {
+                // Search in the sub folder if one was specified
+                searchFolder = new DirectoryInfo(Path.Combine(_root.FullName, folder));
+
+                // For sub folders verify it exists
+                // The root is expected to exist and should throw if it does not
+                getFiles = searchFolder.Exists;
+
+                // try a case-insensitive search
+                if (!getFiles)
+                {
+                    searchFolder = _root.GetDirectories().FirstOrDefault(d => d.Name.Equals(folder, StringComparison.OrdinalIgnoreCase));
+                    getFiles = searchFolder?.Exists == true;
+                }
+            }
+
+            if (getFiles)
+            {
+                // Enumerate root folder filtering out nupkg files
+                foreach (var file in searchFolder.GetFiles("*", SearchOption.AllDirectories))
+                {
+                    var path = GetRelativePath(_root, file);
+
+                    // disallow nupkgs in the root
+                    if (!IsFileInRoot(path) || !IsNupkg(path))
+                    {
+                        yield return path;
+                    }
+                }
+            }
+
+            yield break;
+        }
+
+        /// <summary>
+        /// True if the path does not contain /
+        /// </summary>
+        private static bool IsFileInRoot(string path)
+        {
+#if NETCOREAPP
+            return path.IndexOf('/', StringComparison.Ordinal) == -1;
+#else
+            return path.IndexOf('/') == -1;
+#endif
+        }
+
+        /// <summary>
+        /// True if the path ends with .nupkg
+        /// </summary>
+        private static bool IsNupkg(string path)
+        {
+            return path.EndsWith(PackagingCoreConstants.NupkgExtension, StringComparison.OrdinalIgnoreCase) == true;
+        }
+
+        /// <summary>
+        /// Build the relative path in the same format that ZipArchive uses
+        /// </summary>
+        private static string GetRelativePath(DirectoryInfo root, FileInfo file)
+        {
+            var parents = new Stack<DirectoryInfo>();
+
+            var parent = file.Directory;
+
+            while (parent != null
+                   && !StringComparer.OrdinalIgnoreCase.Equals(parent.FullName, root.FullName))
+            {
+                parents.Push(parent);
+                parent = parent.Parent;
+            }
+
+            if (parent == null)
+            {
+                // the given file path does not appear under root
+                throw new FileNotFoundException(file.FullName);
+            }
+
+            var parts = parents.Select(d => d.Name).Concat(new string[] { file.Name });
+
+            return string.Join("/", parts);
+        }
+
+        public override IEnumerable<string> CopyFiles(
+            string destination,
+            IEnumerable<string> packageFiles,
+            ExtractPackageFileDelegate extractFile,
+            ILogger logger,
+            CancellationToken token)
+        {
+            var filesCopied = new List<string>();
+
+            foreach (var packageFile in packageFiles)
+            {
+                token.ThrowIfCancellationRequested();
+
+                var sourceFile = GetFile(packageFile);
+
+                var targetPath = Path.Combine(destination, packageFile);
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+
+                using (var fileStream = sourceFile.OpenRead())
+                {
+                    targetPath = extractFile(sourceFile.FullName, targetPath, fileStream);
+                    if (targetPath != null)
+                    {
+                        ZipArchiveExtensions.UpdateFileTime(targetPath, sourceFile.LastWriteTimeUtc);
+                        filesCopied.Add(targetPath);
+                    }
+                }
+            }
+
+            return filesCopied;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // do nothing here
+        }
+
+        public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
+        {
+            return TaskResult.Null<PrimarySignature>();
+        }
+
+        public override Task<bool> IsSignedAsync(CancellationToken token)
+        {
+            return TaskResult.False;
+        }
+
+        public override Task ValidateIntegrityAsync(SignatureContent signatureContent, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<byte[]> GetArchiveHashAsync(HashAlgorithmName hashAlgorithm, CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings)
+        {
+            return false;
+        }
+
+        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
@@ -9,7 +9,7 @@ public class PackagesConfigUpdaterTests : TestBase
     public void PathToPackagesDirectoryCanBeDetermined(string projectContents, string dependencyName, string dependencyVersion, string expectedPackagesDirectoryPath)
     {
         var projectBuildFile = ProjectBuildFile.Parse("/", "project.csproj", projectContents);
-        var actualPackagesDirectorypath = PackagesConfigUpdater.GetPathToPackagesDirectory(projectBuildFile, dependencyName, dependencyVersion);
+        var actualPackagesDirectorypath = PackagesConfigUpdater.GetPathToPackagesDirectory(projectBuildFile, dependencyName, dependencyVersion, "packages.config");
         Assert.Equal(expectedPackagesDirectoryPath, actualPackagesDirectorypath);
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -119,6 +116,109 @@ public partial class UpdateWorkerTests
                   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
                 </packages>
                 """);
+        }
+
+        [Fact]
+        public async Task UpdateSingleDependencyInPackagesConfig_SpecifiedDependencyHasNoPackagesPath()
+        {
+            // update jQuery from 1.6.4 to 3.7.1
+            await TestUpdateForProject("jQuery", "1.6.4", "3.7.1",
+                // existing
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Newtonsoft.Json">
+                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="jQuery" version="1.6.4" targetFramework="net45" />
+                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                // expected
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Newtonsoft.Json">
+                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="jQuery" version="3.7.1" targetFramework="net46" />
+                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
+        }
+
+        [Fact]
+        public async Task UpdateSingleDependencyInPackagesConfig_NoPackagesPathCanBeFound()
+        {
+            // update jQuery from 3.7.0 to 3.7.1
+            await TestUpdateForProject("jQuery", "3.7.0", "3.7.1",
+                // existing
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="jQuery" version="3.7.0" targetFramework="net45" />
+                    </packages>
+                    """,
+                // expected
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="jQuery" version="3.7.1" targetFramework="net45" />
+                    </packages>
+                    """);
         }
 
         [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/SdkPackageUpdaterHelperTests.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace NuGetUpdater.Core.Test.Utilities
 {
-    public class SdkPackageUpdaterHelperTests
+    public class SdkPackageUpdaterHelperTests : TestBase
     {
         [Fact]
         public async Task DirectoryBuildFilesAreOnlyPulledInFromParentDirectories()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Xml.XPath;
 
 using Microsoft.Language.Xml;
 
@@ -23,7 +20,7 @@ internal static class PackagesConfigUpdater
         string dependencyName,
         string previousDependencyVersion,
         string newDependencyVersion,
-        bool isTransitive,
+        string packagesConfigPath,
         Logger logger
     )
     {
@@ -33,7 +30,7 @@ internal static class PackagesConfigUpdater
 
         // ensure local packages directory exists
         var projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);
-        var packagesSubDirectory = GetPathToPackagesDirectory(projectBuildFile, dependencyName, previousDependencyVersion);
+        var packagesSubDirectory = GetPathToPackagesDirectory(projectBuildFile, dependencyName, previousDependencyVersion, packagesConfigPath);
         if (packagesSubDirectory is null)
         {
             logger.Log($"    Project [{projectPath}] does not reference this dependency.");
@@ -43,8 +40,6 @@ internal static class PackagesConfigUpdater
         logger.Log($"    Using packages directory [{packagesSubDirectory}] for project [{projectPath}].");
 
         var projectDirectory = Path.GetDirectoryName(projectPath);
-        var packagesConfigPath = PathHelper.JoinPath(projectDirectory, NuGetHelper.PackagesConfigFileName);
-
         var packagesDirectory = PathHelper.JoinPath(projectDirectory, packagesSubDirectory);
         Directory.CreateDirectory(packagesDirectory);
 
@@ -83,7 +78,7 @@ internal static class PackagesConfigUpdater
 
         using (new WebApplicationTargetsConditionPatcher(projectPath))
         {
-            RunNuget(updateArgs, restoreArgs, packagesDirectory, logger);
+            RunNugetUpdate(updateArgs, restoreArgs, projectDirectory ?? packagesDirectory, logger);
         }
 
         projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);
@@ -96,7 +91,7 @@ internal static class PackagesConfigUpdater
         await projectBuildFile.SaveAsync();
     }
 
-    private static void RunNuget(List<string> updateArgs, List<string> restoreArgs, string packagesDirectory, Logger logger)
+    private static void RunNugetUpdate(List<string> updateArgs, List<string> restoreArgs, string projectDirectory, Logger logger)
     {
         var outputBuilder = new StringBuilder();
         var writer = new StringWriter(outputBuilder);
@@ -110,7 +105,7 @@ internal static class PackagesConfigUpdater
         try
         {
 
-            Environment.CurrentDirectory = packagesDirectory;
+            Environment.CurrentDirectory = projectDirectory;
             var retryingAfterRestore = false;
 
         doRestore:
@@ -122,13 +117,21 @@ internal static class PackagesConfigUpdater
             logger.Log($"    Output:\n{fullOutput}");
             if (result != 0)
             {
-                // If the `packages.config` file contains a delisted package, the initial `update` operation will fail
-                // with the message listed below.  The solution is to run `nuget.exe restore ...` and retry.
+                // The initial `update` command can fail for several reasons:
+                // 1. One possibility is that the `packages.config` file contains a delisted package.  If that's the
+                //    case, `update` will fail with the message "Existing packages must be restored before performing
+                //    an install or update."
+                // 2. Another possibility is that the `update` command fails because the package contains no assemblies
+                //    and doesn't appear in the cache.  The message in this case will be "Could not install package
+                //    '<name> <version>'...the package does not contain any assembly references or content files that
+                //    are compatible with that framework.".
+                // The solution in all cases is to run `restore` then try the update again.
                 if (!retryingAfterRestore &&
-                    fullOutput.Contains("Existing packages must be restored before performing an install or update."))
+                    (fullOutput.Contains("Existing packages must be restored before performing an install or update.") ||
+                    fullOutput.Contains("the package does not contain any assembly references or content files that are compatible with that framework.")))
                 {
-                    logger.Log($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
                     retryingAfterRestore = true;
+                    logger.Log($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
                     outputBuilder.Clear();
                     var exitCodeAgain = Program.Main(restoreArgs.ToArray());
                     var restoreOutput = outputBuilder.ToString();
@@ -157,7 +160,7 @@ internal static class PackagesConfigUpdater
         }
     }
 
-    internal static string? GetPathToPackagesDirectory(ProjectBuildFile projectBuildFile, string dependencyName, string dependencyVersion)
+    internal static string? GetPathToPackagesDirectory(ProjectBuildFile projectBuildFile, string dependencyName, string dependencyVersion, string packagesConfigPath)
     {
         // the packages directory can be found from the hint path of the matching dependency, e.g., when given "Newtonsoft.Json", "7.0.1", and a project like this:
         // <Project>
@@ -200,6 +203,24 @@ internal static class PackagesConfigUpdater
                         partialPathMatch = subpath;
                     }
                 }
+            }
+        }
+
+        if (partialPathMatch is null)
+        {
+            // if we got this far, we couldn't find the packages directory for the specified dependency and there are 2 possibilities:
+            // 1. the dependency doesn't actually exist in this project
+            // 2. the dependency exists, but doesn't have any assemblies, e.g., jQuery
+
+            // first let's check the packages.config file to see if we actually need it.
+            XDocument packagesDocument = XDocument.Load(packagesConfigPath);
+            var hasPackage = packagesDocument.XPathSelectElements("/packages/package")
+                .Where(e => e.Attribute("id")?.Value.Equals(dependencyName, StringComparison.OrdinalIgnoreCase) == true).Any();
+            if (hasPackage)
+            {
+                // the dependency exists in the packages.config file, so it must be the second case
+                // the vast majority of projects found in the wild use this, and since we have nothing to look for, we'll just have to hope
+                partialPathMatch = "../packages";
             }
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -134,9 +134,9 @@ public class UpdaterWorker
 
         _logger.Log($"Updating project [{projectPath}]");
 
-        if (NuGetHelper.TryGetPackagesConfigFile(projectPath, out _))
+        if (NuGetHelper.TryGetPackagesConfigFile(projectPath, out var packagesConfigPath))
         {
-            await PackagesConfigUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, _logger);
+            await PackagesConfigUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, packagesConfigPath, _logger);
         }
 
         // Some repos use a mix of packages.config and PackageReference


### PR DESCRIPTION
Some packages (e.g., `jQuery`) don't contain assemblies, but if they're in a `packages.config` scenario, that can pose 2 issues with updating.

1. We can't determine the local packages directory.
2. The update process will fail unless `restore` has been run first.

To correct the first issue, we fall back to a relative packages path of `../packages` which is by far the most common value used.  Since the given package has no assemblies, this fall back value won't be written back to the `.csproj`; it's just temporary.

To correct the second issue it was just a case of expanding our detection logic of when we need to run `restore` before retrying `update`.

Part of this fix uncovered an issue where NuGet package are sometimes checked for a `content` directory with a case-sensitive search.  The test package used, however (`jQuery`), names that directory `Content` which doesn't match.  The fix was to copy a single file from the submodule and make the check case-insensitive.