### PR TITLE
fix exceptions from integration tests due to no metadata finders

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -297,6 +297,7 @@ module Dependabot
           when "gitlab" then fetch_gitlab_file_list
           when "azure" then fetch_azure_file_list
           when "codecommit" then [] # TODO: Fetch Files from Codecommit
+          when "example" then []
           else raise "Unexpected repo provider '#{T.must(source).provider}'"
           end
         end

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -51,6 +51,7 @@ module Dependabot
             when "bitbucket" then bitbucket_compare_path(new_tag, previous_tag)
             when "gitlab" then gitlab_compare_path(new_tag, previous_tag)
             when "azure" then azure_compare_path(new_tag, previous_tag)
+            when "example" then ""
             else raise "Unexpected source provider '#{T.must(source).provider}'"
             end
 

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -242,7 +242,7 @@ module Dependabot
           when "github" then fetch_github_releases
           # Bitbucket and CodeCommit don't support releases and
           # Azure can't list API for annotated tags
-          when "bitbucket", "azure", "codecommit" then []
+          when "bitbucket", "azure", "codecommit", "example" then []
           when "gitlab" then fetch_gitlab_releases
           else raise "Unexpected repo provider '#{T.must(source).provider}'"
           end

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -317,6 +317,7 @@ module Dependabot
         when "azure" then recent_azure_commit_messages
         when "bitbucket" then recent_bitbucket_commit_messages
         when "codecommit" then recent_codecommit_commit_messages
+        when "example" then []
         else raise "Unsupported provider: #{source.provider}"
         end
       end
@@ -402,6 +403,7 @@ module Dependabot
             when "azure" then last_azure_dependabot_commit_message
             when "bitbucket" then last_bitbucket_dependabot_commit_message
             when "codecommit" then last_codecommit_dependabot_commit_message
+            when "example" then nil
             else raise "Unsupported provider: #{source.provider}"
             end,
             T.nilable(String)

--- a/silent/lib/dependabot/silent.rb
+++ b/silent/lib/dependabot/silent.rb
@@ -7,7 +7,7 @@ require "dependabot/silent/file_fetcher"
 require "dependabot/silent/file_parser"
 require "dependabot/silent/update_checker"
 require "dependabot/silent/file_updater"
-# require "dependabot/silent/metadata_finder" TODO
+require "dependabot/silent/metadata_finder"
 require "dependabot/silent/requirement"
 require "dependabot/silent/version"
 
@@ -18,3 +18,5 @@ Dependabot::PullRequestCreator::Labeler
 require "dependabot/dependency"
 Dependabot::Dependency
   .register_production_check("silent", ->(groups) { groups.empty? || groups.include?("prod") })
+
+Dependabot::MetadataFinders.register("silent", Dependabot::Silent::MetadataFinder)

--- a/silent/lib/dependabot/silent/metadata_finder.rb
+++ b/silent/lib/dependabot/silent/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/metadata_finders"
@@ -9,12 +9,14 @@ module Dependabot
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
 
+      sig { returns(String) }
       def homepage_url
         ""
       end
 
       private
 
+      sig { override.returns(Dependabot::Source) }
       def look_up_source
         Dependabot::Source.new(
           provider: "example",

--- a/silent/lib/dependabot/silent/metadata_finder.rb
+++ b/silent/lib/dependabot/silent/metadata_finder.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+require "dependabot/metadata_finders"
+require "dependabot/metadata_finders/base"
+
+module Dependabot
+  module Silent
+    class MetadataFinder < Dependabot::MetadataFinders::Base
+      extend T::Sig
+
+      def homepage_url
+        ""
+      end
+
+      private
+
+      def look_up_source
+        Dependabot::Source.new(
+          provider: "example",
+          hostname: "example.com",
+          api_endpoint: "https://example.com/api/v3",
+          repo: dependency.name,
+          directory: nil,
+          branch: nil
+        )
+      end
+    end
+  end
+end

--- a/silent/lib/dependabot/silent/metadata_finder.rb
+++ b/silent/lib/dependabot/silent/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/metadata_finders"


### PR DESCRIPTION
In #9560 we started revealing the exceptions that were being thrown in the metadata finders.

This caused the "silent" integration test output to be full of exceptions making it difficult to see what was going on in the test.

This implements the minimum amount to prevent exceptions in the logs of the integration tests.