### PR TITLE
cache results of the discovery tool

### DIFF
--- a/nuget/lib/dependabot/nuget/discovery/discovery_json_reader.rb
+++ b/nuget/lib/dependabot/nuget/discovery/discovery_json_reader.rb
@@ -65,8 +65,6 @@ module Dependabot
         @workspace_discovery ||= T.let(begin
           return nil unless discovery_json.content
 
-          Dependabot.logger.info("Discovery JSON content: #{discovery_json.content}")
-
           parsed_json = T.let(JSON.parse(T.must(discovery_json.content)), T::Hash[String, T.untyped])
           WorkspaceDiscovery.from_json(parsed_json)
         end, T.nilable(WorkspaceDiscovery))

--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -22,13 +22,19 @@ module Dependabot
         workspace_path = project_files.first&.directory
         return [] unless workspace_path
 
-        # run discovery for the repo
-        NativeHelpers.run_nuget_discover_tool(repo_root: T.must(repo_contents_path),
-                                              workspace_path: workspace_path,
-                                              output_path: DiscoveryJsonReader.discovery_file_path,
-                                              credentials: credentials)
+        # `workspace_path` is the only unique value here so we use it as the cache key
+        cache = T.let(CacheManager.cache("file_parser.parse"), T::Hash[String, T::Array[Dependabot::Dependency]])
+        key = workspace_path
+        cache[key] ||= begin
+          # run discovery for the repo
+          NativeHelpers.run_nuget_discover_tool(repo_root: T.must(repo_contents_path),
+                                                workspace_path: workspace_path,
+                                                output_path: DiscoveryJsonReader.discovery_file_path,
+                                                credentials: credentials)
+          discovered_dependencies.dependencies
+        end
 
-        discovered_dependencies.dependencies
+        T.must(cache[key])
       end
 
       private
@@ -37,6 +43,8 @@ module Dependabot
       def discovered_dependencies
         discovery_json = DiscoveryJsonReader.discovery_json
         return DependencySet.new unless discovery_json
+
+        Dependabot.logger.info("Discovery JSON content: #{discovery_json.content}")
 
         DiscoveryJsonReader.new(
           discovery_json: discovery_json


### PR DESCRIPTION
The newly added `discover` command is only dependent on the `workspace_path` value, so use that as a cache key.

Previously, it was possible for the `discover` command to be run multiple times and in some large repos, that could lead to a timeout.  Also moved the reporting of the results of the `discover` command to just after it actually runs so it's not repeated in the log.