### PR TITLE
Ignoring the fixture files in workflow (dependency review and code QL) runs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
     branches: [ main ]
     paths-ignore:
       - '*/spec/fixtures/**'
+      - '*/helpers/test/*/fixtures/**'
       - 'common/lib/dependabot.rb'
   schedule:
     - cron: '41 4 * * 3'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,12 @@
 name: Dependency Review
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:
+  pull_request:
+    # yamllint disable-line rule:truthy
+    branches: [ main ]
+    paths-ignore:
+      - '*/spec/fixtures/**'
+      - '*/helpers/test/*/fixtures/**'
+      - 'common/lib/dependabot.rb'
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,6 @@
 name: Dependency Review
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
-    # yamllint disable-line rule:truthy
     branches: [ main ]
     paths-ignore:
       - '*/spec/fixtures/**'


### PR DESCRIPTION
Adding ignore helpet test fixtures to both code QL and dependency review jobs.