### PR TITLE
fail sooner when PR creation data is incomplete

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -21,21 +21,18 @@ module Dependabot
     extend T::Sig
     extend Forwardable
 
-    class MissingPreviousVersion < DependabotError
+    class InvalidUpdatedDependencies < DependabotError
       extend T::Sig
 
-      sig { params(deps: T::Array[String]).void }
-      def initialize(deps)
-        super("Previous version was not provided for the following dependencies: #{deps.join(', ')}")
-      end
-    end
+      sig { params(deps_no_previous_version: T::Array[String], deps_no_change: T::Array[String]).void }
+      def initialize(deps_no_previous_version:, deps_no_change:)
+        msg = ""
+        if deps_no_previous_version.any?
+          msg += "Previous version was not provided for: '#{deps_no_previous_version.join(', ')}' "
+        end
+        msg += "No requirements change for: '#{deps_no_change.join(', ')}'" if deps_no_change.any?
 
-    class MissingRequirementsChange < DependabotError
-      extend T::Sig
-
-      sig { params(deps: T::Array[String]).void }
-      def initialize(deps)
-        super("Requirements was not changed for the following dependencies: #{deps.join(', ')}")
+        super(msg)
       end
     end
 
@@ -68,12 +65,7 @@ module Dependabot
     sig { params(dependency_change: Dependabot::DependencyChange, base_commit_sha: String).void }
     def create_pull_request(dependency_change, base_commit_sha)
       if Experiments.enabled?("dependency_change_validation")
-        updated_deps = dependency_change.updated_dependencies
-        deps_missing_previous = updated_deps.reject(&:previous_version)
-        raise MissingPreviousVersion, deps_missing_previous.map(&:name) unless deps_missing_previous.empty?
-
-        deps_missing_change = updated_deps.reject { |dep| requirements_changed?(dep) }
-        raise MissingRequirementsChange, deps_missing_change.map(&:name) unless deps_missing_change.empty?
+        check_dependencies_have_previous_version(dependency_change.updated_dependencies)
       end
 
       if Experiments.enabled?("threaded_metadata")
@@ -255,6 +247,19 @@ module Dependabot
     def truncate(string, max: 120)
       snip = max - 3
       string.length > max ? "#{string[0...snip]}..." : string
+    end
+
+    sig { params(updated_dependencies: T::Array[Dependabot::Dependency]).void }
+    def check_dependencies_have_previous_version(updated_dependencies)
+      return if updated_dependencies.all? { |d| requirements_changed?(d) }
+      return if updated_dependencies.all?(&:previous_version)
+
+      deps_no_previous_version = updated_dependencies.reject(&:previous_version)
+      deps_no_change = updated_dependencies.reject { |d| requirements_changed?(d) }
+      raise InvalidUpdatedDependencies.new(
+        deps_no_previous_version: deps_no_previous_version.map(&:name),
+        deps_no_change: deps_no_change.map(&:name)
+      )
     end
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Dependabot::Service do
         .to eql([["dependabot-fortran ( from 1.7.0 to 1.8.0 ), dependabot-pascal ( from 2.7.0 to 2.8.0 )", :created]])
     end
 
-    context "when the change is missing a previous version" do
+    context "when the change is missing a previous version and there's no change in requirements" do
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -249,39 +249,15 @@ RSpec.describe Dependabot::Service do
               { file: "Gemfile", requirement: "~> 1.8.0", groups: [], source: nil }
             ],
             previous_requirements: [
-              { file: "Gemfile", requirement: "~> 1.7.0", groups: [], source: nil }
-            ]
-          )
-        ]
-      end
-
-      it "raises a MissingPreviousVersion error" do
-        expect { service.create_pull_request(dependency_change, base_sha) }
-          .to raise_error(Dependabot::Service::MissingPreviousVersion)
-      end
-    end
-
-    context "when the change is missing a requirements change" do
-      let(:dependencies) do
-        [
-          Dependabot::Dependency.new(
-            name: "dependabot-fortran",
-            package_manager: "bundler",
-            version: "1.8.0",
-            previous_version: "1.7.0",
-            requirements: [
-              { file: "Gemfile", requirement: "~> 1.8.0", groups: [], source: nil }
-            ],
-            previous_requirements: [
               { file: "Gemfile", requirement: "~> 1.8.0", groups: [], source: nil }
             ]
           )
         ]
       end
 
-      it "raises a MissingRequirementsChange error" do
+      it "raises an InvalidUpdatedDependencies error" do
         expect { service.create_pull_request(dependency_change, base_sha) }
-          .to raise_error(Dependabot::Service::MissingRequirementsChange)
+          .to raise_error(Dependabot::Service::InvalidUpdatedDependencies)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

The PullRequestCreator refuses to create PRs when either the `previous_version` is absent or the `previous_requirements` reveal there were no changes to a dependency.

That code is here: https://github.com/dependabot/dependabot-core/blob/75b48123458652e6572c1ac6ab0934b63412f371/common/lib/dependabot/pull_request_creator.rb#L224-L231

This results in what looks like successful runs ending with a PR not being created. 

To improve this, we need to move the validation check closer to where the issue is. In this PR, I added behind an experiment the same check right before sending the PR data to the client.

This will give us, and customers, more information about the nature of the problem, since it will tell us which dependency is failing and why. Then we can target which ecosystems need help and see if we can fix them.

### How will you know you've accomplished your goal?

We should start seeing the errors from the Updater side and track them in Sentry along with the dependency name and ecosystem.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
