### PR TITLE
Monkey patch on Bundler::materialize_for_installation for resolve Bundler::LazySpecification issue

### DIFF
--- a/bundler/helpers/v2/monkey_patches/bundler_spec_set_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/bundler_spec_set_patch.rb
@@ -1,0 +1,23 @@
+# typed: false
+# frozen_string_literal: true
+
+require "bundler/definition"
+
+# description needs update
+#
+module BundlerSpecSetPatch
+  def materialized_for_all_platforms
+    @specs.map do |s|
+      next s unless s.is_a?(LazySpecification)
+
+      s.source.cached!
+      s.source.remote!
+      spec = s.materialize_for_installation
+      raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
+
+      spec
+    end
+  end
+end
+
+Bundler::SpecSet.prepend(BundlerSpecSetPatch)

--- a/bundler/helpers/v2/monkey_patches/definition_bundler_spec_set_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_bundler_spec_set_patch.rb
@@ -3,8 +3,8 @@
 
 require "bundler/spec_set"
 
-# description needs update
-#
+# monkey patch materialized_for_all_platforms for lazy specification issue resolution
+# https://github.com/dependabot/dependabot-core/pull/9807
 module BundlerSpecSetPatch
   def materialized_for_all_platforms
     @specs.map do |s|

--- a/bundler/helpers/v2/monkey_patches/definition_bundler_spec_set_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_bundler_spec_set_patch.rb
@@ -1,19 +1,19 @@
 # typed: false
 # frozen_string_literal: true
 
-require "bundler/definition"
+require "bundler/spec_set"
 
 # description needs update
 #
 module BundlerSpecSetPatch
   def materialized_for_all_platforms
     @specs.map do |s|
-      next s unless s.is_a?(LazySpecification)
+      next s unless s.is_a?(Bundler::LazySpecification)
 
       s.source.cached!
       s.source.remote!
       spec = s.materialize_for_installation
-      raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
+      raise Bundler::GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
 
       spec
     end

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -17,6 +17,7 @@ end
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "bundler_spec_set_patch"
 
 require "functions"
 

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -17,7 +17,7 @@ end
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
-require "bundler_spec_set_patch"
+require "definition_bundler_spec_set_patch"
 
 require "functions"
 

--- a/bundler/helpers/v2/spec/definition_bundler_spec_set_patch_spec.rb
+++ b/bundler/helpers/v2/spec/definition_bundler_spec_set_patch_spec.rb
@@ -1,0 +1,42 @@
+# typed: false
+# frozen_string_literal: true
+
+require "native_spec_helper"
+require "shared_contexts"
+
+RSpec.describe Bundler::LazySpecification do
+  let(:specification) do
+    spec = Bundler::LazySpecification.new("example", "1.1.0", nil)
+    spec.extend(BundlerSpecSetPatch)
+    spec
+  end
+
+  describe "#default_gem?" do
+    let(:default_spec_dir) { "/mocked/default/spec/dir" }
+    before do
+      allow(Gem).to receive(:default_specifications_dir).and_return(default_spec_dir)
+    end
+
+    context "when the gem is a default gem" do
+      it "returns true if the loaded_from path is in the default specifications directory" do
+        specification.loaded_from = File.join(default_spec_dir, "example-1.1.0.gemspec")
+        expect(specification.default_gem?).to be true
+      end
+    end
+
+    context "when loaded_from is nil" do
+      it "returns false" do
+        specification.loaded_from = nil
+        expect(specification.default_gem?).to be false
+      end
+    end
+
+    context "when the gem is not a default gem" do
+      it "returns false if the loaded_from path is not in the default specifications directory" do
+        non_default_dir = "/path/to/non/default/directory"
+        specification.loaded_from = File.join(non_default_dir, "example-1.1.0.gemspec")
+        expect(specification.default_gem?).to be false
+      end
+    end
+  end
+end

--- a/bundler/helpers/v2/spec/definition_bundler_spec_set_patch_spec.rb
+++ b/bundler/helpers/v2/spec/definition_bundler_spec_set_patch_spec.rb
@@ -1,42 +1,68 @@
 # typed: false
 # frozen_string_literal: true
 
+# rubocop:disable RSpec/FilePath
+# rubocop:disable RSpec/SpecFilePathFormat
+
 require "native_spec_helper"
 require "shared_contexts"
+require "bundler/spec_set"
 
-RSpec.describe Bundler::LazySpecification do
-  let(:specification) do
-    spec = Bundler::LazySpecification.new("example", "1.1.0", nil)
-    spec.extend(BundlerSpecSetPatch)
-    spec
+RSpec.describe Bundler::SpecSet do
+  let(:primary_source) { instance_double(Bundler::Source::Git) }
+  let(:secondary_source) { instance_double(Bundler::Source::Path) }
+  let(:primary_spec_set) do
+    instance_double(Bundler::LazySpecification, full_name: "foo-1.0.0-x86_64-linux", source: primary_source)
+  end
+  let(:secondary_spec_set) do
+    instance_double(Bundler::LazySpecification, full_name: "foo-1.0.0-arm64-darwin", source: secondary_source)
   end
 
-  describe "#default_gem?" do
-    let(:default_spec_dir) { "/mocked/default/spec/dir" }
-    before do
-      allow(Gem).to receive(:default_specifications_dir).and_return(default_spec_dir)
-    end
+  before do
+    allow(primary_spec_set).to receive(:is_a?).with(Bundler::LazySpecification).and_return(true)
+    allow(secondary_spec_set).to receive(:is_a?).with(Bundler::LazySpecification).and_return(true)
 
-    context "when the gem is a default gem" do
-      it "returns true if the loaded_from path is in the default specifications directory" do
-        specification.loaded_from = File.join(default_spec_dir, "example-1.1.0.gemspec")
-        expect(specification.default_gem?).to be true
+    allow(primary_source).to receive(:cached!)
+    allow(primary_source).to receive(:remote!)
+    allow(secondary_source).to receive(:cached!)
+    allow(secondary_source).to receive(:remote!)
+
+    allow(primary_spec_set).to receive(:materialize_for_installation).and_return(primary_spec_set)
+    allow(secondary_spec_set).to receive(:materialize_for_installation).and_return(secondary_spec_set)
+  end
+
+  describe "#materialized_for_all_platforms" do
+    context "when cache_all_platforms is enabled" do
+      let(:spec_set) { described_class.new([primary_spec_set, secondary_spec_set]) }
+
+      before do
+        described_class.prepend(BundlerSpecSetPatch)
       end
-    end
 
-    context "when loaded_from is nil" do
-      it "returns false" do
-        specification.loaded_from = nil
-        expect(specification.default_gem?).to be false
+      it "uses cached gems for secondary sources" do
+        expect(primary_spec_set.source).to receive(:cached!).ordered
+        expect(primary_spec_set.source).to receive(:remote!).ordered
+        expect(primary_spec_set).to receive(:materialize_for_installation).and_return(primary_spec_set).ordered
+
+        expect(secondary_spec_set.source).to receive(:cached!).ordered
+        expect(secondary_spec_set.source).to receive(:remote!).ordered
+        expect(secondary_spec_set).to receive(:materialize_for_installation).and_return(secondary_spec_set).ordered
+
+        result = spec_set.materialized_for_all_platforms
+        expect(result).to include(primary_spec_set, secondary_spec_set)
       end
-    end
 
-    context "when the gem is not a default gem" do
-      it "returns false if the loaded_from path is not in the default specifications directory" do
-        non_default_dir = "/path/to/non/default/directory"
-        specification.loaded_from = File.join(non_default_dir, "example-1.1.0.gemspec")
-        expect(specification.default_gem?).to be false
+      it "raises an error if a gem cannot be found in any of the sources" do
+        allow(primary_spec_set).to receive(:materialize_for_installation).and_return(nil)
+
+        expect do
+          spec_set.materialized_for_all_platforms
+        end.to raise_error(Bundler::GemNotFound,
+                           "Could not find foo-1.0.0-x86_64-linux in any of the sources")
       end
     end
   end
 end
+
+# rubocop:enable RSpec/FilePath
+# rubocop:enable RSpec/SpecFilePathFormat

--- a/bundler/helpers/v2/spec/native_spec_helper.rb
+++ b/bundler/helpers/v2/spec/native_spec_helper.rb
@@ -12,6 +12,7 @@ $LOAD_PATH.unshift(File.expand_path("../../spec_helpers", __dir__))
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
+require "definition_bundler_spec_set_patch"
 require "git_source_patch"
 
 require "functions"


### PR DESCRIPTION
### Draft

**Context** : https://github.com/dependabot/dependabot-core/issues/9781

"To solve lazy specification error, we need to update rubygem in Dependabot core with the release having the fix in the below comment. But before we do that, we also need to make few changes into Dependabot core to support the release as Dependabot relies on the @unlock[:gems] value in Bundler::Definition, which is now removed at initialize time

More detailed context: https://github.com/rubygems/rubygems/pull/7659#issuecomment-2114690972

This task will unblock the cargo private registry support for GA"

**Fix applied:**  Applied monkey patch on Bundler::materialize_for_installation
