### PR TITLE
Enabling SharedExamples Rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -212,16 +212,6 @@ RSpec/ScatteredSetup:
     - 'nuget/spec/dependabot/nuget/file_fetcher_spec.rb'
     - 'python/spec/dependabot/python/file_fetcher_spec.rb'
 
-# Offense count: 24
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: string, symbol
-RSpec/SharedExamples:
-  Exclude:
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
-    - 'pub/spec/spec_helper.rb'
-    - 'updater/spec/dependabot/service_spec.rb'
-
 # Offense count: 10
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, IgnoreMetadata.
 # Include: **/*_spec.rb

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -709,7 +709,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   end
 
   context "with a git dependency" do
-    include_context :uses_temp_dir
+    include_context "with temp dir"
 
     let(:project) { "git_dependency" }
 
@@ -784,7 +784,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   end
 
   context "when working for a flutter project" do
-    include_context :uses_temp_dir
+    include_context "with temp dir"
 
     let(:project) { "requires_flutter" }
     let(:requirements_to_unlock) { :all }
@@ -808,7 +808,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   end
 
   context "when working for a flutter project requiring a flutter beta" do
-    include_context :uses_temp_dir
+    include_context "with temp dir"
 
     let(:project) { "requires_latest_beta" }
     let(:requirements_to_unlock) { :all }

--- a/pub/spec/spec_helper.rb
+++ b/pub/spec/spec_helper.rb
@@ -29,7 +29,7 @@ def run_git(args, dir)
   stdout
 end
 
-shared_context :uses_temp_dir do
+shared_context "with temp dir" do
   around do |example|
     Dir.mktmpdir("rspec-") do |dir|
       @temp_dir = dir

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dependabot::Service do
     api_client
   end
 
-  shared_context :a_pr_was_created do
+  shared_context "with a created pr" do
     let(:source) do
       instance_double(Dependabot::Source, provider: "github", repo: "dependabot/dependabot-core", directory: "/")
     end
@@ -98,7 +98,7 @@ RSpec.describe Dependabot::Service do
     end
   end
 
-  shared_context :a_pr_was_updated do
+  shared_context "with an updated pr" do
     let(:source) do
       instance_double(Dependabot::Source, provider: "github", repo: "dependabot/dependabot-core", directory: "/")
     end
@@ -147,7 +147,7 @@ RSpec.describe Dependabot::Service do
     end
   end
 
-  shared_context :a_pr_was_closed do
+  shared_context "with an closd pr" do
     let(:dependency_name) { "dependabot-fortran" }
     let(:reason) { :dependency_removed }
 
@@ -156,7 +156,7 @@ RSpec.describe Dependabot::Service do
     end
   end
 
-  shared_context :an_error_was_reported do
+  shared_context "with a reported error" do
     before do
       service.record_update_job_error(
         error_type: :epoch_error,
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::Service do
     end
   end
 
-  shared_context :a_dependency_error_was_reported do
+  shared_context "with a reported dependency error" do
     let(:dependency) do
       Dependabot::Dependency.new(
         name: "dependabot-cobol",
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#create_pull_request" do
-    include_context :a_pr_was_created
+    include_context "with a created pr"
 
     before do
       Dependabot::Experiments.register("dependency_change_validation", true)
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#update_pull_request" do
-    include_context :a_pr_was_updated
+    include_context "with an updated pr"
 
     it "delegates to @client" do
       expect(mock_client).to have_received(:update_pull_request).with(dependency_change, base_sha)
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#close_pull_request" do
-    include_context :a_pr_was_closed
+    include_context "with an closd pr"
 
     it "delegates to @client" do
       expect(mock_client).to have_received(:close_pull_request).with(dependency_name, reason)
@@ -287,7 +287,7 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#record_update_job_error" do
-    include_context :an_error_was_reported
+    include_context "with a reported error"
 
     it "delegates to @client" do
       expect(mock_client).to have_received(:record_update_job_error).with(
@@ -515,7 +515,7 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when a pr was created" do
-      include_context :a_pr_was_created
+      include_context "with a created pr"
 
       it "includes the summary of the created PR" do
         service.create_pull_request(dependency_change, base_sha)
@@ -527,7 +527,7 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when a pr was updated" do
-      include_context :a_pr_was_updated
+      include_context "with an updated pr"
 
       it "includes the summary of the updated PR" do
         expect(service.summary)
@@ -536,7 +536,7 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when a pr was closed" do
-      include_context :a_pr_was_closed
+      include_context "with an closd pr"
 
       it "includes the summary of the closed PR" do
         expect(service.summary)
@@ -545,7 +545,7 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when there was an error" do
-      include_context :an_error_was_reported
+      include_context "with a reported error"
 
       it "includes an error count" do
         expect(service.summary)
@@ -559,7 +559,7 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when there was an dependency error" do
-      include_context :a_dependency_error_was_reported
+      include_context "with a reported dependency error"
 
       it "includes an error count" do
         expect(service.summary)
@@ -575,8 +575,8 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when there was a mix of pr activity" do
-      include_context :a_pr_was_updated
-      include_context :a_pr_was_closed
+      include_context "with an updated pr"
+      include_context "with an closd pr"
 
       it "includes the summary of the updated PR" do
         expect(service.summary)
@@ -590,10 +590,10 @@ RSpec.describe Dependabot::Service do
     end
 
     context "when there was a mix of pr and error activity" do
-      include_context :a_pr_was_created
-      include_context :a_pr_was_closed
-      include_context :an_error_was_reported
-      include_context :a_dependency_error_was_reported
+      include_context "with a created pr"
+      include_context "with an closd pr"
+      include_context "with a reported error"
+      include_context "with a reported dependency error"
 
       before do
         service.create_pull_request(dependency_change, base_sha)


### PR DESCRIPTION
### What are you trying to accomplish?

The RSpec rubocop rule [SharedExamples](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples) had been blocked from running on several fies.  This PR corrects that issue

### Anything you want to highlight for special attention from reviewers?

This PR shoud just change a few names of shared examples in two or three rspec files.  Since these were included in other files, the other files had to be run against it.

### How will you know you've accomplished your goal?

The tests will run effectively without any change in performance.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
