### PR TITLE
Replace hardcoded "sanitized-package" with the actual package name

### DIFF
--- a/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
+++ b/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
@@ -21,7 +21,7 @@ module Dependabot
           # in the lockfile.
           content =
             "from setuptools import setup\n\n" \
-            "setup(name=\"sanitized-package\",version=\"0.0.1\"," \
+            "setup(name=\"#{package_name}\",version=\"0.0.1\"," \
             "install_requires=#{install_requires_array.to_json}," \
             "extras_require=#{extras_require_hash.to_json}"
 
@@ -84,6 +84,12 @@ module Dependabot
                 setup_cfg&.dup&.tap { |f| f.name = "setup.cfg" }
               ].compact
             ).dependency_set
+        end
+
+        def package_name
+          content = setup_file.content
+          match = content.match(/name\s*=\s*['"](?<package_name>[^'"]+)['"]/)
+          match ? match[:package_name] : "default_package_name"
         end
       end
     end

--- a/python/spec/dependabot/python/file_updater/setup_file_sanitizer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/setup_file_sanitizer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Dependabot::Python::FileUpdater::SetupFileSanitizer do
     it "extracts the install_requires" do
       expect(sanitized_content).to eq(
         "from setuptools import setup\n\n" \
-        'setup(name="sanitized-package",version="0.0.1",' \
+        'setup(name="python-package",version="0.0.1",' \
         'install_requires=["boto3==1.3.1","flake8<3.0.0,>2.5.4",' \
         '"gocardless-pro","pandas==0.19.2","pep8==1.7.0","psycopg2==2.6.1",' \
         '"raven==5.32.0","requests==2.12.*","scipy==0.18.1",' \
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::Python::FileUpdater::SetupFileSanitizer do
       it "extracts the install_requires and conserves extras" do
         expect(sanitized_content).to eq(
           "from setuptools import setup\n\n" \
-          'setup(name="sanitized-package",version="0.0.1",' \
+          'setup(name="default_package_name",version="0.0.1",' \
           'install_requires=["requests[security]==2.12.*",' \
           '"scipy==0.18.1","scikit-learn==0.18.1"],' \
           "extras_require={})"
@@ -58,7 +58,7 @@ RSpec.describe Dependabot::Python::FileUpdater::SetupFileSanitizer do
       it "includes pbr" do
         expect(sanitized_content).to eq(
           "from setuptools import setup\n\n" \
-          'setup(name="sanitized-package",version="0.0.1",' \
+          'setup(name="default_package_name",version="0.0.1",' \
           'install_requires=["raven"],extras_require={},' \
           'setup_requires=["pbr"],pbr=True)'
         )


### PR DESCRIPTION
Fix #6387

Fetch the actual package name and replace hardcoded "sanitised-package" with the actual package name