### PR TITLE
Migrate to new `spoom srb coverage` command

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -31,7 +31,7 @@ jobs:
           bundle exec spoom srb bump --from=true --to=strict --dry
           bundle exec spoom srb bump --from=strict --to=strong --dry
 
-      - run: bundle exec spoom coverage timeline --save
+      - run: bundle exec spoom srb coverage snapshot --save
 
       - if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: bundle exec srb tc
 
-      - run: bundle exec spoom coverage
+      - run: bundle exec spoom srb coverage
 
       - run: |
           bundle exec spoom srb bump --from=false --to=true --dry

--- a/script/generate-coverage-report
+++ b/script/generate-coverage-report
@@ -18,4 +18,4 @@ done
 echo Download complete
 
 echo Generating coverage report
-bundle exec spoom coverage report
+bundle exec spoom srb coverage report


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Fix the spoom coverage report generation.

It hasn't been generating a new report since 24th April due to the command we were using being deprecated.

Related to #9876 

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

The deprecation warning is gone and the report is being generated again.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
