### PR TITLE
update to 8.0.300 SDK

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK
-ARG DOTNET_SDK_VERSION=8.0.202
+ARG DOTNET_SDK_VERSION=8.0.300
 ARG DOTNET_SDK_INSTALL_URL=https://dot.net/v1/dotnet-install.sh
 ENV DOTNET_INSTALL_DIR=/usr/local/dotnet/current
 ENV DOTNET_NOLOGO=true

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -91,6 +91,7 @@ public partial class DiscoveryWorkerTests
                           </ItemGroup>
                         </Project>
                         """),
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
@@ -108,6 +109,7 @@ public partial class DiscoveryWorkerTests
                 expectedResult: new()
                 {
                     FilePath = "",
+                    ExpectedProjectCount = 2,
                     Projects = [
                         new()
                         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -135,6 +135,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                       </ItemGroup>
                     </Project>
                     """),
+                ("Directory.Build.props", "<Project />"),
                 ("Directory.Packages.props", """
                     <Project>
                       <PropertyGroup>
@@ -151,6 +152,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 FilePath = "src",
+                ExpectedProjectCount = 2,
                 Projects = [
                     new()
                     {
@@ -203,6 +205,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                       </ItemGroup>
                     </Project>
                     """),
+                ("Directory.Build.props", "<Project />"),
                 ("Directory.Packages.props", """
                     <Project>
                       <PropertyGroup>
@@ -274,6 +277,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 FilePath = "",
+                ExpectedProjectCount = 2,
                 Projects = [
                     new()
                     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryDirectory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryDirectory.cs
@@ -50,9 +50,14 @@ public sealed class TemporaryDirectory : IDisposable
         var parentDirectory = Path.GetDirectoryName(temporaryDirectory.DirectoryPath)!;
 
         // prevent directory crawling
-        await File.WriteAllTextAsync(Path.Combine(parentDirectory, "Directory.Build.props"), "<Project />");
+        await File.WriteAllTextAsync(Path.Combine(parentDirectory, "Directory.Build.props"), """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+            </Project>
+            """);
         await File.WriteAllTextAsync(Path.Combine(parentDirectory, "Directory.Build.targets"), "<Project />");
-        await File.WriteAllTextAsync(Path.Combine(parentDirectory, "Directory.Packages.props"), "<Project />");
 
         foreach (var (path, contents) in fileContents)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -674,6 +674,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -739,6 +740,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1036,6 +1038,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1103,6 +1106,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1170,6 +1174,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1233,6 +1238,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1290,6 +1296,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -1473,6 +1480,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     // initial props files
                     ("Directory.Packages.props", """
                         <Project>
@@ -1556,6 +1564,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     // initial props files
                     ("Directory.Packages.props", """
                         <Project>
@@ -1641,6 +1650,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     // initial props files
                     ("Directory.Packages.props", """
                         <Project>
@@ -1900,6 +1910,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>
@@ -2174,6 +2185,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     // initial props files
                     ("Directory.Packages.props", """
                         <Project>
@@ -2246,6 +2258,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     // initial props files
                     ("Directory.Packages.props", """
                         <Project>
@@ -2481,6 +2494,7 @@ public partial class UpdateWorkerTests
                     """,
                 additionalFiles:
                 [
+                    ("Directory.Build.props", "<Project />"),
                     ("Directory.Packages.props", """
                         <Project>
                           <PropertyGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -542,12 +542,12 @@ internal static partial class MSBuildHelper
               <PropertyGroup>
                 <!-- For Windows-specific apps -->
                 <EnableWindowsTargeting>true</EnableWindowsTargeting>
+                <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
               </PropertyGroup>
             </Project>
             """);
 
         await File.WriteAllTextAsync(Path.Combine(tempDir.FullName, "Directory.Build.targets"), "<Project />");
-        await File.WriteAllTextAsync(Path.Combine(tempDir.FullName, "Directory.Packages.props"), "<Project />");
 
         return tempProjectPath;
     }

--- a/nuget/helpers/lib/NuGetUpdater/global.json
+++ b/nuget/helpers/lib/NuGetUpdater/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.202",
+    "version": "8.0.300",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The behavior around handling `Directory.Packages.props` has subtly changed in the `*.300` SDK which meant for unit tests, an empty `Directory.Build.props` had to be written and in other cases writing an empty `Directory.Packages.props` wasn't the correct thing to do any more.

More details about the difference with handling `Directory.Packages.props` can be found at NuGet/Home#13453.