### PR TITLE
Enabling PredicateMatcher Rubocop rule on RSpec.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,23 +158,6 @@ RSpec/OverwritingSetup:
     - 'terraform/spec/dependabot/terraform/file_parser_spec.rb'
     - 'updater/spec/dependabot/dependency_snapshot_spec.rb'
 
-# Offense count: 47
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Strict, EnforcedStyle, AllowedExplicitMatchers.
-# SupportedStyles: inflected, explicit
-RSpec/PredicateMatcher:
-  Exclude:
-    - 'common/spec/dependabot/dependency_file_spec.rb'
-    - 'common/spec/dependabot/dependency_group_spec.rb'
-    - 'common/spec/dependabot/experiments_spec.rb'
-    - 'common/spec/dependabot/file_updaters/artifact_updater_spec.rb'
-    - 'common/spec/dependabot/file_updaters/vendor_updater_spec.rb'
-    - 'common/spec/dependabot/workspace/git_spec.rb'
-    - 'npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb'
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
-    - 'python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb'
-    - 'updater/spec/dependabot/job_spec.rb'
-
 # Offense count: 4
 RSpec/RepeatedExample:
   Exclude:

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
       end
     end
@@ -189,7 +189,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_falsey
-        expect(file.deleted?).to be_falsey
+        expect(file).not_to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
       end
     end
@@ -219,7 +219,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end
@@ -249,7 +249,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end
@@ -280,7 +280,7 @@ RSpec.describe Dependabot::DependencyFile do
 
       it "has the correct operation properties" do
         expect(file.deleted).to be_truthy
-        expect(file.deleted?).to be_truthy
+        expect(file).to be_deleted
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
       end
     end

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe Dependabot::DependencyGroup do
       context "when no dependencies are assigned to the group" do
         it "returns true if the dependency matches a pattern" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency1)).to be_truthy
+          expect(dependency_group).to be_contains(test_dependency1)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency2)).to be_falsey
+          expect(dependency_group).not_to be_contains(test_dependency2)
         end
 
         it "returns false if the dependency does not match any patterns" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group).not_to be_contains(production_dependency)
         end
       end
 
@@ -138,17 +138,17 @@ RSpec.describe Dependabot::DependencyGroup do
 
         it "returns true if the dependency is in the dependency list" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency1)).to be_truthy
+          expect(dependency_group).to be_contains(test_dependency1)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency2)).to be_falsey
+          expect(dependency_group).not_to be_contains(test_dependency2)
         end
 
         it "returns false if the dependency is not in the dependency list and does not match a pattern" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group).not_to be_contains(production_dependency)
         end
       end
     end
@@ -161,12 +161,12 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type" do
-        expect(dependency_group.contains?(production_dependency)).to be_truthy
+        expect(dependency_group).to be_contains(production_dependency)
       end
 
       it "returns false if the dependency does not match the specified type" do
-        expect(dependency_group.contains?(test_dependency1)).to be_falsey
-        expect(dependency_group.contains?(test_dependency2)).to be_falsey
+        expect(dependency_group).not_to be_contains(test_dependency1)
+        expect(dependency_group).not_to be_contains(test_dependency2)
       end
 
       context "when a dependency is specifically excluded" do
@@ -178,7 +178,7 @@ RSpec.describe Dependabot::DependencyGroup do
         end
 
         it "returns false even if the dependency matches the specified type" do
-          expect(dependency_group.contains?(production_dependency)).to be_falsey
+          expect(dependency_group).not_to be_contains(production_dependency)
         end
       end
     end
@@ -193,15 +193,15 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type and a pattern" do
-        expect(dependency_group.contains?(test_dependency1)).to be_truthy
+        expect(dependency_group).to be_contains(test_dependency1)
       end
 
       it "returns false if the dependency only matches the pattern" do
-        expect(dependency_group.contains?(production_dependency)).to be_falsey
+        expect(dependency_group).not_to be_contains(production_dependency)
       end
 
       it "returns false if the dependency matches the specified type and pattern but is excluded" do
-        expect(dependency_group.contains?(test_dependency2)).to be_falsey
+        expect(dependency_group).not_to be_contains(test_dependency2)
       end
     end
   end

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe Dependabot::DependencyGroup do
       context "when no dependencies are assigned to the group" do
         it "returns true if the dependency matches a pattern" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group).to be_contains(test_dependency1)
+          expect(dependency_group.contains?(test_dependency1)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group).not_to be_contains(test_dependency2)
+          expect(dependency_group.contains?(test_dependency2)).to be(false)
         end
 
         it "returns false if the dependency does not match any patterns" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group).not_to be_contains(production_dependency)
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
 
@@ -138,17 +138,17 @@ RSpec.describe Dependabot::DependencyGroup do
 
         it "returns true if the dependency is in the dependency list" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group).to be_contains(test_dependency1)
+          expect(dependency_group.contains?(test_dependency1)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group).not_to be_contains(test_dependency2)
+          expect(dependency_group.contains?(test_dependency2)).to be(false)
         end
 
         it "returns false if the dependency is not in the dependency list and does not match a pattern" do
           expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group).not_to be_contains(production_dependency)
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
     end
@@ -161,12 +161,12 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type" do
-        expect(dependency_group).to be_contains(production_dependency)
+        expect(dependency_group.contains?(production_dependency)).to be(true)
       end
 
       it "returns false if the dependency does not match the specified type" do
-        expect(dependency_group).not_to be_contains(test_dependency1)
-        expect(dependency_group).not_to be_contains(test_dependency2)
+        expect(dependency_group.contains?(test_dependency1)).to be(false)
+        expect(dependency_group.contains?(test_dependency2)).to be(false)
       end
 
       context "when a dependency is specifically excluded" do
@@ -178,7 +178,7 @@ RSpec.describe Dependabot::DependencyGroup do
         end
 
         it "returns false even if the dependency matches the specified type" do
-          expect(dependency_group).not_to be_contains(production_dependency)
+          expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
     end
@@ -193,15 +193,15 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type and a pattern" do
-        expect(dependency_group).to be_contains(test_dependency1)
+        expect(dependency_group.contains?(test_dependency1)).to be(true)
       end
 
       it "returns false if the dependency only matches the pattern" do
-        expect(dependency_group).not_to be_contains(production_dependency)
+        expect(dependency_group.contains?(production_dependency)).to be(false)
       end
 
       it "returns false if the dependency matches the specified type and pattern but is excluded" do
-        expect(dependency_group).not_to be_contains(test_dependency2)
+        expect(dependency_group.contains?(test_dependency2)).to be(false)
       end
     end
   end

--- a/common/spec/dependabot/experiments_spec.rb
+++ b/common/spec/dependabot/experiments_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Dependabot::Experiments do
   it "can register experiments as enabled" do
     described_class.register(:my_test, true)
 
-    expect(described_class.enabled?(:my_test)).to be_truthy
+    expect(described_class).to be_enabled(:my_test)
   end
 
   it "works with string names and symbols" do
     described_class.register("my_test", true)
 
-    expect(described_class.enabled?("my_test")).to be_truthy
-    expect(described_class.enabled?(:my_test)).to be_truthy
+    expect(described_class).to be_enabled("my_test")
+    expect(described_class).to be_enabled(:my_test)
   end
 end

--- a/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/artifact_updater_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
         f.name == "vendor/cache/business-1.5.0.gem"
       end
 
-      expect(file.binary?).to be_truthy
+      expect(file).to be_binary
     end
 
     it "marks created files as such" do
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
     end
 
@@ -87,7 +87,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
       end
 
       expect(file.deleted).to be_truthy
-      expect(file.deleted?).to be_truthy
+      expect(file).to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
     end
 
@@ -132,7 +132,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
           f.name == "vendor/cache/iso8859.txt"
         end
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
 
       it "does not mark all files as binary" do
@@ -140,7 +140,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
           f.name == "vendor/cache/utf8.txt"
         end
 
-        expect(file.binary?).to be_falsy
+        expect(file).not_to be_binary
       end
     end
 
@@ -210,7 +210,7 @@ RSpec.describe Dependabot::FileUpdaters::ArtifactUpdater do
 
         file = updated_files.find { |f| f.name == "vendor/cache/new_#{name}" }
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
     end
   end

--- a/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
         f.name == "vendor/cache/business-1.5.0.gem"
       end
 
-      expect(file.binary?).to be_truthy
+      expect(file).to be_binary
     end
 
     it "marks created files as such" do
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::CREATE
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_falsey
-      expect(file.deleted?).to be_falsey
+      expect(file).not_to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       end
 
       expect(file.deleted).to be_truthy
-      expect(file.deleted?).to be_truthy
+      expect(file).to be_deleted
       expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
     end
 
@@ -131,7 +131,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
           f.name == "vendor/cache/iso8859.txt"
         end
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
 
       it "does not mark all files as binary" do
@@ -139,7 +139,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
           f.name == "vendor/cache/utf8.txt"
         end
 
-        expect(file.binary?).to be_falsy
+        expect(file).not_to be_binary
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
 
         file = updated_files.find { |f| f.name == "vendor/cache/new_#{name}" }
 
-        expect(file.binary?).to be_truthy
+        expect(file).to be_binary
       end
     end
   end

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Dependabot::Workspace::Git do
         expect(workspace.change_attempts.first.memo).to eq("timecop")
         expect(workspace.change_attempts.first.error).not_to be_nil
         expect(workspace.change_attempts.first.error.message).to eq("uh oh")
-        expect(workspace.change_attempts.first.error?).to be_truthy
-        expect(workspace.change_attempts.first.success?).to be_falsy
+        expect(workspace.change_attempts.first).to be_error
+        expect(workspace.change_attempts.first).not_to be_success
       end
 
       context "when there are untracked/ignored files" do
@@ -243,8 +243,8 @@ RSpec.describe Dependabot::Workspace::Git do
         )
         expect(workspace.change_attempts.first.memo).to eq("Update timecop")
         expect(workspace.change_attempts.first.error).to be_nil
-        expect(workspace.change_attempts.first.error?).to be_falsy
-        expect(workspace.change_attempts.first.success?).to be_truthy
+        expect(workspace.change_attempts.first).not_to be_error
+        expect(workspace.change_attempts.first).to be_success
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       end
 
       it "returns false when there is a newer version available" do
-        expect(checker.up_to_date?).to be_falsy
+        expect(checker).not_to be_up_to_date
       end
     end
 
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       end
 
       it "is up to date because there's nothing to update" do
-        expect(checker.up_to_date?).to be_truthy
+        expect(checker).to be_up_to_date
       end
     end
   end

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       end
 
       it "can update" do
-        expect(checker.vulnerable?).to be_truthy
+        expect(checker).to be_vulnerable
         expect(checker.lowest_resolvable_security_fix_version).to eq("2.0.0")
         expect(updated_dependencies).to eq [
           {

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
             source: nil
           }]
         )
-        expect(dependency.production?).to be_truthy
+        expect(dependency).to be_production
       end
     end
 

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -425,8 +425,8 @@ RSpec.describe Dependabot::Job do
 
       it "registers the experiments with Dependabot::Experiments" do
         job
-        expect(Dependabot::Experiments.enabled?(:kebab_case)).to be_truthy
-        expect(Dependabot::Experiments.enabled?(:simpe)).to be_falsey
+        expect(Dependabot::Experiments).to be_enabled(:kebab_case)
+        expect(Dependabot::Experiments).not_to be_enabled(:simpe)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
The Predicate Matcher rubocop rule is disabled for some files.  This Pull request will re-enable it.

### Anything you want to highlight for special attention from reviewers?
Please review for duplicated code blocks which escaped the autocorrect.  This is a rework of PR #9910 9910, which had more merge conflicts than were fixable.

### How will you know you've accomplished your goal?
This rubocop rule will work as desired

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
