### PR TITLE
Prevent github actions with same name ending after hyphen to be updated

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -78,7 +78,7 @@ module Dependabot
             old_declaration
             .gsub(/@.*+/, "@#{new_ref}")
 
-          # Replace the old declaration that's preceded by a non-word character
+          # Replace the old declaration that's preceded by a non-word character (unless it's a hyphen)
           # and followed by a whitespace character (comments) or EOL.
           # If the declaration is followed by a comment that lists the version associated
           # with the SHA source ref, then update the comment to the human-readable new version.
@@ -88,7 +88,7 @@ module Dependabot
           updated_content =
             updated_content
             .gsub(
-              /(?<=\W|"|')#{Regexp.escape(old_declaration)}["']?(?<comment>\s+#.*)?(?=\s|$)/
+              /(?<=[^a-zA-Z_-]|"|')#{Regexp.escape(old_declaration)}["']?(?<comment>\s+#.*)?(?=\s|$)/
             ) do |match|
               comment = Regexp.last_match(:comment)
               match.gsub!(old_declaration, new_declaration)

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -296,6 +296,50 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         end
       end
 
+      context "with actions name having same ending" do
+        let(:workflow_file_body) do
+          fixture("workflow_files", "same_name_ending.yml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/cache",
+            version: nil,
+            package_manager: "github_actions",
+            previous_version: nil,
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              metadata: { declaration_string: "actions/cache@v1" },
+              source: {
+                type: "git",
+                url: "https://github.com/actions/cache",
+                ref: "v1",
+                branch: nil
+              }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              metadata: { declaration_string: "actions/cache@v4" },
+              source: {
+                type: "git",
+                url: "https://github.com/actions/cache",
+                ref: "v4",
+                branch: nil
+              }
+            }]
+          )
+        end
+
+        it "updates only actions/cache" do
+          expect(updated_workflow_file.content).to include "actions/cache@v4"
+          expect(updated_workflow_file.content).to include "julia-actions/cache@v1"
+          expect(updated_workflow_file.content).not_to include "julia-actions/cache@v4\n"
+        end
+      end
+
       context "with pinned SHA hash and version in comment" do
         let(:service_pack_url) do
           "https://github.com/actions/checkout.git/info/refs" \

--- a/github_actions/spec/fixtures/workflow_files/same_name_ending.yml
+++ b/github_actions/spec/fixtures/workflow_files/same_name_ending.yml
@@ -1,0 +1,9 @@
+name: Dependabot
+on: [push]
+jobs:
+  ci:
+    name: Ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v1
+      - uses: julia-actions/cache@v1


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
Prevent the case where one action has the name of another with a prefix followed by a - (hyphen). For instance, julia-actions/cache and actions/cache.
This is done by updating the regex that matches the action names. `\W` used before does not match `-`, so I changed to the explicit `[^a-zA-Z_-]`.
I have also created a test and a fixture to use in the test.

<!-- What issues does this affect or fix? -->
Fix #9885

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The new test should capture the use case presented in #9885. I tested it before and after the fix, so it does appear to be testing what I propose.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
