### PR TITLE
Enable Docker content trust

### DIFF
--- a/script/_common
+++ b/script/_common
@@ -41,6 +41,10 @@ function docker_build() {
     export DEPENDABOT_USER_GID=1000
   fi
 
+  # Only check Docker Content Trust for the updater-core image
+  # shellcheck disable=SC2034 # Used implicitly in docker build
+  DOCKER_CONTENT_TRUST=1
+
   # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
   docker build \
     $DOCKER_BUILD_ARGS \
@@ -52,6 +56,9 @@ function docker_build() {
     -t "$UPDATER_CORE_IMAGE" \
     -f Dockerfile.updater-core \
     .
+
+  # We don't sign the updater image with Notary, so disable Docker Content Trust for remaining builds
+  unset DOCKER_CONTENT_TRUST
 
   export UPDATER_IMAGE_NAME="$UPDATER_IMAGE$TAG"
 


### PR DESCRIPTION
This change enabled [Docker content trust][1] which verifies the signatures of container images used by docker. This is only done for the base image, which is built on top of Ubuntu.

The signature can be manually verified as follows:

```bash
$ docker trust inspect --pretty docker.io/library/ubuntu:22.04

Signatures for docker.io/library/ubuntu:22.04

SIGNED TAG   DIGEST                                                             SIGNERS
22.04        6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d   (Repo Admin)

Administrative keys for docker.io/library/ubuntu:22.04

  Repository Key:       8273733f491f362bb36710fd8a99f78c3fbaecd8d09333985c76f1064b80760f
  Root Key:     1f9bc7ae6335ae41ee03e983c0e31303901be567b4cdb3fc7c7363f0591128ff
```

Why are we using Docker content trust to verify signatures, when I am talking about signing container images with cosign in #9546 I hear you ask? I hope this explains things: https://xkcd.com/927/

[1]: https://docs.docker.com/engine/security/trust/