### PR TITLE
Change dependabot-core license to MIT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 👋 Want to give us feedback on Dependabot, or contribute to it? That's great - thank you so much!
 
-By submitting a contribution, you agree that contribution is licensed to GitHub under the [MIT license](LICENSE.txt).
+By submitting a contribution, you agree that contribution is licensed to GitHub under the [MIT license](LICENSE).
 
 #### Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 👋 Want to give us feedback on Dependabot, or contribute to it? That's great - thank you so much!
 
-By submitting a contribution, you agree that contribution is licensed to GitHub under the [MIT-0 license](https://github.com/aws/mit-0).
+By submitting a contribution, you agree that contribution is licensed to GitHub under the [MIT license](LICENSE.txt).
 
 #### Overview
 
@@ -42,11 +42,8 @@ In `dependabot-core`, each ecosystem implementation is in its own gem so you can
 we have not merged by creating a [script](https://github.com/dependabot/dependabot-script) to run your own gem or
 fork of core, e.g. [dependabot-lein-runner](https://github.com/CGA1123/dependabot-lein-runner)
 
-Our plan in the year ahead is to invest more developer time directly in `dependabot-core` to improve our architecture so
-each ecosystem is more isolated and testable. We also want to make a consistency pass on existing ecosystems so that there
-is a clearer interface between core and the language-specific tooling.
-
-Our goal is make it easier to create and test Dependabot extensions so there is a paved path for running additional
+We are investing more developer time directly in `dependabot-core` to improve our architecture so that
+each ecosystem is more isolated and testable. Our goal is make it easier to create and test Dependabot extensions so there is a paved path for running additional
 ecosystems in the future.
 
 ## Stalebot

--- a/LICENSE
+++ b/LICENSE
@@ -1,39 +1,21 @@
-The Prosperity Public License 2.0.0
+MIT License
 
-Contributor: GitHub Inc.
+Copyright GitHub, Inc.
 
-Source Code: https://github.com/dependabot/dependabot-core
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This license lets you use and share this software for free,
-with a trial-length time limit on commercial use. Specifically:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-If you follow the rules below, you may do everything with this
-software that would otherwise infringe either the contributor's
-copyright in it, any patent claim the contributor can license
-that covers this software as of the contributor's latest
-contribution, or both.
-
-1. You must limit use of this software in any manner primarily
-   intended for or directed toward commercial advantage or
-   private monetary compensation to a trial period of 32
-   consecutive calendar days. This limit does not apply to use in
-   developing feedback, modifications, or extensions that you
-   contribute back to those giving this license.
-
-2. Ensure everyone who gets a copy of this software from you, in
-   source code or any other form, gets the text of this license
-   and the contributor and source code lines above.
-
-3. Do not make any legal claim against anyone for infringing any
-   patent claim they would infringe by using this software alone,
-   accusing this software, with or without changes, alone or as
-   part of a larger application.
-
-You are excused for unknowingly breaking rule 1 if you stop
-doing anything requiring this license within 30 days of
-learning you broke the rule.
-
-**This software comes as is, without any warranty at all. As far
-as the law allows, the contributor will not be liable for any
-damages related to this software or this license, for any kind of
-legal claim.**
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Welcome to the public home of Dependabot :dependabot:.
 - [Contributing to Dependabot](#contributing-to-dependabot)
   - [Reporting Issues and Feature Requests](#reporting-issues-and-feature-requests)
   - [Submitting Pull Requests](#submitting-pull-requests)
+  - [New Ecosystems](#new-ecosystems)
 - [Development Guide](#development-guide)
   - [Getting a Development Environment Running](#getting-a-development-environment-running)
   - [Debugging Problems](#debugging-problems)
   - [Running Tests](#running-tests)
   - [Profiling](#profiling)
 - [Architecture and Code Layout](#architecture-and-code-layout)
-- [License and Project History](#license-and-project-history)
+- [Trademarks](#trademarks)
 - [Notes for Project Maintainers](#notes-for-project-maintainers)
 
 ---
@@ -96,7 +97,7 @@ A good rule of thumb is that if you have questions about the _diff_ in a PR, it 
 
 ### Disclosing Security Issues
 
-If you believe you have found a security vulnerability in Dependabot please submit the vulnerability to GitHub Security [Bug Bounty](https://bounty.github.com/) so that we can resolve the issue before it is disclosed publicly.
+If you believe you have found a security vulnerability in Dependabot, please review [our security policy](https://github.com/dependabot/dependabot-core/security/policy) for details about disclosing them to the GitHub Bug Bounty program, so we can work to resolve the issue before it is disclosed publicly.
 
 ## Submitting Pull Requests
 
@@ -111,11 +112,9 @@ Contribution workflow:
 
 Please refer to the [CONTRIBUTING](CONTRIBUTING.md) guidelines for more information.
 
-### New Ecosystems
-
-Currently, the Dependabot team is not accepting support for new ecosystems. We are prioritising upgrades to already supported ecosystems at this time.
-
-Please refer to the [CONTRIBUTING](CONTRIBUTING.md) guidelines for more information.
+## New Ecosystems
+	
+If you're interested in contributing support for a new ecosystem, please refer to the [contributing guidelines](CONTRIBUTING.md#contributing-new-ecosystems) for more information.
 
 # Development Guide
 
@@ -496,41 +495,20 @@ sequenceDiagram
 
 This also means if Dependabot-Core ever has a security vulnerability, those creds are still not at risk of being exposed.
 
-# License and Project History
 
-## Why is this public?
+# Trademarks
 
-As the name suggests, Dependabot-Core is the core of Dependabot (the rest of the
-app is pretty much just a UI and database). If we were paranoid about someone
-stealing our business then we'd be keeping it under lock and key.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of GitHub trademarks or logos is
+subject to and must follow [GitHub Logos and Usage](https://github.com/logos). Use of GitHub trademarks or logos in modified versions of this project must not
+cause confusion or imply GitHub sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
 
-Dependabot-Core is public because we're more interested in it having an
-impact than we are in making a buck from it. We'd love you to use
-[Dependabot](https://docs.github.com/en/code-security/dependabot) so that we can continue to develop it, but if you want
-to build and host your own version then this library should make doing so a
-*lot* easier.
+# History
 
-If you use Dependabot-Core then we'd love to hear what you build! If you are curious about what we are currently working on, [check out our public board!](https://github.com/orgs/dependabot/projects/5/views/6)
+Dependabot and dependabot-core started life as [Bump](https://github.com/gocardless/bump) and
+[Bump Core](https://github.com/gocardless/bump-core), back when @hmarr and @greysteil were working at
+[GoCardless](https://gocardless.com).
 
-## License
-
-We use the License Zero Prosperity Public License, which essentially enshrines
-the following:
-
-- If you would like to use Dependabot-Core in a non-commercial capacity, such as
-  to host a bot at your workplace, then we give you full permission to do so. In
-  fact, we'd love you to and will help and support you however we can.
-- If you would like to add Dependabot's functionality to your for-profit
-  company's offering then we DO NOT give you permission to use Dependabot-Core
-  to do so.
-
-## History
-
-Dependabot and Dependabot-Core started life as [Bump](https://github.com/gocardless/bump) and
-[Bump Core](https://github.com/gocardless/bump-core), back when Harry and Grey were working at
-[GoCardless](https://gocardless.com). We remain grateful for the help and support of
-GoCardless in helping make Dependabot possible - if you need to collect
-recurring payments from Europe, check them out.
+Dependabot became a part of GitHub in 2019!
 
 # Notes for project maintainers
 

--- a/bundler/spec/fixtures/projects/bundler1/local_gemspec_needs_updates/common/dependabot-common.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/local_gemspec_needs_updates/common/dependabot-common.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.author       = "Dependabot"
   spec.email        = "opensource@github.com"
   spec.homepage     = "https://github.com/dependabot/dependabot-core"
-  spec.license      = "Nonstandard" # License Zero Prosperity Public License
+  spec.license     = "MIT"
 
   spec.version = "0.218.0"
   spec.required_ruby_version = ">= 3.1.0"

--- a/bundler/spec/fixtures/projects/bundler1/local_gemspec_needs_updates/common/dependabot-common.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/local_gemspec_needs_updates/common/dependabot-common.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.author       = "Dependabot"
   spec.email        = "opensource@github.com"
   spec.homepage     = "https://github.com/dependabot/dependabot-core"
-  spec.license     = "MIT"
+  spec.license      = "Nonstandard" # License Zero Prosperity Public License
 
   spec.version = "0.218.0"
   spec.required_ruby_version = ">= 3.1.0"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.author       = "Dependabot"
   spec.email        = "opensource@github.com"
   spec.homepage     = "https://github.com/dependabot/dependabot-core"
-  spec.license      = "Nonstandard" # License Zero Prosperity Public License
+  spec.license     = "MIT"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues",

--- a/composer/helpers/v1/composer.json
+++ b/composer/helpers/v1/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dependabot/composer-v1-helper",
     "description": "A helper package for Dependabot to perform updates using Composer",
-    "license": "The Prosperity Public License 2.0.0",
+    "license": "MIT",
     "require": {
         "php": "^7.4",
         "ext-json": "*",

--- a/composer/helpers/v2/composer.json
+++ b/composer/helpers/v2/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dependabot/composer-v2-helper",
     "description": "A helper package for Dependabot to perform updates using Composer",
-    "license": "The Prosperity Public License 2.0.0",
+    "license": "MIT",
     "require": {
         "php": "^7.4",
         "ext-json": "*",

--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.email       = "opensource@github.com"
   spec.files       = [] # intentionally empty, this is a placeholder gem to prevent namesquatting
   spec.homepage    = "https://github.com/dependabot/dependabot-core"
-  spec.license = "Nonstandard" # License Zero Prosperity Public License
+  spec.license     = "MIT"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues"


### PR DESCRIPTION
We are relicensing dependabot-core to MIT. This PR also includes several changes to the README and CONTRIBUTING files to reference the new license, and updates to Gemspecs to include the new license. 