### PR TITLE
prevent sorbet from bumping in dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     groups:
       sorbet:
         patterns:
+          - "*-sorbet"
+          - "sorbet-*"
           - "sorbet"
           - "tapioca"
       aws-sdk:


### PR DESCRIPTION
I noticed sorbet is getting into our dev-dependencies group: https://github.com/dependabot/dependabot-core/pull/9582

This is because there are other sorbet related projects like sorbet-runtime, rubocop-sorbet, etc.

So by capturing all of those in the sorbet group, it should be easier to bump together, then our dev-dependencies group is easier to merge.