### PR TITLE
fix nuget ignored package version handling

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -125,6 +125,7 @@ module Dependabot
         updated_dependencies += DependencyFinder.new(
           dependency: updated_dependency,
           dependency_files: dependency_files,
+          ignored_versions: ignored_versions,
           credentials: credentials,
           repo_contents_path: @repo_contents_path
         ).updated_peer_dependencies

--- a/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/dependency_finder.rb
@@ -37,13 +37,15 @@ module Dependabot
           params(
             dependency: Dependabot::Dependency,
             dependency_files: T::Array[Dependabot::DependencyFile],
+            ignored_versions: T::Array[String],
             credentials: T::Array[Dependabot::Credential],
             repo_contents_path: T.nilable(String)
           ).void
         end
-        def initialize(dependency:, dependency_files:, credentials:, repo_contents_path:)
+        def initialize(dependency:, dependency_files:, ignored_versions:, credentials:, repo_contents_path:)
           @dependency             = dependency
           @dependency_files       = dependency_files
+          @ignored_versions       = ignored_versions
           @credentials            = credentials
           @repo_contents_path     = repo_contents_path
         end
@@ -126,6 +128,9 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        sig { returns(T::Array[String]) }
+        attr_reader :ignored_versions
 
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
@@ -280,7 +285,7 @@ module Dependabot
             dependency: dep,
             dependency_files: dependency_files,
             credentials: credentials,
-            ignored_versions: [],
+            ignored_versions: ignored_versions,
             raise_on_ignored: false,
             security_advisories: [],
             repo_contents_path: repo_contents_path

--- a/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
@@ -134,6 +134,7 @@ module Dependabot
           DependencyFinder.new(
             dependency: dependency,
             dependency_files: dependency_files,
+            ignored_versions: ignored_versions,
             credentials: credentials,
             repo_contents_path: repo_contents_path
           ).updated_peer_dependencies.each do |peer_dependency|

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -187,12 +187,11 @@ module Dependabot
         end
         def filter_ignored_versions(possible_versions)
           filtered = possible_versions
-
           ignored_versions.each do |req|
-            ignore_req = requirement_class.new(parse_requirement_string(req))
+            ignore_reqs = parse_requirement_string(req).map { |r| requirement_class.new(r) }
             filtered =
               filtered
-              .reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
+              .reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v.fetch(:version)) } }
           end
 
           if @raise_on_ignored && filter_lower_versions(filtered).empty? &&

--- a/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
+      ignored_versions: [],
       credentials: credentials,
       repo_contents_path: "test/repo"
     )

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     end
 
     context "when a version range is specified using Ruby syntax" do
-      let(:ignored_versions) { [">= 2.a, < 3.0.0"] }
+      let(:ignored_versions) { [">= 2.a"] }
       let(:expected_version) { "1.1.2" }
 
       its([:version]) { is_expected.to eq(version_class.new("1.1.2")) }
@@ -272,6 +272,13 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
           expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
         end
       end
+    end
+
+    context "when the user is ignoring all versions but a very specific one" do
+      let(:ignored_versions) { ["< 1.1.1, > 1.1.1"] }
+      let(:expected_version) { "1.1.1" }
+
+      its([:version]) { is_expected.to eq(expected_version_instance) }
     end
 
     context "with a custom repo in a nuget.config file" do
@@ -688,7 +695,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     its([:version]) { is_expected.to eq(version_class.new("2.0.0")) }
 
     context "when the user is ignoring the lowest version" do
-      let(:ignored_versions) { [">= 2.a, <= 2.0.0"] }
+      let(:ignored_versions) { ["<= 2.0.0"] }
       let(:expected_version) { "2.0.3" }
 
       its([:version]) { is_expected.to eq(version_class.new("2.0.3")) }


### PR DESCRIPTION
The current handling of `ignored_versions` in a `job.yml` file is incorrect.  Consider an example from the unit tests; a `job.yml` could list that for a certain package, `ignored_versions` should be `< 1.1.1, > 1.1.1` which should be read as "ignore anything below 1.1.1 and ignore anything above 1.1.1" which boils down to "only accept version 1.1.1".  The previous implementation did a slightly different thing of "negate (version is less than 1.1.1 AND version is greater than 1.1.1)" which is impossible; this was a wrong application of our good friend [De Morgan](https://en.wikipedia.org/wiki/De_Morgan%27s_laws).

The proper fix here is to turn that check into "negate (version is less than 1.1.1 OR version is greater than 1.1.1)".  Thankfully the Maven updater does the correct thing so I could almost directly copy what was done there.

Some additional changes had to be made, namely ensuring that the `ignored_versions` property was passed around everywhere and fixing some unit tests that weren't correct.