### PR TITLE
Update bundler from 2.5.9 to 2.5.11

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -116,7 +116,7 @@ RUN gem update --system $RUBYGEMS_VERSION
 # When bumping Bundler, need to also:
 # * Regenerate `updater/Gemfile.lock` via `BUNDLE_GEMFILE=updater/Gemfile bundle lock --update --bundler`
 # * Regenerate `Gemfile.lock` via `bundle lock --update --bundler`.
-ARG BUNDLER_V2_VERSION=2.5.9
+ARG BUNDLER_V2_VERSION=2.5.11
 
 RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
  rm -rf /var/lib/gems/*/cache/* && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,4 +410,4 @@ DEPENDENCIES
   webrick (>= 1.7)
 
 BUNDLED WITH
-   2.5.9
+   2.5.11

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -433,4 +433,4 @@ DEPENDENCIES
   webrick (>= 1.7)
 
 BUNDLED WITH
-   2.5.9
+   2.5.11


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md

FYI, a side effect of this update:
After merging this PR, dependabot will strip credentials from the Gemfile.lock if there are any. E.g. for sidekiq-pro. This is because as of Bundler 2.5.10 gem credentials are never written to Gemfile.lock. See this PR:
https://github.com/rubygems/rubygems/pull/7560

Our app is using Bundler 2.5.10+, so we're currently having to fight with dependabot because when we run `bundle install` the credentials get stripped and then when dependabot runs it puts them back in, since it's using an older version of Bundler.