### PR TITLE
don't fail when a dependency doesn't have a previous version

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -356,6 +356,11 @@ module Dependabot
       end
     end
 
+    sig { returns(T::Boolean) }
+    def requirements_changed?
+      (requirements - T.must(previous_requirements)).any?
+    end
+
     private
 
     sig { void }

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -139,7 +139,7 @@ module Dependabot
     end
 
     sig { returns(T::Boolean) }
-    def previous_version?
+    def all_have_previous_version?
       return true if updated_dependencies.all?(&:requirements_changed?)
       return true if updated_dependencies.all?(&:previous_version)
 
@@ -148,8 +148,7 @@ module Dependabot
 
     sig { void }
     def check_dependencies_have_previous_version
-      return if updated_dependencies.all?(&:requirements_changed?)
-      return if updated_dependencies.all?(&:previous_version)
+      return if all_have_previous_version?
 
       deps_no_previous_version = updated_dependencies.reject(&:previous_version)
       deps_no_change = updated_dependencies.reject(&:requirements_changed?)

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -145,7 +145,7 @@ module Dependabot
       false
     end
 
-    sig { params(updated_dependencies: T::Array[Dependabot::Dependency]).void }
+    sig { void }
     def check_dependencies_have_previous_version
       return if updated_dependencies.all?(&:requirements_changed?)
       return if updated_dependencies.all?(&:previous_version)

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -16,6 +16,21 @@ module Dependabot
   class DependencyChange
     extend T::Sig
 
+    class InvalidUpdatedDependencies < DependabotError
+      extend T::Sig
+
+      sig { params(deps_no_previous_version: T::Array[String], deps_no_change: T::Array[String]).void }
+      def initialize(deps_no_previous_version:, deps_no_change:)
+        msg = ""
+        if deps_no_previous_version.any?
+          msg += "Previous version was not provided for: '#{deps_no_previous_version.join(', ')}' "
+        end
+        msg += "No requirements change for: '#{deps_no_change.join(', ')}'" if deps_no_change.any?
+
+        super(msg)
+      end
+    end
+
     sig { returns(Dependabot::Job) }
     attr_reader :job
 
@@ -120,6 +135,27 @@ module Dependabot
       end
       updated_dependencies.compact!
       updated_dependency_files.compact!
+    end
+
+    sig { returns(T::Boolean) }
+    def previous_version?
+      return true if updated_dependencies.all?(&:requirements_changed?)
+      return true if updated_dependencies.all?(&:previous_version)
+
+      false
+    end
+
+    sig { params(updated_dependencies: T::Array[Dependabot::Dependency]).void }
+    def check_dependencies_have_previous_version
+      return if updated_dependencies.all?(&:requirements_changed?)
+      return if updated_dependencies.all?(&:previous_version)
+
+      deps_no_previous_version = updated_dependencies.reject(&:previous_version)
+      deps_no_change = updated_dependencies.reject(&:requirements_changed?)
+      raise InvalidUpdatedDependencies.new(
+        deps_no_previous_version: deps_no_previous_version.map(&:name),
+        deps_no_change: deps_no_change.map(&:name)
+      )
     end
 
     sig { returns(T::Boolean) }

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/errors"
 
 # This class describes a change to the project's Dependencies which has been
 # determined by a Dependabot operation.
@@ -16,7 +17,7 @@ module Dependabot
   class DependencyChange
     extend T::Sig
 
-    class InvalidUpdatedDependencies < DependabotError
+    class InvalidUpdatedDependencies < Dependabot::DependabotError
       extend T::Sig
 
       sig { params(deps_no_previous_version: T::Array[String], deps_no_change: T::Array[String]).void }

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -21,21 +21,6 @@ module Dependabot
     extend T::Sig
     extend Forwardable
 
-    class InvalidUpdatedDependencies < DependabotError
-      extend T::Sig
-
-      sig { params(deps_no_previous_version: T::Array[String], deps_no_change: T::Array[String]).void }
-      def initialize(deps_no_previous_version:, deps_no_change:)
-        msg = ""
-        if deps_no_previous_version.any?
-          msg += "Previous version was not provided for: '#{deps_no_previous_version.join(', ')}' "
-        end
-        msg += "No requirements change for: '#{deps_no_change.join(', ')}'" if deps_no_change.any?
-
-        super(msg)
-      end
-    end
-
     sig { returns(T::Array[T.untyped]) }
     attr_reader :pull_requests
 

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -21,6 +21,8 @@ module Dependabot
       # can be used for PR creation.
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
       def compile_all_dependency_changes_for(group)
         prepare_workspace
 
@@ -101,6 +103,8 @@ module Dependabot
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def dependency_file_parser(dependency_files)
         Dependabot::FileParsers.for_package_manager(job.package_manager).new(

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -86,9 +86,9 @@ module Dependabot
         )
 
         if Experiments.enabled?("dependency_change_validation") && !dependency_change.previous_version?
-          deps_no_previous_version = dependency_change.updated_dependencies.reject(&:previous_version)
-          deps_no_change = dependency_change.updated_dependencies.reject(&:requirements_changed?)
-          msg = "Skipping change to #{dependency.name}: "
+          deps_no_previous_version = dependency_change.updated_dependencies.reject(&:previous_version).map(&:name)
+          deps_no_change = dependency_change.updated_dependencies.reject(&:requirements_changed?).map(&:name)
+          msg = "Skipping change to group #{group.name} in directory #{job.source.directory}: "
           if deps_no_previous_version.any?
             msg += "Previous version was not provided for: '#{deps_no_previous_version.join(', ')}' "
           end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -84,7 +84,7 @@ module Dependabot
           dependency_group: group
         )
 
-        if Experiments.enabled?("dependency_change_validation") && !dependency_change.previous_version?
+        if Experiments.enabled?("dependency_change_validation") && !dependency_change.all_have_previous_version?
           log_missing_previous_version(dependency_change)
           return nil
         end

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -69,7 +69,7 @@ module Dependabot
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(group)
           else
-            dependency_changes = job.source.directories.map do |directory|
+            dependency_changes = job.source.directories.filter_map do |directory|
               job.source.directory = directory
               dependency_snapshot.current_directory = directory
               compile_all_dependency_changes_for(group)

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -117,7 +117,7 @@ module Dependabot
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(dependency_snapshot.job_group)
           else
-            dependency_changes = job.source.directories.map do |directory|
+            dependency_changes = job.source.directories.filter_map do |directory|
               job.source.directory = directory
               dependency_snapshot.current_directory = directory
               compile_all_dependency_changes_for(dependency_snapshot.job_group)

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -76,6 +76,7 @@ module Dependabot
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity
         def check_and_create_pull_request(dependency)
           checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
 
@@ -106,17 +107,6 @@ module Dependabot
 
           if updated_deps.empty?
             raise "Dependabot found some dependency requirements to unlock, yet it failed to update any dependencies"
-          end
-
-          # The PR will be rejected if this happens, so we avoid tainting the whole group by skipping.
-          deps_no_previous_version = updated_deps.reject(&:previous_version)
-          deps_no_change = updated_deps.reject(&:requirements_changed?)
-          if deps_no_previous_version.any? && deps_no_change.any?
-            msg = "Skipping #{dependency.name} because"
-            msg += " some dependencies bumped have no previous version" if deps_no_previous_version.any?
-            msg += " and" if deps_no_previous_version.any? && deps_no_change.any?
-            msg += " some dependencies bumped have no change in requirements" if deps_no_change.any?
-            return Dependabot.logger.info(msg)
           end
 
           if (existing_pr = existing_pull_request(updated_deps))
@@ -156,6 +146,7 @@ module Dependabot
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def log_up_to_date(dependency)
           Dependabot.logger.info(

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -76,7 +76,6 @@ module Dependabot
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/CyclomaticComplexity
         def check_and_create_pull_request(dependency)
           checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
 
@@ -146,7 +145,6 @@ module Dependabot
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/AbcSize
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def log_up_to_date(dependency)
           Dependabot.logger.info(

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Dependabot::Service do
 
       it "raises an InvalidUpdatedDependencies error" do
         expect { service.create_pull_request(dependency_change, base_sha) }
-          .to raise_error(Dependabot::Service::InvalidUpdatedDependencies)
+          .to raise_error(Dependabot::DependencyChange::InvalidUpdatedDependencies)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

In https://github.com/dependabot/dependabot-core/pull/9888 I moved the failure out of the service and into the Updater.

In this PR, I prevent the failure by removing the questionable update, and logging to tell us what's happening.

It seems there are various reasons why an update with no previous version will happen, but rather than failing the job or a group, we should log it and continue on.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

We should stop seeing the error being reported.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
