### PR TITLE
Enabled Rubocop rule for the MetadataStyle test

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -135,16 +135,6 @@ RSpec/MessageChain:
 RSpec/MessageSpies:
   Enabled: false
 
-# Offense count: 8
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: hash, symbol
-RSpec/MetadataStyle:
-  Exclude:
-    - 'hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb'
-    - 'terraform/spec/dependabot/terraform/file_parser_spec.rb'
-    - 'updater/spec/dependabot/file_fetcher_command_spec.rb'
-
 # Offense count: 1
 RSpec/MultipleDescribes:
   Exclude:

--- a/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::VersionResolver do
     context "with a dependency with a bad specification" do
       let(:mixfile_fixture_name) { "bad_spec" }
 
-      it "raises a DependencyFileNotResolvable error", skip_ci: true do
+      it "raises a DependencyFileNotResolvable error", :skip_ci do
         expect { resolver.latest_resolvable_version }
           .to raise_error(Dependabot::DependencyFileNotResolvable)
       end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -914,7 +914,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
-    context "with a private module proxy that can't be reached", vcr: true do
+    context "with a private module proxy that can't be reached", :vcr do
       before do
         artifactory_repo_url = "http://artifactory.dependabot.com/artifactory/tf-modules/azurerm"
 

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       Dependabot::Experiments.reset!
     end
 
-    it "fetches the files and writes the fetched files to output.json", vcr: true do
+    it "fetches the files and writes the fetched files to output.json", :vcr do
       expect(api_client).not_to receive(:mark_job_as_processed)
 
       perform_job
@@ -56,7 +56,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       expect(dependency_file["content_encoding"]).to eq("utf-8")
     end
 
-    context "when the fetcher raises a ToolVersionNotSupported error", vcr: true do
+    context "when the fetcher raises a ToolVersionNotSupported error", :vcr do
       before do
         allow_any_instance_of(Dependabot::Bundler::FileFetcher)
           .to receive(:commit).and_return("a" * 40)
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
-    context "when the fetcher raises a file fetcher error (cloud)", vcr: true do
+    context "when the fetcher raises a file fetcher error (cloud)", :vcr do
       before do
         allow_any_instance_of(Dependabot::Bundler::FileFetcher)
           .to receive(:commit)
@@ -172,7 +172,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
-    context "when the fetcher raises a file fetcher error (ghes)", vcr: true do
+    context "when the fetcher raises a file fetcher error (ghes)", :vcr do
       before do
         allow_any_instance_of(Dependabot::Bundler::FileFetcher)
           .to receive(:commit)
@@ -232,7 +232,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
-    context "when vendoring dependencies", vcr: true do
+    context "when vendoring dependencies", :vcr do
       let(:job_definition) do
         JSON.parse(fixture("jobs/job_with_vendor_dependencies.json"))
       end
@@ -314,7 +314,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
-    context "when the connectivity check is enabled", vcr: true do
+    context "when the connectivity check is enabled", :vcr do
       before do
         allow(ENV).to receive(:[]).and_call_original
         allow(ENV).to receive(:[]).with("ENABLE_CONNECTIVITY_CHECK").and_return("1")


### PR DESCRIPTION
### What are you trying to accomplish?
The Rubocop rule to check for MetadataStyle was excluded on several files.  This PR will re-enable that issue.

### Anything you want to highlight for special attention from reviewers?
Please be on alert for multiple lines doing the same thing.

### How will you know you've accomplished your goal?

The rubocop rule will be enforced on the entire application.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
