### PR TITLE
Upgrade httparty to 0.22.0

### DIFF
--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.3.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -208,7 +209,8 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     io-console (0.7.2)
@@ -224,9 +226,10 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.6)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     netrc (0.11.0)
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)


### PR DESCRIPTION
### What are you trying to accomplish?

Warnings due to using old httparty were partially fixed by https://github.com/dependabot/dependabot-core/pull/9770.

However, you still get runtime warnings like the following:

```
    updater | /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/httparty-0.21.0/lib/httparty.rb:10: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of httparty-0.21.0 to add csv into its gemspec.
```

because the update was not applied to `updater/` folder.

This PR also updates the dependency in updater/Gemfile.lock.

### Anything you want to highlight for special attention from reviewers?

Follow up to #9770 and #9873.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
