### PR TITLE
Use non-deprecated `spoom srb bump` command

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -27,9 +27,9 @@ jobs:
       - run: bundle exec spoom coverage
 
       - run: |
-          bundle exec spoom bump --from=false --to=true --dry
-          bundle exec spoom bump --from=true --to=strict --dry
-          bundle exec spoom bump --from=strict --to=strong --dry
+          bundle exec spoom srb bump --from=false --to=true --dry
+          bundle exec spoom srb bump --from=true --to=strict --dry
+          bundle exec spoom srb bump --from=strict --to=strong --dry
 
       - run: bundle exec spoom coverage timeline --save
 


### PR DESCRIPTION
Our [spoom GitHub Actions workflow][1] is currently printing a warning for this step

```
Warning: This command is deprecated. Please use spoom srb bump instead.
```

This change migrates us from using `spoom bump` to `spoom srb bump`.

[1]: https://github.com/dependabot/dependabot-core/actions/workflows/sorbet.yml