### PR TITLE
enabled RSpec Not To Not rubocop.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -149,13 +149,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 8
 
-# Offense count: 357
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: not_to, to_not
-RSpec/NotToNot:
-  Enabled: false
-
 # Offense count: 16
 RSpec/OverwritingSetup:
   Exclude:

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
       its(:length) { is_expected.to eq(1) }
 
       it "is not included" do
-        expect(dependencies.map(&:name)).to_not include("statesman")
+        expect(dependencies.map(&:name)).not_to include("statesman")
       end
     end
 
@@ -415,7 +415,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
       its(:length) { is_expected.to eq(15) }
 
       it "does not include the path dependency" do
-        expect(dependencies.map(&:name)).to_not include("example")
+        expect(dependencies.map(&:name)).not_to include("example")
       end
 
       it "includes the path dependency's sub-dependency" do
@@ -428,7 +428,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         let(:dependency_files) { bundler_project_dependency_files("version_specified_gemfile_specification") }
 
         it "includes the path dependency" do
-          expect(dependencies.map(&:name)).to_not include("example")
+          expect(dependencies.map(&:name)).not_to include("example")
         end
       end
     end
@@ -855,7 +855,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         its(:length) { is_expected.to eq(1) }
 
         it "is not included" do
-          expect(dependencies.map(&:name)).to_not include("statesman")
+          expect(dependencies.map(&:name)).not_to include("statesman")
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
           bundler_project_dependency_file("gemfile_with_nested_block", filename: "example.gemspec").content
         end
 
-        specify { expect { sanitizer.rewrite(content) }.to_not raise_error }
+        specify { expect { sanitizer.rewrite(content) }.not_to raise_error }
       end
     end
 

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
           bundler_project_dependency_file("gemfile_unevaluatable_ruby", filename: "example.gemspec")
         end
 
-        it { is_expected.to_not include("ruby '") }
+        it { is_expected.not_to include("ruby '") }
       end
 
       context "with an existing ruby version" do
@@ -165,7 +165,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
           end
 
           it { is_expected.to include("ruby '1.9.3'\n") }
-          it { is_expected.to_not include(%(ruby "2.2.0")) }
+          it { is_expected.not_to include(%(ruby "2.2.0")) }
           it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
         end
 
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
           end
 
           it { is_expected.to include("ruby '1.9.3'\n") }
-          it { is_expected.to_not include(%(ruby "2.2.0")) }
+          it { is_expected.not_to include(%(ruby "2.2.0")) }
         end
 
         context "when loaded from a file" do
@@ -186,7 +186,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
           end
 
           it { is_expected.to include("ruby '1.9.3'\n") }
-          it { is_expected.to_not include("ruby File.open") }
+          it { is_expected.not_to include("ruby File.open") }
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
               :get,
               "https://gems.example.com/api/v1/gems/business.json"
             )
-          expect(WebMock).to_not have_requested(:get, rubygems_gemspec_url)
+          expect(WebMock).not_to have_requested(:get, rubygems_gemspec_url)
         end
 
         context "when with no source" do
@@ -178,7 +178,7 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
               .to eq("https://github.com/gocardless/business")
             expect(WebMock)
               .to have_requested(:get, "https://gems.greysteil.com/api/v1/gems/business.json")
-            expect(WebMock).to_not have_requested(:get, rubygems_gemspec_url)
+            expect(WebMock).not_to have_requested(:get, rubygems_gemspec_url)
           end
         end
       end
@@ -204,7 +204,7 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
               :get,
               "https://rubygems.org/api/v1/gems/business.json"
             )
-          expect(WebMock).to_not have_requested(:get, rubygems_gemspec_url)
+          expect(WebMock).not_to have_requested(:get, rubygems_gemspec_url)
         end
 
         context "when the response doesn't match" do

--- a/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::FilePreparer do
             )
           end
 
-          its(:content) { is_expected.to_not include("ruby '1.9.3'") }
+          its(:content) { is_expected.not_to include("ruby '1.9.3'") }
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
 
@@ -123,7 +123,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           let(:raise_on_ignored) { true }
 
           it "doesn't raise an error" do
-            expect { latest_version_details }.to_not raise_error
+            expect { latest_version_details }.not_to raise_error
           end
         end
       end
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           let(:raise_on_ignored) { true }
 
           it "doesn't raise an error" do
-            expect { latest_version_details }.to_not raise_error
+            expect { latest_version_details }.not_to raise_error
           end
         end
       end
@@ -147,7 +147,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           let(:raise_on_ignored) { true }
 
           it "doesn't raise an error" do
-            expect { latest_version_details }.to_not raise_error
+            expect { latest_version_details }.not_to raise_error
           end
         end
       end
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         it "fetches the latest SHA-1 hash" do
           commit_sha = finder.latest_version_details[:commit_sha]
           expect(commit_sha).to match(/^[0-9a-f]{40}$/)
-          expect(commit_sha).to_not eq(current_version)
+          expect(commit_sha).not_to eq(current_version)
         end
 
         context "when the gem has a bad branch" do

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         expect { latest_resolvable_version_details }
           .to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
           # Test that the temporary path isn't included in the error message
-          expect(error.message).to_not include("dependabot_20")
+          expect(error.message).not_to include("dependabot_20")
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -698,7 +698,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         it "doesn't persist any temporary changes to Bundler's root" do
           expect { checker.latest_resolvable_version }
-            .to_not(change(::Bundler, :root))
+            .not_to(change(::Bundler, :root))
         end
 
         context "when that requires other files" do
@@ -762,7 +762,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           it "fetches the latest SHA-1 hash" do
             version = checker.latest_resolvable_version
             expect(version).to match(/^[0-9a-f]{40}$/)
-            expect(version).to_not eq(current_version)
+            expect(version).not_to eq(current_version)
           end
 
           context "when the Gemfile doesn't specify a git source" do
@@ -821,7 +821,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           it "fetches the latest SHA-1 hash" do
             version = checker.latest_resolvable_version
             expect(version).to match(/^[0-9a-f]{40}$/)
-            expect(version).to_not eq(current_version)
+            expect(version).not_to eq(current_version)
           end
         end
 
@@ -1051,7 +1051,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           it "fetches the latest SHA-1 hash" do
             version = checker.latest_resolvable_version
             expect(version).to match(/^[0-9a-f]{40}$/)
-            expect(version).to_not eq "c5bf1bd47935504072ac0eba1006cf4d67af6a7a"
+            expect(version).not_to eq "c5bf1bd47935504072ac0eba1006cf4d67af6a7a"
           end
         end
 
@@ -1664,7 +1664,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
               expect(updated_requirements.count).to eq(1)
               expect(updated_requirements.first[:requirement]).to eq(">= 0")
-              expect(updated_requirements.first[:source]).to_not be_nil
+              expect(updated_requirements.first[:source]).not_to be_nil
             end
           end
         end

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
       its(:length) { is_expected.to eq(10) }
 
       it "excludes the source application / library" do
-        expect(dependencies.map(&:name)).to_not include("dependabot")
+        expect(dependencies.map(&:name)).not_to include("dependabot")
       end
 
       describe "top level dependencies" do

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
 
     it "doesn't store the files permanently" do
       expect { updated_lockfile_content }
-        .to_not(change { Dir.entries(tmp_path) })
+        .not_to(change { Dir.entries(tmp_path) })
     end
 
-    it { expect { updated_lockfile_content }.to_not output.to_stdout }
+    it { expect { updated_lockfile_content }.not_to output.to_stdout }
 
     context "when using a toolchain file that is too old" do
       let(:toolchain_file) do
@@ -168,7 +168,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
             checksum = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
           CHECKSUM
         )
-        expect(updated_lockfile_content).to_not include(
+        expect(updated_lockfile_content).not_to include(
           <<~CHECKSUM
             checksum = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
           CHECKSUM
@@ -267,7 +267,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
               checksum = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
             CHECKSUM
           )
-          expect(updated_lockfile_content).to_not include("[metadata]")
+          expect(updated_lockfile_content).not_to include("[metadata]")
         end
       end
 
@@ -324,7 +324,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
             expect(updated_lockfile_content)
               .to include("git+ssh://git@github.com/BurntSushi/utf8-ranges#" \
                           "be9b8dfcaf449453cbf83ac85260ee80323f4f77")
-            expect(updated_lockfile_content).to_not include("git+https://")
+            expect(updated_lockfile_content).not_to include("git+https://")
 
             content = updated_lockfile_content
             expect(content.scan('name = "utf8-ranges"').count).to eq(1)
@@ -411,7 +411,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           expect(updated_lockfile_content).to include(
             "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
           )
-          expect(updated_lockfile_content).to_not include(
+          expect(updated_lockfile_content).not_to include(
             "bc2a4457b0c25dae6fee3dcd631ccded31e97d689b892c26554e096aa08dd136"
           )
         end
@@ -464,7 +464,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           expect(updated_lockfile_content).to include(
             "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
           )
-          expect(updated_lockfile_content).to_not include(
+          expect(updated_lockfile_content).not_to include(
             "b3a89a0c46ba789b8a247d4c567aed4d7c68e624672d238b45cc3ec20dc9f940"
           )
         end
@@ -510,7 +510,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           expect(updated_lockfile_content).to include(
             "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
           )
-          expect(updated_lockfile_content).to_not include(
+          expect(updated_lockfile_content).not_to include(
             "b3a89a0c46ba789b8a247d4c567aed4d7c68e624672d238b45cc3ec20dc9f940"
           )
         end

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
 
       it { is_expected.to include(%(time = "0.1.38")) }
       it { is_expected.to include(%(regex = "0.1.41")) }
-      it { is_expected.to_not include(%("time" = "0.1.12")) }
+      it { is_expected.not_to include(%("time" = "0.1.12")) }
 
       context "with similarly named dependencies" do
         let(:manifest_fixture_name) { "similar_names" }
@@ -71,7 +71,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
 
         it { is_expected.to include(%(time = "0.1.38")) }
         it { is_expected.to include(%(regex = "0.1.41")) }
-        it { is_expected.to_not include(%("time" = "0.1.12")) }
+        it { is_expected.not_to include(%("time" = "0.1.12")) }
       end
 
       context "with a target-specific dependency" do

--- a/cargo/spec/dependabot/cargo/file_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
     subject(:updated_files) { updater.updated_dependency_files }
 
     it "doesn't store the files permanently" do
-      expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+      expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
     end
 
     it "returns DependencyFile objects" do
       updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
     end
 
-    it { expect { updated_files }.to_not output.to_stdout }
+    it { expect { updated_files }.not_to output.to_stdout }
     its(:length) { is_expected.to eq(1) }
 
     context "without a lockfile" do
@@ -130,7 +130,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
           expect(updated_lockfile_content).to include(
             "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
           )
-          expect(updated_lockfile_content).to_not include(
+          expect(updated_lockfile_content).not_to include(
             "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
           )
         end

--- a/cargo/spec/dependabot/cargo/update_checker/file_preparer_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/file_preparer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::FilePreparer do
             expect(prepared_manifest_file.content)
               .to include('time = ">= 0.1.12"')
             expect(prepared_manifest_file.content)
-              .to_not include('time = "<= 0.1.12"')
+              .not_to include('time = "<= 0.1.12"')
           end
         end
 

--- a/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -153,7 +153,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -179,7 +179,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         expect { latest_resolvable_version }
           .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             # Test that the temporary path isn't included in the error message
-            expect(error.message).to_not include("dependabot_20")
+            expect(error.message).not_to include("dependabot_20")
             expect(error.message).to include("requires a nightly version")
           end
       end
@@ -189,7 +189,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         expect { latest_resolvable_version }
           .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             # Test that the temporary path isn't included in the error message
-            expect(error.message).to_not include("dependabot_20")
+            expect(error.message).not_to include("dependabot_20")
             expect(error.message)
               .to include("feature `metabuild` is required")
           end
@@ -208,7 +208,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         expect { latest_resolvable_version }
           .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             # Test that the temporary path isn't included in the error message
-            expect(error.message).to_not include("dependabot_20")
+            expect(error.message).not_to include("dependabot_20")
             expect(error.message)
               .to include("no matching package named `no_exist_bad_time` found")
           end
@@ -222,7 +222,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
           expect { latest_resolvable_version }
             .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
               # Test that the temporary path isn't included in the error message
-              expect(error.message).to_not include("dependabot_20")
+              expect(error.message).not_to include("dependabot_20")
               expect(error.message)
                 .to include("no matching package named `no_exist_bad_time`")
             end
@@ -237,7 +237,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
           expect { latest_resolvable_version }
             .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
               # Test that the temporary path isn't included in the error message
-              expect(error.message).to_not include("dependabot_20")
+              expect(error.message).not_to include("dependabot_20")
               expect(error.message.downcase)
                 .to include("invalid character `;` in package name")
             end
@@ -542,7 +542,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
           expect { latest_resolvable_version }
             .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
               # Test that the temporary path isn't included in the error message
-              expect(error.message).to_not include("dependabot_20")
+              expect(error.message).not_to include("dependabot_20")
 
               # Test that the right details are included
               expect(error.message).to include("wasn't a root")

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Clients::Azure do
           .to_return(status: 200, body: fixture("azure", "master_branch.json"))
       end
 
-      specify { expect { fetch_commit }.to_not raise_error }
+      specify { expect { fetch_commit }.not_to raise_error }
 
       it { is_expected.to eq("9c8376e9b2e943c2c72fac4b239876f377f0305a") }
     end
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::Clients::Azure do
                   json_body = JSON.parse(req.body)
                   expect(json_body.fetch("commits").count).to eq(1)
                   expect(json_body.fetch("commits").first.keys)
-                    .to_not include("author")
+                    .not_to include("author")
                 end
             )
         end
@@ -258,7 +258,7 @@ RSpec.describe Dependabot::Clients::Azure do
           .to_return(status: 200, body: response_body)
       end
 
-      specify { expect { autocomplete_pull_request }.to_not raise_error }
+      specify { expect { autocomplete_pull_request }.not_to raise_error }
 
       it { is_expected.to eq(JSON.parse(response_body)) }
     end
@@ -303,7 +303,7 @@ RSpec.describe Dependabot::Clients::Azure do
           .to_return(status: 200, body: response_body)
       end
 
-      specify { expect { pull_request }.to_not raise_error }
+      specify { expect { pull_request }.not_to raise_error }
 
       it { is_expected.to eq(JSON.parse(response_body)) }
     end

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "default_reviewers_no_data.json"))
       end
 
-      specify { expect { default_reviewers }.to_not raise_error }
+      specify { expect { default_reviewers }.not_to raise_error }
 
       it { is_expected.to eq([]) }
     end
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "default_reviewers_with_data.json"))
       end
 
-      specify { expect { default_reviewers }.to_not raise_error }
+      specify { expect { default_reviewers }.not_to raise_error }
 
       it { is_expected.to eq([{ uuid: "{00000000-0000-0000-0000-000000000001}" }]) }
     end
@@ -75,7 +75,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 401, body: fixture("bitbucket", "current_user_no_access.json"))
       end
 
-      specify { expect { default_reviewers }.to_not raise_error }
+      specify { expect { default_reviewers }.not_to raise_error }
 
       it {
         is_expected.to eq(
@@ -115,7 +115,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 201)
       end
 
-      specify { expect { create_pull_request }.to_not raise_error }
+      specify { expect { create_pull_request }.not_to raise_error }
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
       client.current_user
     end
 
-    specify { expect { current_user }.to_not raise_error }
+    specify { expect { current_user }.not_to raise_error }
 
     it { is_expected.to eq("{11111111-6349-0000-aea6-111111111111}") }
   end
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "pull_requests_no_match.json"))
       end
 
-      specify { expect { pull_requests }.to_not raise_error }
+      specify { expect { pull_requests }.not_to raise_error }
 
       it { is_expected.to eq([]) }
     end
@@ -156,7 +156,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "pull_requests_with_match.json"))
       end
 
-      specify { expect { pull_requests }.to_not raise_error }
+      specify { expect { pull_requests }.not_to raise_error }
 
       it {
         is_expected.to eq([
@@ -196,7 +196,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "pull_requests_with_match.json"))
       end
 
-      specify { expect { pull_requests }.to_not raise_error }
+      specify { expect { pull_requests }.not_to raise_error }
 
       it {
         is_expected.to eq([
@@ -236,7 +236,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 200, body: fixture("bitbucket", "pull_requests_no_match.json"))
       end
 
-      specify { expect { pull_requests }.to_not raise_error }
+      specify { expect { pull_requests }.not_to raise_error }
 
       it {
         is_expected.to eq([
@@ -296,7 +296,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 201)
       end
 
-      specify { expect { decline_pull_request }.to_not raise_error }
+      specify { expect { decline_pull_request }.not_to raise_error }
     end
 
     context "without provided comment" do
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
           .to_return(status: 201)
       end
 
-      specify { expect { decline_pull_request }.to_not raise_error }
+      specify { expect { decline_pull_request }.not_to raise_error }
     end
   end
 end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
           )
       end
 
-      specify { expect { fetch_commit }.to_not raise_error }
+      specify { expect { fetch_commit }.not_to raise_error }
 
       it { is_expected.to eq("9c8376e9b2e943c2c72fac4b239876f377f0305a") }
 

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Dependabot::DependencyFile do
       let(:file1) { described_class.new(name: "Gemfile", content: "a") }
       let(:file2) { described_class.new(name: "Gemfile", content: "b") }
 
-      specify { expect(file1).to_not eq(file2) }
+      specify { expect(file1).not_to eq(file2) }
     end
   end
 

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::Dependency do
         }]
       end
 
-      specify { expect { dependency }.to_not raise_error }
+      specify { expect { dependency }.not_to raise_error }
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe Dependabot::Dependency do
       let(:dependency1) { described_class.new(**args) }
       let(:dependency2) { described_class.new(**args.merge(name: "dep2")) }
 
-      specify { expect(dependency1).to_not eq(dependency2) }
+      specify { expect(dependency1).not_to eq(dependency2) }
     end
   end
 

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1244,7 +1244,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
           let(:directory) { "app/" }
 
           it "gets the file" do
-            expect { files }.to_not raise_error
+            expect { files }.not_to raise_error
           end
         end
 
@@ -1265,7 +1265,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
           let(:directory) { "/app" }
 
           it "gets the file" do
-            expect { files }.to_not raise_error
+            expect { files }.not_to raise_error
           end
         end
 
@@ -1286,7 +1286,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
           let(:directory) { "a/pp" }
 
           it "gets the file" do
-            expect { files }.to_not raise_error
+            expect { files }.not_to raise_error
           end
         end
       end
@@ -1668,7 +1668,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
               proc { "" }
             )
 
-          expect { clone_repo_contents }.to_not raise_error
+          expect { clone_repo_contents }.not_to raise_error
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).thrice
           expect(file_fetcher_instance).to have_received(:sleep).once
         end
@@ -1702,7 +1702,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
           expect { clone_repo_contents }.to raise_error(Dependabot::RepoNotFound)
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).once
-          expect(file_fetcher_instance).to_not have_received(:sleep)
+          expect(file_fetcher_instance).not_to have_received(:sleep)
         end
       end
     end

--- a/common/spec/dependabot/file_parsers/base_spec.rb
+++ b/common/spec/dependabot/file_parsers/base_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dependabot::FileParsers::Base do
       let(:files) { [gemfile] }
 
       it "doesn't raise" do
-        expect { parser_instance }.to_not raise_error
+        expect { parser_instance }.not_to raise_error
       end
     end
 

--- a/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
         `touch vendor/cache/ignored.txt`
       end
 
-      expect(updated_files.map(&:name)).to_not include(
+      expect(updated_files.map(&:name)).not_to include(
         "vendor/cache/ignored.txt"
       )
     end
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
         `touch some-file.txt`
       end
 
-      expect(updated_files.map(&:name)).to_not include(
+      expect(updated_files.map(&:name)).not_to include(
         "some-file.txt"
       )
     end
@@ -157,7 +157,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       it "does not include the directory in the name" do
-        expect(updated_files.first.name).to_not include("nested")
+        expect(updated_files.first.name).not_to include("nested")
       end
 
       it "sets the right directory" do

--- a/common/spec/dependabot/file_updaters/base_spec.rb
+++ b/common/spec/dependabot/file_updaters/base_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::FileUpdaters::Base do
       let(:files) { [gemfile] }
 
       it "doesn't raise" do
-        expect { updater_instance }.to_not raise_error
+        expect { updater_instance }.not_to raise_error
       end
     end
 
@@ -93,6 +93,6 @@ RSpec.describe Dependabot::FileUpdaters::Base do
     its(:content) { is_expected.to eq("codes") }
     its(:directory) { is_expected.to eq(file.directory) }
 
-    specify { expect { updated_file }.to_not(change(file, :content)) }
+    specify { expect { updated_file }.not_to(change(file, :content)) }
   end
 end

--- a/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
         `touch vendor/cache/ignored.txt`
       end
 
-      expect(updated_files.map(&:name)).to_not include(
+      expect(updated_files.map(&:name)).not_to include(
         "vendor/cache/ignored.txt"
       )
     end
@@ -113,7 +113,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
         `touch some-file.txt`
       end
 
-      expect(updated_files.map(&:name)).to_not include(
+      expect(updated_files.map(&:name)).not_to include(
         "some-file.txt"
       )
     end
@@ -156,7 +156,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       it "does not include the directory in the name" do
-        expect(updated_files.first.name).to_not include("nested")
+        expect(updated_files.first.name).not_to include("nested")
       end
 
       it "sets the right directory" do

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1039,7 +1039,7 @@ RSpec.describe Dependabot::GitCommitChecker do
           let(:raise_on_ignored) { true }
 
           it "doesn't raise an error" do
-            expect { local_tag_for_latest_version }.to_not raise_error
+            expect { local_tag_for_latest_version }.not_to raise_error
           end
         end
 
@@ -1052,7 +1052,7 @@ RSpec.describe Dependabot::GitCommitChecker do
             let(:raise_on_ignored) { true }
 
             it "doesn't raise an error" do
-              expect { local_tag_for_latest_version }.to_not raise_error
+              expect { local_tag_for_latest_version }.not_to raise_error
             end
           end
         end

--- a/common/spec/dependabot/pull_request_creator/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/azure_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
               json_body = JSON.parse(req.body)
               expect(json_body.fetch("commits").count).to eq(1)
               expect(json_body.fetch("commits").first.keys)
-                .to_not include("author")
+                .not_to include("author")
             end
         )
       expect(WebMock)
@@ -205,7 +205,7 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
                   json_body = JSON.parse(req.body)
                   expect(json_body.fetch("commits").count).to eq(1)
                   expect(json_body.fetch("commits").first.keys)
-                    .to_not include("author")
+                    .not_to include("author")
                 end
             )
         end
@@ -240,7 +240,7 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
         end
 
         it "creates a commit and pull request with the right details" do
-          expect(creator.create).to_not be_nil
+          expect(creator.create).not_to be_nil
 
           expect(WebMock)
             .to have_requested(
@@ -273,12 +273,12 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
           expect(creator.create).to be_nil
 
           expect(WebMock)
-            .to_not have_requested(
+            .not_to have_requested(
               :post,
               "#{repo_api_url}/pushes?api-version=5.0"
             )
           expect(WebMock)
-            .to_not have_requested(
+            .not_to have_requested(
               :post,
               "#{repo_api_url}/pullrequests?api-version=5.0"
             )

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
           end
 
           it "creates a commit and merge request with the right details" do
-            expect(creator.create).to_not be_nil
+            expect(creator.create).not_to be_nil
 
             expect(WebMock)
               .to have_requested(:post, "#{repo_api_url}/repository/commits")
@@ -409,10 +409,10 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
           end
 
           it "creates a merge request but not a commit" do
-            expect(creator.create).to_not be_nil
+            expect(creator.create).not_to be_nil
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/repository/commits")
+              .not_to have_requested(:post, "#{repo_api_url}/repository/commits")
             expect(WebMock)
               .to have_requested(:post, "#{repo_api_url}/merge_requests")
           end
@@ -435,9 +435,9 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
           expect(creator.create).to be_nil
 
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/repository/commits")
+            .not_to have_requested(:post, "#{repo_api_url}/repository/commits")
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/merge_requests")
+            .not_to have_requested(:post, "#{repo_api_url}/merge_requests")
         end
       end
     end

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
 
           it "quietly ignores losing the race" do
             expect { labeler.create_default_labels_if_required }
-              .to_not raise_error
+              .not_to raise_error
             expect(labeler.labels_for_pr).to include("dependencies")
           end
         end
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           labeler.create_default_labels_if_required
 
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/labels")
+            .not_to have_requested(:post, "#{repo_api_url}/labels")
         end
 
         context "when dealing with the label that is only present after paginating" do
@@ -161,7 +161,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
         end
 
@@ -230,7 +230,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
         end
 
@@ -273,7 +273,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
 
         it "does not create a 'dependencies' label" do
           labeler.create_default_labels_if_required
-          expect(WebMock).to_not have_requested(:post, "#{repo_api_url}/labels")
+          expect(WebMock).not_to have_requested(:post, "#{repo_api_url}/labels")
         end
 
         context "when label_language is true" do
@@ -283,7 +283,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
         end
 
@@ -294,7 +294,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
         end
       end
@@ -334,7 +334,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
             expect(labeler.labels_for_pr).to include("security")
           end
         end
@@ -429,7 +429,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           labeler.create_default_labels_if_required
 
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/labels")
+            .not_to have_requested(:post, "#{repo_api_url}/labels")
         end
       end
 
@@ -440,7 +440,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           labeler.create_default_labels_if_required
 
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/labels")
+            .not_to have_requested(:post, "#{repo_api_url}/labels")
         end
 
         context "when the label is not exist" do
@@ -450,7 +450,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
         end
       end
@@ -491,7 +491,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             labeler.create_default_labels_if_required
 
             expect(WebMock)
-              .to_not have_requested(:post, "#{repo_api_url}/labels")
+              .not_to have_requested(:post, "#{repo_api_url}/labels")
             expect(labeler.labels_for_pr).to include("security")
           end
         end
@@ -574,7 +574,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
       context "when dealing with an automerge candidate" do
         let(:automerge_candidate) { true }
 
-        it { is_expected.to_not include("automerge") }
+        it { is_expected.not_to include("automerge") }
 
         context "when dealing with a repo that has an automerge label" do
           let(:labels_fixture_name) { "labels_with_automerge_tag.json" }
@@ -589,12 +589,12 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
         context "when dealing with a repo that has an automerge label" do
           let(:labels_fixture_name) { "labels_with_automerge_tag.json" }
 
-          it { is_expected.to_not include("automerge") }
+          it { is_expected.not_to include("automerge") }
         end
       end
 
       context "when dealing with a repo without patch, minor and major labels" do
-        it { is_expected.to_not include("patch") }
+        it { is_expected.not_to include("patch") }
       end
 
       context "when dealing with a repo that has patch, minor and major labels" do
@@ -611,7 +611,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             context "when the tags are for an auto-releasing tool" do
               let(:labels_fixture_name) { "labels_with_semver_tags_auto.json" }
 
-              it { is_expected.to_not include("patch") }
+              it { is_expected.not_to include("patch") }
             end
           end
 
@@ -623,7 +623,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             context "when the tags are for an auto-releasing tool" do
               let(:labels_fixture_name) { "labels_with_semver_tags_auto.json" }
 
-              it { is_expected.to_not include("patch") }
+              it { is_expected.not_to include("patch") }
             end
           end
 
@@ -636,7 +636,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             context "when the tags are for an auto-releasing tool" do
               let(:labels_fixture_name) { "labels_with_semver_tags_auto.json" }
 
-              it { is_expected.to_not include("patch") }
+              it { is_expected.not_to include("patch") }
             end
           end
 
@@ -986,7 +986,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           label_pr
 
           expect(WebMock)
-            .to_not have_requested(:post, "#{repo_api_url}/issues/1/labels")
+            .not_to have_requested(:post, "#{repo_api_url}/issues/1/labels")
         end
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -3306,7 +3306,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       it "doesn't include a signoff line" do
-        expect(pr_message).to_not include("Signed-off-by")
+        expect(pr_message).not_to include("Signed-off-by")
       end
     end
 
@@ -3314,7 +3314,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       let(:trailers) { { "Changelog" => "dependency" } }
 
       it "doesn't include git trailer" do
-        expect(pr_message).to_not include("Changelog: dependency")
+        expect(pr_message).not_to include("Changelog: dependency")
       end
     end
   end

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
       it "doesn't update source branch head commit in AzureDevOps" do
         updater.update
         expect(WebMock)
-          .to_not have_requested(:post, branch_update_url)
+          .not_to have_requested(:post, branch_update_url)
       end
 
       it "returns nil" do
@@ -125,7 +125,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
       it "doesn't update source branch head commit in AzureDevOps" do
         updater.update
         expect(WebMock)
-          .to_not have_requested(:post, branch_update_url)
+          .not_to have_requested(:post, branch_update_url)
       end
 
       it "returns nil" do

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
       it "doesn't push a commit to GitHub" do
         updater.update
         expect(WebMock)
-          .to_not have_requested(:post, "#{watched_repo_url}/git/trees")
+          .not_to have_requested(:post, "#{watched_repo_url}/git/trees")
       end
 
       it "returns nil" do
@@ -424,7 +424,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
         it "does not update the base branch" do
           updater.update
 
-          expect(WebMock).to_not have_requested(:patch, pull_request_url)
+          expect(WebMock).not_to have_requested(:patch, pull_request_url)
         end
       end
 
@@ -438,7 +438,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
             )
         end
 
-        specify { expect { updater.update }.to_not raise_error }
+        specify { expect { updater.update }.not_to raise_error }
       end
     end
 

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
       it "doesn't push a commit to Gitlab" do
         updater.update
         expect(WebMock)
-          .to_not have_requested(:post, commit_url)
+          .not_to have_requested(:post, commit_url)
       end
 
       it "returns nil" do
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
       it "doesn't push a commit to Gitlab" do
         updater.update
         expect(WebMock)
-          .to_not have_requested(:post, commit_url)
+          .not_to have_requested(:post, commit_url)
       end
 
       it "returns nil" do

--- a/common/spec/dependabot/security_advisory_spec.rb
+++ b/common/spec/dependabot/security_advisory_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Dependabot::SecurityAdvisory do
     context "with valid version arrays" do
       let(:vulnerable_versions) { [Gem::Requirement.new(">= 1")] }
 
-      specify { expect { security_advisory }.to_not raise_error }
+      specify { expect { security_advisory }.not_to raise_error }
     end
   end
 

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Dependabot::Source do
         }
       end
 
-      specify { expect { source }.to_not raise_error }
+      specify { expect { source }.not_to raise_error }
     end
 
     context "with a hostname but no api_endpoint" do

--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
       it { is_expected.to be_truthy }
 
       it "doesn't attempt to resolve the dependency" do
-        expect(updater_instance).to_not receive(:latest_resolvable_version)
+        expect(updater_instance).not_to receive(:latest_resolvable_version)
         up_to_date
       end
     end
@@ -246,9 +246,9 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         it { is_expected.to be_falsey }
 
         it "doesn't attempt to resolve the dependency" do
-          expect(updater_instance).to_not receive(:latest_resolvable_version)
+          expect(updater_instance).not_to receive(:latest_resolvable_version)
           expect(updater_instance)
-            .to_not receive(:latest_resolvable_version_with_no_unlock)
+            .not_to receive(:latest_resolvable_version_with_no_unlock)
           can_update
         end
       end
@@ -305,9 +305,9 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         it { is_expected.to be_falsey }
 
         it "doesn't attempt to resolve the dependency" do
-          expect(updater_instance).to_not receive(:latest_resolvable_version)
+          expect(updater_instance).not_to receive(:latest_resolvable_version)
           expect(updater_instance)
-            .to_not receive(:latest_version_resolvable_with_full_unlock?)
+            .not_to receive(:latest_version_resolvable_with_full_unlock?)
           can_update
         end
       end
@@ -372,7 +372,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
       it { is_expected.to be_falsey }
 
       it "doesn't attempt to resolve the dependency" do
-        expect(updater_instance).to_not receive(:latest_resolvable_version)
+        expect(updater_instance).not_to receive(:latest_resolvable_version)
         can_update
       end
     end

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -611,7 +611,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
         expect(updated_lockfile_content)
           .to include('"5267b03b1e4861c4657ede17a88f13ef479db482"')
         expect(updated_lockfile_content)
-          .to_not include('"303b8a83c87d5c6d749926cf02620465a5dcd0f2"')
+          .not_to include('"303b8a83c87d5c6d749926cf02620465a5dcd0f2"')
         expect(updated_lockfile_content).to include('"version":"dev-example"')
 
         # Does update the specified dependency
@@ -620,7 +620,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
         expect(updated_lockfile_content).to include('"version":"v1.6.0"')
 
         # Cleans up the additions we made
-        expect(updated_lockfile_content).to_not include('"support": {')
+        expect(updated_lockfile_content).not_to include('"support": {')
       end
     end
 

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Dependabot::Composer::FileUpdater do
     subject(:updated_files) { updater.updated_dependency_files }
 
     it "doesn't store the files permanently or output to stdout" do
-      expect { expect { updated_files }.to_not(output.to_stdout) }
-        .to_not(change { Dir.entries(tmp_path) })
+      expect { expect { updated_files }.not_to(output.to_stdout) }
+        .not_to(change { Dir.entries(tmp_path) })
     end
 
     it "returns DependencyFile objects" do

--- a/composer/spec/dependabot/composer/metadata_finder_spec.rb
+++ b/composer/spec/dependabot/composer/metadata_finder_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
 
         it "doesn't hit packagist" do
           source_url
-          expect(WebMock).to_not have_requested(:get, packagist_url)
+          expect(WebMock).not_to have_requested(:get, packagist_url)
         end
       end
     end

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
 
       it "doesn't hit the main registry (since requested not to)" do
         finder.latest_version
-        expect(WebMock).to_not have_requested(:get, packagist_url)
+        expect(WebMock).not_to have_requested(:get, packagist_url)
       end
 
       context "when a 404 is returned" do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -295,7 +295,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -329,7 +329,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         end
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end

--- a/elm/spec/dependabot/elm/file_updater_spec.rb
+++ b/elm/spec/dependabot/elm/file_updater_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe Dependabot::Elm::FileUpdater do
     subject(:updated_files) { updater.updated_dependency_files }
 
     it "doesn't store the files permanently" do
-      expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+      expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
     end
 
     it "returns DependencyFile objects" do
       updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
     end
 
-    it { expect { updated_files }.to_not output.to_stdout }
+    it { expect { updated_files }.not_to output.to_stdout }
     its(:length) { is_expected.to eq(1) }
 
     describe "the elm.json file" do

--- a/elm/spec/dependabot/elm/requirement_spec.rb
+++ b/elm/spec/dependabot/elm/requirement_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Dependabot::Elm::Requirement do
 
       it { is_expected.to eq(Gem::Requirement.new("= 1.0.0")) }
       it { is_expected.to be_satisfied_by(Gem::Version.new("1.0.0")) }
-      it { is_expected.to_not be_satisfied_by(Gem::Version.new("1.0.1")) }
+      it { is_expected.not_to be_satisfied_by(Gem::Version.new("1.0.1")) }
 
       context "when specified as a version" do
         let(:requirement_string) { "1.0.0" }

--- a/elm/spec/dependabot/elm/update_checker/elm_19_version_resolver_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker/elm_19_version_resolver_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe namespace::Elm19VersionResolver do
           expect { latest_resolvable_version }
             .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
               # Test that the temporary path isn't included in the error message
-              expect(error.message).to_not include("dependabot_20")
+              expect(error.message).not_to include("dependabot_20")
               expect(error.message).to include("do not work with Elm 0.19.0")
             end
         end
@@ -92,7 +92,7 @@ RSpec.describe namespace::Elm19VersionResolver do
           expect { latest_resolvable_version }
             .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
               # Test that the temporary path isn't included in the error message
-              expect(error.message).to_not include("dependabot_20")
+              expect(error.message).not_to include("dependabot_20")
               expect(error.message).to include("object at project.dependencies")
             end
         end

--- a/elm/spec/dependabot/elm/update_checker_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -224,7 +224,7 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -84,17 +84,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
       its(:content) do
         is_expected.to include "\"actions/setup-node@v1.1.0\"\n"
-        is_expected.to_not include "\"actions/setup-node@master\""
+        is_expected.not_to include "\"actions/setup-node@master\""
       end
 
       its(:content) do
         is_expected.to include "'actions/setup-node@v1.1.0'\n"
-        is_expected.to_not include "'actions/setup-node@master'"
+        is_expected.not_to include "'actions/setup-node@master'"
       end
 
       its(:content) do
         is_expected.to include "actions/setup-node@v1.1.0\n"
-        is_expected.to_not include "actions/setup-node@master"
+        is_expected.not_to include "actions/setup-node@master"
       end
 
       its(:content) { is_expected.to include "actions/checkout@master\n" }
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
         its(:content) { is_expected.to include "actions/aws/ec2@v1.1.0\n" }
         its(:content) { is_expected.to include "actions/aws@v1.1.0\n" }
-        its(:content) { is_expected.to_not include "actions/aws/ec2@master" }
+        its(:content) { is_expected.not_to include "actions/aws/ec2@master" }
         its(:content) { is_expected.to include "actions/checkout@master\n" }
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     let(:branch) { "without-go-sum" }
 
     it "doesn't raise an error" do
-      expect { file_fetcher_instance.files }.to_not raise_error
+      expect { file_fetcher_instance.files }.not_to raise_error
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     let(:submodule_contents_path) { File.join(repo_contents_path, "examplelib") }
 
     it "clones them" do
-      expect { file_fetcher_instance.files }.to_not raise_error
+      expect { file_fetcher_instance.files }.not_to raise_error
       expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
     end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         context "when dealing with a go 1.11 go.mod" do
           let(:project_name) { "go_1.11" }
 
-          it { is_expected.to_not include("go 1.") }
+          it { is_expected.not_to include("go 1.") }
           it { is_expected.to include("module github.com/dependabot/vgotest\n\nrequire") }
         end
 
@@ -248,9 +248,9 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
           it "removes old entries from the go.sum" do
             is_expected
-              .to_not include(%(rsc.io/quote v1.4.0 h1:))
+              .not_to include(%(rsc.io/quote v1.4.0 h1:))
             is_expected
-              .to_not include(%(rsc.io/quote v1.4.0/go.mod h1:))
+              .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
           end
 
           describe "a non-existent dependency with a pseudo-version" do
@@ -285,7 +285,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             let(:project_name) { "no_top_level_package" }
 
             it "does not raise an error" do
-              expect { updater.updated_go_sum_content }.to_not raise_error
+              expect { updater.updated_go_sum_content }.not_to raise_error
             end
           end
 
@@ -307,9 +307,9 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
             it "removes old entries from the go.sum" do
               is_expected
-                .to_not include(%(rsc.io/quote v1.4.0 h1:))
+                .not_to include(%(rsc.io/quote v1.4.0 h1:))
               is_expected
-                .to_not include(%(rsc.io/quote v1.4.0/go.mod h1:))
+                .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
             end
 
             it "does not leave a temporary file lingering in the repo" do
@@ -378,7 +378,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             []
           end
 
-          it { is_expected.to_not include(%(rsc.io/quote)) }
+          it { is_expected.not_to include(%(rsc.io/quote)) }
         end
       end
     end
@@ -473,7 +473,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       end
 
       it do
-        is_expected.to_not include("github.com/pkg/errors")
+        is_expected.not_to include("github.com/pkg/errors")
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -70,14 +70,14 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
 
-    it { expect { updated_files }.to_not output.to_stdout }
+    it { expect { updated_files }.not_to output.to_stdout }
 
     it "includes an updated go.mod" do
-      expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+      expect(updated_files.find { |f| f.name == "go.mod" }).not_to be_nil
     end
 
     it "includes an updated go.sum" do
-      expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+      expect(updated_files.find { |f| f.name == "go.sum" }).not_to be_nil
     end
 
     context "with an indirect dependency update" do
@@ -85,11 +85,11 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       let(:previous_requirements) { [] }
 
       it "includes an updated go.mod" do
-        expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+        expect(updated_files.find { |f| f.name == "go.mod" }).not_to be_nil
       end
 
       it "includes an updated go.sum" do
-        expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+        expect(updated_files.find { |f| f.name == "go.sum" }).not_to be_nil
       end
     end
 
@@ -128,7 +128,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       let(:files) { [go_mod] }
 
       it "doesn't add a toolchain directive" do
-        expect(updated_files.first.content).to_not include("toolchain")
+        expect(updated_files.first.content).not_to include("toolchain")
       end
     end
 
@@ -168,11 +168,11 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       end
 
       it "includes an updated go.mod" do
-        expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+        expect(updated_files.find { |f| f.name == "go.mod" }).not_to be_nil
       end
 
       it "includes an updated go.sum" do
-        expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+        expect(updated_files.find { |f| f.name == "go.sum" }).not_to be_nil
       end
 
       it "disables the tidy option" do
@@ -207,11 +207,11 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         end
 
         it "includes an updated go.mod" do
-          expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+          expect(updated_files.find { |f| f.name == "go.mod" }).not_to be_nil
         end
 
         it "includes an updated go.sum" do
-          expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+          expect(updated_files.find { |f| f.name == "go.sum" }).not_to be_nil
         end
       end
     end
@@ -278,7 +278,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         end
 
         expect(modules_file.content)
-          .to_not include "github.com/pkg/errors v0.8.0"
+          .not_to include "github.com/pkg/errors v0.8.0"
         expect(modules_file.content).to include "github.com/pkg/errors v0.9.1"
       end
 
@@ -294,7 +294,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
             Format formats the stack of Frames according to the fmt.Formatter interface.
           LINE
         )
-        expect(stack_file.content).to_not include(
+        expect(stack_file.content).not_to include(
           <<~LINE
             segments from the beginning of the file path until the number of path
           LINE

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       let(:current_version) { "1.1.0" }
 
       it "doesn't return pre-release" do
-        expect(finder.lowest_security_fix_version).to_not eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
+        expect(finder.lowest_security_fix_version).not_to eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
       end
     end
   end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
 
       it "excludes the dependency with the missing property" do
         expect(dependencies.map(&:name))
-          .to_not include("org.scala-lang:scala-library")
+          .not_to include("org.scala-lang:scala-library")
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
 
       it "excludes the dependency with the missing property" do
         expect(dependencies.map(&:name))
-          .to_not include("org.gradle:gradle-tooling-api")
+          .not_to include("org.gradle:gradle-tooling-api")
       end
     end
 

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version_details }.to_not raise_error
+        expect { latest_version_details }.not_to raise_error
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end
@@ -216,7 +216,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Dependabot::Hex::FileFetcher do
         expect(file_fetcher_instance.files.map(&:name))
           .to include("apps/bank/mix.exs")
         expect(file_fetcher_instance.files.map(&:name))
-          .to_not include("apps/bank_web/mix.exs")
+          .not_to include("apps/bank_web/mix.exs")
       end
     end
 

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
 
     it "doesn't store the files permanently" do
       expect { updated_lockfile_content }
-        .to_not(change { Dir.entries(tmp_path) })
+        .not_to(change { Dir.entries(tmp_path) })
     end
 
-    it { expect { updated_lockfile_content }.to_not output.to_stdout }
+    it { expect { updated_lockfile_content }.not_to output.to_stdout }
 
     it "updates the dependency version in the lockfile" do
       expect(updated_lockfile_content).to include %({:hex, :plug, "1.4.3")
@@ -342,7 +342,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       it "updates the dependency version in the lockfile" do
         expect(updated_lockfile_content).to include("phoenix.git")
         expect(updated_lockfile_content)
-          .to_not include("178ce1a2344515e9145599970313fcc190d4b881")
+          .not_to include("178ce1a2344515e9145599970313fcc190d4b881")
       end
     end
 

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe Dependabot::Hex::FileUpdater do
     subject(:updated_files) { updater.updated_dependency_files }
 
     it "doesn't store the files permanently" do
-      expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+      expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
     end
 
     it "returns DependencyFile objects" do
       updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
     end
 
-    it { expect { updated_files }.to_not output.to_stdout }
+    it { expect { updated_files }.not_to output.to_stdout }
     its(:length) { is_expected.to eq(2) }
 
     context "without a lockfile" do

--- a/hex/spec/dependabot/hex/requirement_spec.rb
+++ b/hex/spec/dependabot/hex/requirement_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dependabot::Hex::Requirement do
       let(:requirement_string) { "== 1.0.0" }
 
       it { is_expected.to be_satisfied_by(Gem::Version.new("1.0.0")) }
-      it { is_expected.to_not be_satisfied_by(Gem::Version.new("1.0.1")) }
+      it { is_expected.not_to be_satisfied_by(Gem::Version.new("1.0.1")) }
     end
   end
 

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -121,7 +121,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -556,9 +556,9 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
             let(:ref) { nil }
 
             it "updates the dependency" do
-              expect(latest_resolvable_version).to_not be_nil
+              expect(latest_resolvable_version).not_to be_nil
               expect(latest_resolvable_version)
-                .to_not eq("178ce1a2344515e9145599970313fcc190d4b881")
+                .not_to eq("178ce1a2344515e9145599970313fcc190d4b881")
               expect(latest_resolvable_version).to match(/^[0-9a-f]{40}$/)
             end
           end
@@ -715,9 +715,9 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
           let(:ref) { nil }
 
           it "updates the dependency" do
-            expect(new_version).to_not be_nil
+            expect(new_version).not_to be_nil
             expect(new_version)
-              .to_not eq("178ce1a2344515e9145599970313fcc190d4b881")
+              .not_to eq("178ce1a2344515e9145599970313fcc190d4b881")
             expect(new_version).to match(/^[0-9a-f]{40}$/)
           end
         end

--- a/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dependabot::Maven::FileParser::PropertyValueFinder do
       context "when the property contains a tricky to split string" do
         let(:property_name) { "accumulo.1.6.version" }
 
-        specify { expect { property_details }.to_not raise_error }
+        specify { expect { property_details }.not_to raise_error }
       end
 
       context "when there are duplicate tags then read the latest" do

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Dependabot::Maven::FileParser do
 
         it "doesn't include the plugin" do
           expect(dependencies.map(&:name))
-            .to_not include("${project.groupId}:maven-install-plugin")
+            .not_to include("${project.groupId}:maven-install-plugin")
         end
       end
     end

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           end
 
           its(:content) { is_expected.to include "<version>3.0.0-M2</version>" }
-          its(:content) { is_expected.not_to include "<version>2.10.4</versio" }
+          its(:content) { is_expected.not_to include "<version>2.10.4</version>" }
         end
 
         context "when both versions are hard-coded, and are identical" do
@@ -288,7 +288,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           end
 
           its(:content) { is_expected.to include "<version>3.0.0-M2</version>" }
-          its(:content) { is_expected.not_to include "<version>2.10.4</versio" }
+          its(:content) { is_expected.not_to include "<version>2.10.4</version>" }
 
           context "when they have different scopes" do
             let(:pom_body) { fixture("poms", "repeated_dev_and_prod.xml") }

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           end
 
           its(:content) { is_expected.to include "<version>3.0.0-M2</version>" }
-          its(:content) { is_expected.to_not include "<version>2.10.4</versio" }
+          its(:content) { is_expected.not_to include "<version>2.10.4</versio" }
         end
 
         context "when both versions are hard-coded, and are identical" do
@@ -288,7 +288,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           end
 
           its(:content) { is_expected.to include "<version>3.0.0-M2</version>" }
-          its(:content) { is_expected.to_not include "<version>2.10.4</versio" }
+          its(:content) { is_expected.not_to include "<version>2.10.4</versio" }
 
           context "when they have different scopes" do
             let(:pom_body) { fixture("poms", "repeated_dev_and_prod.xml") }
@@ -327,7 +327,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
             end
 
             its(:content) { is_expected.to include "<version>3.0.0-M2</versio" }
-            its(:content) { is_expected.to_not include "<version>2.10.4</vers" }
+            its(:content) { is_expected.not_to include "<version>2.10.4</vers" }
           end
         end
       end

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version_details }.to_not raise_error
+        expect { latest_version_details }.not_to raise_error
       end
     end
 
@@ -257,7 +257,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end
@@ -658,7 +658,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { lowest_security_fix_version_details }.to_not raise_error
+          expect { lowest_security_fix_version_details }.not_to raise_error
         end
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         expect(file_fetcher_instance.files.count).to eq(2)
         expect(file_fetcher_instance.files.map(&:name)).to include(".npmrc")
         expect(file_fetcher_instance.files.map(&:name))
-          .to_not include("package-lock.json")
+          .not_to include("package-lock.json")
       end
     end
   end
@@ -1117,7 +1117,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           expect(file_fetcher_instance.files.map(&:name))
             .to include("packages/package2/package.json")
           expect(file_fetcher_instance.files.map(&:name))
-            .to_not include("packages/package/package.json")
+            .not_to include("packages/package/package.json")
         end
       end
 
@@ -1263,7 +1263,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         expect(file_fetcher_instance.files.map(&:name))
           .to include("packages/package2/package.json")
         expect(file_fetcher_instance.files.map(&:name))
-          .to_not include("other_package/package.json")
+          .not_to include("other_package/package.json")
       end
     end
   end
@@ -1725,7 +1725,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         it "fetches the other workspaces, ignoring the empty folder" do
           expect(file_fetcher_instance.files.count).to eq(4)
           expect(file_fetcher_instance.files.map(&:name))
-            .to_not include("packages/package2/package.json")
+            .not_to include("packages/package2/package.json")
         end
       end
 
@@ -1825,7 +1825,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         expect(file_fetcher_instance.files.map(&:name))
           .to include("packages/package2/package.json")
         expect(file_fetcher_instance.files.map(&:name))
-          .to_not include("other_package/package.json")
+          .not_to include("other_package/package.json")
       end
 
       context "when one of the repos isn't fetchable" do
@@ -1851,7 +1851,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         it "fetches package.json from the workspace dependencies it can" do
           expect(file_fetcher_instance.files.count).to eq(4)
           expect(file_fetcher_instance.files.map(&:name))
-            .to_not include("packages/package2/package.json")
+            .not_to include("packages/package2/package.json")
           expect(file_fetcher_instance.files.map(&:name))
             .to include("other_package/package.json")
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         it "excludes the dependency" do
           # Lockfile contains 11 dependencies but one is an alias
           expect(dependencies.count).to eq(10)
-          expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
+          expect(dependencies.map(&:name)).not_to include("my-fetch-factory")
         end
       end
 
@@ -125,7 +125,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         it "generates updated lockfile which excludes empty version dependencies." do
           # excluding empty version
           expect(dependencies.count).to eq(9)
-          expect(dependencies.map(&:name)).to_not include("encoding")
+          expect(dependencies.map(&:name)).not_to include("encoding")
         end
       end
 
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         it "excludes the dependency" do
           # Lockfile contains 11 dependencies but one is an alias
           expect(dependencies.count).to eq(10)
-          expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
+          expect(dependencies.map(&:name)).not_to include("my-fetch-factory")
         end
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
           it "doesn't include the path-based dependency" do
             expect(top_level_dependencies.length).to eq(3)
-            expect(top_level_dependencies.map(&:name)).to_not include("etag")
+            expect(top_level_dependencies.map(&:name)).not_to include("etag")
           end
         end
 
@@ -531,7 +531,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
               it "is excluded" do
                 expect(top_level_dependencies.map(&:name))
-                  .to_not include("is-number")
+                  .not_to include("is-number")
               end
             end
           end
@@ -1073,7 +1073,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
           it "doesn't include the path-based dependency" do
             expect(top_level_dependencies.length).to eq(3)
-            expect(top_level_dependencies.map(&:name)).to_not include("etag")
+            expect(top_level_dependencies.map(&:name)).not_to include("etag")
           end
         end
 
@@ -1086,7 +1086,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           it "doesn't include the submodule dependency" do
-            expect(dependencies.map(&:name)).to_not include("pino-pretty")
+            expect(dependencies.map(&:name)).not_to include("pino-pretty")
           end
         end
 
@@ -1095,7 +1095,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
           it "doesn't include the link dependency" do
             expect(top_level_dependencies.length).to eq(3)
-            expect(top_level_dependencies.map(&:name)).to_not include("etag")
+            expect(top_level_dependencies.map(&:name)).not_to include("etag")
           end
         end
 
@@ -1105,7 +1105,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           it "doesn't include the aliased dependency" do
             expect(top_level_dependencies.length).to eq(1)
             expect(top_level_dependencies.map(&:name)).to eq(["etag"])
-            expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
+            expect(dependencies.map(&:name)).not_to include("my-fetch-factory")
           end
         end
 
@@ -1115,7 +1115,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           it "doesn't include the aliased dependency" do
             expect(top_level_dependencies.length).to eq(1)
             expect(top_level_dependencies.map(&:name)).to eq(["etag"])
-            expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
+            expect(dependencies.map(&:name)).not_to include("my-fetch-factory")
           end
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -80,13 +80,13 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       let(:files) { project_dependency_files("npm6_and_yarn/simple") }
 
       it "updates the files" do
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
         expect(updated_files.count).to eq(3)
       end
 
       it "native helpers don't output to stdout" do
-        expect { updated_files }.to_not output.to_stdout
+        expect { updated_files }.not_to output.to_stdout
       end
     end
 
@@ -339,7 +339,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             "is-number@jonschlinkert/is-number:"
           )
 
-          expect(updated_yarn_lock.content).to_not include("d5ac0584ee")
+          expect(updated_yarn_lock.content).not_to include("d5ac0584ee")
           expect(updated_yarn_lock.content).to include(
             "https://codeload.github.com/jonschlinkert/is-number/tar.gz/0c6b15a88bc10cd47f67a09506399dfc9ddc075d"
           )
@@ -359,7 +359,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
             expect(updated_yarn_lock.content).to include("is-number")
             expect(updated_yarn_lock.content).to include("0c6b15a88b")
-            expect(updated_yarn_lock.content).to_not include("af885e2e890")
+            expect(updated_yarn_lock.content).not_to include("af885e2e890")
           end
 
           context "when the lockfile has an outdated source" do
@@ -383,7 +383,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
               expect(updated_yarn_lock.content).to include(
                 "is-number@https://github.com/jonschlinkert/is-number.git"
               )
-              expect(updated_yarn_lock.content).to_not include("af885e2e890")
+              expect(updated_yarn_lock.content).not_to include("af885e2e890")
             end
           end
 
@@ -439,7 +439,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
               expect(updated_yarn_lock.content)
                 .to include('slick-carousel@git://github.com/brianfryer/slick":')
               expect(updated_yarn_lock.content).to include("a2aa3fec")
-              expect(updated_yarn_lock.content).to_not include("280b56016")
+              expect(updated_yarn_lock.content).not_to include("280b56016")
             end
           end
 
@@ -459,7 +459,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
               expect(updated_yarn_lock.content).to include("is-number")
               expect(updated_yarn_lock.content).to include("0c6b15a88bc")
-              expect(updated_yarn_lock.content).to_not include("af885e2e890")
+              expect(updated_yarn_lock.content).not_to include("af885e2e890")
               expect(updated_yarn_lock.content)
                 .to include("is-number@git+ssh://git@github.com:jonschlinkert")
             end
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 .to include("is-number@https://dummy-token@github.com/" \
                             "jonschlinkert/is-number.git#master")
               expect(updated_yarn_lock.content).to include("0c6b15a88b")
-              expect(updated_yarn_lock.content).to_not include("af885e2e890")
+              expect(updated_yarn_lock.content).not_to include("af885e2e890")
             end
           end
         end
@@ -3120,8 +3120,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           expect(lockfile.content).to include(%("lodash@npm:1.3.1, lodash@npm:^1.3.1":))
-          expect(lockfile.content).to_not include("lodash@npm:^1.2.1:")
-          expect(lockfile.content).to_not include("workspace-aggregator")
+          expect(lockfile.content).not_to include("lodash@npm:^1.2.1:")
+          expect(lockfile.content).not_to include("workspace-aggregator")
 
           expect(package.content).to include('"lodash": "1.3.1"')
           expect(package.content).to include("\"./packages/*\",\n")
@@ -3156,7 +3156,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
             lockfile = updated_files.find { |f| f.name == "yarn.lock" }
             expect(lockfile.content).to include("chalk@npm:0.4.0")
-            expect(lockfile.content).to_not include("workspace-aggregator")
+            expect(lockfile.content).not_to include("workspace-aggregator")
           end
 
           it "does not add the dependency to the top-level workspace" do
@@ -3292,9 +3292,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
         it "removes details of the old version" do
           expect(updated_yarn_lock.content)
-            .to_not include("babel-register@^6.24.1:")
+            .not_to include("babel-register@^6.24.1:")
           expect(updated_yarn_lock.content)
-            .to_not include("integrity sha512-")
+            .not_to include("integrity sha512-")
         end
       end
 
@@ -3358,7 +3358,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           expect(updated_yarn_lock.content).to include("rimraf@2.6.3")
 
           # Cleaned up in fix-duplicates.js
-          expect(updated_yarn_lock.content).to_not include("rimraf-2.6.2")
+          expect(updated_yarn_lock.content).not_to include("rimraf-2.6.2")
         end
       end
 
@@ -3457,8 +3457,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           expect(lockfile.content).to include("lodash@1.3.1, lodash@^1.3.1:")
-          expect(lockfile.content).to_not include("lodash@^1.2.1:")
-          expect(lockfile.content).to_not include("workspace-aggregator")
+          expect(lockfile.content).not_to include("lodash@^1.2.1:")
+          expect(lockfile.content).not_to include("workspace-aggregator")
 
           expect(package.content).to include('"lodash": "1.3.1"')
           expect(package.content).to include("\"./packages/*\",\n")
@@ -3493,7 +3493,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
             lockfile = updated_files.find { |f| f.name == "yarn.lock" }
             expect(lockfile.content).to include("chalk@0.4.0:")
-            expect(lockfile.content).to_not include("workspace-aggregator")
+            expect(lockfile.content).not_to include("workspace-aggregator")
           end
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
 
       it "doesn't hit npm" do
         source_url
-        expect(WebMock).to_not have_requested(:get, npm_url)
+        expect(WebMock).not_to have_requested(:get, npm_url)
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
         expect(WebMock)
           .to have_requested(:get, npm_url + "/latest").once
         expect(WebMock)
-          .to_not have_requested(:get, npm_url)
+          .not_to have_requested(:get, npm_url)
       end
 
       context "with a monorepo that specifies a directory" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version_from_registry }.to_not raise_error
+        expect { latest_version_from_registry }.not_to raise_error
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_from_registry }.to_not raise_error
+          expect { latest_version_from_registry }.not_to raise_error
         end
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_from_registry }.to_not raise_error
+          expect { latest_version_from_registry }.not_to raise_error
         end
       end
     end
@@ -131,7 +131,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_from_registry }.to_not raise_error
+          expect { latest_version_from_registry }.not_to raise_error
         end
       end
     end
@@ -766,7 +766,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
 
         it "does not raise an error" do
           expect { version_finder.latest_version_from_registry }
-            .to_not raise_error
+            .not_to raise_error
         end
       end
 

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
                                                dependency: dependency,
                                                is_transitive: is_transitive,
                                                credentials: [])
-        expect(Dependabot.logger).to_not have_received(:error)
+        expect(Dependabot.logger).not_to have_received(:error)
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version_details }.to_not raise_error
+        expect { latest_version_details }.not_to raise_error
       end
     end
 
@@ -182,7 +182,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end
@@ -197,7 +197,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version_details }.to_not raise_error
+          expect { latest_version_details }.not_to raise_error
         end
       end
     end

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -672,7 +672,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       let(:ignored_versions) { ["< 1.14.13"] }
 
       it "doesn't raise an error" do
-        expect { checker.latest_version }.to_not raise_error
+        expect { checker.latest_version }.not_to raise_error
       end
     end
 
@@ -682,7 +682,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       let(:ignored_versions) { ["> 1.8.0"] }
 
       it "doesn't raise an error" do
-        expect { checker.latest_version }.to_not raise_error
+        expect { checker.latest_version }.not_to raise_error
       end
     end
 
@@ -692,7 +692,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       let(:ignored_versions) { [">= 0"] }
 
       it "doesn't raise an error" do
-        expect { checker.latest_version }.to_not raise_error
+        expect { checker.latest_version }.not_to raise_error
       end
     end
 

--- a/python/spec/dependabot/python/file_parser/pipfile_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pipfile_files_parser_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Dependabot::Python::FileParser::PipfileFilesParser do
       let(:lockfile_fixture_name) { "only_dev.lock" }
 
       it "excludes the missing dependency" do
-        expect(dependencies.map(&:name)).to_not include("missing")
+        expect(dependencies.map(&:name)).not_to include("missing")
       end
 
       describe "the dependency" do
@@ -341,7 +341,7 @@ RSpec.describe Dependabot::Python::FileParser::PipfileFilesParser do
       let(:lockfile_fixture_name) { "git_source.lock" }
 
       it "excludes the git dependency" do
-        expect(dependencies.map(&:name)).to_not include("pythonfinder")
+        expect(dependencies.map(&:name)).not_to include("pythonfinder")
       end
 
       describe "the (non-git) dependency" do

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
       its(:length) { is_expected.to eq(15) }
 
       it "doesn't include the Python requirement" do
-        expect(dependencies.map(&:name)).to_not include("python")
+        expect(dependencies.map(&:name)).not_to include("python")
       end
 
       context "with a string declaration" do
@@ -89,7 +89,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:pyproject_fixture_name) { "dir_dependency.toml" }
 
         it "excludes path dependency" do
-          expect(dependency_names).to_not include("toml")
+          expect(dependency_names).not_to include("toml")
         end
 
         it "includes non-path dependencies" do
@@ -103,7 +103,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:pyproject_fixture_name) { "git_dependency.toml" }
 
         it "excludes git dependency" do
-          expect(dependency_names).to_not include("toml")
+          expect(dependency_names).not_to include("toml")
         end
 
         it "includes non-git dependencies" do
@@ -117,7 +117,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:pyproject_fixture_name) { "url_dependency.toml" }
 
         it "excludes url dependency" do
-          expect(dependency_names).to_not include("toml")
+          expect(dependency_names).not_to include("toml")
         end
 
         it "includes non-url dependencies" do
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:pyproject_fixture_name) { "poetry_non_package_mode.toml" }
 
         it "parses correctly with no metadata" do
-          expect { parser.dependency_set }.to_not raise_error
+          expect { parser.dependency_set }.not_to raise_error
         end
       end
     end
@@ -150,7 +150,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
       its(:length) { is_expected.to eq(36) }
 
       it "doesn't include the Python requirement" do
-        expect(dependencies.map(&:name)).to_not include("python")
+        expect(dependencies.map(&:name)).not_to include("python")
       end
 
       describe "a development sub-dependency" do
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:poetry_lock_fixture_name) { "dir_dependency.lock" }
 
         it "excludes the path dependency" do
-          expect(dependency_names).to_not include("toml")
+          expect(dependency_names).not_to include("toml")
         end
 
         it "includes non-path dependencies" do
@@ -189,7 +189,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:poetry_lock_fixture_name) { "git_dependency.lock" }
 
         it "excludes the git dependency" do
-          expect(dependencies.map(&:name)).to_not include("toml")
+          expect(dependencies.map(&:name)).not_to include("toml")
         end
       end
 
@@ -198,7 +198,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         let(:poetry_lock_fixture_name) { "url_dependency.lock" }
 
         it "excludes the url dependency" do
-          expect(dependencies.map(&:name)).to_not include("toml")
+          expect(dependencies.map(&:name)).not_to include("toml")
         end
       end
 

--- a/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::Python::FileParser::SetupFileParser do
 
           it "excludes the dependency importing a version" do
             expect(dependencies.count).to eq(14)
-            expect(dependencies.map(&:name)).to_not include("acme")
+            expect(dependencies.map(&:name)).not_to include("acme")
           end
         end
       end

--- a/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       expect(updated_files.first.content)
         .to include("pbr==4.0.2\n    # via mock")
       expect(updated_files.first.content).to include("# This file is autogen")
-      expect(updated_files.first.content).to_not include("--hash=sha")
+      expect(updated_files.first.content).not_to include("--hash=sha")
     end
 
     context "with a mismatch in filename" do
@@ -98,7 +98,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content)
           .to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
-        expect(updated_files.first.content).to_not include("--hash=sha")
+        expect(updated_files.first.content).not_to include("--hash=sha")
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content).to include("psycopg2==2.7.6")
         expect(updated_files.first.content).to include("--no-binary psycopg2")
         expect(updated_files.first.content)
-          .to_not include("--no-binary psycopg2==")
+          .not_to include("--no-binary psycopg2==")
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content).to include("attrs==18.1.0")
         expect(updated_files.first.content).to include("4b90b09eeeb9b88c35bc64")
         expect(updated_files.first.content)
-          .to_not include("# This file is autogen")
+          .not_to include("# This file is autogen")
       end
 
       context "when needing an augmented hashin" do
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
             .to include("--hash=sha256:bb6f5d5507621e0298794b")
           expect(updated_files.first.content)
             .to include("# via pyasn1-modules")
-          expect(updated_files.first.content).to_not include("WARNING")
+          expect(updated_files.first.content).not_to include("WARNING")
         end
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       it "updates the requirements.txt, keeping the unmet dep out of it" do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).to include("attrs==18.1.0")
-        expect(updated_files.first.content).to_not include("flaky")
+        expect(updated_files.first.content).not_to include("flaky")
       end
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         it "does not include the unsafe dependency" do
           expect(updated_files.count).to eq(1)
           expect(updated_files.first.content).to include("flake8==3.6.0")
-          expect(updated_files.first.content).to_not include("setuptools")
+          expect(updated_files.first.content).not_to include("setuptools")
           expect(updated_files.first.content).to end_with("via flake8\n")
         end
       end
@@ -229,11 +229,11 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content).to include("attrs==18.1.0")
         expect(updated_files.first.content)
           .to include("-e file:///Users/greysteil/code/python-test")
-        expect(updated_files.first.content).to_not include("tmp/dependabot")
+        expect(updated_files.first.content).not_to include("tmp/dependabot")
         expect(updated_files.first.content)
           .to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
-        expect(updated_files.first.content).to_not include("--hash=sha")
+        expect(updated_files.first.content).not_to include("--hash=sha")
       end
 
       context "when needing sanitization", :slow do
@@ -318,7 +318,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content)
           .to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
-        expect(updated_files.first.content).to_not include("--hash=sha")
+        expect(updated_files.first.content).not_to include("--hash=sha")
       end
     end
 
@@ -347,7 +347,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.count).to eq(2)
         expect(updated_files.first.content).to include("Attrs<=18.1.0")
         expect(updated_files.last.content).to include("attrs==18.1.0")
-        expect(updated_files.last.content).to_not include("# via mock")
+        expect(updated_files.last.content).not_to include("# via mock")
       end
 
       context "with an additional requirements.txt" do
@@ -520,7 +520,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.first.content).to include("--strip-extras")
         expect(updated_files.first.content).to include("cachecontrol==0.12.10")
         expect(updated_files.first.content)
-          .to_not include("cachecontrol[filecache]==")
+          .not_to include("cachecontrol[filecache]==")
       end
     end
 
@@ -548,7 +548,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       it "do not include pycurl" do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).to include("--resolver=legacy")
-        expect(updated_files.first.content).to_not include("pycurl")
+        expect(updated_files.first.content).not_to include("pycurl")
       end
     end
   end

--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
           .to eq([{ "url" => "https://pypi.org/${ENV_VAR}",
                     "verify_ssl" => true }])
         expect(updated_lockfile.content)
-          .to_not include("pypi.org/simple")
+          .not_to include("pypi.org/simple")
         expect(json_lockfile["develop"]["pytest"]["version"]).to eq("==3.4.0")
       end
     end

--- a/python/spec/dependabot/python/file_updater/pipfile_manifest_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_manifest_updater_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileManifestUpdater do
       end
 
       it { is_expected.to include('Pytest = "==3.4.1"') }
-      it { is_expected.to_not include('Pytest = "==3.4.0"') }
+      it { is_expected.not_to include('Pytest = "==3.4.0"') }
 
       context "when different" do
         let(:pipfile_fixture_name) { "prod_and_dev_different" }

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -826,7 +826,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
         expect(repo_obj[0][:url]).to eq(credentials[0]["index-url"])
 
         user_pass = "#{credentials[0]['user']}:#{credentials[0]['password']}@"
-        expect(repo_obj[0][:url]).to_not include(user_pass)
+        expect(repo_obj[0][:url]).not_to include(user_pass)
       end
     end
   end

--- a/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
       it { is_expected.to include("pytest = \"3.7.4\"\n") }
 
       it "does not include the version for path deps" do
-        expect(freeze_top_level_dependencies_except).to_not include(
+        expect(freeze_top_level_dependencies_except).not_to include(
           "path = \"../toml\"\n" \
           "version = \"0.10.0\"\n"
         )
@@ -179,7 +179,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
       it { is_expected.to include("pytest = \"3.7.4\"\n") }
 
       it "does not include the version for path deps" do
-        expect(freeze_top_level_dependencies_except).to_not include(
+        expect(freeze_top_level_dependencies_except).not_to include(
           "path = \"toml-8.2.54.tar.gz\"\n" \
           "version = \"8.2.54\"\n"
         )
@@ -198,7 +198,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
       it { is_expected.to include("pytest = \"6.2.4\"\n") }
 
       it "does not include the version for url deps" do
-        expect(freeze_top_level_dependencies_except).to_not include(
+        expect(freeze_top_level_dependencies_except).not_to include(
           "url = \"https://github.com/uiri/toml/archive/refs/tags/0.10.2.tar.gz\"\n" \
           "version = \"0.10.2\"\n"
         )

--- a/python/spec/dependabot/python/file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       it "delegates to PipfileFileUpdater" do
         expect(described_class::PipfileFileUpdater)
           .to receive(:new).and_call_original
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       end
     end
@@ -164,7 +164,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       it "delegates to PipfileFileUpdater" do
         expect(described_class::PipfileFileUpdater)
           .to receive(:new).and_call_original
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       end
     end
@@ -252,7 +252,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       it "delegates to RequirementFileUpdater" do
         expect(described_class::RequirementFileUpdater)
           .to receive(:new).and_call_original
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       end
     end
@@ -298,7 +298,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       it "delegates to PoetryFileUpdater" do
         expect(described_class::PoetryFileUpdater)
           .to receive(:new).and_call_original
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       end
     end
@@ -387,7 +387,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       it "delegates to RequirementFileUpdater" do
         expect(described_class::RequirementFileUpdater)
           .to receive(:new).and_call_original
-        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        expect { updated_files }.not_to(change { Dir.entries(tmp_path) })
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       end
     end

--- a/python/spec/dependabot/python/metadata_finder_spec.rb
+++ b/python/spec/dependabot/python/metadata_finder_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Dependabot::Python::MetadataFinder do
 
       it "doesn't call pypi" do
         source_url
-        expect(WebMock).to_not have_requested(:get, pypi_url).once
+        expect(WebMock).not_to have_requested(:get, pypi_url).once
       end
     end
 

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Dependabot::Python::Requirement do
       let(:requirement_string) { "== 1.3.0" }
 
       it { is_expected.to be_satisfied_by(Gem::Version.new("1.3.0")) }
-      it { is_expected.to_not be_satisfied_by(Gem::Version.new("1.3.1")) }
+      it { is_expected.not_to be_satisfied_by(Gem::Version.new("1.3.1")) }
 
       context "with a v-prefix" do
         let(:requirement_string) { "== v1.3.0" }
 
         it { is_expected.to be_satisfied_by(Gem::Version.new("1.3.0")) }
-        it { is_expected.to_not be_satisfied_by(Gem::Version.new("1.3.1")) }
+        it { is_expected.not_to be_satisfied_by(Gem::Version.new("1.3.1")) }
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Python::Requirement do
 
       it "implements arbitrary equality" do
         expect(requirement).to be_satisfied_by(version_class.new("1.3.0"))
-        expect(requirement).to_not be_satisfied_by(version_class.new("1.3"))
+        expect(requirement).not_to be_satisfied_by(version_class.new("1.3"))
       end
     end
 

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       let(:raise_on_ignored) { true }
 
       it "doesn't raise an error" do
-        expect { latest_version }.to_not raise_error
+        expect { latest_version }.not_to raise_error
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end
@@ -235,7 +235,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
         let(:raise_on_ignored) { true }
 
         it "doesn't raise an error" do
-          expect { latest_version }.to_not raise_error
+          expect { latest_version }.not_to raise_error
         end
       end
     end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "origin_label::github::cloudposse/terraform-null-label::tags/0.3.7"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.3.7")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -358,7 +358,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "logs::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.2.2")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -377,7 +377,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "distribution_label::bitbucket::cloudposse/terraform-null-label"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to be_nil
           expect(dependency.requirements).to eq([{
             requirement: nil,
@@ -396,7 +396,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "dns::github::cloudposse/terraform-aws-route53-cluster-zone::tags/0.2.5"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.2.5")
           expect(dependency.requirements).to eq([{
             requirement: nil,
@@ -415,7 +415,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "duplicate_label::github::cloudposse/terraform-null-label::tags/0.3.7"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.3.7")
           expect(dependency.requirements).to eq([{
             requirement: nil,
@@ -434,7 +434,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "github_ssh_without_protocol::github::cloudposse/terraform-aws-jenkins::tags/0.4.0"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.4.0")
           expect(dependency.requirements).to eq([{
             requirement: nil,
@@ -466,7 +466,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
 
         it "has the right details for the child_module_one child_label git dependency (uses git@github.com)" do
           dependency = dependencies.find { |x| x.name == "child::github::cloudposse/terraform-aws-jenkins::tags/0.4.0" }
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.4.0")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -485,7 +485,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "child::github::cloudposse/terraform-aws-s3-log-storage::tags/0.2.2"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.2.2")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -502,7 +502,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
 
         it "has the right details for the child_module_one distribution_label duplicate git repo different provider" do
           dependency = dependencies.find { |x| x.name == "distribution_label::github::cloudposse/terraform-null-label" }
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to be_nil
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -521,7 +521,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "distribution_label::bitbucket::cloudposse/terraform-null-label"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to be_nil
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -540,7 +540,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "dns_dup::github::cloudposse/terraform-aws-route53-cluster-zone::tags/0.2.5"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.2.5")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -559,7 +559,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "dns::github::cloudposse/terraform-aws-route53-cluster-zone::tags/0.2.5"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.2.5")
           expect(dependency.requirements).to match_array([
             {
@@ -591,7 +591,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "codecommit_repo::codecommit::test-repo::0.10.0"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.10.0")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -610,7 +610,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name.include? "unknown_repo::git_provider::repo_name/git_repo("
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("1.0.0")
           expect(dependency.requirements).to match_array([{
             requirement: nil,
@@ -636,7 +636,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
           dependency = dependencies.find do |x|
             x.name == "gitlab_ssh_without_protocol::gitlab::cloudposse/terraform-aws-jenkins::tags/0.4.0"
           end
-          expect(dependency).to_not be_nil
+          expect(dependency).not_to be_nil
           expect(dependency.version).to eq("0.4.0")
           expect(dependency.requirements).to eq([{
             requirement: nil,

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
 
       it "do not tells the backend about the error" do
-        expect(api_client).to_not receive(:record_update_job_unknown_error)
+        expect(api_client).not_to receive(:record_update_job_unknown_error)
         expect(api_client).to receive(:mark_job_as_processed)
 
         expect { perform_job }.to output(/Error during file fetching; aborting/).to_stdout_from_any_process

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
 
       it "captures the exception and does not records the update job unknown error api" do
         expect(service).to receive(:capture_exception)
-        expect(service).to_not receive(:record_update_job_unknown_error)
+        expect(service).not_to receive(:record_update_job_unknown_error)
 
         perform_job
         Dependabot::Experiments.reset!

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
       end
 
       it "records error with only update job error api service, logs the backtrace and captures the exception" do
-        expect(mock_service).to_not receive(:record_update_job_unknown_error)
+        expect(mock_service).not_to receive(:record_update_job_unknown_error)
 
         expect(mock_service).to receive(:capture_exception).with(
           error: error,

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:create_pull_request)
+          expect(service).not_to receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).with(
             {
               error_type: "dependency_file_not_supported",
@@ -332,7 +332,7 @@ RSpec.describe Dependabot::Updater do
             ]
           )
 
-          expect(service).to_not receive(:create_pull_request)
+          expect(service).not_to receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).with(
             {
               error_type: "security_update_not_possible",
@@ -462,7 +462,7 @@ RSpec.describe Dependabot::Updater do
 
           updater.run
 
-          expect(service).to_not have_received(:record_update_job_error)
+          expect(service).not_to have_received(:record_update_job_error)
         end
       end
 
@@ -735,8 +735,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-          expect(service).to_not receive(:create_pull_request)
+          expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+          expect(service).not_to receive(:create_pull_request)
 
           updater.run
         end
@@ -840,10 +840,10 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        expect(checker).to_not receive(:can_update?)
-        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-        expect(service).to_not receive(:create_pull_request)
-        expect(service).to_not receive(:record_update_job_error)
+        expect(checker).not_to receive(:can_update?)
+        expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+        expect(service).not_to receive(:create_pull_request)
+        expect(service).not_to receive(:record_update_job_error)
         expect(Dependabot.logger)
           .to receive(:info)
           .with("Pull request already exists for dummy-pkg-b " \
@@ -870,9 +870,9 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false, false)
         expect(checker).to receive(:can_update?).and_return(true, false)
-        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-        expect(service).to_not receive(:create_pull_request)
-        expect(service).to_not receive(:record_update_job_error)
+        expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+        expect(service).not_to receive(:create_pull_request)
+        expect(service).not_to receive(:record_update_job_error)
         expect(Dependabot.logger)
           .to receive(:info)
           .with("Pull request already exists for dummy-pkg-b@1.2.0")
@@ -908,8 +908,8 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false)
         expect(checker).to receive(:can_update?).and_return(true)
-        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-        expect(service).to_not receive(:create_pull_request)
+        expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+        expect(service).not_to receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error)
           .with(
             error_type: "pull_request_exists_for_security_update",
@@ -953,9 +953,9 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        expect(checker).to_not receive(:can_update?)
-        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-        expect(service).to_not receive(:create_pull_request)
+        expect(checker).not_to receive(:can_update?)
+        expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+        expect(service).not_to receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error)
           .with(
             error_type: "pull_request_exists_for_latest_version",
@@ -1054,8 +1054,8 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false)
         expect(checker).to receive(:can_update?).and_return(true)
-        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
-        expect(service).to_not receive(:create_pull_request)
+        expect(Dependabot::DependencyChangeBuilder).not_to receive(:create_from)
+        expect(service).not_to receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error)
           .with(
             error_type: "pull_request_exists_for_security_update",
@@ -1392,7 +1392,7 @@ RSpec.describe Dependabot::Updater do
             service = build_service
             updater = build_updater(service: service, job: job)
 
-            expect(service).to_not receive(:create_pull_request)
+            expect(service).not_to receive(:create_pull_request)
             expect(service).to receive(:record_update_job_error).with(
               {
                 error_type: "security_update_not_needed",
@@ -1429,7 +1429,7 @@ RSpec.describe Dependabot::Updater do
             service = build_service
             updater = build_updater(service: service, job: job)
 
-            expect(service).to_not receive(:close_pull_request)
+            expect(service).not_to receive(:close_pull_request)
 
             updater.run
           end
@@ -1538,7 +1538,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1576,7 +1576,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1614,7 +1614,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1629,7 +1629,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:record_update_job_error)
+          expect(service).not_to receive(:record_update_job_error)
 
           updater.run
         end
@@ -1646,7 +1646,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1684,7 +1684,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1722,7 +1722,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1764,7 +1764,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1931,7 +1931,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -1969,7 +1969,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -2007,7 +2007,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -2022,7 +2022,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:record_update_job_error)
+          expect(service).not_to receive(:record_update_job_error)
 
           updater.run
         end
@@ -2039,7 +2039,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -2077,7 +2077,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -2115,7 +2115,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end
@@ -2157,7 +2157,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).to_not receive(:capture_exception)
+          expect(service).not_to receive(:capture_exception)
 
           updater.run
         end


### PR DESCRIPTION
### What are you trying to accomplish?

The RSpec NotToNot rubocop is disabled.  This pull request will enable it.

### Anything you want to highlight for special attention from reviewers?

Please check for things that autocorrect pull requests may have mistakenly changed.
### How will you know you've accomplished your goal?

This rubocop rule will be in effect across the board.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
