### PR TITLE
Specify patch levels for previous Rubies

### DIFF
--- a/bundler/helpers/v1/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v1/monkey_patches/definition_ruby_version_patch.rb
@@ -12,7 +12,7 @@ module BundlerDefinitionRubyVersionPatch
           Gem::Specification.new("ruby\0", requested_version)
       end
 
-      %w(2.5.3p105 2.6.10p210 2.7.6p219 3.0.7 3.1.5 3.2.4).each do |version|
+      %w(2.5.3p105 2.6.10p210 2.7.6p219 3.0.7p220 3.1.5p252 3.2.4p170).each do |version|
         sources.metadata_source.specs << Gem::Specification.new("ruby\0", version)
       end
     end


### PR DESCRIPTION
These were omitted in a previous pull request. I'm unsure if Bundler v1 needs them, so I'm defaulting to making sure they're present.

The patch levels were determined by installing Ruby locally.