### PR TITLE
Enable YJIT for even-numbered update jobs

### DIFF
--- a/updater/bin/fetch_files.rb
+++ b/updater/bin/fetch_files.rb
@@ -32,9 +32,7 @@ trap("TERM") do
 end
 
 begin
-  if Dependabot::Environment.job_id.to_i.even?
-    RubyVM::YJIT.enable
-  end
+  RubyVM::YJIT.enable if Dependabot::Environment.job_id.to_i.even?
 
   Dependabot::FileFetcherCommand.new.run
 rescue Dependabot::RunFailure

--- a/updater/bin/fetch_files.rb
+++ b/updater/bin/fetch_files.rb
@@ -32,6 +32,10 @@ trap("TERM") do
 end
 
 begin
+  if Dependabot::Environment.job_id.to_i.even?
+    RubyVM::YJIT.enable
+  end
+
   Dependabot::FileFetcherCommand.new.run
 rescue Dependabot::RunFailure
   exit 1

--- a/updater/bin/update_files.rb
+++ b/updater/bin/update_files.rb
@@ -36,6 +36,10 @@ trap("TERM") do
 end
 
 begin
+  if Dependabot::Environment.job_id.to_i.even?
+    RubyVM::YJIT.enable
+  end
+
   if flamegraph
     Flamegraph.generate("/tmp/dependabot-flamegraph.html") do
       Dependabot::UpdateFilesCommand.new.run

--- a/updater/bin/update_files.rb
+++ b/updater/bin/update_files.rb
@@ -36,9 +36,7 @@ trap("TERM") do
 end
 
 begin
-  if Dependabot::Environment.job_id.to_i.even?
-    RubyVM::YJIT.enable
-  end
+  RubyVM::YJIT.enable if Dependabot::Environment.job_id.to_i.even?
 
   if flamegraph
     Flamegraph.generate("/tmp/dependabot-flamegraph.html") do


### PR DESCRIPTION
We primarily upgraded to Ruby 3.3 so that we could enable YJIT. We did this in order to hopefully mitigate some of the performance issues some of our larger customers have faced.

This change enables YJIT for _some_ update jobs. The reason for the incremental enablement is that we would like to measure the impact that YJIT has before adopting it fully (which we intend to do).