### PR TITLE
Replace cargo registry keyword from the credentials to use new keyword registry

### DIFF
--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -17,7 +17,7 @@ module Dependabot
           # (We must add these environment variables here, or 'cargo update' will not think it is
           # configured properly for the private registries.)
 
-          token_env_var = "CARGO_REGISTRIES_#{cred['cargo_registry'].upcase.tr('-', '_')}_TOKEN"
+          token_env_var = "CARGO_REGISTRIES_#{cred['registry'].upcase.tr('-', '_')}_TOKEN"
 
           token = "placeholder_token"
           if cred["token"].nil?


### PR DESCRIPTION
## Context

The Cargo private registry is working with CLI + Core but failing with Dependabot API + Core

The issue arises because the cargo_registry key is missing in one of the entries in the Dependabot API, which results in a nil value when accessed in the core code, leading to the error mentioned earlier. 


Fix:
To fix the issue adding a new cargo private registry key, in the `.dependabot.yml file` as an additional parameter: `cargo_registry: registry name` and changes in this PR uses that key.

