### PR TITLE
Enable Docker content trust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      DOCKER_CONTENT_TRUST: 1
     strategy:
       fail-fast: false
       matrix:
@@ -70,6 +73,7 @@ jobs:
   updater:
     env:
       DOCKER_BUILDKIT: 1
+      DOCKER_CONTENT_TRUST: 1
     name: Updater
     runs-on: ubuntu-latest
     steps:
@@ -102,6 +106,7 @@ jobs:
   integration:
     env:
       DOCKER_BUILDKIT: 1
+      DOCKER_CONTENT_TRUST: 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -75,6 +75,7 @@ jobs:
       packages: write
     env:
       DEPENDABOT_UPDATER_VERSION: ${{ github.sha }}
+      DOCKER_CONTENT_TRUST: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -54,6 +54,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
       NAME: ${{ matrix.suite.name }}
       ECOSYSTEM: ${{ matrix.suite.ecosystem }}
+      DOCKER_CONTENT_TRUST: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      DOCKER_CONTENT_TRUST: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -59,6 +59,8 @@ jobs:
   e2e:
     needs: discover
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CONTENT_TRUST: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This change enabled [Docker content trust][1], which verifies the signatures of container images used by docker.

Why are we using Docker content trust to verify signatures, when I am talking about signing container images with cosign in #9546 I hear you ask? I hope this explains things: https://xkcd.com/927/

[1]: https://docs.docker.com/engine/security/trust/