### PR TITLE
fix ignore conditions nil error

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -885,7 +885,7 @@ module Dependabot
         )
       end
 
-      sig { params(err: StandardError).void }
+      sig { params(method: String, err: StandardError).void }
       def suppress_error(method, err)
         Dependabot.logger.error("Error while generating #{method}: #{err.message}")
         Dependabot.logger.error(err.backtrace&.join("\n"))

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "time"
 require "pathname"
 require "sorbet-runtime"
 
@@ -127,6 +128,7 @@ module Dependabot
         truncate_pr_message(msg)
       rescue StandardError => e
         Dependabot.logger.error("Error while generating PR message: #{e.message}")
+        Dependabot.logger.error(e.backtrace&.join("\n"))
         suffixed_pr_message_header + prefixed_pr_message_footer
       end
 
@@ -162,6 +164,7 @@ module Dependabot
         message
       rescue StandardError => e
         Dependabot.logger.error("Error while generating commit message: #{e.message}")
+        Dependabot.logger.error(e.backtrace&.join("\n"))
         message = commit_subject
         message += "\n\n" + T.must(message_trailers) if message_trailers
         message
@@ -276,6 +279,7 @@ module Dependabot
         pr_name_prefixer.pr_name_prefix
       rescue StandardError => e
         Dependabot.logger.error("Error while generating PR name: #{e.message}")
+        Dependabot.logger.error(e.backtrace&.join("\n"))
         ""
       end
 
@@ -735,9 +739,9 @@ module Dependabot
         # Return an empty string if no valid ignore conditions after filtering
         return "" if valid_ignore_conditions.empty?
 
-        # Sort them by updated_at (or created_at if updated_at is nil), taking the latest 20
+        # Sort them by updated_at, taking the latest 20
         sorted_ignore_conditions = valid_ignore_conditions.sort_by do |ic|
-          ic["updated_at"].nil? ? T.must(ic["created_at"]) : T.must(ic["updated_at"])
+          ic["updated-at"].nil? ? Time.at(0).iso8601 : T.must(ic["updated-at"])
         end.last(20)
 
         # Map each condition to a row string

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -127,8 +127,7 @@ module Dependabot
 
         truncate_pr_message(msg)
       rescue StandardError => e
-        Dependabot.logger.error("Error while generating PR message: #{e.message}")
-        Dependabot.logger.error(e.backtrace&.join("\n"))
+        suppress_error("PR message", e)
         suffixed_pr_message_header + prefixed_pr_message_footer
       end
 
@@ -163,8 +162,7 @@ module Dependabot
         message += "\n\n" + T.must(message_trailers) if message_trailers
         message
       rescue StandardError => e
-        Dependabot.logger.error("Error while generating commit message: #{e.message}")
-        Dependabot.logger.error(e.backtrace&.join("\n"))
+        suppress_error("commit message", e)
         message = commit_subject
         message += "\n\n" + T.must(message_trailers) if message_trailers
         message
@@ -278,8 +276,7 @@ module Dependabot
       def pr_name_prefix
         pr_name_prefixer.pr_name_prefix
       rescue StandardError => e
-        Dependabot.logger.error("Error while generating PR name: #{e.message}")
-        Dependabot.logger.error(e.backtrace&.join("\n"))
+        suppress_error("PR name", e)
         ""
       end
 
@@ -886,6 +883,12 @@ module Dependabot
           T.must(dependencies.first).package_manager,
           T.nilable(String)
         )
+      end
+
+      sig { params(err: StandardError).void }
+      def suppress_error(method, err)
+        Dependabot.logger.error("Error while generating #{method}: #{err.message}")
+        Dependabot.logger.error(err.backtrace&.join("\n"))
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -2645,7 +2645,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                   "dependency-name" => "business#{i}",
                   "version-requirement" => "<= 1.#{i}.0",
                   "source" => "@dependabot ignore command",
-                  "updated_at" => Time.now
+                  "updated-at" => i == 4 ? nil : Time.now.iso8601
                 }
               )
             end
@@ -2655,9 +2655,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             expect(pr_message).to include(
               "| Dependency Name | Ignore Conditions |\n" \
               "| --- | --- |\n" \
+              "| business4 | [<= 1.4.0] |\n" \
               "| business2 | [<= 1.2.0] |\n" \
               "| business3 | [<= 1.3.0] |\n" \
-              "| business4 | [<= 1.4.0] |\n" \
               "| business5 | [<= 1.5.0] |\n"
             )
           end


### PR DESCRIPTION
fixes #9457

This adds the stacktrace to the logs which allowed me to track down one of the other issues in #9457.

In job.json we started sending `updated-at` in the ignore conditions so it could be used for sorting, but here in the code it was used incorrectly as `updated_at`. 

Then later when types were applied, a `T.must` was added which always fails because neither `created_at` nor `created-at` are ever sent in the payload.

It would be best if `job.rb` immediately parsed the `job.json` into types and passed those around instead of hashes. That would help avoid this problem in the future.

From what I can tell, `updated-at` should always be sent, but I was a bit defensive and set the time to the epoch for any that don't have that field set.