### PR TITLE
RSpec enable predicate matcher

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,6 @@ RSpec/BeforeAfterAll:
 RSpec/ExampleLength:
   Max: 98
 
-
 # Offense count: 10
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
@@ -163,22 +162,6 @@ RSpec/OverwritingSetup:
     - 'terraform/spec/dependabot/terraform/file_parser_spec.rb'
     - 'updater/spec/dependabot/dependency_snapshot_spec.rb'
 
-# Offense count: 47
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Strict, EnforcedStyle, AllowedExplicitMatchers.
-# SupportedStyles: inflected, explicit
-RSpec/PredicateMatcher:
-  Exclude:
-    - 'common/spec/dependabot/dependency_file_spec.rb'
-    - 'common/spec/dependabot/dependency_group_spec.rb'
-    - 'common/spec/dependabot/experiments_spec.rb'
-    - 'common/spec/dependabot/file_updaters/artifact_updater_spec.rb'
-    - 'common/spec/dependabot/file_updaters/vendor_updater_spec.rb'
-    - 'common/spec/dependabot/workspace/git_spec.rb'
-    - 'npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb'
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
-    - 'python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb'
-    - 'updater/spec/dependabot/job_spec.rb'
 
 # Offense count: 4
 RSpec/RepeatedExample:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -198,11 +198,6 @@ RSpec/RepeatedExampleGroupBody:
 RSpec/RepeatedExampleGroupDescription:
   Enabled: false
 
-# Offense count: 251
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/ScatteredLet:
-  Enabled: false
-
 # Offense count: 36
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ScatteredSetup:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: bundler
   specs:
-    dependabot-bundler (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-bundler (0.259.0)
+      dependabot-common (= 0.259.0)
       parallel (~> 1.24)
 
 PATH
   remote: cargo
   specs:
-    dependabot-cargo (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-cargo (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: common
   specs:
-    dependabot-common (0.260.0)
+    dependabot-common (0.259.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -37,107 +37,107 @@ PATH
 PATH
   remote: composer
   specs:
-    dependabot-composer (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-composer (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: devcontainers
   specs:
-    dependabot-devcontainers (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-devcontainers (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: docker
   specs:
-    dependabot-docker (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-docker (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: elm
   specs:
-    dependabot-elm (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-elm (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: git_submodules
   specs:
-    dependabot-git_submodules (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-git_submodules (0.259.0)
+      dependabot-common (= 0.259.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: github_actions
   specs:
-    dependabot-github_actions (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-github_actions (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: go_modules
   specs:
-    dependabot-go_modules (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-go_modules (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: gradle
   specs:
-    dependabot-gradle (0.260.0)
-      dependabot-common (= 0.260.0)
-      dependabot-maven (= 0.260.0)
+    dependabot-gradle (0.259.0)
+      dependabot-common (= 0.259.0)
+      dependabot-maven (= 0.259.0)
 
 PATH
   remote: hex
   specs:
-    dependabot-hex (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-hex (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: maven
   specs:
-    dependabot-maven (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-maven (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-npm_and_yarn (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: nuget
   specs:
-    dependabot-nuget (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-nuget (0.259.0)
+      dependabot-common (= 0.259.0)
       rubyzip (>= 2.3.2, < 3.0)
 
 PATH
   remote: pub
   specs:
-    dependabot-pub (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-pub (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: python
   specs:
-    dependabot-python (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-python (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: silent
   specs:
-    dependabot-silent (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-silent (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: swift
   specs:
-    dependabot-swift (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-swift (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: terraform
   specs:
-    dependabot-terraform (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-terraform (0.259.0)
+      dependabot-common (= 0.259.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: bundler
   specs:
-    dependabot-bundler (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-bundler (0.260.0)
+      dependabot-common (= 0.260.0)
       parallel (~> 1.24)
 
 PATH
   remote: cargo
   specs:
-    dependabot-cargo (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-cargo (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: common
   specs:
-    dependabot-common (0.259.0)
+    dependabot-common (0.260.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -37,107 +37,107 @@ PATH
 PATH
   remote: composer
   specs:
-    dependabot-composer (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-composer (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: devcontainers
   specs:
-    dependabot-devcontainers (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-devcontainers (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: docker
   specs:
-    dependabot-docker (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-docker (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: elm
   specs:
-    dependabot-elm (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-elm (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: git_submodules
   specs:
-    dependabot-git_submodules (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-git_submodules (0.260.0)
+      dependabot-common (= 0.260.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: github_actions
   specs:
-    dependabot-github_actions (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-github_actions (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: go_modules
   specs:
-    dependabot-go_modules (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-go_modules (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: gradle
   specs:
-    dependabot-gradle (0.259.0)
-      dependabot-common (= 0.259.0)
-      dependabot-maven (= 0.259.0)
+    dependabot-gradle (0.260.0)
+      dependabot-common (= 0.260.0)
+      dependabot-maven (= 0.260.0)
 
 PATH
   remote: hex
   specs:
-    dependabot-hex (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-hex (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: maven
   specs:
-    dependabot-maven (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-maven (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-npm_and_yarn (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: nuget
   specs:
-    dependabot-nuget (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-nuget (0.260.0)
+      dependabot-common (= 0.260.0)
       rubyzip (>= 2.3.2, < 3.0)
 
 PATH
   remote: pub
   specs:
-    dependabot-pub (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-pub (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: python
   specs:
-    dependabot-python (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-python (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: silent
   specs:
-    dependabot-silent (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-silent (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: swift
   specs:
-    dependabot-swift (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-swift (0.260.0)
+      dependabot-common (= 0.260.0)
 
 PATH
   remote: terraform
   specs:
-    dependabot-terraform (0.259.0)
-      dependabot-common (= 0.259.0)
+    dependabot-terraform (0.260.0)
+      dependabot-common (= 0.260.0)
 
 GEM
   remote: https://rubygems.org/

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -259,6 +259,13 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
 
     context "with a private rubygems source" do
       let(:dependency_files) { bundler_project_dependency_files("specified_source") }
+      let(:subprocess_error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: error_message,
+          error_context: {},
+          error_class: error_class
+        )
+      end
       let(:source) { { type: "rubygems" } }
       let(:registry_url) { "https://repo.fury.io/greysteil/" }
       let(:gemfury_business_url) do
@@ -288,14 +295,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           .and_return(
             ["1.5.0", "1.9.0", "1.10.0.beta"]
           )
-      end
-
-      let(:subprocess_error) do
-        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-          message: error_message,
-          error_context: {},
-          error_class: error_class
-        )
       end
 
       its([:version]) { is_expected.to eq(Gem::Version.new("1.9.0")) }

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -128,9 +128,9 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         context "when attempting to update Bundler" do
           let(:dependency_name) { "bundler" }
-          include_context "when stubbing rubygems versions api"
-
           let(:dependency_files) { bundler_project_dependency_files("bundler_specified") }
+
+          include_context "when stubbing rubygems versions api"
 
           its([:version]) { is_expected.to eq(Gem::Version.new("1.16.3")) }
 

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 }
               }]
             end
+            let(:upload_pack_fixture) { "business" }
 
             before do
               stub_request(:get, rubygems_url + "versions/business.json")
@@ -320,8 +321,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                   headers: git_header
                 )
             end
-
-            let(:upload_pack_fixture) { "business" }
 
             it "fetches the latest SHA-1 hash of the latest version tag" do
               expect(checker.latest_version)
@@ -883,6 +882,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 }
               }]
             end
+            let(:upload_pack_fixture) { "business" }
 
             before do
               stub_request(:get, rubygems_url + "versions/business.json")
@@ -899,8 +899,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                   headers: git_header
                 )
             end
-
-            let(:upload_pack_fixture) { "business" }
 
             it "fetches the latest SHA-1 hash of the latest version tag" do
               expect(checker.latest_resolvable_version)
@@ -964,6 +962,23 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
             context "when updating the gem results in a conflict" do
               let(:dependency_files) { bundler_project_dependency_files("git_source_with_tag_conflict") }
+              let(:dependency_name) { "onfido" }
+              let(:current_version) do
+                "7b36eac82a7e42049052a58af0a7943fe0363714"
+              end
+              let(:requirements) do
+                [{
+                  file: "Gemfile",
+                  requirement: ">= 0",
+                  groups: [],
+                  source: {
+                    type: "git",
+                    url: "https://github.com/hvssle/onfido",
+                    branch: "master",
+                    ref: "v0.4.0"
+                  }
+                }]
+              end
 
               before do
                 allow_any_instance_of(Dependabot::GitCommitChecker)
@@ -980,25 +995,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                     body: fixture("git", "upload_packs", "onfido"),
                     headers: git_header
                   )
-              end
-
-              let(:dependency_name) { "onfido" }
-              let(:current_version) do
-                "7b36eac82a7e42049052a58af0a7943fe0363714"
-              end
-
-              let(:requirements) do
-                [{
-                  file: "Gemfile",
-                  requirement: ">= 0",
-                  groups: [],
-                  source: {
-                    type: "git",
-                    url: "https://github.com/hvssle/onfido",
-                    branch: "master",
-                    ref: "v0.4.0"
-                  }
-                }]
               end
 
               it { is_expected.to eq(dependency.version) }
@@ -1108,6 +1104,21 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         context "when updating the gem results in a conflict" do
           let(:dependency_files) { bundler_project_dependency_files("git_source_with_conflict") }
+          let(:dependency_name) { "onfido" }
+          let(:current_version) { "1.13.0" }
+          let(:requirements) do
+            [{
+              file: "Gemfile",
+              requirement: ">= 0",
+              groups: [],
+              source: {
+                type: "git",
+                url: "https://github.com/hvssle/onfido",
+                branch: "master",
+                ref: "master"
+              }
+            }]
+          end
 
           before do
             allow_any_instance_of(Dependabot::GitCommitChecker)
@@ -1130,22 +1141,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               .to receive(:latest_resolvable_version_details)
               .with(remove_git_source: true)
               .and_return(version: Gem::Version.new("2.0.0"))
-          end
-
-          let(:dependency_name) { "onfido" }
-          let(:current_version) { "1.13.0" }
-          let(:requirements) do
-            [{
-              file: "Gemfile",
-              requirement: ">= 0",
-              groups: [],
-              source: {
-                type: "git",
-                url: "https://github.com/hvssle/onfido",
-                branch: "master",
-                ref: "master"
-              }
-            }]
           end
 
           it { is_expected.to be_nil }

--- a/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe Dependabot::Cargo::MetadataFinder do
     subject(:source_url) { finder.source_url }
 
     let(:crates_url) { "https://crates.io/api/v1/crates/bitflags" }
+    let(:crates_response) do
+      fixture("crates_io_responses", crates_fixture_name)
+    end
+    let(:crates_fixture_name) { "bitflags.json" }
 
     before do
       stub_request(:get, crates_url)
@@ -57,11 +61,6 @@ RSpec.describe Dependabot::Cargo::MetadataFinder do
           body: crates_response
         )
     end
-
-    let(:crates_response) do
-      fixture("crates_io_responses", crates_fixture_name)
-    end
-    let(:crates_fixture_name) { "bitflags.json" }
 
     context "when there is a github link in the crates.io response" do
       let(:crates_fixture_name) { "bitflags.json" }

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -6,13 +6,6 @@ require "dependabot/clients/bitbucket"
 
 RSpec.describe Dependabot::Clients::Bitbucket do
   let(:current_user_url) { "https://api.bitbucket.org/2.0/user?fields=uuid" }
-
-  before do
-    stub_request(:get, current_user_url)
-      .with(headers: { "Authorization" => "Bearer #{access_token}" })
-      .to_return(status: 200, body: fixture("bitbucket", "current_user.json"))
-  end
-
   let(:access_token) { "access_token" }
   let(:credentials) do
     [Dependabot::Credential.new({
@@ -29,6 +22,12 @@ RSpec.describe Dependabot::Clients::Bitbucket do
   let(:source) { Dependabot::Source.from_url(base_url + "/src/master/") }
   let(:client) do
     described_class.for_source(source: source, credentials: credentials)
+  end
+
+  before do
+    stub_request(:get, current_user_url)
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 200, body: fixture("bitbucket", "current_user.json"))
   end
 
   describe "#default_reviewers" do

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -127,14 +127,14 @@ RSpec.describe Dependabot::Config::UpdateConfig do
           package_manager: "fake-package-manager"
         )
       end
+      let(:ignore_conditions) do
+        [Dependabot::Config::IgnoreCondition.new(dependency_name: "very-cool-package", versions: [">= 0"])]
+      end
+
       before do
         Dependabot::Dependency.register_name_normaliser("fake-package-manager", lambda { |name|
                                                                                   name.downcase.gsub(/[_=]/, "-")
                                                                                 })
-      end
-
-      let(:ignore_conditions) do
-        [Dependabot::Config::IgnoreCondition.new(dependency_name: "very-cool-package", versions: [">= 0"])]
       end
 
       it "normalizes the dependency name to match" do

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
       end
     end
@@ -189,7 +189,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -219,7 +219,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end
@@ -249,7 +249,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end
@@ -280,7 +280,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe Dependabot::DependencyGroup do
       context "when no dependencies are assigned to the group" do
         it "returns true if the dependency matches a pattern" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency1)).to be_truthy
+          expect(dependency_group.contains?(test_dependency1)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency2)).to be_falsey
+          expect(dependency_group.contains?(test_dependency2)).to be(false)
         end
 
         it "returns false if the dependency does not match any patterns" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
 
@@ -138,17 +138,17 @@ RSpec.describe Dependabot::DependencyGroup do
 
         it "returns true if the dependency is in the dependency list" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency1)).to be_truthy
+          expect(dependency_group.contains?(test_dependency1)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency2)).to be_falsey
+          expect(dependency_group.contains?(test_dependency2)).to be(false)
         end
 
         it "returns false if the dependency is not in the dependency list and does not match a pattern" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
     end
@@ -161,12 +161,12 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type" do
-        expect(dependency_group.contains?(production_dependency)).to be_truthy
+        expect(dependency_group.contains?(production_dependency)).to be(true)
       end
 
       it "returns false if the dependency does not match the specified type" do
-        expect(dependency_group.contains?(test_dependency1)).to be_falsey
-        expect(dependency_group.contains?(test_dependency2)).to be_falsey
+        expect(dependency_group.contains?(test_dependency1)).to be(false)
+        expect(dependency_group.contains?(test_dependency2)).to be(false)
       end
 
       context "when a dependency is specifically excluded" do
@@ -178,7 +178,7 @@ RSpec.describe Dependabot::DependencyGroup do
         end
 
         it "returns false even if the dependency matches the specified type" do
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
     end
@@ -193,15 +193,15 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type and a pattern" do
-        expect(dependency_group.contains?(test_dependency1)).to be_truthy
+        expect(dependency_group.contains?(test_dependency1)).to be(true)
       end
 
       it "returns false if the dependency only matches the pattern" do
-        expect(dependency_group.contains?(production_dependency)).to be_falsey
+        expect(dependency_group.contains?(production_dependency)).to be(false)
       end
 
       it "returns false if the dependency matches the specified type and pattern but is excluded" do
-        expect(dependency_group.contains?(test_dependency2)).to be_falsey
+        expect(dependency_group.contains?(test_dependency2)).to be(false)
       end
     end
   end

--- a/common/spec/dependabot/experiments_spec.rb
+++ b/common/spec/dependabot/experiments_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Dependabot::Experiments do
   it "can register experiments as enabled" do
     described_class.register(:my_test, true)
 
-    expect(described_class.enabled?(:my_test)).to be_truthy
+    expect(described_class).to be_enabled(:my_test)
   end
 
   it "works with string names and symbols" do
     described_class.register("my_test", true)
 
-    expect(described_class.enabled?("my_test")).to be_truthy
-    expect(described_class.enabled?(:my_test)).to be_truthy
+    expect(described_class).to be_enabled("my_test")
+    expect(described_class).to be_enabled(:my_test)
   end
 end

--- a/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
         f.name == "vendor/cache/business-1.5.0.gem"
       end
 
-      expect(file.binary?).to be_truthy
+      expect(file).to be_binary
     end
 
     it "marks created files as such" do
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
     end
 
@@ -87,7 +87,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_truthy
-      expect(file.deleted?).to be_truthy
+      expect(file).to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
     end
 
@@ -132,7 +132,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
           f.name == "vendor/cache/iso8859.txt"
         end
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
 
       it "does not mark all files as binary" do
@@ -140,7 +140,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
           f.name == "vendor/cache/utf8.txt"
         end
 
-        expect(file.binary?).to be_falsy
+        expect(file).not_to be_binary
       end
     end
 
@@ -210,7 +210,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
 
         file = updated_files.find { |f| f.name == "vendor/cache/new_#{name}" }
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
     end
   end

--- a/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
         f.name == "vendor/cache/business-1.5.0.gem"
       end
 
-      expect(file.binary?).to be_truthy
+      expect(file).to be_binary
     end
 
     it "marks created files as such" do
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_truthy
-      expect(file.deleted?).to be_truthy
+      expect(file).to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
           f.name == "vendor/cache/iso8859.txt"
         end
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
 
       it "does not mark all files as binary" do
@@ -139,7 +139,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
           f.name == "vendor/cache/utf8.txt"
         end
 
-        expect(file.binary?).to be_falsy
+        expect(file).not_to be_binary
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
 
         file = updated_files.find { |f| f.name == "vendor/cache/new_#{name}" }
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
     end
   end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -171,10 +171,12 @@ RSpec.describe Dependabot::GitCommitChecker do
 
       context "with source code hosted on GitHub" do
         let(:repo_url) { "https://api.github.com/repos/gocardless/business" }
+        let(:upload_pack_fixture) { "no_tags" }
         let(:service_pack_url) do
           "https://github.com/gocardless/business.git/info/refs" \
             "?service=git-upload-pack"
         end
+
         before do
           stub_request(:get, service_pack_url)
             .to_return(
@@ -185,8 +187,6 @@ RSpec.describe Dependabot::GitCommitChecker do
               }
             )
         end
-
-        let(:upload_pack_fixture) { "no_tags" }
 
         context "when there are no tags on GitHub" do
           let(:upload_pack_fixture) { "no_tags" }
@@ -299,6 +299,7 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
 
         let(:source_url) { "https://bitbucket.org/gocardless/business" }
+        let(:upload_pack_fixture) { "business" }
         let(:service_pack_url) do
           "https://bitbucket.org/gocardless/business.git/info/refs" \
             "?service=git-upload-pack"
@@ -307,6 +308,7 @@ RSpec.describe Dependabot::GitCommitChecker do
           "https://api.bitbucket.org/2.0/repositories/" \
             "gocardless/business/commits/?exclude=v1.5.0&include=df9f605"
         end
+
         before do
           stub_request(:get, service_pack_url)
             .to_return(
@@ -317,8 +319,6 @@ RSpec.describe Dependabot::GitCommitChecker do
               }
             )
         end
-
-        let(:upload_pack_fixture) { "business" }
 
         context "when not included in a release" do
           before do
@@ -490,13 +490,13 @@ RSpec.describe Dependabot::GitCommitChecker do
                 ref: "master"
               }
             end
+            let(:ref) { "my_ref" }
+
             before do
               url = "https://dodgyhost.com/gocardless/business.git"
               stub_request(:get, url + "/info/refs?service=git-upload-pack")
                 .to_raise(Excon::Error::Timeout)
             end
-
-            let(:ref) { "my_ref" }
 
             it "raises a helpful error" do
               expect { checker.head_commit_for_current_branch }
@@ -874,9 +874,11 @@ RSpec.describe Dependabot::GitCommitChecker do
           ref: "1a21311"
         }
       end
+      let(:upload_pack_fixture) { "monolog" }
 
       let(:repo_url) { "https://github.com/gocardless/business.git" }
       let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+
       before do
         stub_request(:get, service_pack_url)
           .to_return(
@@ -887,8 +889,6 @@ RSpec.describe Dependabot::GitCommitChecker do
             }
           )
       end
-
-      let(:upload_pack_fixture) { "monolog" }
 
       it { is_expected.to be(true) }
 
@@ -924,9 +924,11 @@ RSpec.describe Dependabot::GitCommitChecker do
     subject { checker.head_commit_for_local_branch("example") }
 
     let(:tip_of_example) { "303b8a83c87d5c6d749926cf02620465a5dcd0f2" }
+    let(:upload_pack_fixture) { "monolog" }
 
     let(:repo_url) { "https://github.com/gocardless/business.git" }
     let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+
     before do
       stub_request(:get, service_pack_url)
         .to_return(
@@ -937,8 +939,6 @@ RSpec.describe Dependabot::GitCommitChecker do
           }
         )
     end
-
-    let(:upload_pack_fixture) { "monolog" }
 
     it { is_expected.to eq(tip_of_example) }
   end
@@ -947,7 +947,9 @@ RSpec.describe Dependabot::GitCommitChecker do
     subject(:local_tag_for_latest_version) { checker.local_tag_for_latest_version }
 
     let(:repo_url) { "https://github.com/gocardless/business.git" }
+    let(:upload_pack_fixture) { "no_tags" }
     let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+
     before do
       stub_request(:get, service_pack_url)
         .to_return(
@@ -958,8 +960,6 @@ RSpec.describe Dependabot::GitCommitChecker do
           }
         )
     end
-
-    let(:upload_pack_fixture) { "no_tags" }
 
     context "with no tags on GitHub" do
       it { is_expected.to be_nil }
@@ -1386,9 +1386,11 @@ RSpec.describe Dependabot::GitCommitChecker do
           ref: source_commit
         }
       end
+      let(:upload_pack_fixture) { "actions-checkout" }
 
       let(:repo_url) { "https://github.com/actions/checkout.git" }
       let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+
       before do
         stub_request(:get, service_pack_url)
           .to_return(
@@ -1399,8 +1401,6 @@ RSpec.describe Dependabot::GitCommitChecker do
             }
           )
       end
-
-      let(:upload_pack_fixture) { "actions-checkout" }
 
       context "when the source commit is a tag" do
         let(:source_commit) { "a81bbbf8298c0fa03ea29cdc473d45769f953675" }
@@ -1445,9 +1445,11 @@ RSpec.describe Dependabot::GitCommitChecker do
         ref: source_ref
       }
     end
+    let(:upload_pack_fixture) { "actions-checkout-moving-v2" }
 
     let(:repo_url) { "https://github.com/actions/checkout.git" }
     let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+
     before do
       stub_request(:get, service_pack_url)
         .to_return(
@@ -1458,8 +1460,6 @@ RSpec.describe Dependabot::GitCommitChecker do
           }
         )
     end
-
-    let(:upload_pack_fixture) { "actions-checkout-moving-v2" }
 
     context "when moving major tag" do
       let(:source_ref) { "v2" }

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -285,6 +285,11 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     subject(:head_commit_for_ref) { checker.head_commit_for_ref(ref) }
 
     let(:ref) { "v1.0.0" }
+    let(:service_pack_url) do
+      "https://github.com/gocardless/business.git/info/refs" \
+        "?service=git-upload-pack"
+    end
+    let(:upload_pack_fixture) { "business" }
 
     before do
       stub_request(:get, service_pack_url)
@@ -296,13 +301,6 @@ RSpec.describe Dependabot::GitMetadataFetcher do
           }
         )
     end
-
-    let(:service_pack_url) do
-      "https://github.com/gocardless/business.git/info/refs" \
-        "?service=git-upload-pack"
-    end
-
-    let(:upload_pack_fixture) { "business" }
 
     it "gets the correct commit SHA (not the tag SHA)" do
       expect(head_commit_for_ref)

--- a/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
       let(:github_url) do
         "https://api.github.com/repos/gocardless/business/contents/"
       end
+      let(:changelog_body) { fixture("github", "changelog_contents.json") }
 
       let(:github_status) { 200 }
 
@@ -140,8 +141,6 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
                      body: changelog_body,
                      headers: { "Content-Type" => "application/json" })
       end
-
-      let(:changelog_body) { fixture("github", "changelog_contents.json") }
 
       context "with a changelog" do
         let(:github_response) { fixture("github", "business_files.json") }
@@ -936,6 +935,13 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
             suggested_changelog_url: suggested_changelog_url
           )
         end
+        let(:github_contents_response) do
+          fixture("github", "business_files.json")
+        end
+        let(:github_changelog_url) do
+          "https://api.github.com/repos/mperham/sidekiq/contents/" \
+            "Pro-Changes.md?ref=master"
+        end
         let(:suggested_changelog_url) do
           "github.com/mperham/sidekiq/blob/master/Pro-Changes.md"
         end
@@ -949,15 +955,6 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
             .to_return(status: 200,
                        body: suggested_github_response,
                        headers: { "Content-Type" => "application/json" })
-        end
-
-        let(:github_contents_response) do
-          fixture("github", "business_files.json")
-        end
-
-        let(:github_changelog_url) do
-          "https://api.github.com/repos/mperham/sidekiq/contents/" \
-            "Pro-Changes.md?ref=master"
         end
 
         it { is_expected.to eq(expected_pruned_changelog) }

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
       package_manager: package_manager
     )
   end
+  let(:service_pack_url) do
+    "https://github.com/gocardless/business.git/info/refs" \
+      "?service=git-upload-pack"
+  end
+  let(:upload_pack_fixture) { "business" }
   let(:package_manager) { "dummy" }
   let(:dependency_name) { "business" }
   let(:dependency_version) { "1.4.0" }
@@ -43,6 +48,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
       repo: "gocardless/#{dependency_name}"
     )
   end
+
   before do
     stub_request(:get, service_pack_url)
       .to_return(
@@ -53,12 +59,6 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         }
       )
   end
-
-  let(:service_pack_url) do
-    "https://github.com/gocardless/business.git/info/refs" \
-      "?service=git-upload-pack"
-  end
-  let(:upload_pack_fixture) { "business" }
 
   describe "#commits_url" do
     subject(:commits_url) { builder.commits_url }

--- a/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
@@ -548,6 +548,8 @@ RSpec.describe Dependabot::MetadataFinders::Base::ReleaseFinder do
       let(:gitlab_url) do
         "https://gitlab.com/api/v4/projects/org%2Fbusiness/repository/tags"
       end
+      let(:dependency_version) { "1.4.0" }
+      let(:dependency_previous_version) { "1.3.0" }
       let(:source) do
         Dependabot::Source.new(
           provider: "gitlab",
@@ -563,9 +565,6 @@ RSpec.describe Dependabot::MetadataFinders::Base::ReleaseFinder do
                      body: gitlab_response,
                      headers: { "Content-Type" => "application/json" })
       end
-
-      let(:dependency_version) { "1.4.0" }
-      let(:dependency_previous_version) { "1.3.0" }
 
       it "gets the right text" do
         expect(releases_text)

--- a/common/spec/dependabot/metadata_finders/base_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Dependabot::MetadataFinders::Base do
       package_manager: "bundler"
     )
   end
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "github",
+      repo: "gocardless/#{dependency_name}"
+    )
+  end
   let(:dependency_name) { "business" }
   let(:dependency_version) { "1.4.0" }
   let(:dependency_previous_version) { "1.0.0" }
@@ -35,14 +41,8 @@ RSpec.describe Dependabot::MetadataFinders::Base do
       "password" => "token"
     }]
   end
-  before { allow(finder).to receive(:source).and_return(source) }
 
-  let(:source) do
-    Dependabot::Source.new(
-      provider: "github",
-      repo: "gocardless/#{dependency_name}"
-    )
-  end
+  before { allow(finder).to receive(:source).and_return(source) }
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -71,15 +71,15 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
       let(:source) do
         Dependabot::Source.new(provider: "github", repo: "gocardless/bump")
       end
+      let(:labels_fixture_name) { "labels_with_dependencies.json" }
       let(:repo_api_url) { "https://api.github.com/repos/#{source.repo}" }
+
       before do
         stub_request(:get, "#{repo_api_url}/labels?per_page=100")
           .to_return(status: 200,
                      body: fixture("github", labels_fixture_name),
                      headers: json_header)
       end
-
-      let(:labels_fixture_name) { "labels_with_dependencies.json" }
 
       context "when the 'dependencies' label doesn't yet exist" do
         let(:labels_fixture_name) { "labels_without_dependencies.json" }
@@ -506,15 +506,15 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
       let(:source) do
         Dependabot::Source.new(provider: "github", repo: "gocardless/bump")
       end
+      let(:labels_fixture_name) { "labels_with_dependencies.json" }
       let(:repo_api_url) { "https://api.github.com/repos/#{source.repo}" }
+
       before do
         stub_request(:get, "#{repo_api_url}/labels?per_page=100")
           .to_return(status: 200,
                      body: fixture("github", labels_fixture_name),
                      headers: json_header)
       end
-
-      let(:labels_fixture_name) { "labels_with_dependencies.json" }
 
       context "when a 'dependencies' label exists" do
         let(:labels_fixture_name) { "labels_with_dependencies.json" }

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -843,6 +843,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })
       end
+      let(:commits_response) { fixture("github", "commits.json") }
 
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")
@@ -852,8 +853,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             headers: json_header
           )
       end
-
-      let(:commits_response) { fixture("github", "commits.json") }
 
       it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0 in the all-the-things group") }
 
@@ -946,6 +945,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       let(:source) do
         Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directories: ["/foo", "/bar"])
       end
+      let(:commits_response) { fixture("github", "commits.json") }
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "go_modules", rules: { patterns: ["*"] })
       end
@@ -959,8 +959,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             headers: json_header
           )
       end
-
-      let(:commits_response) { fixture("github", "commits.json") }
 
       it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0 in the go_modules group across 1 directory") }
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -407,14 +407,13 @@ RSpec.describe Dependabot::SharedHelpers do
     end
 
     let(:credentials) { [] }
+    let(:git_config_path) { File.expand_path(".gitconfig", tmp) }
+    let(:configured_git_config) { with_git_configured { `cat #{git_config_path}` } }
+    let(:configured_git_credentials) { with_git_configured { `cat #{Dir.pwd}/git.store` } }
 
     def with_git_configured(&block)
       Dependabot::SharedHelpers.with_git_configured(credentials: credentials, &block)
     end
-
-    let(:git_config_path) { File.expand_path(".gitconfig", tmp) }
-    let(:configured_git_config) { with_git_configured { `cat #{git_config_path}` } }
-    let(:configured_git_credentials) { with_git_configured { `cat #{Dir.pwd}/git.store` } }
 
     context "when the global .gitconfig has a safe directory" do
       before do

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Dependabot::Workspace::Git do
         expect(workspace.change_attempts.first.memo).to eq("timecop")
         expect(workspace.change_attempts.first.error).not_to be_nil
         expect(workspace.change_attempts.first.error.message).to eq("uh oh")
-        expect(workspace.change_attempts.first.error?).to be_truthy
-        expect(workspace.change_attempts.first.success?).to be_falsy
+        expect(workspace.change_attempts.first).to be_error
+        expect(workspace.change_attempts.first).not_to be_success
       end
 
       context "when there are untracked/ignored files" do
@@ -243,8 +243,8 @@ RSpec.describe Dependabot::Workspace::Git do
         )
         expect(workspace.change_attempts.first.memo).to eq("Update timecop")
         expect(workspace.change_attempts.first.error).to be_nil
-        expect(workspace.change_attempts.first.error?).to be_falsy
-        expect(workspace.change_attempts.first.success?).to be_truthy
+        expect(workspace.change_attempts.first).not_to be_error
+        expect(workspace.change_attempts.first).to be_success
       end
     end
   end

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -432,8 +432,6 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
 
     context "with a private registry" do
       let(:project_name) { "private_registry" }
-      before { `composer clear-cache --quiet` }
-
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "dependabot/dummy-pkg-a",
@@ -454,6 +452,8 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
           package_manager: "composer"
         )
       end
+
+      before { `composer clear-cache --quiet` }
 
       context "with good credentials" do
         let(:gemfury_deploy_token) { ENV.fetch("GEMFURY_DEPLOY_TOKEN", nil) }
@@ -480,8 +480,6 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
 
     context "with a laravel nova" do
       let(:project_name) { "laravel_nova" }
-      before { `composer clear-cache --quiet` }
-
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "laravel/nova",
@@ -502,6 +500,8 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
           package_manager: "composer"
         )
       end
+
+      before { `composer clear-cache --quiet` }
 
       context "with bad credentials" do
         let(:credentials) do

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "with a git dependency" do
       let(:project_name) { "git_source" }
+      let(:upload_pack_fixture) { "monolog" }
 
       let(:dependency_version) { "5267b03b1e4861c4657ede17a88f13ef479db482" }
       let(:requirements) do
@@ -145,6 +146,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         "https://github.com/dependabot/monolog.git/info/refs" \
           "?service=git-upload-pack"
       end
+
       before do
         stub_request(:get, service_pack_url)
           .to_return(
@@ -155,8 +157,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
             }
           )
       end
-
-      let(:upload_pack_fixture) { "monolog" }
 
       it { is_expected.to eq("303b8a83c87d5c6d749926cf02620465a5dcd0f2") }
     end
@@ -321,8 +321,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "with a private registry" do
       let(:project_name) { "private_registry" }
-      before { `composer clear-cache --quiet` }
-
       let(:dependency_name) { "dependabot/dummy-pkg-a" }
       let(:dependency_version) { nil }
       let(:requirements) do
@@ -333,6 +331,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           source: nil
         }]
       end
+
+      before { `composer clear-cache --quiet` }
 
       before do
         url = "https://php.fury.io/dependabot-throwaway/packages.json"

--- a/docker/lib/dependabot/docker/utils/credentials_finder.rb
+++ b/docker/lib/dependabot/docker/utils/credentials_finder.rb
@@ -1,9 +1,8 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "aws-sdk-ecr"
 require "base64"
-require "sorbet-runtime"
 
 require "dependabot/credential"
 require "dependabot/errors"
@@ -17,7 +16,6 @@ module Dependabot
         AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+)\.amazonaws\.com/
         DEFAULT_DOCKER_HUB_REGISTRY = "registry.hub.docker.com"
 
-        sig { params(credentials: T::Array[Dependabot::Credential]).void }
         def initialize(credentials)
           @credentials = credentials
         end
@@ -34,20 +32,14 @@ module Dependabot
           build_aws_credentials(registry_details)
         end
 
-        sig { returns(T.nilable(String)) }
         def base_registry
-          @base_registry ||= T.let(
-            credentials.find do |cred|
-              cred["type"] == "docker_registry" && cred.replaces_base?
-            end,
-            T.nilable(Dependabot::Credential)
-          )
-          @base_registry ||= Dependabot::Credential.new({ "registry" => DEFAULT_DOCKER_HUB_REGISTRY,
-                                                          "credentials" => nil })
+          @base_registry ||= credentials.find do |cred|
+            cred["type"] == "docker_registry" && cred.replaces_base?
+          end
+          @base_registry ||= { "registry" => DEFAULT_DOCKER_HUB_REGISTRY, "credentials" => nil }
           @base_registry["registry"]
         end
 
-        sig { params(registry: String).returns(T::Boolean) }
         def using_dockerhub?(registry)
           registry == DEFAULT_DOCKER_HUB_REGISTRY
         end
@@ -84,11 +76,11 @@ module Dependabot
 
           # Otherwise, we need to use the provided Access Key ID and secret to
           # generate a temporary username and password
-          @authorization_tokens ||= T.let({}, T.nilable(T::Hash[String, String]))
+          @authorization_tokens ||= {}
           @authorization_tokens[registry_hostname] ||=
             ecr_client.get_authorization_token.authorization_data.first.authorization_token
           username, password =
-            Base64.decode64(T.must(@authorization_tokens[registry_hostname])).split(":")
+            Base64.decode64(@authorization_tokens[registry_hostname]).split(":")
           registry_details.merge(Dependabot::Credential.new({ "username" => username, "password" => password }))
         rescue Aws::Errors::MissingCredentialsError,
                Aws::ECR::Errors::UnrecognizedClientException,

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -870,6 +870,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
     context "when the dependencies have an underscore followed by sha-like strings" do
       let(:dependency_name) { "nixos/nix" }
+      let(:version) { "2.1.3" }
       let(:tags_fixture_name) { "nixos-nix.json" }
       let(:repo_url) do
         "https://registry.hub.docker.com/v2/nixos/nix/"
@@ -877,6 +878,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       let(:headers_response) do
         fixture("docker", "registry_manifest_headers", "generic.json")
       end
+
       before do
         stub_request(:get, repo_url + "tags/list")
           .and_return(status: 200, body: registry_tags)
@@ -888,8 +890,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             headers: JSON.parse(headers_response)
           )
       end
-
-      let(:version) { "2.1.3" }
 
       it "ignores the sha-like part" do
         expect(latest_version).to eq("2.10.0")

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -345,17 +345,6 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           "https://github.com/actions/checkout.git/info/refs" \
             "?service=git-upload-pack"
         end
-        before do
-          stub_request(:get, service_pack_url)
-            .to_return(
-              status: 200,
-              body: fixture("git", "upload_packs", "checkout"),
-              headers: {
-                "content-type" => "application/x-git-upload-pack-advertisement"
-              }
-            )
-        end
-
         let(:workflow_file_body) do
           fixture("workflow_files", "pinned_sources_version_comments.yml")
         end
@@ -413,6 +402,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
               metadata: { declaration_string: "actions/checkout@v2.2.0" }
             }]
           )
+        end
+
+        before do
+          stub_request(:get, service_pack_url)
+            .to_return(
+              status: 200,
+              body: fixture("git", "upload_packs", "checkout"),
+              headers: {
+                "content-type" => "application/x-git-upload-pack-advertisement"
+              }
+            )
         end
 
         it "updates SHA version" do

--- a/gradle/spec/dependabot/gradle/update_checker/multi_dependency_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/multi_dependency_updater_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe namespace::MultiDependencyUpdater do
       ignored_versions: ignored_versions
     )
   end
+  ########################
+  # Dependency set setup #
+  ########################
+
+  let(:jcenter_metadata_url_protoc) do
+    "https://jcenter.bintray.com/" \
+      "com/google/protobuf/protoc/maven-metadata.xml"
+  end
+  let(:jcenter_metadata_url_protobuf_java) do
+    "https://jcenter.bintray.com/" \
+      "com/google/protobuf/protobuf-java/maven-metadata.xml"
+  end
+  let(:jcenter_metadata_url_protobuf_java_util) do
+    "https://jcenter.bintray.com/" \
+      "com/google/protobuf/protobuf-java-util/maven-metadata.xml"
+  end
 
   let(:version_class) { Dependabot::Gradle::Version }
   let(:credentials) { [] }
@@ -81,23 +97,6 @@ RSpec.describe namespace::MultiDependencyUpdater do
         status: 200,
         body: fixture("maven_central_metadata", "with_release.xml")
       )
-  end
-
-  ########################
-  # Dependency set setup #
-  ########################
-
-  let(:jcenter_metadata_url_protoc) do
-    "https://jcenter.bintray.com/" \
-      "com/google/protobuf/protoc/maven-metadata.xml"
-  end
-  let(:jcenter_metadata_url_protobuf_java) do
-    "https://jcenter.bintray.com/" \
-      "com/google/protobuf/protobuf-java/maven-metadata.xml"
-  end
-  let(:jcenter_metadata_url_protobuf_java_util) do
-    "https://jcenter.bintray.com/" \
-      "com/google/protobuf/protobuf-java-util/maven-metadata.xml"
   end
 
   before do

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -275,15 +275,14 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
     context "with a dependency with a private organization" do
       let(:mixfile_body) { fixture("mixfiles", "private_package") }
-      let(:lockfile_body) { fixture("lockfiles", "private_package") }
-
-      before { `mix hex.organization deauth dependabot` }
-
       let(:dependency_name) { "example_package_a" }
       let(:version) { "1.0.0" }
       let(:dependency_requirements) do
         [{ file: "mix.exs", requirement: "~> 1.0.0", groups: [], source: nil }]
       end
+      let(:lockfile_body) { fixture("lockfiles", "private_package") }
+
+      before { `mix hex.organization deauth dependabot` }
 
       context "with good credentials" do
         let(:hex_pm_org_token) { ENV.fetch("HEX_PM_ORGANIZATION_TOKEN", nil) }
@@ -376,15 +375,14 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
     context "with a dependency from a private repo" do
       let(:mixfile_body) { fixture("mixfiles", "private_repo") }
-      let(:lockfile_body) { fixture("lockfiles", "private_repo") }
-
-      before { `mix hex.repo remove dependabot` }
-
       let(:dependency_name) { "jason" }
       let(:version) { "1.0.0" }
       let(:dependency_requirements) do
         [{ file: "mix.exs", requirement: "~> 1.0.0", groups: [], source: nil }]
       end
+      let(:lockfile_body) { fixture("lockfiles", "private_repo") }
+
+      before { `mix hex.repo remove dependabot` }
 
       context "with good credentials" do
         let(:credentials) do

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -889,6 +889,17 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
 
       context "when inheriting from a remote POM" do
         let(:pom_body) { fixture("poms", "remote_parent_pom.xml") }
+        let(:dependency_name) { "org.apache.logging.log4j:log4j-api" }
+        let(:dependency_version) { "2.7" }
+        let(:dependency_requirements) do
+          [{
+            file: "pom.xml",
+            requirement: "2.7",
+            groups: [],
+            source: nil,
+            metadata: { property_name: "log4j2.version" }
+          }]
+        end
 
         let(:struts_apps_maven_url) do
           "https://repo.maven.apache.org/maven2/" \
@@ -910,18 +921,6 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
             .to_return(status: 200, body: struts_apps_maven_response)
           stub_request(:get, struts_parent_maven_url)
             .to_return(status: 200, body: struts_parent_maven_response)
-        end
-
-        let(:dependency_name) { "org.apache.logging.log4j:log4j-api" }
-        let(:dependency_version) { "2.7" }
-        let(:dependency_requirements) do
-          [{
-            file: "pom.xml",
-            requirement: "2.7",
-            groups: [],
-            source: nil,
-            metadata: { property_name: "log4j2.version" }
-          }]
         end
 
         it { is_expected.to be(false) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         directory: directory
       )
     end
-    let(:url) { "https://api.github.com/repos/dependabot-fixtures/dependabot-yarn-lfs-fixture/contents/" }
-    let(:repo) { "dependabot-fixtures/dependabot-yarn-lfs-fixture" }
-    let(:repo_contents_path) { Dir.mktmpdir }
-    after { FileUtils.rm_rf(repo_contents_path) }
-
     let(:file_fetcher_instance) do
       described_class.new(source: source, credentials: credentials, repo_contents_path: repo_contents_path)
     end
+    let(:url) { "https://api.github.com/repos/dependabot-fixtures/dependabot-yarn-lfs-fixture/contents/" }
+    let(:repo) { "dependabot-fixtures/dependabot-yarn-lfs-fixture" }
+    let(:repo_contents_path) { Dir.mktmpdir }
+
+    after { FileUtils.rm_rf(repo_contents_path) }
 
     it "pulls files from lfs after cloning" do
       # Calling #files triggers the clone

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -571,6 +571,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
           context "when specifying a semver requirement" do
             let(:files) { project_dependency_files("npm6/github_dependency_semver") }
+            let(:git_pack_fixture_name) { "is-number" }
 
             before do
               git_url = "https://github.com/jonschlinkert/is-number.git"
@@ -586,8 +587,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   headers: git_header
                 )
             end
-
-            let(:git_pack_fixture_name) { "is-number" }
 
             its(:length) { is_expected.to eq(1) }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -607,6 +607,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
       context "with a requirement" do
         let(:req) { "^4.0.0" }
+        let(:git_pack_fixture_name) { "is-number" }
         let(:ref) { "master" }
         let(:old_req) { "^2.0.0" }
         let(:old_ref) { "master" }
@@ -628,8 +629,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
               headers: git_header
             )
         end
-
-        let(:git_pack_fixture_name) { "is-number" }
 
         it "updates the package.json and the lockfiles" do
           expect(updated_files.map(&:name))
@@ -2449,6 +2448,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
         context "with a requirement" do
           let(:req) { "^4.0.0" }
+          let(:git_pack_fixture_name) { "is-number" }
           let(:ref) { "master" }
           let(:old_req) { "^2.0.0" }
           let(:old_ref) { "master" }
@@ -2470,8 +2470,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 headers: git_header
               )
           end
-
-          let(:git_pack_fixture_name) { "is-number" }
 
           it "updates the package.json and the lockfiles" do
             expect(updated_files.map(&:name))

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/sub_dependency_files_filterer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/sub_dependency_files_filterer_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe Dependabot::NpmAndYarn::SubDependencyFilesFilterer do
   let(:dependency_files) do
     project_dependency_files(project_name)
   end
-  let(:project_name) { "npm6_and_yarn/nested_sub_dependency_update" }
-  let(:updated_dependencies) { [dependency] }
-
-  def project_dependency_file(file_name)
-    dependency_files.find { |f| f.name == file_name }
-  end
-
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "extend",
@@ -32,6 +25,12 @@ RSpec.describe Dependabot::NpmAndYarn::SubDependencyFilesFilterer do
       requirements: [],
       package_manager: "npm_and_yarn"
     )
+  end
+  let(:project_name) { "npm6_and_yarn/nested_sub_dependency_update" }
+  let(:updated_dependencies) { [dependency] }
+
+  def project_dependency_file(file_name)
+    dependency_files.find { |f| f.name == file_name }
   end
 
   describe ".files_requiring_update" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
         expect(Dir.children(".")).to match_array(
           %w(package.json .npmrc)
         )
-        expect(File.read(".npmrc")).to be_empty
+        expect(File.empty?(".npmrc")).to be(true)
       end
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
         expect(Dir.children(".")).to match_array(
           %w(package.json .npmrc .yarnrc)
         )
-        expect(File.read(".npmrc")).not_to be_empty
+        expect(File.empty?(".npmrc")).to be(true)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
       credentials: credentials
     )
   end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "abind",
+      version: "1.0.5",
+      requirements: [],
+      package_manager: "npm_and_yarn"
+    )
+  end
 
   let(:credentials) do
     [Dependabot::Credential.new({
@@ -28,15 +36,6 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
 
   def project_dependency_file(file_name)
     dependency_files.find { |f| f.name == file_name }
-  end
-
-  let(:dependency) do
-    Dependabot::Dependency.new(
-      name: "abind",
-      version: "1.0.5",
-      requirements: [],
-      package_manager: "npm_and_yarn"
-    )
   end
 
   describe "#write_temporary_dependency_files" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -8,16 +8,6 @@ require "dependabot/npm_and_yarn/update_checker/latest_version_finder"
 
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
   let(:registry_base) { "https://registry.npmjs.org" }
-  let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
-  let(:registry_response) { fixture("npm_responses", "#{escaped_dependency_name}.json") }
-  let(:login_form) { fixture("npm_responses", "login_form.html") }
-  before do
-    stub_request(:get, registry_listing_url)
-      .to_return(status: 200, body: registry_response)
-    stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
-      .to_return(status: 200)
-  end
-
   let(:version_finder) do
     described_class.new(
       dependency: dependency,
@@ -32,7 +22,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
   let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_files) { project_dependency_files("npm6/no_lockfile") }
-
   let(:credentials) do
     [Dependabot::Credential.new({
       "type" => "git_source",
@@ -41,7 +30,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       "password" => "token"
     })]
   end
-
   let(:dependency_name) { "etag" }
   let(:escaped_dependency_name) { dependency_name.gsub("/", "%2F") }
   let(:unscoped_dependency_name) { dependency_name.split("/").last }
@@ -57,6 +45,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
     )
   end
   let(:dependency_version) { "1.0.0" }
+  let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
+  let(:registry_response) { fixture("npm_responses", "#{escaped_dependency_name}.json") }
+  let(:login_form) { fixture("npm_responses", "login_form.html") }
+
+  before do
+    stub_request(:get, registry_listing_url)
+      .to_return(status: 200, body: registry_response)
+    stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
+      .to_return(status: 200)
+  end
 
   describe "#latest_version_from_registry" do
     subject(:latest_version_from_registry) { version_finder.latest_version_from_registry }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       dependency_group: group
     )
   end
+  let(:dependency_files) { project_dependency_files(project_name) }
+  let(:credentials) do
+    [Dependabot::Credential.new({
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    })]
+  end
+  let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
+  let(:group) { nil }
   let(:latest_version_finder) do
     Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder.new(
       dependency: dependency,
@@ -47,6 +58,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
   let(:opentelemetry_context_async_hooks_registry_response) do
     fixture("npm_responses", "opentelemetry-context-async-hooks.json")
   end
+
   before do
     stub_request(:get, react_dom_registry_listing_url)
       .to_return(status: 200, body: react_dom_registry_response)
@@ -61,21 +73,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
     stub_request(:get, opentelemetry_context_async_hooks_registry_listing_url)
       .to_return(status: 200, body: opentelemetry_context_async_hooks_registry_response)
   end
-
-  let(:dependency_files) { project_dependency_files(project_name) }
-
-  let(:credentials) do
-    [Dependabot::Credential.new({
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    })]
-  end
-
-  let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
-
-  let(:group) { nil }
 
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { resolver.latest_resolvable_version }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       end
 
       it "returns false when there is a newer version available" do
-        expect(checker.up_to_date?).to be_falsy
+        expect(checker).not_to be_up_to_date
       end
     end
 
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       end
 
       it "is up to date because there's nothing to update" do
-        expect(checker.up_to_date?).to be_truthy
+        expect(checker).to be_up_to_date
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -320,13 +320,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
     context "when dealing with a scoped package name" do
       let(:dependency_name) { "@dependabot-fixtures/npm-parent-dependency" }
-      let(:target_version) { "2.0.2" }
-      before do
-        allow_any_instance_of(described_class::VersionResolver)
-          .to receive(:latest_resolvable_version)
-          .and_return(Gem::Version.new("1.7.0"))
-      end
-
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,
@@ -339,6 +332,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           }],
           package_manager: "npm_and_yarn"
         )
+      end
+      let(:target_version) { "2.0.2" }
+
+      before do
+        allow_any_instance_of(described_class::VersionResolver)
+          .to receive(:latest_resolvable_version)
+          .and_return(Gem::Version.new("1.7.0"))
       end
 
       it { is_expected.to be_truthy }
@@ -418,11 +418,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           package_manager: "npm_and_yarn"
         )
       end
+      let(:upload_pack_fixture) { "is-number" }
+      let(:commit_compare_response) do
+        fixture("github", "commit_compare_diverged.json")
+      end
       let(:registry_listing_url) { "https://registry.npmjs.org/is-number" }
       let(:registry_response) do
         fixture("npm_responses", "is_number.json")
       end
       let(:current_version) { "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8" }
+
       before do
         git_url = "https://github.com/jonschlinkert/is-number.git"
         git_header = {
@@ -445,11 +450,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
             body: commit_compare_response,
             headers: { "Content-Type" => "application/json" }
           )
-      end
-
-      let(:upload_pack_fixture) { "is-number" }
-      let(:commit_compare_response) do
-        fixture("github", "commit_compare_diverged.json")
       end
 
       context "with a branch" do
@@ -1761,24 +1761,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
   context "when types dependency specified" do
     let(:dependency_name) { "jquery" }
-    let(:target_version) { "3.6.0" }
-    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fjquery" }
-    let(:types_response) do
-      fixture("npm_responses", "types_jquery.json")
-    end
-    before do
-      stub_request(:get, registry_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url)
-        .to_return(status: 200, body: types_response)
-      stub_request(:get, types_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url + "/3.3.10")
-        .to_return(status: 200)
-      stub_request(:get, types_listing_url + "/3.5.14")
-        .to_return(status: 200)
-    end
-
     let(:dependency_files) { project_dependency_files("yarn/ts_fully_typed") }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -1795,6 +1777,24 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         groups: [],
         source: nil
       }]
+    end
+    let(:target_version) { "3.6.0" }
+    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fjquery" }
+    let(:types_response) do
+      fixture("npm_responses", "types_jquery.json")
+    end
+
+    before do
+      stub_request(:get, registry_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url)
+        .to_return(status: 200, body: types_response)
+      stub_request(:get, types_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url + "/3.3.10")
+        .to_return(status: 200)
+      stub_request(:get, types_listing_url + "/3.5.14")
+        .to_return(status: 200)
     end
 
     it "returns both dependencies for update" do
@@ -1832,12 +1832,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
   context "when types dependency is not specified" do
     let(:dependency_name) { "jquery" }
-    let(:target_version) { "3.6.0" }
-    before do
-      stub_request(:get, registry_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-    end
-
     let(:dependency_files) { project_dependency_files("yarn/ts_missing_types") }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -1855,6 +1849,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         source: nil
       }]
     end
+    let(:target_version) { "3.6.0" }
+
+    before do
+      stub_request(:get, registry_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+    end
 
     it "returns only one dependency" do
       updated_deps = checker.updated_dependencies(requirements_to_unlock: :own)
@@ -1865,22 +1865,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
   context "when no update to @types available" do
     let(:dependency_name) { "jquery" }
-    let(:target_version) { "3.6.0" }
-    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fjquery" }
-    let(:types_response) do
-      fixture("npm_responses", "types_jquery.json")
-    end
-    before do
-      stub_request(:get, registry_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url)
-        .to_return(status: 200, body: types_response)
-      stub_request(:get, types_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url + "/3.5.14")
-        .to_return(status: 200)
-    end
-
     let(:dependency_files) { project_dependency_files("yarn/ts_no_type_update") }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -1898,6 +1882,22 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         source: nil
       }]
     end
+    let(:target_version) { "3.6.0" }
+    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fjquery" }
+    let(:types_response) do
+      fixture("npm_responses", "types_jquery.json")
+    end
+
+    before do
+      stub_request(:get, registry_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url)
+        .to_return(status: 200, body: types_response)
+      stub_request(:get, types_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url + "/3.5.14")
+        .to_return(status: 200)
+    end
 
     it "only updates original package" do
       updated_deps = checker.updated_dependencies(requirements_to_unlock: :all)
@@ -1908,24 +1908,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
   context "when types is a normal dependency" do
     let(:dependency_name) { "node-forge" }
-    let(:target_version) { "1.3.1" }
-    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fnode-forge" }
-    let(:types_response) do
-      fixture("npm_responses", "types_node-forge.json")
-    end
-    before do
-      stub_request(:get, registry_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url)
-        .to_return(status: 200, body: types_response)
-      stub_request(:get, types_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, types_listing_url + "/1.0.0")
-        .to_return(status: 200)
-      stub_request(:get, types_listing_url + "/1.0.1")
-        .to_return(status: 200)
-    end
-
     let(:dependency_files) { project_dependency_files("yarn/ts_fully_typed") }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -1943,6 +1925,24 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         source: nil
       }]
     end
+    let(:target_version) { "1.3.1" }
+    let(:types_listing_url) { "https://registry.yarnpkg.com/@types%2Fnode-forge" }
+    let(:types_response) do
+      fixture("npm_responses", "types_node-forge.json")
+    end
+
+    before do
+      stub_request(:get, registry_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url)
+        .to_return(status: 200, body: types_response)
+      stub_request(:get, types_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, types_listing_url + "/1.0.0")
+        .to_return(status: 200)
+      stub_request(:get, types_listing_url + "/1.0.1")
+        .to_return(status: 200)
+    end
 
     it "returns 2 dependencies to update" do
       updated_deps = checker.updated_dependencies(requirements_to_unlock: :all)
@@ -1954,26 +1954,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
   context "when types dependency is checked and updated original package exists" do
     let(:registry_listing_url) { "https://registry.yarnpkg.com/node-forge" }
-    let(:registry_response) do
-      fixture("npm_responses", "node-forge.json")
-    end
-    let(:types_listing_url) { "https://registry.npmjs.org/@types%2Fnode-forge" }
-    let(:types_response) do
-      fixture("npm_responses", "types_node-forge.json")
-    end
-    before do
-      stub_request(:get, registry_listing_url)
-        .to_return(status: 200, body: registry_response)
-      stub_request(:get, registry_listing_url + "/latest")
-        .to_return(status: 200, body: "{}")
-      stub_request(:get, registry_listing_url + "/1.3.1")
-        .to_return(status: 200)
-      stub_request(:get, types_listing_url)
-        .to_return(status: 200, body: types_response)
-      stub_request(:head, "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.0.1.tgz")
-        .to_return(status: 200)
-    end
-
     let(:dependency_files) { project_dependency_files("yarn/ts_fully_typed") }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -1990,6 +1970,26 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         groups: [],
         source: nil
       }]
+    end
+    let(:registry_response) do
+      fixture("npm_responses", "node-forge.json")
+    end
+    let(:types_listing_url) { "https://registry.npmjs.org/@types%2Fnode-forge" }
+    let(:types_response) do
+      fixture("npm_responses", "types_node-forge.json")
+    end
+
+    before do
+      stub_request(:get, registry_listing_url)
+        .to_return(status: 200, body: registry_response)
+      stub_request(:get, registry_listing_url + "/latest")
+        .to_return(status: 200, body: "{}")
+      stub_request(:get, registry_listing_url + "/1.3.1")
+        .to_return(status: 200)
+      stub_request(:get, types_listing_url)
+        .to_return(status: 200, body: types_response)
+      stub_request(:head, "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.0.1.tgz")
+        .to_return(status: 200)
     end
 
     it "returns 0 dependencies to update" do

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -402,6 +402,7 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
 
       context "when the spec overrides the default package sources" do
         let(:config_file_fixture_name) { "override_def_source_with_same_key.config" }
+        let(:config_file_fixture_name) { "override_def_source_with_same_key_default.config" }
 
         before do
           repo_url = "https://www.myget.org/F/exceptionless/api/v3/index.json"
@@ -411,8 +412,6 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
               body: fixture("nuget_responses", "myget_base.json")
             )
         end
-
-        let(:config_file_fixture_name) { "override_def_source_with_same_key_default.config" }
 
         it "when the default api key of default registry is provided without clear" do
           expect(dependency_urls).to match_array(

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       end
 
       it "can update" do
-        expect(checker.vulnerable?).to be_truthy
+        expect(checker).to be_vulnerable
         expect(checker.lowest_resolvable_security_fix_version).to eq("2.0.0")
         expect(updated_dependencies).to eq [
           {

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe Dependabot::Python::FileFetcher do
       let(:repo_contents) do
         fixture("github", "contents_python_only_requirements.json")
       end
+      let(:requirements_fixture_name) { "requirements_content.json" }
 
       before do
         stub_request(:get, url + "requirements.txt?ref=sha")
@@ -158,8 +159,6 @@ RSpec.describe Dependabot::Python::FileFetcher do
             headers: { "content-type" => "application/json" }
           )
       end
-
-      let(:requirements_fixture_name) { "requirements_content.json" }
 
       it "fetches the requirements.txt file" do
         expect(file_fetcher_instance.files.count).to eq(1)

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
             source: nil
           }]
         )
-        expect(dependency.production?).to be_truthy
+        expect(dependency).to be_production
       end
     end
 

--- a/python/spec/dependabot/python/metadata_finder_spec.rb
+++ b/python/spec/dependabot/python/metadata_finder_spec.rb
@@ -80,6 +80,8 @@ RSpec.describe Dependabot::Python::MetadataFinder do
           "index-url" => "https://username:password@pypi.posrip.com/pypi/"
         })]
       end
+      let(:pypi_response) { fixture("pypi", "pypi_response.json") }
+
       before do
         private_url = "https://pypi.posrip.com/pypi/#{dependency_name}/json"
         stub_request(:get, pypi_url).to_return(status: 404, body: "")
@@ -87,8 +89,6 @@ RSpec.describe Dependabot::Python::MetadataFinder do
           .with(basic_auth: %w(username password))
           .to_return(status: 200, body: pypi_response)
       end
-
-      let(:pypi_response) { fixture("pypi", "pypi_response.json") }
 
       it { is_expected.to eq("https://github.com/spotify/luigi") }
 

--- a/python/spec/dependabot/python/update_checker/index_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/index_finder_spec.rb
@@ -14,36 +14,8 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
       dependency: dependency
     )
   end
-  let(:credentials) do
-    [Dependabot::Credential.new({
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    })]
-  end
-  let(:dependency_files) { [requirements_file] }
-  let(:dependency) do
-    Dependabot::Dependency.new(
-      name: "requests",
-      version: "2.4.1",
-      requirements: [{
-        requirement: "==2.4.1",
-        file: "requirements.txt",
-        groups: ["dependencies"],
-        source: nil
-      }],
-      package_manager: "pip"
-    )
-  end
-
-  before do
-    stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
-  end
-
   let(:pypi_url) { "https://pypi.org/simple/luigi/" }
   let(:pypi_response) { fixture("pypi", "pypi_simple_response.html") }
-
   let(:pipfile) do
     Dependabot::DependencyFile.new(
       name: "Pipfile",
@@ -72,6 +44,32 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
     )
   end
   let(:pip_conf_fixture_name) { "custom_index" }
+  let(:credentials) do
+    [Dependabot::Credential.new({
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    })]
+  end
+  let(:dependency_files) { [requirements_file] }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "requests",
+      version: "2.4.1",
+      requirements: [{
+        requirement: "==2.4.1",
+        file: "requirements.txt",
+        groups: ["dependencies"],
+        source: nil
+      }],
+      package_manager: "pip"
+    )
+  end
+
+  before do
+    stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
+  end
 
   describe "#index_urls" do
     subject(:index_urls) { finder.index_urls }

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: ../bundler
   specs:
-    dependabot-bundler (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-bundler (0.259.0)
+      dependabot-common (= 0.259.0)
       parallel (~> 1.24)
 
 PATH
   remote: ../cargo
   specs:
-    dependabot-cargo (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-cargo (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../common
   specs:
-    dependabot-common (0.260.0)
+    dependabot-common (0.259.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -37,107 +37,107 @@ PATH
 PATH
   remote: ../composer
   specs:
-    dependabot-composer (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-composer (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../devcontainers
   specs:
-    dependabot-devcontainers (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-devcontainers (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../docker
   specs:
-    dependabot-docker (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-docker (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../elm
   specs:
-    dependabot-elm (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-elm (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../git_submodules
   specs:
-    dependabot-git_submodules (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-git_submodules (0.259.0)
+      dependabot-common (= 0.259.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: ../github_actions
   specs:
-    dependabot-github_actions (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-github_actions (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../go_modules
   specs:
-    dependabot-go_modules (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-go_modules (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../gradle
   specs:
-    dependabot-gradle (0.260.0)
-      dependabot-common (= 0.260.0)
-      dependabot-maven (= 0.260.0)
+    dependabot-gradle (0.259.0)
+      dependabot-common (= 0.259.0)
+      dependabot-maven (= 0.259.0)
 
 PATH
   remote: ../hex
   specs:
-    dependabot-hex (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-hex (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../maven
   specs:
-    dependabot-maven (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-maven (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-npm_and_yarn (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../nuget
   specs:
-    dependabot-nuget (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-nuget (0.259.0)
+      dependabot-common (= 0.259.0)
       rubyzip (>= 2.3.2, < 3.0)
 
 PATH
   remote: ../pub
   specs:
-    dependabot-pub (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-pub (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../python
   specs:
-    dependabot-python (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-python (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../silent
   specs:
-    dependabot-silent (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-silent (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../swift
   specs:
-    dependabot-swift (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-swift (0.259.0)
+      dependabot-common (= 0.259.0)
 
 PATH
   remote: ../terraform
   specs:
-    dependabot-terraform (0.260.0)
-      dependabot-common (= 0.260.0)
+    dependabot-terraform (0.259.0)
+      dependabot-common (= 0.259.0)
 
 GEM
   remote: https://rubygems.org/
@@ -359,7 +359,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet-runtime (0.5.11415)
+    sorbet-runtime (0.5.11353)
     stackprof (0.2.25)
     stringio (3.1.0)
     terminal-table (3.0.2)

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -425,8 +425,8 @@ RSpec.describe Dependabot::Job do
 
       it "registers the experiments with Dependabot::Experiments" do
         job
-        expect(Dependabot::Experiments.enabled?(:kebab_case)).to be_truthy
-        expect(Dependabot::Experiments.enabled?(:simpe)).to be_falsey
+        expect(Dependabot::Experiments).to be_enabled(:kebab_case)
+        expect(Dependabot::Experiments).not_to be_enabled(:simpe)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
The Predicate Matcher rubocop rule is disabled for some files.  This Pull request will re-enable it.

### Anything you want to highlight for special attention from reviewers?
Please review for duplicated code blocks which escaped the autocorrect.

### How will you know you've accomplished your goal?
This rubocop rule will work as desired

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
