### PR TITLE
restrict C# nuget unit tests to local package feeds

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.Build" Version="17.5.0" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.5.0" ExcludeAssets="Runtime" PrivateAssets="All" />
 
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
     <PackageVersion Include="NuGet.Core" Version="2.14.0-rtm-832" Aliases="CoreV2" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
@@ -1,8 +1,9 @@
-using System.Collections.Immutable;
 using System.Text;
 
 using NuGetUpdater.Core;
+using NuGetUpdater.Core.Test;
 using NuGetUpdater.Core.Test.Discover;
+using NuGetUpdater.Core.Test.Update;
 
 using Xunit;
 
@@ -19,81 +20,87 @@ public partial class EntryPointTests
         {
             string solutionPath = "path/to/solution.sln";
             await RunAsync(path =>
-            [
-                "discover",
-                "--repo-root",
-                path,
-                "--workspace",
-                path,
-            ],
-            new[]
-            {
-                (solutionPath, """
-                    Microsoft Visual Studio Solution File, Format Version 12.00
-                    # Visual Studio 14
-                    VisualStudioVersion = 14.0.22705.0
-                    MinimumVisualStudioVersion = 10.0.40219.1
-                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "my", "my.csproj", "{782E0C0A-10D3-444D-9640-263D03D2B20C}"
-                    EndProject
-                    Global
-                      GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                        Debug|Any CPU = Debug|Any CPU
-                        Release|Any CPU = Release|Any CPU
-                      EndGlobalSection
-                      GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.Build.0 = Release|Any CPU
-                      EndGlobalSection
-                      GlobalSection(SolutionProperties) = preSolution
-                        HideSolutionNode = FALSE
-                      EndGlobalSection
-                    EndGlobal
-                    """),
-                ("path/to/my.csproj", """
-                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                      <PropertyGroup>
-                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                      </PropertyGroup>
-                      <ItemGroup>
-                        <None Include="packages.config" />
-                      </ItemGroup>
-                      <ItemGroup>
-                        <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                          <Private>True</Private>
-                        </Reference>
-                      </ItemGroup>
-                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                    </Project>
-                    """),
-                ("path/to/packages.config", """
-                    <packages>
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                    </packages>
-                    """)
-            },
-            expectedResult: new()
-            {
-                FilePath = "",
-                Projects = [
-                    new()
-                    {
-                        FilePath = "path/to/my.csproj",
-                        TargetFrameworks = ["net45"],
-                        ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 2, // Should we ignore Microsoft.NET.ReferenceAssemblies?
-                        Dependencies = [
-                            new("Newtonsoft.Json", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
-                        ],
-                        Properties = [
-                            new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
-                        ],
-                    }
-                ]
-            });
+                [
+                    "discover",
+                    "--repo-root",
+                    path,
+                    "--workspace",
+                    path,
+                ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                ],
+                initialFiles:
+                new[]
+                {
+                    (solutionPath, """
+                        Microsoft Visual Studio Solution File, Format Version 12.00
+                        # Visual Studio 14
+                        VisualStudioVersion = 14.0.22705.0
+                        MinimumVisualStudioVersion = 10.0.40219.1
+                        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "my", "my.csproj", "{782E0C0A-10D3-444D-9640-263D03D2B20C}"
+                        EndProject
+                        Global
+                          GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                            Debug|Any CPU = Debug|Any CPU
+                            Release|Any CPU = Release|Any CPU
+                          EndGlobalSection
+                          GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                            {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                            {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                            {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                            {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.Build.0 = Release|Any CPU
+                          EndGlobalSection
+                          GlobalSection(SolutionProperties) = preSolution
+                            HideSolutionNode = FALSE
+                          EndGlobalSection
+                        EndGlobal
+                        """),
+                    ("path/to/my.csproj", """
+                        <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
+                          <ItemGroup>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                              <Private>True</Private>
+                            </Reference>
+                          </ItemGroup>
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """),
+                    ("path/to/packages.config", """
+                        <packages>
+                          <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                        </packages>
+                        """)
+                },
+                expectedResult: new()
+                {
+                    FilePath = "",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "path/to/my.csproj",
+                            TargetFrameworks = ["net45"],
+                            ReferencedProjectPaths = [],
+                            ExpectedDependencyCount = 2,
+                            Dependencies = [
+                                new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
+                            ],
+                            Properties = [
+                                new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
+                            ],
+                        }
+                    ]
+                }
+            );
         }
 
         [Fact]
@@ -101,58 +108,64 @@ public partial class EntryPointTests
         {
             var projectPath = "path/to/my.csproj";
             await RunAsync(path =>
-            [
-                "discover",
-                "--repo-root",
-                path,
-                "--workspace",
-                path,
-            ],
-            new[]
-            {
-                (projectPath, """
-                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                      <PropertyGroup>
-                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                      </PropertyGroup>
-                      <ItemGroup>
-                        <None Include="packages.config" />
-                      </ItemGroup>
-                      <ItemGroup>
-                        <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                          <Private>True</Private>
-                        </Reference>
-                      </ItemGroup>
-                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                    </Project>
-                    """),
-                ("path/to/packages.config", """
-                    <packages>
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                    </packages>
-                    """)
-            },
-            expectedResult: new()
-            {
-                FilePath = "",
-                Projects = [
-                    new()
-                    {
-                        FilePath = projectPath,
-                        TargetFrameworks = ["net45"],
-                        ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 2, // Should we ignore Microsoft.NET.ReferenceAssemblies?
-                        Dependencies = [
-                            new("Newtonsoft.Json", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
-                        ],
-                        Properties = [
-                            new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
-                        ],
-                    }
-                ]
-            });
+                [
+                    "discover",
+                    "--repo-root",
+                    path,
+                    "--workspace",
+                    path,
+                ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                ],
+                initialFiles:
+                new[]
+                {
+                    (projectPath, """
+                        <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
+                          <ItemGroup>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                              <Private>True</Private>
+                            </Reference>
+                          </ItemGroup>
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """),
+                    ("path/to/packages.config", """
+                        <packages>
+                          <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                        </packages>
+                        """)
+                },
+                expectedResult: new()
+                {
+                    FilePath = "",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = projectPath,
+                            TargetFrameworks = ["net45"],
+                            ReferencedProjectPaths = [],
+                            ExpectedDependencyCount = 2,
+                            Dependencies = [
+                                new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
+                            ],
+                            Properties = [
+                                new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
+                            ],
+                        }
+                    ]
+                }
+            );
         }
 
         [Fact]
@@ -160,58 +173,64 @@ public partial class EntryPointTests
         {
             var workspacePath = "path/to/";
             await RunAsync(path =>
-            [
-                "discover",
-                "--repo-root",
-                path,
-                "--workspace",
-                Path.Combine(path, workspacePath),
-            ],
-            new[]
-            {
-                ("path/to/my.csproj", """
-                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                      <PropertyGroup>
-                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                      </PropertyGroup>
-                      <ItemGroup>
-                        <None Include="packages.config" />
-                      </ItemGroup>
-                      <ItemGroup>
-                        <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                          <Private>True</Private>
-                        </Reference>
-                      </ItemGroup>
-                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                    </Project>
-                    """),
-                ("path/to/packages.config", """
-                    <packages>
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                    </packages>
-                    """)
-            },
-            expectedResult: new()
-            {
-                FilePath = workspacePath,
-                Projects = [
-                    new()
-                    {
-                        FilePath = "my.csproj",
-                        TargetFrameworks = ["net45"],
-                        ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 2, // Should we ignore Microsoft.NET.ReferenceAssemblies?
-                        Dependencies = [
-                            new("Newtonsoft.Json", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
-                        ],
-                        Properties = [
-                            new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
-                        ],
-                    }
-                ]
-            });
+                [
+                    "discover",
+                    "--repo-root",
+                    path,
+                    "--workspace",
+                    Path.Combine(path, workspacePath),
+                ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                ],
+                initialFiles:
+                new[]
+                {
+                    ("path/to/my.csproj", """
+                        <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
+                          <ItemGroup>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                              <Private>True</Private>
+                            </Reference>
+                          </ItemGroup>
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """),
+                    ("path/to/packages.config", """
+                        <packages>
+                          <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                        </packages>
+                        """)
+                },
+                expectedResult: new()
+                {
+                    FilePath = workspacePath,
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "my.csproj",
+                            TargetFrameworks = ["net45"],
+                            ReferencedProjectPaths = [],
+                            ExpectedDependencyCount = 2,
+                            Dependencies = [
+                                new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
+                            ],
+                            Properties = [
+                                new("TargetFrameworkVersion", "v4.5", "path/to/my.csproj"),
+                            ],
+                        }
+                    ]
+                }
+            );
         }
 
         [Fact]
@@ -288,7 +307,8 @@ public partial class EntryPointTests
         private static async Task RunAsync(
             Func<string, string[]> getArgs,
             TestFile[] initialFiles,
-            ExpectedWorkspaceDiscoveryResult expectedResult)
+            ExpectedWorkspaceDiscoveryResult expectedResult,
+            MockNuGetPackage[]? packages = null)
         {
             var actualResult = await RunDiscoveryAsync(initialFiles, async path =>
             {
@@ -302,6 +322,7 @@ public partial class EntryPointTests
 
                 try
                 {
+                    await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, path);
                     var args = getArgs(path);
                     var result = await Program.Main(args);
                     if (result != 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
@@ -1,7 +1,4 @@
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 
 using NuGetUpdater.Core;
 using NuGetUpdater.Core.Test;
@@ -26,12 +23,18 @@ public partial class EntryPointTests
                     "--solution-or-project",
                     Path.Combine(path, "path/to/solution.sln"),
                     "--dependency",
-                    "Newtonsoft.Json",
+                    "Some.package",
                     "--new-version",
                     "13.0.1",
                     "--previous-version",
                     "7.0.1",
                 ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
+                initialFiles:
                 [
                     ("path/to/solution.sln", """
                         Microsoft Visual Studio Solution File, Format Version 12.00
@@ -66,8 +69,8 @@ public partial class EntryPointTests
                             <None Include="packages.config" />
                           </ItemGroup>
                           <ItemGroup>
-                            <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                              <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
                               <Private>True</Private>
                             </Reference>
                           </ItemGroup>
@@ -76,10 +79,11 @@ public partial class EntryPointTests
                         """),
                     ("path/to/packages.config", """
                         <packages>
-                          <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                         </packages>
                         """)
                 ],
+                expectedFiles:
                 [
                     ("path/to/my.csproj", """
                         <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -91,8 +95,8 @@ public partial class EntryPointTests
                             <None Include="packages.config" />
                           </ItemGroup>
                           <ItemGroup>
-                            <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                              <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
                               <Private>True</Private>
                             </Reference>
                           </ItemGroup>
@@ -102,10 +106,11 @@ public partial class EntryPointTests
                     ("path/to/packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
-                          <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
@@ -119,13 +124,19 @@ public partial class EntryPointTests
                     "--solution-or-project",
                     Path.Combine(path, "path/to/my.csproj"),
                     "--dependency",
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "--new-version",
                     "13.0.1",
                     "--previous-version",
                     "7.0.1",
                     "--verbose"
                 ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
+                initialFiles:
                 [
                     ("path/to/my.csproj", """
                         <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -137,8 +148,8 @@ public partial class EntryPointTests
                             <None Include="packages.config" />
                           </ItemGroup>
                           <ItemGroup>
-                            <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                              <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
                               <Private>True</Private>
                             </Reference>
                           </ItemGroup>
@@ -147,10 +158,11 @@ public partial class EntryPointTests
                         """),
                     ("path/to/packages.config", """
                         <packages>
-                          <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                         </packages>
                         """)
                 ],
+                expectedFiles:
                 [
                     ("path/to/my.csproj", """
                         <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -162,8 +174,8 @@ public partial class EntryPointTests
                             <None Include="packages.config" />
                           </ItemGroup>
                           <ItemGroup>
-                            <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                              <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                            <Reference Include="Some.Package">
+                              <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
                               <Private>True</Private>
                             </Reference>
                           </ItemGroup>
@@ -173,10 +185,11 @@ public partial class EntryPointTests
                     ("path/to/packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
-                          <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
@@ -190,12 +203,17 @@ public partial class EntryPointTests
                     "--solution-or-project",
                     $"{path}/some-dir/dirs.proj",
                     "--dependency",
-                    "NuGet.Versioning",
+                    "Some.Package",
                     "--new-version",
                     "6.6.1",
                     "--previous-version",
                     "6.1.0",
                     "--verbose"
+                ],
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "6.1.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "6.6.1", "net8.0"),
                 ],
                 initialFiles:
                 [
@@ -211,12 +229,12 @@ public partial class EntryPointTests
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <OutputType>Exe</OutputType>
-                            <TargetFramework>net6.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                             <ImplicitUsings>enable</ImplicitUsings>
                             <Nullable>enable</Nullable>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+                            <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -224,12 +242,12 @@ public partial class EntryPointTests
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <OutputType>Exe</OutputType>
-                            <TargetFramework>net6.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                             <ImplicitUsings>enable</ImplicitUsings>
                             <Nullable>enable</Nullable>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+                            <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -237,7 +255,7 @@ public partial class EntryPointTests
                         <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                         
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+                            <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
 
                         </Project>
@@ -258,12 +276,12 @@ public partial class EntryPointTests
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <OutputType>Exe</OutputType>
-                            <TargetFramework>net6.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                             <ImplicitUsings>enable</ImplicitUsings>
                             <Nullable>enable</Nullable>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
+                            <PackageReference Include="Some.Package" Version="6.6.1" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -271,12 +289,12 @@ public partial class EntryPointTests
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <OutputType>Exe</OutputType>
-                            <TargetFramework>net6.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                             <ImplicitUsings>enable</ImplicitUsings>
                             <Nullable>enable</Nullable>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
+                            <PackageReference Include="Some.Package" Version="6.6.1" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -284,7 +302,7 @@ public partial class EntryPointTests
                         <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                         
                           <ItemGroup>
-                            <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
+                            <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
 
                         </Project>
@@ -303,6 +321,14 @@ public partial class EntryPointTests
             // test this, it must be tested in a new process where MSBuild has not been loaded yet and the runner tool
             // must be started with its working directory at the test repo's root.
             using var tempDir = new TemporaryDirectory();
+
+            MockNuGetPackage[] testPackages =
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+            ];
+            await MockNuGetPackagesInDirectory(testPackages, tempDir.DirectoryPath);
+
             var globalJsonPath = Path.Join(tempDir.DirectoryPath, "global.json");
             var srcGlobalJsonPath = Path.Join(tempDir.DirectoryPath, "src", "global.json");
             string globalJsonContent = """
@@ -322,20 +348,21 @@ public partial class EntryPointTests
                     <TargetFramework>net8.0</TargetFramework>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                    <PackageReference Include="Some.Package" Version="7.0.1" />
                   </ItemGroup>
                 </Project>
                 """);
-            var executableName = $"NuGetUpdater.Cli{(Environment.OSVersion.Platform == PlatformID.Win32NT ? ".exe" : "")}";
+            var executableName = Path.Join(Path.GetDirectoryName(GetType().Assembly.Location), "NuGetUpdater.Cli.dll");
             var executableArgs = string.Join(" ",
             [
+                executableName,
                 "update",
                 "--repo-root",
                 tempDir.DirectoryPath,
                 "--solution-or-project",
                 projectPath,
                 "--dependency",
-                "Newtonsoft.Json",
+                "Some.Package",
                 "--new-version",
                 "13.0.1",
                 "--previous-version",
@@ -350,7 +377,7 @@ public partial class EntryPointTests
                 workingDirectory = Path.Join(workingDirectory, workingDirectoryPath);
             }
 
-            var (exitCode, output, error) = await ProcessEx.RunAsync(executableName, executableArgs, workingDirectory: workingDirectory);
+            var (exitCode, output, error) = await ProcessEx.RunAsync("dotnet", executableArgs, workingDirectory: workingDirectory);
             Assert.True(exitCode == 0, $"Error running update on unsupported SDK.\nSTDOUT:\n{output}\nSTDERR:\n{error}");
 
             // verify project update
@@ -366,7 +393,7 @@ public partial class EntryPointTests
             Assert.Contains("99.99.99", updatedGlobalJsonContents);
         }
 
-        private static async Task Run(Func<string, string[]> getArgs, (string Path, string Content)[] initialFiles, (string, string)[] expectedFiles)
+        private static async Task Run(Func<string, string[]> getArgs, (string Path, string Content)[] initialFiles, (string, string)[] expectedFiles, MockNuGetPackage[]? packages = null)
         {
             var actualFiles = await RunUpdate(initialFiles, async path =>
             {
@@ -380,6 +407,7 @@ public partial class EntryPointTests
 
                 try
                 {
+                    await MockNuGetPackagesInDirectory(packages, path);
                     var args = getArgs(path);
                     var result = await Program.Main(args);
                     if (result != 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -3,9 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Test.Update;
 using NuGetUpdater.Core.Test.Utilities;
 
 using Xunit;
+using Xunit.Sdk;
 
 namespace NuGetUpdater.Core.Test.Discover;
 
@@ -16,10 +18,13 @@ public class DiscoveryWorkerTestBase
     protected static async Task TestDiscoveryAsync(
         string workspacePath,
         TestFile[] files,
-        ExpectedWorkspaceDiscoveryResult expectedResult)
+        ExpectedWorkspaceDiscoveryResult expectedResult,
+        MockNuGetPackage[]? packages = null)
     {
         var actualResult = await RunDiscoveryAsync(files, async directoryPath =>
         {
+            await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath);
+
             var worker = new DiscoveryWorker(new Logger(verbose: true));
             await worker.RunAsync(directoryPath, workspacePath, DiscoveryWorker.DiscoveryResultFileName);
         });

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.DotNetToolsJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.DotNetToolsJson.cs
@@ -10,6 +10,7 @@ public partial class DiscoveryWorkerTests
         public async Task DiscoversDependencies()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     (".config/dotnet-tools.json", """
@@ -45,13 +46,15 @@ public partial class DiscoveryWorkerTests
                         ]
                     },
                     ExpectedProjectCount = 0,
-                });
+                }
+            );
         }
 
         [Fact]
         public async Task ReportsFailure()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     (".config/dotnet-tools.json", """
@@ -85,7 +88,8 @@ public partial class DiscoveryWorkerTests
                         ExpectedDependencyCount = 0,
                     },
                     ExpectedProjectCount = 0,
-                });
+                }
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
@@ -10,6 +10,7 @@ public partial class DiscoveryWorkerTests
         public async Task DiscoversDependencies()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("global.json", """
@@ -35,13 +36,15 @@ public partial class DiscoveryWorkerTests
                         ]
                     },
                     ExpectedProjectCount = 0,
-                });
+                }
+            );
         }
 
         [Fact]
         public async Task ReportsFailure()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("global.json", """
@@ -65,7 +68,8 @@ public partial class DiscoveryWorkerTests
                         ExpectedDependencyCount = 0,
                     },
                     ExpectedProjectCount = 0,
-                });
+                }
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -1,5 +1,3 @@
-using System.Collections.Immutable;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Discover;
@@ -12,20 +10,18 @@ public partial class DiscoveryWorkerTests
         public async Task DiscoversDependencies()
         {
             await TestDiscoveryAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net46"),
+                    MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net46"),
+                ],
                 workspacePath: "",
                 files: [
                     ("packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
-                          <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net46" />
-                          <package id="Microsoft.Net.Compilers" version="1.0.1" targetFramework="net46" developmentDependency="true" />
-                          <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
-                          <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
-                          <package id="Newtonsoft.Json" version="8.0.3" allowedVersions="[8,10)" targetFramework="net46" />
-                          <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
-                          <package id="NuGet.Server" version="2.11.2" targetFramework="net46" />
-                          <package id="RouteMagic" version="1.3" targetFramework="net46" />
-                          <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+                          <package id="Package.A" version="1.0.0" targetFramework="net46" />
+                          <package id="Package.B" version="2.0.0" targetFramework="net46" />
                         </packages>
                         """),
                     ("myproj.csproj", """
@@ -49,19 +45,13 @@ public partial class DiscoveryWorkerTests
                             TargetFrameworks = ["net46"],
                             Dependencies = [
                                 new("Microsoft.NETFramework.ReferenceAssemblies", "1.0.3", DependencyType.Unknown, TargetFrameworks: ["net46"], IsTransitive: true),
-                                new("Microsoft.CodeDom.Providers.DotNetCompilerPlatform", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("Microsoft.Net.Compilers", "1.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("Microsoft.Web.Infrastructure", "1.0.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("Microsoft.Web.Xdt", "2.1.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("Newtonsoft.Json", "8.0.3", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("NuGet.Core", "2.11.1", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("NuGet.Server", "2.11.2", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("RouteMagic", "1.3", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
-                                new("WebActivatorEx", "2.1.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Package.B", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
                             ],
                         }
                     ],
-                });
+                }
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -10,29 +10,27 @@ public partial class DiscoveryWorkerTests
         public async Task ReturnsPackageReferencesMissingVersions()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("myproj.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <Description>Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.</Description>
-                            <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
+                            <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
                           </PropertyGroup>
 
                           <ItemGroup>
                             <EmbeddedResource Include="ErrorHandling\Resources\**\*.*;Diagnostics\Resources\**\*.*;Diagnostics\Views\**\*.*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
                           </ItemGroup>
 
-                          <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-                            <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
-                            <PackageReference Include="Microsoft.AspNetCore.App" />
-                            <PackageReference Include="Microsoft.NET.Test.Sdk" Version="" />
-                            <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" version="1.1.0"></PackageReference>
-                            <PackageReference Include="System.Collections.Specialized"><Version>4.3.0</Version></PackageReference>
+                          <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+                            <PackageReference Include="Package.A" Version="1.1.1" />
+                            <PackageReference Include="Package.B" />
                           </ItemGroup>
 
-                          <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-                            <Reference Include="System.Xml" />
+                          <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+                            <Reference Include="Package.C" />
                           </ItemGroup>
                         </Project>
                         """)
@@ -44,44 +42,43 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
-                            ExpectedDependencyCount = 52,
+                            ExpectedDependencyCount = 3,
                             Dependencies = [
-                                new("Microsoft.Extensions.DependencyModel", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("Microsoft.AspNetCore.App", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("Microsoft.NET.Test.Sdk", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
                                 new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                                new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("System.Collections.Specialized", "4.3.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
+                                new("Package.A", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                new("Package.B", "", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                             ],
                             Properties = [
                                 new("Description", "Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.", "myproj.csproj"),
-                                new("TargetFrameworks", "netstandard1.6;net462", "myproj.csproj"),
+                                new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
-                            TargetFrameworks = ["net462", "netstandard1.6"],
+                            TargetFrameworks = ["net7.0", "net8.0"],
                             ReferencedProjectPaths = [],
                         }
                     ],
-                });
+                }
+            );
         }
 
         [Fact]
         public async Task WithDirectoryPackagesProps()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("myproj.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
                             <Description>Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.</Description>
-                            <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
+                            <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
                           </PropertyGroup>
 
                           <ItemGroup>
                             <EmbeddedResource Include="ErrorHandling\Resources\**\*.*;Diagnostics\Resources\**\*.*;Diagnostics\Views\**\*.*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
                           </ItemGroup>
 
-                          <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+                          <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
                             <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
                             <PackageReference Include="Microsoft.AspNetCore.App" />
                             <PackageReference Include="Microsoft.NET.Test.Sdk" Version="" />
@@ -89,7 +86,7 @@ public partial class DiscoveryWorkerTests
                             <PackageReference Include="System.Collections.Specialized"><Version>4.3.0</Version></PackageReference>
                           </ItemGroup>
 
-                          <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+                          <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
                             <Reference Include="System.Xml" />
                           </ItemGroup>
                         </Project>
@@ -115,21 +112,21 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
-                            ExpectedDependencyCount = 52,
+                            ExpectedDependencyCount = 6,
                             Dependencies = [
-                                new("Microsoft.Extensions.DependencyModel", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("Microsoft.AspNetCore.App", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("Microsoft.NET.Test.Sdk", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
+                                new("Microsoft.Extensions.DependencyModel", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                new("Microsoft.AspNetCore.App", "", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                new("Microsoft.NET.Test.Sdk", "", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                                 new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                                new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                new("System.Collections.Specialized", "4.3.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
+                                new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                new("System.Collections.Specialized", "4.3.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                             ],
                             Properties = [
                                 new("Description", "Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.", "myproj.csproj"),
                                 new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
-                                new("TargetFrameworks", "netstandard1.6;net462", "myproj.csproj"),
+                                new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
-                            TargetFrameworks = ["net462", "netstandard1.6"],
+                            TargetFrameworks = ["net7.0", "net8.0"],
                         },
                     ],
                     DirectoryPackagesProps = new()
@@ -143,13 +140,15 @@ public partial class DiscoveryWorkerTests
                             new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
                         ],
                     },
-                });
+                }
+            );
         }
 
         [Fact]
         public async Task WithDirectoryBuildPropsAndTargets()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("project.csproj", """
@@ -157,7 +156,7 @@ public partial class DiscoveryWorkerTests
 
                           <PropertyGroup>
                             <OutputType>Exe</OutputType>
-                            <TargetFramework>net6.0</TargetFramework>
+                            <TargetFramework>net7.0</TargetFramework>
                             <ImplicitUsings>enable</ImplicitUsings>
                             <Nullable>enable</Nullable>
                           </PropertyGroup>
@@ -195,16 +194,16 @@ public partial class DiscoveryWorkerTests
                             FilePath = "project.csproj",
                             ExpectedDependencyCount = 3,
                             Dependencies = [
-                                new("NuGet.Versioning", "6.1.0", DependencyType.PackageReference, TargetFrameworks: ["net6.0"], IsDirect: false),
-                                new("Microsoft.CodeAnalysis.Analyzers", "3.3.0", DependencyType.PackageReference, TargetFrameworks: ["net6.0"], IsDirect: false),
+                                new("NuGet.Versioning", "6.1.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: false),
+                                new("Microsoft.CodeAnalysis.Analyzers", "3.3.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: false),
                             ],
                             Properties = [
                                 new("ImplicitUsings", "enable", "project.csproj"),
                                 new("Nullable", "enable", "project.csproj"),
                                 new("OutputType", "Exe", "project.csproj"),
-                                new("TargetFramework", "net6.0", "project.csproj"),
+                                new("TargetFramework", "net7.0", "project.csproj"),
                             ],
-                            TargetFrameworks = ["net6.0"],
+                            TargetFrameworks = ["net7.0"],
                         },
                         new()
                         {
@@ -227,7 +226,8 @@ public partial class DiscoveryWorkerTests
                             TargetFrameworks = [],
                         },
                     ],
-                });
+                }
+            );
         }
 
         [Fact]
@@ -247,20 +247,24 @@ public partial class DiscoveryWorkerTests
                 Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", tempNuGetHttpCacheDirectory);
 
                 await TestDiscoveryAsync(
+                    packages:
+                    [
+                        MockNuGetPackage.CentralPackageVersionsPackage,
+                    ],
                     workspacePath: "",
                     files: [
                         ("myproj.csproj", """
                             <Project Sdk="Microsoft.NET.Sdk">
                               <PropertyGroup>
                                 <Description>Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.</Description>
-                                <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
+                                <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
                               </PropertyGroup>
 
                               <ItemGroup>
                                 <EmbeddedResource Include="ErrorHandling\Resources\**\*.*;Diagnostics\Resources\**\*.*;Diagnostics\Views\**\*.*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
                               </ItemGroup>
 
-                              <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+                              <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
                                 <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
                                 <PackageReference Include="Microsoft.AspNetCore.App" />
                                 <PackageReference Include="Microsoft.NET.Test.Sdk" Version="" />
@@ -268,7 +272,7 @@ public partial class DiscoveryWorkerTests
                                 <PackageReference Include="System.Collections.Specialized"><Version>4.3.0</Version></PackageReference>
                               </ItemGroup>
 
-                              <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+                              <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
                                 <Reference Include="System.Xml" />
                               </ItemGroup>
                             </Project>
@@ -294,25 +298,25 @@ public partial class DiscoveryWorkerTests
                     expectedResult: new()
                     {
                         FilePath = "",
-                        ExpectedProjectCount = 3,
+                        ExpectedProjectCount = 5,
                         Projects = [
                             new()
                             {
                                 FilePath = "myproj.csproj",
-                                ExpectedDependencyCount = 58,
+                                ExpectedDependencyCount = 12,
                                 Dependencies = [
-                                    new("Microsoft.Extensions.DependencyModel", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                    new("Microsoft.AspNetCore.App", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                    new("Microsoft.NET.Test.Sdk", "", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
+                                    new("Microsoft.Extensions.DependencyModel", "1.1.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                    new("Microsoft.AspNetCore.App", "", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                    new("Microsoft.NET.Test.Sdk", "", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                                     new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                                    new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
-                                    new("System.Collections.Specialized", "4.3.0", DependencyType.PackageReference, TargetFrameworks: ["net462", "netstandard1.6"], IsDirect: true),
+                                    new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                    new("System.Collections.Specialized", "4.3.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                                 ],
                                 Properties = [
                                     new("Description", "Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.", "myproj.csproj"),
-                                    new("TargetFrameworks", "netstandard1.6;net462", "myproj.csproj"),
+                                    new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                                 ],
-                                TargetFrameworks = ["net462", "netstandard1.6"],
+                                TargetFrameworks = ["net7.0", "net8.0"],
                             },
                             new()
                             {
@@ -327,7 +331,8 @@ public partial class DiscoveryWorkerTests
                                 ],
                             },
                         ],
-                    });
+                    }
+                );
             }
             finally
             {
@@ -341,6 +346,7 @@ public partial class DiscoveryWorkerTests
         public async Task ReturnsDependenciesThatCannotBeEvaluated()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("myproj.csproj", """
@@ -374,7 +380,8 @@ public partial class DiscoveryWorkerTests
                             ReferencedProjectPaths = [],
                         }
                     ],
-                });
+                }
+            );
         }
 
         [Fact]
@@ -382,6 +389,7 @@ public partial class DiscoveryWorkerTests
         public async Task NoDependenciesReturnedIfNoTargetFrameworkCanBeResolved()
         {
             await TestDiscoveryAsync(
+                packages: [],
                 workspacePath: "",
                 files: [
                     ("myproj.csproj", """
@@ -399,23 +407,29 @@ public partial class DiscoveryWorkerTests
                 {
                     FilePath = "",
                     Projects = []
-                });
+                }
+            );
         }
 
         [Fact]
         public async Task DiscoverReportsTransitivePackageVersionsWithFourPartsForMultipleTargetFrameworks()
         {
             await TestDiscoveryAsync(
+                packages:
+                [
+                    new("Some.Package", "1.2.3.4", Files: [("lib/net7.0/Some.Package.dll", Array.Empty<byte>()), ("lib/net8.0/Some.Package.dll", Array.Empty<byte>())], DependencyGroups: [(null, [("Transitive.Dependency", "5.6.7.8")])]),
+                    new("Transitive.Dependency", "5.6.7.8", Files: [("lib/net7.0/Transitive.Dependency.dll", Array.Empty<byte>()), ("lib/net8.0/Transitive.Dependency.dll", Array.Empty<byte>())]),
+                ],
                 workspacePath: "",
                 files:
                 [
                     ("myproj.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+                            <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="AWSSDK.S3" Version="3.7.307.29" />
+                            <PackageReference Include="Some.Package" Version="1.2.3.4" />
                           </ItemGroup>
                         </Project>
                         """)
@@ -427,19 +441,15 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
+                            ExpectedDependencyCount = 3,
                             Dependencies = [
-                                new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                                new("AWSSDK.S3", "3.7.307.29", DependencyType.PackageReference, TargetFrameworks: ["net8.0", "netstandard2.0"], IsDirect: true),
-                                new("AWSSDK.Core", "3.7.303.27", DependencyType.Unknown, TargetFrameworks: ["net8.0", "netstandard2.0"], IsTransitive: true),
-                                new("Microsoft.Bcl.AsyncInterfaces", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                                new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                                new("System.Runtime.CompilerServices.Unsafe", "4.5.2", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                                new("System.Threading.Tasks.Extensions", "4.5.2", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
+                                new("Some.Package", "1.2.3.4", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
+                                new("Transitive.Dependency", "5.6.7.8", DependencyType.Unknown, TargetFrameworks: ["net7.0", "net8.0"], IsTransitive: true),
                             ],
                             Properties = [
-                                new("TargetFrameworks", "netstandard2.0;net8.0", "myproj.csproj"),
+                                new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
-                            TargetFrameworks = ["net8.0", "netstandard2.0"],
+                            TargetFrameworks = ["net7.0", "net8.0"],
                             ReferencedProjectPaths = [],
                         }
                     ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -11,18 +11,22 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     public async Task TestProjectFiles(string projectPath)
     {
         await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+            ],
             workspacePath: "src",
             files: new[]
             {
                 (projectPath, """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
-                        <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -34,16 +38,16 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     new()
                     {
                         FilePath = Path.GetFileName(projectPath),
-                        TargetFrameworks = ["netstandard2.0"],
+                        TargetFrameworks = ["net8.0"],
                         ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 19,
+                        ExpectedDependencyCount = 2,
                         Dependencies = [
                             new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                            new("Newtonsoft.Json", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["netstandard2.0"], IsDirect: true)
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                         ],
                         Properties = [
-                            new("NewtonsoftJsonPackageVersion", "9.0.1", projectPath),
-                            new("TargetFramework", "netstandard2.0", projectPath),
+                            new("SomePackageVersion", "9.0.1", projectPath),
+                            new("TargetFramework", "net8.0", projectPath),
                         ]
                     }
                 ]
@@ -56,6 +60,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     {
         var projectPath = "src/project.csproj";
         await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+            ],
             workspacePath: "",
             files: new[]
             {
@@ -69,8 +77,8 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         <None Include="packages.config" />
                       </ItemGroup>
                       <ItemGroup>
-                        <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
                           <Private>True</Private>
                         </Reference>
                       </ItemGroup>
@@ -79,7 +87,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     """),
                 ("src/packages.config", """
                     <packages>
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                     </packages>
                     """),
             },
@@ -92,9 +100,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         FilePath = projectPath,
                         TargetFrameworks = ["net45"],
                         ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 2, // Should we ignore Microsoft.NET.ReferenceAssemblies?
+                        ExpectedDependencyCount = 2,
                         Dependencies = [
-                            new("Newtonsoft.Json", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
+                            new("Microsoft.NETFramework.ReferenceAssemblies", "1.0.3", DependencyType.Unknown, TargetFrameworks: ["net45"], IsTransitive: true),
+                            new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
                         ],
                         Properties = [
                             new("TargetFrameworkVersion", "v4.5", projectPath),
@@ -110,17 +119,21 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     {
         var projectPath = "src/project.csproj";
         await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+            ],
             workspacePath: "",
             files: new[]
             {
                 (projectPath, """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" />
+                        <PackageReference Include="Some.Package" />
                       </ItemGroup>
                     </Project>
                     """),
@@ -128,11 +141,11 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     <Project>
                       <PropertyGroup>
                         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                        <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                        <PackageVersion Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -144,17 +157,17 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     new()
                     {
                         FilePath = projectPath,
-                        TargetFrameworks = ["netstandard2.0"],
+                        TargetFrameworks = ["net8.0"],
                         ReferencedProjectPaths = [],
-                        ExpectedDependencyCount = 19,
+                        ExpectedDependencyCount = 2,
                         Dependencies = [
                             new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                            new("Newtonsoft.Json", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["netstandard2.0"], IsDirect: true)
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                         ],
                         Properties = [
                             new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
-                            new("NewtonsoftJsonPackageVersion", "9.0.1", "Directory.Packages.props"),
-                            new("TargetFramework", "netstandard2.0", projectPath),
+                            new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
+                            new("TargetFramework", "net8.0", projectPath),
                         ]
                     }
                 ],
@@ -162,7 +175,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 {
                     FilePath = "Directory.Packages.props",
                     Dependencies = [
-                        new("Newtonsoft.Json", "9.0.1", DependencyType.PackageVersion, IsDirect: true)
+                        new("Some.Package", "9.0.1", DependencyType.PackageVersion, IsDirect: true)
                     ],
                 }
             }
@@ -174,17 +187,21 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     {
         var solutionPath = "solution.sln";
         await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+            ],
             workspacePath: "",
             files: new[]
             {
                 ("src/project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+                        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" />
+                        <PackageReference Include="Some.Package" />
                       </ItemGroup>
                     </Project>
                     """),
@@ -192,11 +209,11 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     <Project>
                       <PropertyGroup>
                         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                        <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
                       </PropertyGroup>
 
                       <ItemGroup>
-                        <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                        <PackageVersion Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """),
@@ -263,16 +280,16 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     new()
                     {
                         FilePath = "src/project.csproj",
-                        TargetFrameworks = ["net6.0", "netstandard2.0"],
-                        ExpectedDependencyCount = 19,
+                        TargetFrameworks = ["net7.0", "net8.0"],
+                        ExpectedDependencyCount = 2,
                         Dependencies = [
                             new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
-                            new("Newtonsoft.Json", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net6.0", "netstandard2.0"], IsDirect: true)
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true)
                         ],
                         Properties = [
                             new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
-                            new("NewtonsoftJsonPackageVersion", "9.0.1", "Directory.Packages.props"),
-                            new("TargetFrameworks", "netstandard2.0;net6.0", "src/project.csproj"),
+                            new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
+                            new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
                         ]
                     }
                 ],
@@ -280,7 +297,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 {
                     FilePath = "Directory.Packages.props",
                     Dependencies = [
-                        new("Newtonsoft.Json", "9.0.1", DependencyType.PackageVersion, IsDirect: true)
+                        new("Some.Package", "9.0.1", DependencyType.PackageVersion, IsDirect: true)
                     ],
                 },
                 GlobalJson = new()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -1,0 +1,419 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace NuGetUpdater.Core.Test
+{
+    public record MockNuGetPackage(
+        string Id,
+        string Version,
+        XElement[]? AdditionalMetadata = null,
+        (string? TargetFramework, (string Id, string Version)[] Packages)[]? DependencyGroups = null,
+        (string Path, byte[] Content)[]? Files = null)
+    {
+        private static readonly XNamespace Namespace = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
+        private static readonly XmlWriterSettings WriterSettings = new()
+        {
+            Encoding = Encoding.UTF8,
+            Indent = true,
+        };
+
+        private XDocument? _nuspec;
+        private Stream? _stream;
+
+        public void WriteToDirectory(string localPackageSourcePath)
+        {
+            string cachePath = Path.Join(localPackageSourcePath, "_nupkg_cache");
+            string nupkgPath = Path.Join(cachePath, $"{Id}.{Version}.nupkg");
+            Directory.CreateDirectory(cachePath);
+            Stream stream = GetZipStream();
+            using (FileStream fileStream = new(nupkgPath, FileMode.Create))
+            {
+                stream.CopyTo(fileStream);
+            }
+
+            // add the package to the local feed; this is equivalent to running
+            //   nuget add <nupkgPath> -source <localPackageSourcePath>
+            // but running that in-process locks the files, so we have to do it manually
+            // the end result is 4 files:
+            //   .nupkg.metadata                // a JSON object with the package's content hash and some other fields
+            //   <id>.<version>.nupkg           // the package itself
+            //   <id>.<version>.nupkg.sha512    // the SHA512 hash of the package
+            //   <id>.nuspec                    // the package's nuspec file
+            string expandedPath = Path.Join(localPackageSourcePath, Id.ToLowerInvariant(), Version);
+            Directory.CreateDirectory(expandedPath);
+            File.Copy(nupkgPath, Path.Join(expandedPath, $"{Id}.{Version}.nupkg".ToLowerInvariant()));
+            using XmlWriter writer = XmlWriter.Create(Path.Join(expandedPath, $"{Id}.nuspec".ToLowerInvariant()), WriterSettings);
+            GetNuspec().WriteTo(writer);
+            using SHA512 sha512 = SHA512.Create();
+            byte[] hash = sha512.ComputeHash(File.ReadAllBytes(nupkgPath));
+            string hashString = Convert.ToBase64String(hash);
+            File.WriteAllText(Path.Join(expandedPath, $"{Id}.{Version}.nupkg.sha512".ToLowerInvariant()), hashString);
+            JsonObject metadata = new()
+            {
+                ["version"] = 2,
+                ["contentHash"] = hashString,
+                ["source"] = null,
+            };
+            File.WriteAllText(Path.Join(expandedPath, ".nupkg.metadata"), metadata.ToString());
+        }
+
+        /// <summary>
+        /// Creates a mock NuGet package with a single assembly in the appropriate `lib/` directory.  The assembly will
+        /// be empty.
+        /// </summary>
+        public static MockNuGetPackage CreateSimplePackage(string id, string version, string targetFramework, (string? TargetFramework, (string Id, string Version)[] Packages)[]? dependencyGroups = null)
+        {
+            return new(
+                id,
+                version,
+                AdditionalMetadata: null,
+                DependencyGroups: dependencyGroups,
+                Files:
+                [
+                    ($"lib/{targetFramework}/{id}.dll", Array.Empty<byte>())
+                ]
+            );
+        }
+
+        /// <summary>
+        /// Creates a mock NuGet package with a single assembly in the appropriate `lib/` directory.  The assembly will
+        /// contain the appropriate `AssemblyVersion` attribute and nothing else.
+        /// </summary>
+        public static MockNuGetPackage CreatePackageWithAssembly(string id, string version, string targetFramework, string assemblyVersion, (string? TargetFramework, (string Id, string Version)[] Packages)[]? dependencyGroups = null)
+        {
+            return new(
+                id,
+                version,
+                AdditionalMetadata: null,
+                DependencyGroups: dependencyGroups,
+                Files:
+                [
+                    ($"lib/{targetFramework}/{id}.dll", CreateAssembly(id, assemblyVersion))
+                ]
+            );
+        }
+
+        /// <summary>
+        /// Creates a mock NuGet package with empty analyzer assemblies for both C# and VB.
+        /// </summary>
+        public static MockNuGetPackage CreateAnalyzerPackage(string id, string version, (string? TargetFramework, (string Id, string Version)[] Packages)[]? dependencyGroups = null)
+        {
+            return new(
+                id,
+                version,
+                AdditionalMetadata:
+                [
+                    new XElement("developmentDependency", "true"),
+                ],
+                DependencyGroups: dependencyGroups,
+                Files:
+                [
+                    ($"analyzers/dotnet/cs/{id}.dll", Array.Empty<byte>()),
+                    ($"analyzers/dotnet/vb/{id}.dll", Array.Empty<byte>()),
+                ]
+            );
+        }
+
+        public static MockNuGetPackage CreateDotNetToolPackage(string id, string version, string targetFramework)
+        {
+            return new(
+                id,
+                version,
+                AdditionalMetadata:
+                [
+                    new XElement("packageTypes",
+                        new XElement("packageType",
+                            new XAttribute("name", "DotnetTool")
+                        )
+                    )
+                ],
+                Files:
+                [
+                    ($"tools/{targetFramework}/any/DotnetToolSettings.xml", Encoding.UTF8.GetBytes($"""
+                        <DotNetCliTool Version="1">
+                          <Commands>
+                            <Command Name="{id}" EntryPoint="{id}.dll" Runner="dotnet" />
+                          </Commands>
+                        </DotNetCliTool>
+                        """)),
+                    ($"tools/{targetFramework}/any/{id}.dll", Array.Empty<byte>()),
+                ]
+            );
+        }
+
+        public static MockNuGetPackage CreateMSBuildSdkPackage(string id, string version, string? sdkPropsContent = null, string? sdkTargetsContent = null)
+        {
+            sdkPropsContent ??= """
+                <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                </Project>
+                """;
+            sdkTargetsContent ??= """
+                <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                </Project>
+                """;
+            return new(
+                id,
+                version,
+                AdditionalMetadata:
+                [
+                    new XElement("packageTypes",
+                        new XElement("packageType",
+                            new XAttribute("name", "MSBuildSdk")
+                        )
+                    )
+                ],
+                Files:
+                [
+                    ("Sdk/Sdk.props", Encoding.UTF8.GetBytes(sdkPropsContent)),
+                    ("Sdk/Sdk.targets", Encoding.UTF8.GetBytes(sdkTargetsContent)),
+                ]
+            );
+        }
+
+        private XDocument GetNuspec()
+        {
+            if (_nuspec is null)
+            {
+                _nuspec = new XDocument(
+                    new XElement(Namespace + "package",
+                        new XElement(Namespace + "metadata",
+                            new XElement(Namespace + "id", Id),
+                            new XElement(Namespace + "version", Version),
+                            new XElement(Namespace + "authors", "MockNuGetPackage"),
+                            new XElement(Namespace + "description", "Mock NuGet package"),
+                            AdditionalMetadata?.Select(a => WithNamespace(a, Namespace)),
+                            new XElement(Namespace + "dependencies",
+                                // dependencies with no target framework
+                                DependencyGroups?.Where(g => g.TargetFramework is null).SelectMany(g =>
+                                    g.Packages.Select(p =>
+                                        new XElement(Namespace + "dependency",
+                                            new XAttribute("id", p.Id),
+                                            new XAttribute("version", p.Version)
+                                        )
+                                    )
+                                ),
+                                // dependencies with a target framework
+                                DependencyGroups?.Where(g => g.TargetFramework is not null).Select(g =>
+                                    new XElement(Namespace + "group",
+                                        new XAttribute("targetFramework", g.TargetFramework!),
+                                        g.Packages.Select(p =>
+                                            new XElement(Namespace + "dependency",
+                                                new XAttribute("id", p.Id),
+                                                new XAttribute("version", p.Version)
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );
+            }
+
+            return _nuspec;
+        }
+
+        private static XElement WithNamespace(XElement element, XNamespace ns)
+        {
+            return new XElement(ns + element.Name.LocalName,
+                element.Attributes(),
+                element.Nodes().Select(n =>
+                {
+                    if (n is XElement e)
+                    {
+                        return WithNamespace(e, ns);
+                    }
+
+                    return n;
+                })
+            );
+        }
+
+        private Stream GetZipStream()
+        {
+            if (_stream is null)
+            {
+                XDocument nuspec = GetNuspec();
+                _stream = new MemoryStream();
+                using ZipArchive zip = new(_stream, ZipArchiveMode.Create, leaveOpen: true);
+                ZipArchiveEntry nuspecEntry = zip.CreateEntry($"{Id}.nuspec");
+                using (Stream contentStream = nuspecEntry.Open())
+                using (XmlWriter writer = XmlWriter.Create(contentStream, WriterSettings))
+                {
+                    nuspec.WriteTo(writer);
+                }
+
+                foreach (var file in Files ?? [])
+                {
+                    ZipArchiveEntry fileEntry = zip.CreateEntry(file.Path);
+                    using Stream contentStream = fileEntry.Open();
+                    contentStream.Write(file.Content, 0, file.Content.Length);
+                }
+            }
+
+            _stream.Seek(0, SeekOrigin.Begin);
+            return _stream;
+        }
+
+        private static byte[] CreateAssembly(string assemblyName, string assemblyVersion)
+        {
+            CSharpCompilationOptions compilationOptions = new(OutputKind.DynamicallyLinkedLibrary);
+            CSharpCompilation compilation = CSharpCompilation.Create(assemblyName, options: compilationOptions)
+                .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+                .AddSyntaxTrees(CSharpSyntaxTree.ParseText($"[assembly: System.Reflection.AssemblyVersionAttribute(\"{assemblyVersion}\")]"));
+            MemoryStream assemblyStream = new();
+            EmitResult emitResult = compilation.Emit(assemblyStream);
+            if (!emitResult.Success)
+            {
+                throw new Exception($"Unable to create test assembly:\n\t{string.Join("\n\t", emitResult.Diagnostics.ToString())}");
+            }
+
+            return assemblyStream.ToArray();
+        }
+
+        // some well-known packages
+        public static MockNuGetPackage CentralPackageVersionsPackage =>
+            CreateMSBuildSdkPackage(
+                "Microsoft.Build.CentralPackageVersions",
+                "2.1.3",
+                sdkTargetsContent: """
+                    <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                        <!-- this is a simplified version of this package used for testing -->
+                        <PropertyGroup>
+                        <CentralPackagesFile Condition=" '$(CentralPackagesFile)' == '' ">$([MSBuild]::GetPathOfFileAbove('Packages.props', $(MSBuildProjectDirectory)))</CentralPackagesFile>
+                        </PropertyGroup>
+                        <Import Project="$(CentralPackagesFile)" Condition="Exists('$(CentralPackagesFile)')" />
+                    </Project>
+                    """
+            );
+
+        private static readonly Lazy<string> BundledVersionsPropsPath = new(() =>
+        {
+            // we need to find the file `Microsoft.NETCoreSdk.BundledVersions.props` in the SDK directory
+
+            DirectoryInfo projectDir = Directory.CreateTempSubdirectory("bundled_versions_props_path_discovery_");
+            try
+            {
+                // get the sdk version
+                string projectPath = Path.Combine(projectDir.FullName, "project.csproj");
+                File.WriteAllText(projectPath, """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Target Name="_ReportCurrentSdkVersion">
+                        <Message Text="_CurrentSdkVersion=$(NETCoreSdkVersion)" Importance="High" />
+                      </Target>
+                    </Project>
+                    """
+                );
+                var (exitCode, stdout, stderr) = ProcessEx.RunAsync("dotnet", $"msbuild {projectPath} /t:_ReportCurrentSdkVersion").Result;
+                if (exitCode != 0)
+                {
+                    throw new Exception($"Failed to report the current SDK version:\n{stdout}\n{stderr}");
+                }
+
+                MatchCollection matches = Regex.Matches(stdout, "_CurrentSdkVersion=(?<SdkVersion>.*)$", RegexOptions.Multiline);
+                if (matches.Count == 0)
+                {
+                    throw new Exception($"Failed to find the current SDK version in the output:\n{stdout}");
+                }
+
+                string sdkVersionString = matches.First().Groups["SdkVersion"].Value.Trim();
+
+                // find the actual SDK directory
+                string privateCoreLibPath = typeof(object).Assembly.Location; // e.g., C:\Program Files\dotnet\shared\Microsoft.NETCore.App\8.0.4\System.Private.CoreLib.dll
+                string sdkDirectory = Path.Combine(Path.GetDirectoryName(privateCoreLibPath)!, "..", "..", "..", "sdk", sdkVersionString); // e.g., C:\Program Files\dotnet\sdk\8.0.204
+                string bundledVersionsPropsPath = Path.Combine(sdkDirectory, "Microsoft.NETCoreSdk.BundledVersions.props");
+                FileInfo normalizedPath = new(bundledVersionsPropsPath);
+                return normalizedPath.FullName;
+            }
+            finally
+            {
+                projectDir.Delete(recursive: true);
+            }
+        });
+
+        private static readonly Dictionary<string, MockNuGetPackage> WellKnownPackages = new();
+        public static MockNuGetPackage WellKnownReferencePackage(string packageName, string targetFramework, (string Path, byte[] Content)[]? files = null)
+        {
+            string key = $"{packageName}/{targetFramework}";
+            if (!WellKnownPackages.ContainsKey(key))
+            {
+                // for the current SDK, the file `Microsoft.NETCoreSdk.BundledVersions.props` contains the version of the
+                // `Microsoft.WindowsDesktop.App.Ref` package that will be needed to build, so we find it by TFM
+                XDocument propsDocument = XDocument.Load(BundledVersionsPropsPath.Value);
+                XElement? matchingFrameworkElement = propsDocument.XPathSelectElement(
+                    $"""
+                    /Project/ItemGroup/KnownFrameworkReference
+                        [
+                            @Include='{packageName}' and
+                            @TargetingPackName='{packageName}.Ref' and
+                            @TargetFramework='{targetFramework}'
+                        ]
+                    """);
+                if (matchingFrameworkElement is null)
+                {
+                    throw new Exception($"Unable to find {packageName}.Ref version for target framework '{targetFramework}'");
+                }
+
+                string expectedVersion = matchingFrameworkElement.Attribute("TargetingPackVersion")!.Value;
+                return new(
+                    $"{packageName}.Ref",
+                    expectedVersion,
+                    AdditionalMetadata:
+                    [
+                        new XElement("packageTypes",
+                            new XElement("packageType",
+                                new XAttribute("name", "DotnetPlatform")
+                            )
+                        )
+                    ],
+                    Files: files
+                );
+            }
+
+            return WellKnownPackages[key];
+        }
+
+        public static MockNuGetPackage[] CommonPackages { get; } =
+        [
+            CreateSimplePackage("NETStandard.Library", "2.0.3", "netstandard2.0"),
+            new MockNuGetPackage("Microsoft.NETFramework.ReferenceAssemblies", "1.0.3"),
+            WellKnownReferencePackage("Microsoft.AspNetCore.App", "net6.0"),
+            WellKnownReferencePackage("Microsoft.AspNetCore.App", "net7.0"),
+            WellKnownReferencePackage("Microsoft.AspNetCore.App", "net8.0"),
+            WellKnownReferencePackage("Microsoft.NETCore.App", "net6.0",
+            [
+                ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
+                    <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="6.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime">
+                    </FileList>
+                    """))
+            ]),
+            WellKnownReferencePackage("Microsoft.NETCore.App", "net7.0",
+            [
+                ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
+                    <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="7.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime">
+                    </FileList>
+                    """))
+            ]),
+            WellKnownReferencePackage("Microsoft.NETCore.App", "net8.0",
+            [
+                ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
+                    <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="8.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime">
+                    </FileList>
+                    """))
+            ]),
+            WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net6.0"),
+            WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net7.0"),
+            WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net8.0"),
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="DiffPlex" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DirsProj.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DirsProj.cs
@@ -1,7 +1,3 @@
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -13,94 +9,111 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UpdateSingleDependencyInDirsProj()
         {
-            await TestUpdateForDirsProj("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForDirsProj("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/test-project.csproj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/test-project.csproj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("src/test-project.csproj",
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/test-project.csproj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/test-project.csproj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("src/test-project.csproj",
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task Update_MissingFileDoesNotThrow()
         {
-            await TestUpdateForDirsProj("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForDirsProj("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.Build.Traversal">
-                  <ItemGroup>
-                    <ProjectReference Include="private\dirs.proj" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.Build.Traversal">
+                      <ItemGroup>
+                        <ProjectReference Include="private\dirs.proj" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.Build.Traversal">
-                  <ItemGroup>
-                    <ProjectReference Include="private\dirs.proj" />
-                  </ItemGroup>
-                </Project>
-                """,
-                additionalFiles: []);
+                    <Project Sdk="Microsoft.Build.Traversal">
+                      <ItemGroup>
+                        <ProjectReference Include="private\dirs.proj" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFiles: []
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInNestedDirsProj()
         {
-            await TestUpdateForDirsProj("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForDirsProj("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/dirs.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/dirs.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("src/dirs.proj",
@@ -117,25 +130,25 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/dirs.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/dirs.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("src/dirs.proj",
@@ -152,31 +165,37 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInNestedDirsProjUsingWildcard()
         {
-            await TestUpdateForDirsProj("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForDirsProj("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/*.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/*.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("src/dirs.proj",
@@ -193,25 +212,25 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="src/*.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="src/*.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("src/dirs.proj",
@@ -228,31 +247,37 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInNestedDirsProjUsingRecursiveWildcard()
         {
-            await TestUpdateForDirsProj("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForDirsProj("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="**/*.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="**/*.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("src/dirs.proj",
@@ -269,25 +294,25 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.Build.NoTargets">
+                    <Project Sdk="Microsoft.Build.NoTargets">
 
-                  <ItemGroup>
-                    <ProjectReference Include="**/*.proj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="**/*.proj" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("src/dirs.proj",
@@ -304,15 +329,16 @@ public partial class UpdateWorkerTests
                         """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         static async Task TestUpdateForDirsProj(
@@ -323,7 +349,8 @@ public partial class UpdateWorkerTests
             string expectedProjectContents,
             bool isTransitive = false,
             (string Path, string Content)[]? additionalFiles = null,
-            (string Path, string Content)[]? additionalFilesExpected = null)
+            (string Path, string Content)[]? additionalFilesExpected = null,
+            MockNuGetPackage[]? packages = null)
         {
             additionalFiles ??= [];
             additionalFilesExpected ??= [];
@@ -334,6 +361,8 @@ public partial class UpdateWorkerTests
 
             var actualResult = await RunUpdate(testFiles, async (temporaryDirectory) =>
             {
+                await MockNuGetPackagesInDirectory(packages, temporaryDirectory);
+
                 var projectPath = Path.Combine(temporaryDirectory, projectFileName);
                 var worker = new UpdaterWorker(new Logger(verbose: true));
                 await worker.RunAsync(temporaryDirectory, projectPath, dependencyName, oldVersion, newVersion, isTransitive);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -11,37 +9,51 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task NoChangeWhenDotNetToolsJsonNotFound()
         {
-            await TestNoChangeforProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+            await TestNoChangeforProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task NoChangeWhenDependencyNotFound()
         {
-            await TestNoChangeforProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+            await TestNoChangeforProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some-Other-Tool", "2.0.0", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     (".config/dotnet-tools.json", """
@@ -49,35 +61,43 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "dotnetsay": {
-                              "version": "2.1.3",
+                            "some-other-tool": {
+                              "version": "2.0.0",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task NoChangeWhenDotNetToolsJsonInUnexpectedLocation()
         {
-            await TestNoChangeforProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+            await TestNoChangeforProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some-Other-Tool", "2.0.0", "net8.0"),
+                ],
                 // initial
                 projectFilePath: "src/project/project.csproj",
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("eng/.config/dotnet-tools.json", """
@@ -85,34 +105,41 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "dotnetsay": {
-                              "version": "2.1.3",
+                            "some-other-tool": {
+                              "version": "2.0.0",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
-        public async Task UpdateSingleDependencyInDirsProj()
+        public async Task UpdateSingleDependency()
         {
-            await TestUpdateForProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+            await TestUpdateForProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     (".config/dotnet-tools.json", """
@@ -120,16 +147,16 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "microsoft.botsay": {
+                            "some.dotnet.tool": {
                               "version": "1.0.0",
                               "commands": [
-                                "botsay"
+                                "some.dotnet.tool"
                               ]
                             },
-                            "dotnetsay": {
+                            "some-other-tool": {
                               "version": "2.1.3",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
@@ -138,16 +165,16 @@ public partial class UpdateWorkerTests
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     (".config/dotnet-tools.json", """
@@ -155,40 +182,47 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "microsoft.botsay": {
+                            "some.dotnet.tool": {
                               "version": "1.1.0",
                               "commands": [
-                                "botsay"
+                                "some.dotnet.tool"
                               ]
                             },
-                            "dotnetsay": {
+                            "some-other-tool": {
                               "version": "2.1.3",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyWithComments()
         {
-            await TestUpdateForProject("Microsoft.BotSay", "1.0.0", "1.1.0",
+            await TestUpdateForProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     (".config/dotnet-tools.json", """
@@ -197,17 +231,17 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "microsoft.botsay": {
+                            "some.dotnet.tool": {
                               // this is a deep comment
                               "version": "1.0.0",
                               "commands": [
-                                "botsay"
+                                "some.dotnet.tool"
                               ]
                             },
-                            "dotnetsay": {
+                            "some-other-tool": {
                               "version": "2.1.3",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
@@ -216,16 +250,16 @@ public partial class UpdateWorkerTests
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     (".config/dotnet-tools.json", """
@@ -234,23 +268,24 @@ public partial class UpdateWorkerTests
                           "version": 1,
                           "isRoot": true,
                           "tools": {
-                            "microsoft.botsay": {
+                            "some.dotnet.tool": {
                               // this is a deep comment
                               "version": "1.1.0",
                               "commands": [
-                                "botsay"
+                                "some.dotnet.tool"
                               ]
                             },
-                            "dotnetsay": {
+                            "some-other-tool": {
                               "version": "2.1.3",
                               "commands": [
-                                "dotnetsay"
+                                "some-other-tool"
                               ]
                             }
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -12,36 +10,39 @@ public partial class UpdateWorkerTests
         public async Task NoChangeWhenGlobalJsonNotFound()
         {
             await TestNoChangeforProject("Microsoft.Build.Traversal", "3.2.0", "4.1.0",
+                packages: [],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task NoChangeWhenDependencyNotFound()
         {
             await TestNoChangeforProject("Microsoft.Build.Traversal", "3.2.0", "4.1.0",
+                packages: [],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("global.json", """
@@ -52,26 +53,28 @@ public partial class UpdateWorkerTests
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task NoChangeWhenGlobalJsonInUnexpectedLocation()
         {
             await TestNoChangeforProject("Microsoft.Build.Traversal", "3.2.0", "4.1.0",
+                packages: [],
                 // initial
                 projectFilePath: "src/project/project.csproj",
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("eng/global.json", """
@@ -85,26 +88,33 @@ public partial class UpdateWorkerTests
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependency()
         {
-            await TestUpdateForProject("Microsoft.Build.Traversal", "3.2.0", "4.1.0",
+            await TestUpdateForProject("Some.MSBuild.Sdk", "3.2.0", "4.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "3.2.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "4.1.0"),
+                ],
                 // initial
                 projectFilePath: "src/project/project.csproj",
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("src/global.json", """
@@ -114,23 +124,23 @@ public partial class UpdateWorkerTests
                             "rollForward": "latestPatch"
                           },
                           "msbuild-sdks": {
-                            "Microsoft.Build.Traversal": "3.2.0"
+                            "Some.MSBuild.Sdk": "3.2.0"
                           }
                         }
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("src/global.json", """
@@ -140,29 +150,36 @@ public partial class UpdateWorkerTests
                             "rollForward": "latestPatch"
                           },
                           "msbuild-sdks": {
-                            "Microsoft.Build.Traversal": "4.1.0"
+                            "Some.MSBuild.Sdk": "4.1.0"
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateDependencyWithComments()
         {
-            await TestUpdateForProject("Microsoft.Build.Traversal", "3.2.0", "4.1.0",
+            await TestUpdateForProject("Some.MSBuild.Sdk", "3.2.0", "4.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "3.2.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "4.1.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("global.json", """
@@ -174,23 +191,23 @@ public partial class UpdateWorkerTests
                           },
                           "msbuild-sdks": {
                             // this is a deep comment
-                            "Microsoft.Build.Traversal": "3.2.0"
+                            "Some.MSBuild.Sdk": "3.2.0"
                           }
                         }
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
                 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("global.json", """
@@ -202,11 +219,12 @@ public partial class UpdateWorkerTests
                           },
                           "msbuild-sdks": {
                             // this is a deep comment
-                            "Microsoft.Build.Traversal": "4.1.0"
+                            "Some.MSBuild.Sdk": "4.1.0"
                           }
                         }
                         """)
-                ]);
+                ]
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -11,74 +9,79 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task ForPackagesProject_UpdatePackageReference_InBuildProps()
         {
-            // update Newtonsoft.Json from 7.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // update Some.Package from 7.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
-                          <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
                         """),
                     ("Directory.Build.props", """
                         <Project>
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                            <PackageReference Include="Some.Package" Version="7.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
-                          <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+                          <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
                         """),
                     ("Directory.Build.props", """
                         <Project>
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -9,120 +9,140 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfig()
         {
-            // update Newtonsoft.Json from 7.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // update Some.Package from 7.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfig_ReferenceHasNoAssemblyVersion()
         {
-            // update Newtonsoft.Json from 7.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // update Some.Package from 7.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfig_SpecifiedDependencyHasNoPackagesPath()
         {
-            // update jQuery from 1.6.4 to 3.7.1
-            await TestUpdateForProject("jQuery", "1.6.4", "3.7.1",
+            // update Package.With.No.Assembly from 1.0.0
+            await TestUpdateForProject("Package.With.No.Assembly", "1.0.0", "1.1.0",
+                packages:
+                [
+                    // this package has no `lib` directory, but it's still valid because it has a `content` directory
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.0.0", Files: [("content/some-content.txt", [])]),
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.1.0", Files: [("content/some-content.txt", [])]),
+                    // this is a regular package that's not being updated
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net46"),
+                ],
                 // existing
                 projectContents: """
                     <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -134,8 +154,8 @@ public partial class UpdateWorkerTests
                         <None Include="packages.config" />
                       </ItemGroup>
                       <ItemGroup>
-                        <Reference Include="Newtonsoft.Json">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.1.0.0\lib\net46\Some.Package.dll</HintPath>
                           <Private>True</Private>
                         </Reference>
                       </ItemGroup>
@@ -144,8 +164,8 @@ public partial class UpdateWorkerTests
                     """,
                 packagesConfigContents: """
                     <packages>
-                      <package id="jQuery" version="1.6.4" targetFramework="net45" />
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                      <package id="Package.With.No.Assembly" version="1.0.0" targetFramework="net46" />
+                      <package id="Some.Package" version="1.0.0" targetFramework="net46" />
                     </packages>
                     """,
                 // expected
@@ -159,8 +179,8 @@ public partial class UpdateWorkerTests
                         <None Include="packages.config" />
                       </ItemGroup>
                       <ItemGroup>
-                        <Reference Include="Newtonsoft.Json">
-                          <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.1.0.0\lib\net46\Some.Package.dll</HintPath>
                           <Private>True</Private>
                         </Reference>
                       </ItemGroup>
@@ -170,8 +190,8 @@ public partial class UpdateWorkerTests
                 expectedPackagesConfigContents: """
                     <?xml version="1.0" encoding="utf-8"?>
                     <packages>
-                      <package id="jQuery" version="3.7.1" targetFramework="net46" />
-                      <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+                      <package id="Package.With.No.Assembly" version="1.1.0" targetFramework="net46" />
+                      <package id="Some.Package" version="1.0.0" targetFramework="net46" />
                     </packages>
                     """
             );
@@ -180,8 +200,14 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfig_NoPackagesPathCanBeFound()
         {
-            // update jQuery from 3.7.0 to 3.7.1
-            await TestUpdateForProject("jQuery", "3.7.0", "3.7.1",
+            // update Package.With.No.Assembly from 1.0.0 to 1.0.0
+            await TestUpdateForProject("Package.With.No.Assembly", "1.0.0", "1.1.0",
+                packages:
+                [
+                    // this package has no `lib` directory, but it's still valid because it has a `content` directory
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.0.0", Files: [("content/some-content.txt", [])]),
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.1.0", Files: [("content/some-content.txt", [])]),
+                ],
                 // existing
                 projectContents: """
                     <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -197,7 +223,7 @@ public partial class UpdateWorkerTests
                     """,
                 packagesConfigContents: """
                     <packages>
-                      <package id="jQuery" version="3.7.0" targetFramework="net45" />
+                      <package id="Package.With.No.Assembly" version="1.0.0" targetFramework="net45" />
                     </packages>
                     """,
                 // expected
@@ -216,219 +242,299 @@ public partial class UpdateWorkerTests
                 expectedPackagesConfigContents: """
                     <?xml version="1.0" encoding="utf-8"?>
                     <packages>
-                      <package id="jQuery" version="3.7.1" targetFramework="net45" />
+                      <package id="Package.With.No.Assembly" version="1.1.0" targetFramework="net45" />
                     </packages>
-                    """);
+                    """
+            );
+        }
+
+        [Fact]
+        public async Task UpdateDependency_NoAssembliesAndContentDirectoryDiffersByCase()
+        {
+            // update Package.With.No.Assembly from 1.0.0 to 1.0.0
+            await TestUpdateForProject("Package.With.No.Assembly", "1.0.0", "1.1.0",
+                packages:
+                [
+                    // this package is expected to have a directory named `content`, but here it differs by case as `Content`
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.0.0", Files: [("Content/some-content.txt", [])]),
+                    new MockNuGetPackage("Package.With.No.Assembly", "1.1.0", Files: [("Content/some-content.txt", [])]),
+                ],
+                // existing
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="Package.With.No.Assembly" version="1.0.0" targetFramework="net45" />
+                    </packages>
+                    """,
+                // expected
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Package.With.No.Assembly" version="1.1.0" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateSingleDependencyInPackagesConfigButNotToLatest()
         {
-            // update Newtonsoft.Json from 7.0.1 to 9.0.1, purposefully not updating all the way to the newest
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "9.0.1",
+            // update Some.Package from 7.0.1 to 9.0.1, purposefully not updating all the way to the newest
+            await TestUpdateForProject("Some.Package", "7.0.1", "9.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.9.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="9.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateSpecifiedVersionInPackagesConfigButNotOthers()
         {
-            // update Newtonsoft.Json from 7.0.1 to 13.0.1, but leave HtmlAgilityPack alone
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // update Some.Package from 7.0.1 to 13.0.1, but leave Some.Unrelated.Package alone
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    // this package is upgraded
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                    // this package is not upgraded
+                    MockNuGetPackage.CreateSimplePackage("Some.Unrelated.Package", "1.0.0", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Unrelated.Package", "1.1.0", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="HtmlAgilityPack, Version=1.11.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\HtmlAgilityPack.1.11.0\lib\net45\HtmlAgilityPack.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="HtmlAgilityPack" version="1.11.0" targetFramework="net45" />
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Unrelated.Package" version="1.0.0" targetFramework="net45" />
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="HtmlAgilityPack, Version=1.11.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\HtmlAgilityPack.1.11.0\lib\net45\HtmlAgilityPack.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="HtmlAgilityPack" version="1.11.0" targetFramework="net45" />
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Unrelated.Package" version="1.0.0" targetFramework="net45" />
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePackagesConfigWithNonStandardLocationOfPackagesDirectory()
         {
-            // update Newtonsoft.Json from 7.0.1 to 13.0.1 with the actual assembly in a non-standard location
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // update Some.Package from 7.0.1 to 13.0.1 with the actual assembly in a non-standard location
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 // existing
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>some-non-standard-location\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>some-non-standard-location\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>some-non-standard-location\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>some-non-standard-location\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateBindingRedirectInAppConfig()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                ],
                 projectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="app.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFiles:
                 [
                     ("app.config", """
@@ -436,7 +542,7 @@ public partial class UpdateWorkerTests
                           <runtime>
                             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
                               <dependentAssembly>
-                                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
                                 <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
                               </dependentAssembly>
                             </assemblyBinding>
@@ -445,32 +551,32 @@ public partial class UpdateWorkerTests
                         """)
                 ],
                 expectedProjectContents: """
-                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-                  <PropertyGroup>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="app.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                  </ItemGroup>
-                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-                </Project>
-                """,
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFilesExpected:
                 [
                     ("app.config", """
@@ -478,104 +584,110 @@ public partial class UpdateWorkerTests
                           <runtime>
                             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
                               <dependentAssembly>
-                                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
                                 <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
                               </dependentAssembly>
                             </assemblyBinding>
                           </runtime>
                         </configuration>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateBindingRedirectInWebConfig()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                ],
                 projectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                    <Content Include="web.config" />
-                    <Content Include="web.Debug.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                    <Content Include="web.Release.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                        <Content Include="web.config" />
+                        <Content Include="web.Debug.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                        <Content Include="web.Release.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFiles:
                 [
                     ("web.config", """
@@ -583,7 +695,7 @@ public partial class UpdateWorkerTests
                           <runtime>
                             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
                               <dependentAssembly>
-                                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
                                 <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
                               </dependentAssembly>
                             </assemblyBinding>
@@ -592,90 +704,90 @@ public partial class UpdateWorkerTests
                         """)
                 ],
                 expectedProjectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                    <Content Include="web.config" />
-                    <Content Include="web.Debug.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                    <Content Include="web.Release.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                        <Content Include="web.config" />
+                        <Content Include="web.Debug.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                        <Content Include="web.Release.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFilesExpected:
                 [
                     ("web.config", """
@@ -683,104 +795,110 @@ public partial class UpdateWorkerTests
                           <runtime>
                             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
                               <dependentAssembly>
-                                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
                                 <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
                               </dependentAssembly>
                             </assemblyBinding>
                           </runtime>
                         </configuration>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task AddsBindingRedirectInWebConfig()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                ],
                 projectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                    <Content Include="web.config" />
-                    <Content Include="web.Debug.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                    <Content Include="web.Release.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                        <Content Include="web.config" />
+                        <Content Include="web.Debug.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                        <Content Include="web.Release.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFiles:
                 [
                     ("web.config", """
@@ -791,90 +909,90 @@ public partial class UpdateWorkerTests
                         """)
                 ],
                 expectedProjectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                    <Content Include="web.config" />
-                    <Content Include="web.Debug.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                    <Content Include="web.Release.config">
-                      <DependentUpon>web.config</DependentUpon>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                        <Content Include="web.config" />
+                        <Content Include="web.Debug.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                        <Content Include="web.Release.config">
+                          <DependentUpon>web.config</DependentUpon>
+                        </Content>
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 additionalFilesExpected:
                 [
                     ("web.config", """
@@ -882,345 +1000,358 @@ public partial class UpdateWorkerTests
                           <runtime>
                             <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
                               <dependentAssembly>
-                                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
                                 <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
                               </dependentAssembly>
                             </assemblyBinding>
                           </runtime>
                         </configuration>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task PackagesConfigUpdateCanHappenEvenWithMismatchedVersionNumbers()
         {
             // `packages.config` reports `7.0.1` and that's what we want to update, but the project file has a mismatch that's corrected
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 projectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                          <HintPath>packages\Some.Package.6.0.8\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 expectedProjectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>ac83fc79-b637-445b-acb0-9be238ad077f</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
         public async Task PackagesConfigUpdateIsNotThwartedBy_VSToolsPath_PropertyBeingSetInUserCode()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net45"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net45"),
+                ],
                 projectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>68ed3303-52a0-47b8-a687-3abbb07530da</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <PropertyGroup>
-                    <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->
-                    <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
-                  </PropertyGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>68ed3303-52a0-47b8-a687-3abbb07530da</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <PropertyGroup>
+                        <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->
+                        <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
+                      </PropertyGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 packagesConfigContents: """
-                <packages>
-                  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-                </packages>
-                """,
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
                 expectedProjectContents: """
-                <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                  <PropertyGroup>
-                    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-                    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-                    <ProductVersion>
-                    </ProductVersion>
-                    <SchemaVersion>2.0</SchemaVersion>
-                    <ProjectGuid>68ed3303-52a0-47b8-a687-3abbb07530da</ProjectGuid>
-                    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-                    <OutputType>Library</OutputType>
-                    <AppDesignerFolder>Properties</AppDesignerFolder>
-                    <RootNamespace>TestProject</RootNamespace>
-                    <AssemblyName>TestProject</AssemblyName>
-                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-                    <DebugSymbols>true</DebugSymbols>
-                    <DebugType>full</DebugType>
-                    <Optimize>false</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>DEBUG;TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-                    <DebugType>pdbonly</DebugType>
-                    <Optimize>true</Optimize>
-                    <OutputPath>bin\</OutputPath>
-                    <DefineConstants>TRACE</DefineConstants>
-                    <ErrorReport>prompt</ErrorReport>
-                    <WarningLevel>4</WarningLevel>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Reference Include="Microsoft.CSharp" />
-                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-                      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-                      <Private>True</Private>
-                    </Reference>
-                    <Reference Include="System.Web.DynamicData" />
-                    <Reference Include="System.Web.Entity" />
-                    <Reference Include="System.Web.ApplicationServices" />
-                    <Reference Include="System" />
-                    <Reference Include="System.Data" />
-                    <Reference Include="System.Core" />
-                    <Reference Include="System.Data.DataSetExtensions" />
-                    <Reference Include="System.Web.Extensions" />
-                    <Reference Include="System.Xml.Linq" />
-                    <Reference Include="System.Drawing" />
-                    <Reference Include="System.Web" />
-                    <Reference Include="System.Xml" />
-                    <Reference Include="System.Configuration" />
-                    <Reference Include="System.Web.Services" />
-                    <Reference Include="System.EnterpriseServices" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <None Include="packages.config" />
-                  </ItemGroup>
-                  <ItemGroup>
-                    <Compile Include="Properties\AssemblyInfo.cs" />
-                  </ItemGroup>
-                  <PropertyGroup>
-                    <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->
-                    <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
-                  </PropertyGroup>
-                  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-                  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-                        Other similar extension points exist, see Microsoft.Common.targets.
-                  <Target Name="BeforeBuild">
-                  </Target>
-                  <Target Name="AfterBuild">
-                  </Target>
-                  -->
-                </Project>
-                """,
+                    <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <PropertyGroup>
+                        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+                        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+                        <ProductVersion>
+                        </ProductVersion>
+                        <SchemaVersion>2.0</SchemaVersion>
+                        <ProjectGuid>68ed3303-52a0-47b8-a687-3abbb07530da</ProjectGuid>
+                        <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+                        <OutputType>Library</OutputType>
+                        <AppDesignerFolder>Properties</AppDesignerFolder>
+                        <RootNamespace>TestProject</RootNamespace>
+                        <AssemblyName>TestProject</AssemblyName>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+                        <DebugSymbols>true</DebugSymbols>
+                        <DebugType>full</DebugType>
+                        <Optimize>false</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>DEBUG;TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+                        <DebugType>pdbonly</DebugType>
+                        <Optimize>true</Optimize>
+                        <OutputPath>bin\</OutputPath>
+                        <DefineConstants>TRACE</DefineConstants>
+                        <ErrorReport>prompt</ErrorReport>
+                        <WarningLevel>4</WarningLevel>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <Reference Include="Microsoft.CSharp" />
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="System.Web.DynamicData" />
+                        <Reference Include="System.Web.Entity" />
+                        <Reference Include="System.Web.ApplicationServices" />
+                        <Reference Include="System" />
+                        <Reference Include="System.Data" />
+                        <Reference Include="System.Core" />
+                        <Reference Include="System.Data.DataSetExtensions" />
+                        <Reference Include="System.Web.Extensions" />
+                        <Reference Include="System.Xml.Linq" />
+                        <Reference Include="System.Drawing" />
+                        <Reference Include="System.Web" />
+                        <Reference Include="System.Xml" />
+                        <Reference Include="System.Configuration" />
+                        <Reference Include="System.Web.Services" />
+                        <Reference Include="System.EnterpriseServices" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <PropertyGroup>
+                        <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->
+                        <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
+                      </PropertyGroup>
+                      <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+                            Other similar extension points exist, see Microsoft.Common.targets.
+                      <Target Name="BeforeBuild">
+                      </Target>
+                      <Target Name="AfterBuild">
+                      </Target>
+                      -->
+                    </Project>
+                    """,
                 expectedPackagesConfigContents: """
-                <?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-                </packages>
-                """);
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """
+            );
         }
 
         [Fact]
@@ -1298,7 +1429,8 @@ public partial class UpdateWorkerTests
             string expectedProjectContents,
             string expectedPackagesConfigContents,
             (string Path, string Content)[]? additionalFiles = null,
-            (string Path, string Content)[]? additionalFilesExpected = null)
+            (string Path, string Content)[]? additionalFilesExpected = null,
+            MockNuGetPackage[]? packages = null)
         {
             var realizedAdditionalFiles = new List<(string Path, string Content)>
             {
@@ -1325,7 +1457,8 @@ public partial class UpdateWorkerTests
                 projectContents,
                 expectedProjectContents,
                 additionalFiles: realizedAdditionalFiles.ToArray(),
-                additionalFilesExpected: realizedAdditionalFilesExpected.ToArray());
+                additionalFilesExpected: realizedAdditionalFilesExpected.ToArray(),
+                packages: packages);
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -1,4 +1,5 @@
-using System.Threading.Tasks;
+using System.Linq;
+using System.Text;
 
 using Xunit;
 
@@ -10,160 +11,180 @@ public partial class UpdateWorkerTests
     {
         [Theory]
         [InlineData("net472")]
-        [InlineData("netstandard2.0")]
-        [InlineData("net5.0")]
-        [InlineData("net6.0")]
         [InlineData("net7.0")]
         [InlineData("net8.0")]
         public async Task UpdateVersionAttribute_InProjectFile_ForPackageReferenceInclude(string tfm)
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", tfm),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", tfm),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>{tfm}</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>{tfm}</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>{tfm}</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>{tfm}</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionChildElement_InProjectFile_ForPackageReferenceInclude()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json">
-                      <Version>9.0.1</Version>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package">
+                          <Version>9.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json">
-                      <Version>13.0.1</Version>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package">
+                          <Version>13.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """
+              );
         }
 
         [Fact]
         public async Task UpdateVersions_InProjectFile_ForDuplicatePackageReferenceInclude()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                    <PackageReference Include="Newtonsoft.Json">
-                        <Version>9.0.1</Version>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                        <PackageReference Include="Some.Package">
+                            <Version>9.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                    <PackageReference Include="Newtonsoft.Json">
-                        <Version>13.0.1</Version>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                        <PackageReference Include="Some.Package">
+                            <Version>13.0.1</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task PartialUpdate_InMultipleProjectFiles_ForVersionConstraint()
         {
-            // update Newtonsoft.Json from 12.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            // update Some.Package from 12.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-                    <ProjectReference Include="../Project/Project.csproj" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="12.0.1" />
+                        <ProjectReference Include="../Project/Project.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     (Path: "src/Project/Project.csproj", Content: """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="[12.0.1, 13.0.0)" />
+                            <PackageReference Include="Some.Package" Version="[12.0.1, 13.0.0)" />
                           </ItemGroup>
                         </Project>
                         """),
                 ],
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                    <ProjectReference Include="../Project/Project.csproj" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                        <ProjectReference Include="../Project/Project.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     (Path: "src/Project/Project.csproj", Content: """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFramework>netstandard2.0</TargetFramework>
+                            <TargetFramework>net8.0</TargetFramework>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="[12.0.1, 13.0.0)" />
+                            <PackageReference Include="Some.Package" Version="[12.0.1, 13.0.0)" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -173,57 +194,82 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForPackageReferenceInclude_Windows()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                    // necessary for the `net8.0-windows10.0.19041.0` TFM
+                    new("Microsoft.Windows.SDK.NET.Ref", "10.0.19041.31", Files:
+                    [
+                        ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
+                            <FileList Name="Windows SDK .NET 6.0">
+                              <!-- contents omitted -->
+                            </FileList>
+                            """)),
+                        ("data/RuntimeList.xml", Encoding.UTF8.GetBytes("""
+                            <FileList Name="Windows SDK .NET 6.0" TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="6.0" FrameworkName="Microsoft.Windows.SDK.NET.Ref">
+                              <!-- contents omitted -->
+                            </FileList>
+                            """)),
+                    ]),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-                    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+                        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
-                    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+                        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InMultipleProjectFiles_ForPackageReferenceInclude()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <ProjectReference Include="lib\Library.csproj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="lib\Library.csproj" />
+                      </ItemGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("lib/Library.csproj", $"""
@@ -233,27 +279,27 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <ProjectReference Include="lib\Library.csproj" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="lib\Library.csproj" />
+                      </ItemGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("lib/Library.csproj", $"""
@@ -263,7 +309,7 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
@@ -271,94 +317,120 @@ public partial class UpdateWorkerTests
         }
 
         [Theory]
-        [InlineData("$(NewtonsoftJsonVersion")]
-        [InlineData("$NewtonsoftJsonVersion)")]
-        [InlineData("$NewtonsoftJsonVersion")]
-        [InlineData("NewtonsoftJsonVersion)")]
+        [InlineData("$(SomePackageVersion")]
+        [InlineData("$SomePackageVersion)")]
+        [InlineData("$SomePackageVersion")]
+        [InlineData("SomePackageVersion)")]
         public async Task Update_InvalidFile_DoesNotThrow(string versionString)
         {
-            await TestNoChangeforProject("Newtonsoft.Json", "9.0.1", "13.0.1",
-                $"""
-                <Project Sdk="Microsoft.NET.Sdk">">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="{versionString}" />
-                  </ItemGroup>
-                </Project>
-                """);
+            await TestNoChangeforProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
+                projectContents: $"""
+                    <Project Sdk="Microsoft.NET.Sdk">">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="{versionString}" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateFindsNearestNugetConfig_AndSucceeds()
         {
-            // Clean the cache to ensure we don't find a cached version of packages.
-            await ProcessEx.RunAsync("dotnet", "nuget locals -c all");
-            // If the Top-Level NugetConfig was found we would have failed.
-            var privateNugetContent = """
+            //
+            // this test needs a very specific setup to run, so we have to do it manually
+            //
+            using TemporaryDirectory tempDirectory = new();
+
+            // the top-level NuGet.Config has a package feed that doesn't exist
+            await File.WriteAllTextAsync(Path.Combine(tempDirectory.DirectoryPath, "NuGet.Config"), """
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
-
                   <packageSources>
                     <clear />
-                    <add key="nuget_PrivateFeed" value="https://api.nuget.org/v3/index.json" />
+                    <add key="local-feed" value="/var/path/that/does/not/exist" />
                   </packageSources>
                 </configuration>
-                """;
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
-                projectFile: (Path: "Directory/Project.csproj", Content: """
-                    <Project Sdk="Microsoft.NET.Sdk">
-                      <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
-                      </PropertyGroup>
-                      <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                      </ItemGroup>
-                    </Project>
-                    """),
                 """
+            );
+
+            // now place the "real" test files under `src/`
+            string srcDirectory = Path.Combine(tempDirectory.DirectoryPath, "src");
+            Directory.CreateDirectory(srcDirectory);
+
+            // the project file
+            string projectPath = Path.Combine(srcDirectory, "project.csproj");
+            await File.WriteAllTextAsync(projectPath, """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                    <PackageReference Include="Some.Package" Version="1.0.0" />
                   </ItemGroup>
                 </Project>
-                """,
-                additionalFiles:
+                """
+            );
+            // another NuGet.Config, but with a usable package feed
+            string packageFeedLocation = Path.Combine(tempDirectory.DirectoryPath, "test-package-feed");
+            Directory.CreateDirectory(packageFeedLocation);
+            await File.WriteAllTextAsync(Path.Combine(srcDirectory, "NuGet.Config"), $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="local-feed" value="{packageFeedLocation}" />
+                  </packageSources>
+                </configuration>
+                """
+            );
+            // populate some packages
+            foreach (MockNuGetPackage package in MockNuGetPackage.CommonPackages.Concat(
                 [
-                    (Path: "NuGet.config", Content: $"""
-                        <?xml version="1.0" encoding="utf-8"?>
-                        <configuration>
-                          <packageSources>
-                            <clear />
-                            <add key="nuget_PublicFeed" value="https://api.nuget.org/v3/BROKEN.json" />
-                          </packageSources>
-                        </configuration>
-                        """),
-                    (Path: "Directory/NuGet.config", Content: privateNugetContent)
-                ]);
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0")
+                ]))
+            {
+                package.WriteToDirectory(packageFeedLocation);
+            }
+
+            //
+            // do the update
+            //
+            UpdaterWorker worker = new(new(verbose: true));
+            await worker.RunAsync(tempDirectory.DirectoryPath, projectPath, "Some.Package", "1.0.0", "1.1.0", isTransitive: false);
+
+            //
+            // verify the update occurred
+            //
+            string actualProjectContents = await File.ReadAllTextAsync(projectPath);
+            Assert.Contains("Version=\"1.1.0\"", actualProjectContents);
         }
 
         [Fact]
         public async Task UpdateReturnsEmptyArray_WhenBuildFails()
         {
-            // Clean the cache to ensure we don't find a cached version of packages.
-            await ProcessEx.RunAsync("dotnet", $"nuget locals -c all");
-            await TestNoChangeforProject("Newtonsoft.Json", "9.0.1", "13.0.1",
-                """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+            await TestNoChangeforProject("Some.Package", "9.0.1", "13.0.1",
+                packages: [], // nothing specified, update will fail
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>netstandard2.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     (Path: "NuGet.config", Content: """
@@ -373,196 +445,233 @@ public partial class UpdateWorkerTests
                           </packageSources>
                         </configuration>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateExactMatchVersionAttribute_InProjectFile_ForPackageReferenceInclude()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                    <PropertyGroup>
-                        <TargetFramework>net6.0</TargetFramework>
-                    </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                        <PropertyGroup>
+                            <TargetFramework>net8.0</TargetFramework>
+                        </PropertyGroup>
 
-                    <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="[9.0.1]" />
-                    </ItemGroup>
-                </Project>
-                """,
+                        <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="[9.0.1]" />
+                        </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                    <PropertyGroup>
-                        <TargetFramework>net6.0</TargetFramework>
-                    </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                        <PropertyGroup>
+                            <TargetFramework>net8.0</TargetFramework>
+                        </PropertyGroup>
 
-                    <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="[13.0.1]" />
-                    </ItemGroup>
-                </Project>
-                """);
+                        <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="[13.0.1]" />
+                        </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task AddPackageReference_InProjectFile_ForTransientDependency()
         {
-            // add transient System.Text.Json from 5.0.1 to 5.0.2
-            await TestUpdateForProject("System.Text.Json", "5.0.1", "5.0.2", isTransitive: true,
+            // add transient package Some.Transient.Dependency from 5.0.1 to 5.0.2
+            await TestUpdateForProject("Some.Transient.Dependency", "5.0.1", "5.0.2", isTransitive: true,
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.1.3", "net8.0", [(null, [("Some.Transient.Dependency", "5.0.1")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transient.Dependency", "5.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transient.Dependency", "5.0.2", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>netcoreapp3.1</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" Version="3.1.3" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="3.1.3" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>netcoreapp3.1</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" Version="3.1.3" />
-                    <PackageReference Include="System.Text.Json" Version="5.0.2" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="3.1.3" />
+                        <PackageReference Include="Some.Transient.Dependency" Version="5.0.2" />
+                      </ItemGroup>
 
-                </Project>
-                """);
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForAnalyzerPackageReferenceInclude()
         {
-            // update Microsoft.CodeAnalysis.Analyzers from 3.3.0 to 3.3.4
-            await TestUpdateForProject("Microsoft.CodeAnalysis.Analyzers", "3.3.0", "3.3.4",
+            // update Some.Analyzer from 3.3.0 to 3.3.4
+            await TestUpdateForProject("Some.Analyzer", "3.3.0", "3.3.4",
+                packages:
+                [
+                    MockNuGetPackage.CreateAnalyzerPackage("Some.Analyzer", "3.3.0"),
+                    MockNuGetPackage.CreateAnalyzerPackage("Some.Analyzer", "3.3.4"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
-                      <PrivateAssets>all</PrivateAssets>
-                      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Analyzer" Version="3.3.0">
+                          <PrivateAssets>all</PrivateAssets>
+                          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
-                      <PrivateAssets>all</PrivateAssets>
-                      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-                    </PackageReference>
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Analyzer" Version="3.3.4">
+                          <PrivateAssets>all</PrivateAssets>
+                          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForMultiplePackageReferences()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.JSON" Version="9.0.1" />
-                    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.PACKAGE" Version="9.0.1" />
+                        <PackageReference Update="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.JSON" Version="13.0.1" />
-                    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.PACKAGE" Version="13.0.1" />
+                        <PackageReference Update="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForPackageReferenceUpdate()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                    <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Update="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Update="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InDirectoryPackages_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -572,23 +681,23 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="9.0.1" />
+                            <PackageVersion Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -598,30 +707,36 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+                            <PackageVersion Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateExactMatchVersionAttribute_InDirectoryPackages_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -631,23 +746,23 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="[9.0.1]" />
+                            <PackageVersion Include="Some.Package" Version="[9.0.1]" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -657,405 +772,465 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="[13.0.1]" />
+                            <PackageVersion Include="Some.Package" Version="[13.0.1]" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProjectFile_ForPackageReferenceIncludeWithExactVersion()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="[$(NewtonsoftJsonPackageVersion)]" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="[$(SomePackagePackageVersion)]" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="[$(NewtonsoftJsonPackageVersion)]" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="[$(SomePackagePackageVersion)]" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateDifferentCasedPropertyValue_InProjectFile_ForPackageReferenceInclude()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(newtonsoftjsonpackageversion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(somepackagepackageversion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(newtonsoftjsonpackageversion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(somepackagepackageversion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProjectFile_ForPackageReferenceInclude()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateExactMatchPropertyValue_InProjectFile_ForPackageReferenceInclude()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>[9.0.1]</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>[9.0.1]</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>[13.0.1]</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>[13.0.1]</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttributeAndPropertyValue_InProjectFile_ForMultiplePackageReferences()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProjectFile_ForPackageReferenceUpdate()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Update="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                    <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Update="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InDirectoryProps_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateExactMatchPropertyValue_InDirectoryProps_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>[9.0.1]</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>[9.0.1]</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>[13.0.1]</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>[13.0.1]</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateVersionOverrideAttributeAndPropertyValue_InProjectFileAndDirectoryProps_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" VersionOverride="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" VersionOverride="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" VersionOverride="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InDirectoryProps_ForGlobalPackageReference()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -1065,19 +1240,19 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <GlobalPackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+                            <GlobalPackageReference Include="Some.Package" Version="9.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -1087,191 +1262,215 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <GlobalPackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                            <GlobalPackageReference Include="Some.Package" Version="13.0.1" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InDirectoryProps_ForGlobalPackageReference()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <GlobalPackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <GlobalPackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <GlobalPackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <GlobalPackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InDirectoryProps_ForPackageReferenceInclude()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial project
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props file
                     ("Directory.Build.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // expected project
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props file
                     ("Directory.Build.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProps_ForPackageReferenceInclude()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial project
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <Import Project="my-properties.props" />
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Import Project="my-properties.props" />
 
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props file
                     ("my-properties.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // expected project
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <Import Project="my-properties.props" />
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Import Project="my-properties.props" />
 
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackagePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props file
                     ("my-properties.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProps_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props files
@@ -1283,30 +1482,30 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Version.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props files
@@ -1318,37 +1517,43 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Version.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValue_InProps_ThenSubstituted_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props files
@@ -1357,11 +1562,11 @@ public partial class UpdateWorkerTests
                           <Import Project="Version.props" />
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>$(NewtonsoftJsonVersion)</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>$(NewtonsoftJsonVersion)</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -1375,16 +1580,16 @@ public partial class UpdateWorkerTests
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props files
@@ -1393,11 +1598,11 @@ public partial class UpdateWorkerTests
                           <Import Project="Version.props" />
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>$(NewtonsoftJsonVersion)</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>$(NewtonsoftJsonVersion)</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
@@ -1408,26 +1613,32 @@ public partial class UpdateWorkerTests
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePropertyValues_InProps_ThenRedefinedAndSubstituted_ForPackageVersion()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props files
@@ -1436,35 +1647,35 @@ public partial class UpdateWorkerTests
                           <Import Project="Version.props" />
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>$(NewtonsoftJsonVersion)</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>$(SomePackageVersion)</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Version.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJSONVersion>9.0.1</NewtonsoftJSONVersion>
-                            <NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePACKAGEVersion>9.0.1</SomePACKAGEVersion>
+                            <SomePackagePackageVersion>9.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" />
-                  </ItemGroup>
-                </Project>
-                """,
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props files
@@ -1473,182 +1684,220 @@ public partial class UpdateWorkerTests
                           <Import Project="Version.props" />
                           <PropertyGroup>
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-                            <NewtonsoftJsonPackageVersion>$(NewtonsoftJsonVersion)</NewtonsoftJsonPackageVersion>
+                            <SomePackagePackageVersion>$(SomePackageVersion)</SomePackagePackageVersion>
                           </PropertyGroup>
 
                           <ItemGroup>
-                            <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+                            <PackageVersion Include="Some.Package" Version="$(SomePackagePackageVersion)" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Version.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJSONVersion>13.0.1</NewtonsoftJSONVersion>
-                            <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
+                            <SomePACKAGEVersion>13.0.1</SomePACKAGEVersion>
+                            <SomePackagePackageVersion>13.0.1</SomePackagePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePeerDependencyWithInlineVersion()
         {
-            await TestUpdateForProject("Microsoft.Extensions.Http", "2.2.0", "7.0.0",
+            await TestUpdateForProject("Some.Package", "2.2.0", "7.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.2.0", "net8.0", [(null, [("Peer.Package", "2.2.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net8.0", [(null, [("Peer.Package", "7.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "2.2.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "7.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="2.2.0" />
+                        <PackageReference Include="Peer.Package" Version="2.2.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.0" />
+                        <PackageReference Include="Peer.Package" Version="7.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePeerDependencyFromPropertyInSameFile()
         {
-            await TestUpdateForProject("Microsoft.Extensions.Http", "2.2.0", "7.0.0",
+            await TestUpdateForProject("Some.Package", "2.2.0", "7.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.2.0", "net8.0", [(null, [("Peer.Package", "2.2.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net8.0", [(null, [("Peer.Package", "7.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "2.2.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "7.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <MicrosoftExtensionsHttpVersion>2.2.0</MicrosoftExtensionsHttpVersion>
-                    <MicrosoftExtensionsLoggingVersion>2.2.0</MicrosoftExtensionsLoggingVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion>2.2.0</SomePackageVersion>
+                        <PeerPackageVersion>2.2.0</PeerPackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                        <PackageReference Include="Peer.Package" Version="$(PeerPackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <MicrosoftExtensionsHttpVersion>7.0.0</MicrosoftExtensionsHttpVersion>
-                    <MicrosoftExtensionsLoggingVersion>7.0.0</MicrosoftExtensionsLoggingVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion>7.0.0</SomePackageVersion>
+                        <PeerPackageVersion>7.0.0</PeerPackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                        <PackageReference Include="Peer.Package" Version="$(PeerPackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatePeerDependencyFromPropertyInDifferentFile()
         {
-            await TestUpdateForProject("Microsoft.Extensions.Http", "2.2.0", "7.0.0",
+            await TestUpdateForProject("Some.Package", "2.2.0", "7.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.2.0", "net8.0", [(null, [("Peer.Package", "2.2.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net8.0", [(null, [("Peer.Package", "7.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "2.2.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "7.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <Import Project="Versions.props" />
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Import Project="Versions.props" />
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                        <PackageReference Include="Peer.Package" Version="$(PeerPackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Versions.props", """
                         <Project>
                           <PropertyGroup>
-                            <MicrosoftExtensionsHttpVersion>2.2.0</MicrosoftExtensionsHttpVersion>
-                            <MicrosoftExtensionsLoggingVersion>2.2.0</MicrosoftExtensionsLoggingVersion>
+                            <SomePackageVersion>2.2.0</SomePackageVersion>
+                            <PeerPackageVersion>2.2.0</PeerPackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <Import Project="Versions.props" />
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Import Project="Versions.props" />
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                        <PackageReference Include="Peer.Package" Version="$(PeerPackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Versions.props", """
                         <Project>
                           <PropertyGroup>
-                            <MicrosoftExtensionsHttpVersion>7.0.0</MicrosoftExtensionsHttpVersion>
-                            <MicrosoftExtensionsLoggingVersion>7.0.0</MicrosoftExtensionsLoggingVersion>
+                            <SomePackageVersion>7.0.0</SomePackageVersion>
+                            <PeerPackageVersion>7.0.0</PeerPackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatePeerDependencyWithInlineVersionAndMultipleTfms()
         {
-            await TestUpdateForProject("Microsoft.Extensions.Http", "2.2.0", "7.0.0",
+            await TestUpdateForProject("Some.Package", "2.2.0", "7.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.2.0", "net7.0", [(null, [("Peer.Package", "2.2.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net7.0", [(null, [("Peer.Package", "7.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "2.2.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Peer.Package", "7.0.0", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="2.2.0" />
+                        <PackageReference Include="Peer.Package" Version="2.2.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.0" />
+                        <PackageReference Include="Peer.Package" Version="7.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task NoUpdateForPeerDependenciesWhichAreHigherVersion()
         {
-            await TestUpdateForProject("Microsoft.Identity.Web", "2.13.0", "2.13.2",
+            await TestUpdateForProject("Some.Package", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", [(null, [("Transitive.Dependency", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0", [(null, [("Transitive.Dependency", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "1.1.0", "net8.0"), // we shouldn't update to this
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Azure.Identity" />
-                    <PackageReference Include="Azure.Security.KeyVault.Keys" />
-                    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
-                    <PackageReference Include="Microsoft.Identity.Web" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Transitive.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -1658,27 +1907,23 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Azure.Identity" Version="1.9.0" />
-                            <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
-                            <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-                            <PackageVersion Include="Microsoft.Identity.Web" Version="2.13.0" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Transitive.Dependency" Version="1.0.0" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Azure.Identity" />
-                    <PackageReference Include="Azure.Security.KeyVault.Keys" />
-                    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
-                    <PackageReference Include="Microsoft.Identity.Web" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Transitive.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -1688,149 +1933,155 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Azure.Identity" Version="1.9.0" />
-                            <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
-                            <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-                            <PackageVersion Include="Microsoft.Identity.Web" Version="2.13.2" />
+                            <PackageVersion Include="Some.Package" Version="1.1.0" />
+                            <PackageVersion Include="Transitive.Dependency" Version="1.0.0" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task UpdatingToNotCompatiblePackageDoesNothing()
         {
-            await TestUpdateForProject("Microsoft.AspNetCore.Authentication.JwtBearer", "3.1.18", "7.0.5",
+            // can't upgrade to the newer package because of a TFM mismatch
+            await TestNoChangeforProject("Some.Package", "7.0.0", "8.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "8.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netcoreapp3.1</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-                  </ItemGroup>
-                </Project>
-                """,
-                expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netcoreapp3.1</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdatingToNotCompatiblePackageDoesNothingWithSingleOfMultileTfmNotSupported()
         {
-            // the requested package upgrade is supported on net7.0, but not netcoreapp3.1, so we skip the whole thing
-            await TestUpdateForProject("Microsoft.AspNetCore.Authentication.JwtBearer", "3.1.18", "7.0.5",
+            // can't upgrade to the newer package because one of the TFMs doesn't match
+            await TestNoChangeforProject("Some.Package", "7.0.0", "8.0.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "8.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-                  </ItemGroup>
-                </Project>
-                """,
-                expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_WhereTargetFrameworksIsSelfReferential()
         {
-            // update Newtonsoft.Json from 9.0.1 to 13.0.1
-            await TestUpdateForProject("Newtonsoft.Json", "9.0.1", "13.0.1",
+            // update Some.Package from 9.0.1 to 13.0.1
+            await TestUpdateForProject("Some.Package", "9.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "netstandard2.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "netstandard2.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net472'))">$(TargetFrameworks);net472</TargetFrameworks>
-                    <TargetFrameworks Condition="!$(TargetFrameworks.Contains('netstandard2.0'))">$(TargetFrameworks);netstandard2.0</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net472'))">$(TargetFrameworks);net472</TargetFrameworks>
+                        <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net8.0'))">$(TargetFrameworks);net8.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net472'))">$(TargetFrameworks);net472</TargetFrameworks>
-                    <TargetFrameworks Condition="!$(TargetFrameworks.Contains('netstandard2.0'))">$(TargetFrameworks);netstandard2.0</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net472'))">$(TargetFrameworks);net472</TargetFrameworks>
+                        <TargetFrameworks Condition="!$(TargetFrameworks.Contains('net8.0'))">$(TargetFrameworks);net8.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task UpdateOfNonExistantPackageDoesNothingEvenIfTransitiveDependencyIsPresent()
         {
-            // package Microsoft.Extensions.Http isn't present, but one of its transitive dependencies is
-            await TestUpdateForProject("Microsoft.Extensions.Http", "2.2.0", "7.0.0",
+            // package Some.Package isn't in the project, but one of its transitive dependencies is
+            await TestNoChangeforProject("Some.Package", "2.2.0", "7.0.0",
+                packages:
+                [
+                    // these packages exist in the feed, but aren't used
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.2.0", "net8.0", [(null, [("Transitive.Dependency", "2.2.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.0", "net8.0", [(null, [("Transitive.Dependency", "7.0.0")])]),
+                    // one of these is used, but we can't update to it
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "2.2.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "7.0.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-                  </ItemGroup>
-                </Project>
-                """,
-                expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Transitive.Dependency" Version="2.2.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task AvoidPackageDowngradeWhenUpdatingDependency()
         {
-            await TestUpdateForProject("Microsoft.VisualStudio.Sdk.TestFramework.Xunit", "17.2.7", "17.6.16",
+            // updating from 1.0.0 to 1.1.0 of Some.Package should not cause a downgrade warning of Some.Dependency; it
+            // should be pulled along, even when the TFM is pulled from a different file.  unrelated packages are ignored
+            await TestUpdateForProject("Some.Package", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", [(null, [("Some.Dependency", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0", [(null, [("Some.Dependency", "1.1.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Dependency", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Dependency", "1.1.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Unrelated.Package", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Unrelated.Package", "1.1.0", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>$(PreferredTargetFramework)</TargetFramework>
-                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-                    <RootNamespace />
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>$(PreferredTargetFramework)</TargetFramework>
+                        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                        <RootNamespace />
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-                    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework" />
-                    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
-                    <PackageReference Include="Moq" />
-                    <PackageReference Include="xunit.runner.visualstudio" />
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Package" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -1840,45 +2091,37 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework" Version="17.2.7" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.2.7" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.36389" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Text.Data" Version="17.6.268" />
-                            <PackageVersion Include="Moq" Version="4.18.2" />
-                            <PackageVersion Include="xunit" Version="2.5.0" />
-                            <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Dependency" Version="1.0.0" />
+                            <PackageVersion Include="Unrelated.Package" Version="1.0.0" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Directory.Build.props", """
                         <Project>
                           <PropertyGroup>
-                            <PreferredTargetFramework>net7.0</PreferredTargetFramework>
+                            <PreferredTargetFramework>net8.0</PreferredTargetFramework>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>$(PreferredTargetFramework)</TargetFramework>
-                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-                    <RootNamespace />
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>$(PreferredTargetFramework)</TargetFramework>
+                        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                        <RootNamespace />
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-                    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework" />
-                    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
-                    <PackageReference Include="Moq" />
-                    <PackageReference Include="xunit.runner.visualstudio" />
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Package" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -1888,45 +2131,47 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework" Version="17.6.16" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.6.16" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.6.36389" />
-                            <PackageVersion Include="Microsoft.VisualStudio.Text.Data" Version="17.6.268" />
-                            <PackageVersion Include="Moq" Version="4.18.4" />
-                            <PackageVersion Include="xunit" Version="2.5.0" />
-                            <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+                            <PackageVersion Include="Some.Package" Version="1.1.0" />
+                            <PackageVersion Include="Some.Dependency" Version="1.1.0" />
+                            <PackageVersion Include="Unrelated.Package" Version="1.0.0" />
                           </ItemGroup>
                         </Project>
                         """),
                     ("Directory.Build.props", """
                         <Project>
                           <PropertyGroup>
-                            <PreferredTargetFramework>net7.0</PreferredTargetFramework>
+                            <PreferredTargetFramework>net8.0</PreferredTargetFramework>
                           </PropertyGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task AddTransitiveDependencyByAddingPackageReferenceAndVersion()
         {
-            await TestUpdateForProject("System.Text.Json", "5.0.0", "5.0.2", isTransitive: true,
+            await TestUpdateForProject("Some.Transitive.Dependency", "5.0.0", "5.0.2", isTransitive: true,
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.1.3", "net8.0", [(null, [("Some.Transitive.Dependency", "5.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "5.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "5.0.2", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props files
@@ -1936,26 +2181,26 @@ public partial class UpdateWorkerTests
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Mongo2Go" Version="3.1.3" />
+                            <PackageVersion Include="Some.Package" Version="3.1.3" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" />
-                    <PackageReference Include="System.Text.Json" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Some.Transitive.Dependency" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props files
@@ -1965,33 +2210,40 @@ public partial class UpdateWorkerTests
                             <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Mongo2Go" Version="3.1.3" />
-                            <PackageVersion Include="System.Text.Json" Version="5.0.2" />
+                            <PackageVersion Include="Some.Package" Version="3.1.3" />
+                            <PackageVersion Include="Some.Transitive.Dependency" Version="5.0.2" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task PinTransitiveDependencyByAddingPackageVersion()
         {
-            await TestUpdateForProject("System.Text.Json", "5.0.0", "5.0.2", isTransitive: true,
+            await TestUpdateForProject("Some.Transitive.Dependency", "5.0.0", "5.0.2", isTransitive: true,
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.1.3", "net8.0", [(null, [("Some.Transitive.Dependency", "5.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "5.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "5.0.2", "net8.0"),
+                ],
                 // initial
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     // initial props files
@@ -2002,26 +2254,26 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Mongo2Go" Version="3.1.3" />
+                            <PackageVersion Include="Some.Package" Version="3.1.3" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 // expected
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
+                    <Project Sdk="Microsoft.NET.Sdk">
 
-                  <PropertyGroup>
-                    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
+                      <PropertyGroup>
+                        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="Mongo2Go" />
-                  </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
 
-                </Project>
-                """,
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // expected props files
@@ -2032,28 +2284,34 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="Mongo2Go" Version="3.1.3" />
-                            <PackageVersion Include="System.Text.Json" Version="5.0.2" />
+                            <PackageVersion Include="Some.Package" Version="3.1.3" />
+                            <PackageVersion Include="Some.Transitive.Dependency" Version="5.0.2" />
                           </ItemGroup>
                         </Project>
                         """)
-                ]);
+                ]
+            );
         }
 
         [Fact]
         public async Task PropsFileNameWithDifferentCasing()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Build.props", """
@@ -2065,22 +2323,22 @@ public partial class UpdateWorkerTests
                     ("Versions.Props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
+                            <SomePackageVersion>12.0.1</SomePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // no change
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // no change
@@ -2093,7 +2351,7 @@ public partial class UpdateWorkerTests
                     ("Versions.Props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+                            <SomePackageVersion>13.0.1</SomePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
@@ -2105,27 +2363,32 @@ public partial class UpdateWorkerTests
         public async Task VersionAttributeWithDifferentCasing_VersionNumberInline()
         {
             // the version attribute in the project has an all lowercase name
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" version="12.0.1" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" version="12.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" version="13.0.1" />
-                  </ItemGroup>
-                </Project>
-                """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
             );
         }
 
@@ -2133,17 +2396,22 @@ public partial class UpdateWorkerTests
         public async Task VersionAttributeWithDifferentCasing_VersionNumberInProperty()
         {
             // the version attribute in the project has an all lowercase name
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Build.props", """
@@ -2154,22 +2422,22 @@ public partial class UpdateWorkerTests
                     ("Versions.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
+                            <SomePackageVersion>12.0.1</SomePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
                 ],
                 // no change
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     // no change
@@ -2182,7 +2450,7 @@ public partial class UpdateWorkerTests
                     ("Versions.props", """
                         <Project>
                           <PropertyGroup>
-                            <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+                            <SomePackageVersion>13.0.1</SomePackageVersion>
                           </PropertyGroup>
                         </Project>
                         """)
@@ -2193,18 +2461,24 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task DirectoryPackagesPropsDoesCentralPackagePinningGetsUpdatedIfTransitiveFlagIsSet()
         {
-            await TestUpdateForProject("xunit.assert", "2.5.2", "2.5.3",
+            await TestUpdateForProject("Some.Package.Extensions", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "1.0.0", "net7.0", [(null, [("Some.Package", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "1.1.0", "net7.0", [(null, [("Some.Package", "1.0.0")])]),
+                ],
                 isTransitive: true,
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package.Extensions" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -2214,22 +2488,22 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="xunit" Version="2.5.2" />
-                            <PackageVersion Include="xunit.assert" Version="2.5.2" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Package.Extensions" Version="1.0.0" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package.Extensions" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -2239,8 +2513,8 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="xunit" Version="2.5.2" />
-                            <PackageVersion Include="xunit.assert" Version="2.5.3" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Package.Extensions" Version="1.1.0" />
                           </ItemGroup>
                         </Project>
                         """)
@@ -2251,18 +2525,24 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task DirectoryPackagesPropsDoesNotGetDuplicateEntryIfCentralTransitivePinningIsUsed()
         {
-            await TestUpdateForProject("xunit.assert", "2.5.2", "2.5.3",
+            await TestUpdateForProject("Some.Package.Extensions", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "1.0.0", "net7.0", [(null, [("Some.Package", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "1.1.0", "net7.0", [(null, [("Some.Package", "1.0.0")])]),
+                ],
                 isTransitive: true,
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package.Extensions" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFiles:
                 [
                     ("Directory.Packages.props", """
@@ -2272,22 +2552,22 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="xunit" Version="2.5.2" />
-                            <PackageVersion Include="xunit.assert" Version="2.5.3" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Package.Extensions" Version="1.1.0" />
                           </ItemGroup>
                         </Project>
                         """)
                 ],
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="xunit" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package.Extensions" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 additionalFilesExpected:
                 [
                     ("Directory.Packages.props", """
@@ -2297,8 +2577,8 @@ public partial class UpdateWorkerTests
                             <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
                           </PropertyGroup>
                           <ItemGroup>
-                            <PackageVersion Include="xunit" Version="2.5.2" />
-                            <PackageVersion Include="xunit.assert" Version="2.5.3" />
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Package.Extensions" Version="1.1.0" />
                           </ItemGroup>
                         </Project>
                         """)
@@ -2309,170 +2589,189 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task PackageWithFourPartVersionCanBeUpdated()
         {
-            await TestUpdateForProject("AWSSDK.Core", "3.7.204.13", "3.7.204.14",
+            await TestUpdateForProject("Some.Package", "1.2.3.4", "1.2.3.5",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3.4", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3.5", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="AWSSDK.Core" Version="3.7.204.13" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.2.3.4" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="AWSSDK.Core" Version="3.7.204.14" />
-                  </ItemGroup>
-                </Project>
-                """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.2.3.5" />
+                      </ItemGroup>
+                    </Project>
+                    """
             );
         }
 
         [Fact]
         public async Task PackageWithOnlyBuildTargetsCanBeUpdated()
         {
-            await TestUpdateForProject("Microsoft.Windows.Compatibility", "7.0.0", "8.0.0",
+            await TestUpdateForProject("Some.Package", "7.0.0", "7.1.0",
+                packages:
+                [
+                    new("Some.Package", "7.0.0", Files: [("buildTransitive/net7.0/_._", [])]),
+                    new("Some.Package", "7.1.0", Files: [("buildTransitive/net7.0/_._", [])]),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net5.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
-                  </ItemGroup>
-                </Project>
-                """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
             );
         }
 
         [Fact]
         public async Task UpdatePackageVersionFromPropertiesWithAndWithoutConditions()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion7) == 'true'">7.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</NewtonsoftJsonVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion Condition="$(UseLegacyVersion7) == 'true'">7.0.1</SomePackageVersion>
+                        <SomePackageVersion>12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion7) == 'true'">7.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</NewtonsoftJsonVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion Condition="$(UseLegacyVersion7) == 'true'">7.0.1</SomePackageVersion>
+                        <SomePackageVersion>13.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
             );
         }
 
         [Fact]
         public async Task UpdatePackageVersionFromPropertyWithConditionCheckingForEmptyString()
         {
-            await TestUpdateForProject("Newtonsoft.Json", "12.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "12.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonVersion Condition="$(NewtonsoftJsonVersion) == ''">12.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</NewtonsoftJsonVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """,
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion Condition="$(SomePackageVersion) == ''">12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """,
                 expectedProjectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
-                    <NewtonsoftJsonVersion Condition="$(NewtonsoftJsonVersion) == ''">13.0.1</NewtonsoftJsonVersion>
-                    <NewtonsoftJsonVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</NewtonsoftJsonVersion>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-                  </ItemGroup>
-                </Project>
-                """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion Condition="$(SomePackageVersion) == ''">13.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(UseLegacyVersion9) == 'true'">9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """
             );
         }
 
         [Fact]
         public async Task NoChange_IfThereAreIncoherentVersions()
         {
-            // Make sure we don't update if there are incoherent versions
-            await TestNoChangeforProject("Microsoft.EntityFrameworkCore.SqlServer", "2.1.0", "2.2.0",
+            // trying to update `Transitive.Dependency` to 1.1.0 would normally pull `Some.Package` from 1.0.0 to 1.1.0,
+            // but the TFM doesn't allow it
+            await TestNoChangeforProject("Transitive.Dependency", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net7.0", [(null, [("Transitive.Dependency", "[1.0.0]")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0", [(null, [("Transitive.Dependency", "[1.1.0]")])]),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "1.0.0", "net7.0"),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "1.1.0", "net7.0"),
+                ],
                 projectContents: """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>netcoreapp2.1</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
-                    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net7.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                        <PackageReference Include="Transitive.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
         }
 
         [Fact]
         public async Task NoChange_IfTargetFrameworkCouldNotBeEvaluated()
         {
             // Make sure we don't throw if the project's TFM is an unresolvable property
-            await TestNoChangeforProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestNoChangeforProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>$(PropertyThatCannotBeResolved)</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                        <PackageReference Include="Some.Package" Version="7.0.1" />
                       </ItemGroup>
                     </Project>
                     """
-                );
+            );
         }
 
         [Fact]
@@ -2480,7 +2779,12 @@ public partial class UpdateWorkerTests
         {
             // enumerating the build files will fail if the Aspire workload is not installed; this test ensures we can
             // still process the update
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
@@ -2488,7 +2792,7 @@ public partial class UpdateWorkerTests
                         <IsAspireHost>true</IsAspireHost>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                        <PackageReference Include="Some.Package" Version="7.0.1" />
                       </ItemGroup>
                     </Project>
                     """,
@@ -2499,7 +2803,7 @@ public partial class UpdateWorkerTests
                         <IsAspireHost>true</IsAspireHost>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
                       </ItemGroup>
                     </Project>
                     """
@@ -2509,16 +2813,22 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UnresolvablePropertyDoesNotStopOtherUpdates()
         {
-            // the property `$(MauiVersion)` cannot be resolved
-            await TestUpdateForProject("Newtonsoft.Json", "7.0.1", "13.0.1",
+            // the property `$(SomeUnresolvableProperty)` cannot be resolved
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Other.Package", "1.0.0", "net8.0"),
+                ],
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-                        <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+                        <PackageReference Include="Some.Other.Package" Version="$(SomeUnresolvableProperty)" />
+                        <PackageReference Include="Some.Package" Version="7.0.1" />
                       </ItemGroup>
                     </Project>
                     """,
@@ -2528,8 +2838,8 @@ public partial class UpdateWorkerTests
                         <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-                        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+                        <PackageReference Include="Some.Other.Package" Version="$(SomeUnresolvableProperty)" />
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
                       </ItemGroup>
                     </Project>
                     """
@@ -2539,31 +2849,40 @@ public partial class UpdateWorkerTests
         [Fact]
         public async Task UpdatingPackageAlsoUpdatesAnythingWithADependencyOnTheUpdatedPackage()
         {
-            // updating SpecFlow from 3.3.30 requires that SpecFlow.Tools.MsBuild.Generation also be updated
-            await TestUpdateForProject("SpecFlow", "3.3.30", "3.4.3",
+            // updating Some.Package from 3.3.30 requires that Some.Package.Extensions also be updated
+            await TestUpdateForProject("Some.Package", "3.3.30", "3.4.3",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.3.30", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.4.0", "net8.0"), // this will be ignored
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "3.4.3", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "3.3.30", "net8.0", [(null, [("Some.Package", "[3.3.30]")])]), // the dependency version is very strict with []
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "3.4.0", "net8.0", [(null, [("Some.Package", "[3.4.0]")])]), // this will be ignored
+                    MockNuGetPackage.CreateSimplePackage("Some.Package.Extensions", "3.4.3", "net8.0", [(null, [("Some.Package", "[3.4.3]")])]),
+                ],
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="SpecFlow" Version="3.3.30" />
-                        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+                        <PackageReference Include="Some.Package" Version="3.3.30" />
+                        <PackageReference Include="Some.Package.Extensions" Version="3.3.30" />
                       </ItemGroup>
                     </Project>
                     """,
                 expectedProjectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="SpecFlow" Version="3.4.3" />
-                        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.4.3" />
+                        <PackageReference Include="Some.Package" Version="3.4.3" />
+                        <PackageReference Include="Some.Package.Extensions" Version="3.4.3" />
                       </ItemGroup>
                     </Project>
                     """
-                );
+            );
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1,5 +1,9 @@
 using System.Collections.Immutable;
 
+using NuGet.Build.Tasks;
+
+using NuGetUpdater.Core.Test.Update;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Utilities;
@@ -15,10 +19,10 @@ public class MSBuildHelperTests : TestBase
         var projectContents = """
             <Project>
                 <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                 </PropertyGroup>
                 <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(PackageVersion1)" />
+                    <PackageReference Include="Some.Package" Version="$(PackageVersion1)" />
                 </ItemGroup>
             </Project>
             """;
@@ -36,10 +40,10 @@ public class MSBuildHelperTests : TestBase
         Assert.Equal("""
             <Project>
                 <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                 </PropertyGroup>
                 <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="1.1.1" />
+                    <PackageReference Include="Some.Package" Version="1.1.1" />
                 </ItemGroup>
             </Project>
             """, evaluatedValue);
@@ -52,10 +56,10 @@ public class MSBuildHelperTests : TestBase
         var projectContents = """
             <Project>
                 <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                 </PropertyGroup>
                 <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="$(PackageVersion1)" />
+                    <PackageReference Include="Some.Package" Version="$(PackageVersion1)" />
                 </ItemGroup>
             </Project>
             """;
@@ -125,10 +129,13 @@ public class MSBuildHelperTests : TestBase
 
     [Theory]
     [MemberData(nameof(GetTopLevelPackageDependencyInfosTestData))]
-    public async Task TopLevelPackageDependenciesCanBeDetermined(TestFile[] buildFileContents, Dependency[] expectedTopLevelDependencies)
+    public async Task TopLevelPackageDependenciesCanBeDetermined(TestFile[] buildFileContents, Dependency[] expectedTopLevelDependencies, MockNuGetPackage[] testPackages)
     {
         using var testDirectory = new TemporaryDirectory();
         var buildFiles = new List<ProjectBuildFile>();
+
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(testPackages, testDirectory.DirectoryPath);
+
         foreach (var (path, content) in buildFileContents)
         {
             var fullPath = Path.Combine(testDirectory.DirectoryPath, path);
@@ -144,30 +151,29 @@ public class MSBuildHelperTests : TestBase
     public async Task AllPackageDependenciesCanBeTraversed()
     {
         using var temp = new TemporaryDirectory();
-        var expectedDependencies = new Dependency[]
-        {
-            new("Microsoft.Bcl.AsyncInterfaces", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.Extensions.Logging", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Logging.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Options", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Primitives", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Buffers", "4.5.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel.Annotations", "5.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Diagnostics.DiagnosticSource", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Memory", "4.5.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
+        MockNuGetPackage[] testPackages =
+        [
+            MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "netstandard2.0", [(null, [("Package.B", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "netstandard2.0", [(null, [("Package.C", "3.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.C", "3.0.0", "netstandard2.0", [(null, [("Package.D", "4.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.D", "4.0.0", "netstandard2.0"),
+        ];
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(testPackages, temp.DirectoryPath);
+
+        Dependency[] expectedDependencies =
+        [
             new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-        };
-        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+            new("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
+            new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
+            new("Package.C", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
+            new("Package.D", "4.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
+        ];
+        Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
             temp.DirectoryPath,
             temp.DirectoryPath,
             "netstandard2.0",
-            [new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown)]);
+            [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)]
+        );
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
@@ -175,101 +181,126 @@ public class MSBuildHelperTests : TestBase
     public async Task AllPackageDependencies_DoNotTruncateLongDependencyLists()
     {
         using var temp = new TemporaryDirectory();
-        var expectedDependencies = new Dependency[]
-        {
-            new("Castle.Core", "4.4.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights.Agent.Intercept", "2.4.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights.DependencyCollector", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights.PerfCounterCollector", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights.WindowsServer", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.AspNet.TelemetryCorrelation", "1.0.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Bcl.AsyncInterfaces", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Caching.Abstractions", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Caching.Memory", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DiagnosticAdapter", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.Extensions.Logging", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Logging.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Options", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.PlatformAbstractions", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Primitives", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Moq", "4.16.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("MSTest.TestFramework", "2.1.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Newtonsoft.Json", "12.0.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("System", "4.1.311.2", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("System.Buffers", "4.5.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Collections.Concurrent", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Collections.Immutable", "1.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Collections.NonGeneric", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Collections.Specialized", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel.Annotations", "5.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel.Primitives", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel.TypeConverter", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Core", "3.5.21022.801", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("System.Data.Common", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Diagnostics.DiagnosticSource", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Diagnostics.PerformanceCounter", "4.5.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Diagnostics.StackTrace", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Dynamic.Runtime", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.IO.FileSystem.Primitives", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Linq", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Linq.Expressions", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Memory", "4.5.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Net.WebHeaderCollection", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ObjectModel", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Private.DataContractSerialization", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Reflection.Emit", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Reflection.Emit.ILGeneration", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Reflection.Emit.Lightweight", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Reflection.Metadata", "1.4.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Reflection.TypeExtensions", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.InteropServices.RuntimeInformation", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.Numerics", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.Serialization.Json", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.Serialization.Primitives", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Security.Claims", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Security.Cryptography.OpenSsl", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Security.Cryptography.Primitives", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Security.Principal", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Text.RegularExpressions", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading.Thread", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading.ThreadPool", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Xml.ReaderWriter", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Xml.XDocument", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Xml.XmlDocument", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Xml.XmlSerializer", "4.3.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.ApplicationInsights.Web", "2.10.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("MSTest.TestAdapter", "2.1.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-        };
+        MockNuGetPackage[] testPackages =
+        [
+            MockNuGetPackage.CreateSimplePackage("Package.1A", "1.0.0", "net8.0", [(null, [("Package.1B", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1B", "2.0.0", "net8.0", [(null, [("Package.1C", "3.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1C", "3.0.0", "net8.0", [(null, [("Package.1D", "4.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1D", "4.0.0", "net8.0", [(null, [("Package.1E", "5.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1E", "5.0.0", "net8.0", [(null, [("Package.1F", "6.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1F", "6.0.0", "net8.0", [(null, [("Package.1G", "7.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1G", "7.0.0", "net8.0", [(null, [("Package.1H", "8.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1H", "8.0.0", "net8.0", [(null, [("Package.1I", "9.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1I", "9.0.0", "net8.0", [(null, [("Package.1J", "10.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1J", "10.0.0", "net8.0", [(null, [("Package.1K", "11.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1K", "11.0.0", "net8.0", [(null, [("Package.1L", "12.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1L", "12.0.0", "net8.0", [(null, [("Package.1M", "13.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1M", "13.0.0", "net8.0", [(null, [("Package.1N", "14.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1N", "14.0.0", "net8.0", [(null, [("Package.1O", "15.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1O", "15.0.0", "net8.0", [(null, [("Package.1P", "16.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1P", "16.0.0", "net8.0", [(null, [("Package.1Q", "17.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1Q", "17.0.0", "net8.0", [(null, [("Package.1R", "18.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1R", "18.0.0", "net8.0", [(null, [("Package.1S", "19.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1S", "19.0.0", "net8.0", [(null, [("Package.1T", "20.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1T", "20.0.0", "net8.0", [(null, [("Package.1U", "21.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1U", "21.0.0", "net8.0", [(null, [("Package.1V", "22.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1V", "22.0.0", "net8.0", [(null, [("Package.1W", "23.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1W", "23.0.0", "net8.0", [(null, [("Package.1X", "24.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1X", "24.0.0", "net8.0", [(null, [("Package.1Y", "25.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1Y", "25.0.0", "net8.0", [(null, [("Package.1Z", "26.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.1Z", "26.0.0", "net8.0", [(null, [("Package.2A", "1.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2A", "1.0.0", "net8.0", [(null, [("Package.2B", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2B", "2.0.0", "net8.0", [(null, [("Package.2C", "3.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2C", "3.0.0", "net8.0", [(null, [("Package.2D", "4.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2D", "4.0.0", "net8.0", [(null, [("Package.2E", "5.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2E", "5.0.0", "net8.0", [(null, [("Package.2F", "6.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2F", "6.0.0", "net8.0", [(null, [("Package.2G", "7.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2G", "7.0.0", "net8.0", [(null, [("Package.2H", "8.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2H", "8.0.0", "net8.0", [(null, [("Package.2I", "9.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2I", "9.0.0", "net8.0", [(null, [("Package.2J", "10.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2J", "10.0.0", "net8.0", [(null, [("Package.2K", "11.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2K", "11.0.0", "net8.0", [(null, [("Package.2L", "12.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2L", "12.0.0", "net8.0", [(null, [("Package.2M", "13.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2M", "13.0.0", "net8.0", [(null, [("Package.2N", "14.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2N", "14.0.0", "net8.0", [(null, [("Package.2O", "15.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2O", "15.0.0", "net8.0", [(null, [("Package.2P", "16.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2P", "16.0.0", "net8.0", [(null, [("Package.2Q", "17.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2Q", "17.0.0", "net8.0", [(null, [("Package.2R", "18.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2R", "18.0.0", "net8.0", [(null, [("Package.2S", "19.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2S", "19.0.0", "net8.0", [(null, [("Package.2T", "20.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2T", "20.0.0", "net8.0", [(null, [("Package.2U", "21.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2U", "21.0.0", "net8.0", [(null, [("Package.2V", "22.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2V", "22.0.0", "net8.0", [(null, [("Package.2W", "23.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2W", "23.0.0", "net8.0", [(null, [("Package.2X", "24.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2X", "24.0.0", "net8.0", [(null, [("Package.2Y", "25.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2Y", "25.0.0", "net8.0", [(null, [("Package.2Z", "26.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Package.2Z", "26.0.0", "net8.0"),
+        ];
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(testPackages, temp.DirectoryPath);
+
+        Dependency[] expectedDependencies =
+        [
+            new("Package.1A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.1B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1C", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1D", "4.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1E", "5.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1F", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1G", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1H", "8.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1I", "9.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1J", "10.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1K", "11.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1L", "12.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1M", "13.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1N", "14.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1O", "15.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1P", "16.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1Q", "17.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1R", "18.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.1S", "19.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1T", "20.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1U", "21.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1V", "22.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1W", "23.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1X", "24.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1Y", "25.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.1Z", "26.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.2B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2C", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2D", "4.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2E", "5.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2F", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2G", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2H", "8.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2I", "9.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2J", "10.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2K", "11.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2L", "12.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2M", "13.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2N", "14.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2O", "15.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2P", "16.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2Q", "17.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2R", "18.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.2S", "19.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2T", "20.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2U", "21.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2V", "22.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2W", "23.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2X", "24.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2Y", "25.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            new("Package.2Z", "26.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+        ];
         var packages = new[]
         {
-            new Dependency("System", "4.1.311.2", DependencyType.Unknown),
-            new Dependency("System.Core", "3.5.21022.801", DependencyType.Unknown),
-            new Dependency("Moq", "4.16.1", DependencyType.Unknown),
-            new Dependency("Castle.Core", "4.4.1", DependencyType.Unknown),
-            new Dependency("MSTest.TestAdapter", "2.1.0", DependencyType.Unknown),
-            new Dependency("MSTest.TestFramework", "2.1.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.Agent.Intercept", "2.4.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.DependencyCollector", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.PerfCounterCollector", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.Web", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.ApplicationInsights.WindowsServer", "2.10.0", DependencyType.Unknown),
-            new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
-            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown)
+            new Dependency("Package.1A", "1.0.0", DependencyType.Unknown),
+            new Dependency("Package.1R", "18.0.0", DependencyType.Unknown),
+            new Dependency("Package.2A", "1.0.0", DependencyType.Unknown),
+            new Dependency("Package.2R", "18.0.0", DependencyType.Unknown),
         };
-        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "netstandard2.0", packages);
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages);
         for (int i = 0; i < actualDependencies.Length; i++)
         {
             var ad = actualDependencies[i];
@@ -284,31 +315,26 @@ public class MSBuildHelperTests : TestBase
     public async Task AllPackageDependencies_DoNotIncludeUpdateOnlyPackages()
     {
         using var temp = new TemporaryDirectory();
-        var expectedDependencies = new Dependency[]
-        {
-            new("Microsoft.Bcl.AsyncInterfaces", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.DependencyInjection.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-            new("Microsoft.Extensions.Logging", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Logging.Abstractions", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Options", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("Microsoft.Extensions.Primitives", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Buffers", "4.5.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.ComponentModel.Annotations", "5.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Diagnostics.DiagnosticSource", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Memory", "4.5.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-        };
+        MockNuGetPackage[] testPackages =
+        [
+            MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net8.0"),
+            MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net8.0"),
+            MockNuGetPackage.CreateSimplePackage("Package.C", "3.0.0", "net8.0"),
+        ];
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(testPackages, temp.DirectoryPath);
+
+        Dependency[] expectedDependencies =
+        [
+            new("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+        ];
         var packages = new[]
         {
-            new Dependency("Microsoft.Extensions.Http", "7.0.0", DependencyType.Unknown),
-            new Dependency("Newtonsoft.Json", "12.0.1", DependencyType.Unknown, IsUpdate: true)
+            new Dependency("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new Dependency("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new Dependency("Package.C", "3.0.0", DependencyType.Unknown, IsUpdate: true)
         };
-        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "netstandard2.0", packages);
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages);
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
@@ -344,75 +370,9 @@ public class MSBuildHelperTests : TestBase
             var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
                 temp.DirectoryPath,
                 temp.DirectoryPath,
-                "netstandard2.0",
-                [new Dependency("Newtonsoft.Json", "4.5.11", DependencyType.Unknown)]
+                "net8.0",
+                [new Dependency("Some.Package", "4.5.11", DependencyType.Unknown)]
             );
-        }
-        finally
-        {
-            // Restore the NuGet caches.
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetPackagesDirectory);
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", nugetHttpCacheDirectory);
-        }
-    }
-
-    [Fact]
-    public async Task GetAllPackageDependencies_LocalNuGetRepos_AreCopiedToTempProject()
-    {
-        // If we end up using this EnvVar pattern again I think it'd be worth it to abstract it out into an IDisposable.
-        var nugetPackagesDirectory = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        var nugetHttpCacheDirectory = Environment.GetEnvironmentVariable("NUGET_HTTP_CACHE_PATH");
-        var logger = new Logger(verbose: true);
-        try
-        {
-            // First create a fake local nuget repository
-            using var restoreDir = new TemporaryDirectory();
-
-            var restoreNuGetPackagesDirectory = Path.Combine(restoreDir.DirectoryPath, ".nuget", "packages");
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", restoreNuGetPackagesDirectory);
-            var restoreNuGetHttpCacheDirectory = Path.Combine(restoreDir.DirectoryPath, ".nuget", "v3-cache");
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", restoreNuGetHttpCacheDirectory);
-
-            using var temp = new TemporaryDirectory();
-            using (var restoreProjectTemp = new TemporaryDirectory())
-            {
-                // dotnet restore .csproj with things we want
-                await MSBuildHelper.DependenciesAreCoherentAsync(restoreProjectTemp.DirectoryPath, restoreProjectTemp.DirectoryPath, "netstandard2.0",
-                    [new Dependency("Newtonsoft.Json", "4.5.11", DependencyType.Unknown)], logger);
-                Assert.True(Directory.Exists(restoreNuGetPackagesDirectory), "packages directory didn't exist");
-                PathHelper.CopyDirectory(restoreNuGetPackagesDirectory, Path.Combine(temp.DirectoryPath, "local_repo"));
-            }
-
-            // It is important to have empty NuGet caches for this test, so override them with temp directories.
-            var tempNuGetPackagesDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "packages");
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", tempNuGetPackagesDirectory);
-            var tempNuGetHttpCacheDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "v3-cache");
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", tempNuGetHttpCacheDirectory);
-
-            // Write the NuGet.config.
-            await File.WriteAllTextAsync(
-                Path.Combine(temp.DirectoryPath, "NuGet.Config"), """
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                  <packageSources>
-                    <clear />
-                    <add key="local-repo" value="local_repo" />
-                  </packageSources>
-                </configuration>
-                """);
-            var expectedDependencies = new Dependency[]
-            {
-                new("Newtonsoft.Json", "4.5.11", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-                new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            };
-            var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
-                temp.DirectoryPath,
-                temp.DirectoryPath,
-                "netstandard2.0",
-                [new Dependency("Newtonsoft.Json", "4.5.11", DependencyType.Unknown)]
-            );
-            Assert.False(Directory.Exists(tempNuGetHttpCacheDirectory), "The .nuget/.v3-cache directory was created, meaning http was used.");
-            AssertEx.Equal(expectedDependencies, actualDependencies);
         }
         finally
         {
@@ -438,47 +398,38 @@ public class MSBuildHelperTests : TestBase
             var tempNuGetHttpCacheDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "v3-cache");
             Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", tempNuGetHttpCacheDirectory);
 
-            // First validate that we are unable to find dependencies for the package version without a NuGet.config.
-            var dependenciesNoNuGetConfig = await MSBuildHelper.GetAllPackageDependenciesAsync(
-                temp.DirectoryPath,
-                temp.DirectoryPath,
-                "netstandard2.0",
-                [new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0-3.23457.5", DependencyType.Unknown)]);
-            Assert.Equal([], dependenciesNoNuGetConfig);
+            // create two local package sources with different packages available in each
+            string localSource1 = Path.Combine(temp.DirectoryPath, "localSource1");
+            Directory.CreateDirectory(localSource1);
+            string localSource2 = Path.Combine(temp.DirectoryPath, "localSource2");
+            Directory.CreateDirectory(localSource2);
 
-            // Write the NuGet.config and try again.
-            await File.WriteAllTextAsync(
-                Path.Combine(temp.DirectoryPath, "NuGet.Config"), """
-                <?xml version="1.0" encoding="utf-8"?>
+            // `Package.A` will only live in `localSource1` and will have a dependency on `Package.B` which is only
+            // available in `localSource2`
+            MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net8.0", [(null, [("Package.B", "2.0.0")])]).WriteToDirectory(localSource1);
+            MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net8.0").WriteToDirectory(localSource2);
+            await File.WriteAllTextAsync(Path.Join(temp.DirectoryPath, "NuGet.Config"), """
                 <configuration>
                   <packageSources>
-                    <clear />
-                    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-                    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+                    <add key="localSource1" value="./localSource1" />
+                    <add key="localSource2" value="./localSource2" />
                   </packageSources>
                 </configuration>
                 """);
 
-            var expectedDependencies = new Dependency[]
-            {
-                new("Microsoft.CodeAnalysis.Common", "4.8.0-3.23457.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"]),
-                new("System.Buffers", "4.5.1", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Collections.Immutable", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Memory", "4.5.5", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Numerics.Vectors", "4.4.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Reflection.Metadata", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Runtime.CompilerServices.Unsafe", "6.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Text.Encoding.CodePages", "7.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("System.Threading.Tasks.Extensions", "4.5.4", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("Microsoft.CodeAnalysis.Analyzers", "3.3.4", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-                new("NETStandard.Library", "2.0.3", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
-            };
-            var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+            Dependency[] expectedDependencies =
+            [
+                new("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+            ];
+
+            Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
                 temp.DirectoryPath,
                 temp.DirectoryPath,
-                "netstandard2.0",
-                [new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0-3.23457.5", DependencyType.Unknown)]
+                "net8.0",
+                [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)]
             );
+
             AssertEx.Equal(expectedDependencies, actualDependencies);
         }
         finally
@@ -492,35 +443,48 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolved()
     {
-        // the package `SpecFlow` was already updated from 3.3.30 to 3.4.3, but this causes a conflict with
-        // `SpecFlow.Tools.MsBuild.Generation` that needs to be resolved
         var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolved)}_");
+        MockNuGetPackage[] testPackages =
+        [
+            // some base packages
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0"),
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.0", "net8.0"),
+            // some packages that are hard-locked to specific versions of the previous package
+            MockNuGetPackage.CreateSimplePackage("Some.Other.Package", "1.0.0", "net8.0", [(null, [("Some.Package", "[1.0.0]")])]),
+            MockNuGetPackage.CreateSimplePackage("Some.Other.Package", "1.1.0", "net8.0", [(null, [("Some.Package", "[1.1.0]")])]),
+            MockNuGetPackage.CreateSimplePackage("Some.Other.Package", "1.2.0", "net8.0", [(null, [("Some.Package", "[1.2.0]")])]),
+        ];
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(testPackages, repoRoot.FullName);
+
+        // the package `Some.Package` was already updated from 1.0.0 to 1.2.0, but this causes a conflict with
+        // `Some.Other.Package` that needs to be resolved
         try
         {
             var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
             await File.WriteAllTextAsync(projectPath, """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
-                    <TargetFramework>netstandard2.0</TargetFramework>
+                    <TargetFramework>net8.0</TargetFramework>
                   </PropertyGroup>
                   <ItemGroup>
-                    <PackageReference Include="SpecFlow" Version="3.4.3" />
-                    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+                    <PackageReference Include="Some.Package" Version="1.2.0" />
+                    <PackageReference Include="Some.Other.Package" Version="1.0.0" />
                   </ItemGroup>
                 </Project>
                 """);
             var dependencies = new[]
             {
-                new Dependency("SpecFlow", "3.4.3", DependencyType.PackageReference),
-                new Dependency("SpecFlow.Tools.MsBuild.Generation", "3.3.30", DependencyType.PackageReference),
+                new Dependency("Some.Package", "1.2.0", DependencyType.PackageReference),
+                new Dependency("Some.Other.Package", "1.0.0", DependencyType.PackageReference),
             };
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "netstandard2.0", dependencies, new Logger(true));
+            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, new Logger(true));
             Assert.NotNull(resolvedDependencies);
             Assert.Equal(2, resolvedDependencies.Length);
-            Assert.Equal("SpecFlow", resolvedDependencies[0].Name);
-            Assert.Equal("3.4.3", resolvedDependencies[0].Version);
-            Assert.Equal("SpecFlow.Tools.MsBuild.Generation", resolvedDependencies[1].Name);
-            Assert.Equal("3.4.3", resolvedDependencies[1].Version);
+            Assert.Equal("Some.Package", resolvedDependencies[0].Name);
+            Assert.Equal("1.2.0", resolvedDependencies[0].Version);
+            Assert.Equal("Some.Other.Package", resolvedDependencies[1].Name);
+            Assert.Equal("1.2.0", resolvedDependencies[1].Version);
         }
         finally
         {
@@ -539,7 +503,7 @@ public class MSBuildHelperTests : TestBase
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+                        <PackageReference Include="Some.Package" Version="12.0.1" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -548,10 +512,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "12.0.1", "12.0.1", null, null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         ];
 
@@ -564,7 +532,7 @@ public class MSBuildHelperTests : TestBase
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json">
+                        <PackageReference Include="Some.Package">
                             <Version>12.0.1</Version>
                         </PackageReference>
                       </ItemGroup>
@@ -575,10 +543,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "12.0.1", "12.0.1", null, null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         ];
 
@@ -591,10 +563,10 @@ public class MSBuildHelperTests : TestBase
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
+                        <SomePackageVersion>12.0.1</SomePackageVersion>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -603,10 +575,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
-                    new(EvaluationResultType.Success, "$(NewtonsoftJsonVersion)", "12.0.1", "NewtonsoftJsonVersion", null))
+                    new(EvaluationResultType.Success, "$(SomePackageVersion)", "12.0.1", "SomePackageVersion", null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         ];
 
@@ -620,11 +596,11 @@ public class MSBuildHelperTests : TestBase
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>netstandard2.0</TargetFramework>
-                        <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
-                        <NewtonsoftJsonVersion Condition="$(PropertyThatDoesNotExist) == 'true'">13.0.1</NewtonsoftJsonVersion>
+                        <SomePackageVersion>12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(PropertyThatDoesNotExist) == 'true'">13.0.1</SomePackageVersion>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -633,10 +609,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
-                    new(EvaluationResultType.Success, "$(NewtonsoftJsonVersion)", "12.0.1", "NewtonsoftJsonVersion", null))
+                    new(EvaluationResultType.Success, "$(SomePackageVersion)", "12.0.1", "SomePackageVersion", null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         ];
 
@@ -650,11 +630,11 @@ public class MSBuildHelperTests : TestBase
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>netstandard2.0</TargetFramework>
-                        <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
-                        <NewtonsoftJsonVersion Condition="'$(PropertyThatDoesNotExist)' == 'true'">13.0.1</NewtonsoftJsonVersion>
+                        <SomePackageVersion>12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="'$(PropertyThatDoesNotExist)' == 'true'">13.0.1</SomePackageVersion>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -663,10 +643,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
-                    new(EvaluationResultType.Success, "$(NewtonsoftJsonVersion)", "12.0.1", "NewtonsoftJsonVersion", null))
+                    new(EvaluationResultType.Success, "$(SomePackageVersion)", "12.0.1", "SomePackageVersion", null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         };
 
@@ -680,11 +664,11 @@ public class MSBuildHelperTests : TestBase
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>netstandard2.0</TargetFramework>
-                        <NewtonsoftJsonVersion Condition="$(NewtonsoftJsonVersion) == ''">12.0.1</NewtonsoftJsonVersion>
-                        <NewtonsoftJsonVersion Condition="$(PropertyThatDoesNotExist) == 'true'">13.0.1</NewtonsoftJsonVersion>
+                        <SomePackageVersion Condition="$(SomePackageVersion) == ''">12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="$(PropertyThatDoesNotExist) == 'true'">13.0.1</SomePackageVersion>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -693,10 +677,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
-                    new(EvaluationResultType.Success, "$(NewtonsoftJsonVersion)", "12.0.1", "NewtonsoftJsonVersion", null))
+                    new(EvaluationResultType.Success, "$(SomePackageVersion)", "12.0.1", "SomePackageVersion", null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         ];
 
@@ -710,11 +698,11 @@ public class MSBuildHelperTests : TestBase
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>netstandard2.0</TargetFramework>
-                        <NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">12.0.1</NewtonsoftJsonVersion>
-                        <NewtonsoftJsonVersion Condition="'$(PropertyThatDoesNotExist)' == 'true'">13.0.1</NewtonsoftJsonVersion>
+                        <SomePackageVersion Condition="'$(SomePackageVersion)' == ''">12.0.1</SomePackageVersion>
+                        <SomePackageVersion Condition="'$(PropertyThatDoesNotExist)' == 'true'">13.0.1</SomePackageVersion>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -723,10 +711,14 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Newtonsoft.Json",
+                    "Some.Package",
                     "12.0.1",
                     DependencyType.PackageReference,
-                    new(EvaluationResultType.Success, "$(NewtonsoftJsonVersion)", "12.0.1", "NewtonsoftJsonVersion", null))
+                    new(EvaluationResultType.Success, "$(SomePackageVersion)", "12.0.1", "SomePackageVersion", null))
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "12.0.1", "net8.0")
             }
         };
 
@@ -739,18 +731,18 @@ public class MSBuildHelperTests : TestBase
                 ("Packages.props", """
                         <Project>
                           <ItemGroup>
-                            <PackageReference Update="Azure.Identity" Version="1.6.0" />
-                            <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.4" />
+                            <PackageReference Update="Package.A" Version="1.6.0" />
+                            <PackageReference Update="Package.B" Version="5.1.4" />
                           </ItemGroup>
                         </Project>
                     """),
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Azure.Identity" Version="1.6.1" />
+                        <PackageReference Include="Package.A" Version="1.6.1" />
                       </ItemGroup>
                     </Project>
                     """)
@@ -759,16 +751,22 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Azure.Identity",
+                    "Package.A",
                     "1.6.0",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "1.6.0", "1.6.0", null, null)),
                 new(
-                    "Microsoft.Data.SqlClient",
+                    "Package.B",
                     "5.1.4",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "5.1.4", "5.1.4", null, null),
                     IsUpdate: true),
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Package.A", "1.6.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.A", "1.6.1", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.B", "5.1.4", "net8.0"),
             }
         ];
 
@@ -781,18 +779,18 @@ public class MSBuildHelperTests : TestBase
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>netstandard2.0</TargetFramework>
+                        <TargetFramework>net8.0</TargetFramework>
                       </PropertyGroup>
                       <ItemGroup>
-                        <PackageReference Include="Azure.Identity" />
+                        <PackageReference Include="Package.A" />
                       </ItemGroup>
                     </Project>
                     """),
                 ("Packages.props", """
                         <Project>
                           <ItemGroup>
-                            <PackageReference Update="Azure.Identity" Version="1.6.0" />
-                            <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.4" />
+                            <PackageReference Update="Package.A" Version="1.6.0" />
+                            <PackageReference Update="Package.B" Version="5.1.4" />
                           </ItemGroup>
                         </Project>
                     """)
@@ -801,16 +799,21 @@ public class MSBuildHelperTests : TestBase
             new Dependency[]
             {
                 new(
-                    "Azure.Identity",
+                    "Package.A",
                     "1.6.0",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "1.6.0", "1.6.0", null, null)),
                 new(
-                    "Microsoft.Data.SqlClient",
+                    "Package.B",
                     "5.1.4",
                     DependencyType.PackageReference,
                     EvaluationResult: new(EvaluationResultType.Success, "5.1.4", "5.1.4", null, null),
                     IsUpdate: true),
+            },
+            new MockNuGetPackage[]
+            {
+                MockNuGetPackage.CreateSimplePackage("Package.A", "1.6.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.B", "5.1.4", "net8.0"),
             }
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -480,11 +480,15 @@ internal static partial class MSBuildHelper
                 // We need to copy local package sources from the NuGet.Config file to the temp directory
                 foreach (var localSource in packageSources.Where(p => p.IsLocal))
                 {
-                    var subDir = localSource.Source.Split(nugetConfigDir)[1];
-                    var destPath = Path.Join(tempDir.FullName, subDir);
-                    if (Directory.Exists(localSource.Source))
+                    // if the source is relative to the original location, copy it to the temp directory
+                    if (PathHelper.IsSubdirectoryOf(nugetConfigDir!, localSource.Source))
                     {
-                        PathHelper.CopyDirectory(localSource.Source, destPath);
+                        string sourceRelativePath = Path.GetRelativePath(nugetConfigDir!, localSource.Source);
+                        string destPath = Path.Join(tempDir.FullName, sourceRelativePath);
+                        if (Directory.Exists(localSource.Source))
+                        {
+                            PathHelper.CopyDirectory(localSource.Source, destPath);
+                        }
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -111,4 +111,22 @@ internal static class PathHelper
             CopyDirectory(subDir.FullName, newDestinationDir);
         }
     }
+
+    public static bool IsSubdirectoryOf(string parentDirectory, string childDirectory)
+    {
+        var parentDirInfo = new DirectoryInfo(parentDirectory);
+        var childDirInfo = new DirectoryInfo(childDirectory);
+
+        while (childDirInfo.Parent is not null)
+        {
+            if (childDirInfo.Parent.FullName == parentDirInfo.FullName)
+            {
+                return true;
+            }
+
+            childDirInfo = childDirInfo.Parent;
+        }
+
+        return false;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/global.json
+++ b/nuget/helpers/lib/NuGetUpdater/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.202",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Comments have been added inline with the code where the most attention should be paid.

In short, if a unit test is written as it was before, the behavior will remain the same; network access to `api.nuget.org` will be allowed.  _However_, as soon as the `packages` parameter is specified, a test-only `NuGet.Config` is written to the test directory which disallows **all** network access and only allows the packages created in a special directory to be queried.  Since we don't use any custom NuGet API handling, this is perfectly fine as we're letting the "real" NuGet handle its sources however it sees fit (which in this case is all from a local feed.)

The vast majority of this PR was changing things like `Newtonsoft.Json` to `Some.Package` and can be ignored.  In some tests the specific package dependencies that made the test case interesting have been explicitly laid out which should help with readability quite a bit.