### PR TITLE
Allow NuGet dependencies to exist with duplicate names but different dependency types

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
@@ -214,6 +214,77 @@ public partial class EntryPointTests
             });
         }
 
+        [Fact]
+        public async Task WithDuplicateDependenciesOfDifferentTypes()
+        {
+            var projectPath = "path/to/my.csproj";
+            var directoryBuildPropsPath = "path/Directory.Build.props";
+            await RunAsync(path =>
+            [
+                "discover",
+                "--repo-root",
+                path,
+                "--workspace",
+                path,
+            ],
+            new[]
+            {
+                (projectPath, """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """),
+                (directoryBuildPropsPath, """
+                    <Project>
+                        <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
+                          <GlobalPackageReference Include="System.Text.Json" Version="8.0.3" />
+                        </ItemGroup>
+                        <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
+                          <PackageReference Include="System.Text.Json" Version="8.0.3" />
+                        </ItemGroup>
+                    </Project>
+                    """)
+            },
+            expectedResult: new()
+            {
+                FilePath = "",
+                Projects = [
+                    new()
+                    {
+                        FilePath = projectPath,
+                        TargetFrameworks = ["net8.0"],
+                        ReferencedProjectPaths = [],
+                        ExpectedDependencyCount = 2,
+                        Dependencies = [
+                            new("Newtonsoft.Json", "7.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
+                            // $(ManagePackageVersionsCentrally) evaluates false by default, we only get a PackageReference
+                            new("System.Text.Json", "8.0.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"])
+                        ],
+                        Properties = [
+                            new("TargetFramework", "net8.0", "path/to/my.csproj"),
+                        ],
+                    },
+                    new()
+                    {
+                        FilePath = directoryBuildPropsPath,
+                        ReferencedProjectPaths = [],
+                        ExpectedDependencyCount = 2,
+                        Dependencies = [
+                            new("System.Text.Json", "8.0.3", DependencyType.PackageReference, IsDirect: true),
+                            new("System.Text.Json", "8.0.3", DependencyType.GlobalPackageReference, IsDirect: true)
+                        ],
+                        Properties = [],
+                    }
+                ]
+            });
+        }
+
         private static async Task RunAsync(
             Func<string, string[]> getArgs,
             TestFile[] initialFiles,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -91,7 +91,7 @@ public class DiscoveryWorkerTestBase
 
             foreach (var expectedDependency in expectedDependencies)
             {
-                var actualDependency = actualDependencies.Single(d => d.Name == expectedDependency.Name);
+                var actualDependency = actualDependencies.Single(d => d.Name == expectedDependency.Name && d.Type == expectedDependency.Type);
                 Assert.Equal(expectedDependency.Name, actualDependency.Name);
                 Assert.Equal(expectedDependency.Version, actualDependency.Version);
                 Assert.Equal(expectedDependency.Type, actualDependency.Type);


### PR DESCRIPTION
* Fixes https://github.com/dependabot/dependabot-core/issues/9612 and https://github.com/dependabot/dependabot-core/issues/9495

`NuGetUpdater.Cli.exe discover` was throwing "An item with teh same key has already been added" in the situation where a centrally-managed Directory.Build.props file would have 2 references for the same package based on a condition such as the repository using central package management.

This is an example that would make the tool throw from my company's centrally-managed [Directory.Build.props file](https://github.com/Particular/RepoStandards/blob/master/src/Directory.Build.props):

```xml
<ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
  <GlobalPackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" />
</ItemGroup>

<ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
  <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
</ItemGroup>
```

If central package management is enabled, then our company-managed Roslyn analyzers package is included as a `GlobalPackageReference`. If not, it's added to the project as a regular `PackageReference`.

But the duplicate name caused a problem with the discover code tried to do `.ToDictionary(…)` on the name alone, so this change uses a lookup to allow multiple values.

A test has been added that demonstrates the desired result.