### PR TITLE
Enforce `true` sigil in `npm_and_yarn` ecosystem

### DIFF
--- a/npm_and_yarn/.rubocop.yml
+++ b/npm_and_yarn/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: ../.rubocop.yml
+
+Sorbet/TrueSigil:
+  Enabled: true


### PR DESCRIPTION
With #9800 and #9827, all of the `npm_and_yarn` ecosystem is now `# typed: true` with Sorbet. This change enforces this requirement with RuboCop to prevent regressions in type safety.