### PR TITLE
Ignore 422 Validation Failed responses when adding assignees to a PR

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -439,10 +439,12 @@ module Dependabot
           pull_request.number,
           assignees
         )
-      rescue Octokit::UnprocessableEntity, Octokit::NotFound
-        # Octokit::UnprocessableEntity - This can happen if an invalid assignee was passed
-        # Octokit::NotFound            - This can happen if a passed assignee login is now an org account
+      rescue Octokit::NotFound
+        # This can happen if a passed assignee login is now an org account
         nil
+      rescue Octokit::UnprocessableEntity => e
+        # This can happen if an invalid assignee was passed
+        raise unless e.message.include?("Could not add assignees")
       end
 
       sig { params(pull_request: T.untyped).void }


### PR DESCRIPTION
Ignore 422 Validation Failed responses when adding assignees to a PR

We are sometimes seeing 422 Validation Failed responses when we add assignees to a PR https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#validation-failed

We don't check that the assignees are real users on the repo so that may be the culprit. For now let's ignore these errors so we can continue to create the PR.