### PR TITLE
Enabling RSpec HooksBefore rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,12 +51,6 @@ RSpec/FilePath:
     - 'nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb'
     - 'nuget/spec/dependabot/nuget/update_checker/tfm_finder_spec.rb'
 
-# Offense count: 56
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/HooksBeforeExamples:
-  Enabled: false
-
-
 # Offense count: 70
 # Configuration parameters: Max, AllowedIdentifiers, AllowedPatterns.
 RSpec/IndexedLet:

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -45,9 +45,8 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
         body: fixture("github", "tool_versions_content.json"),
         headers: { "content-type" => "application/json" }
       )
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   it_behaves_like "a dependency file fetcher"
 

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
     stub_request(:get, File.join(url, ".ruby-version?ref=sha"))
       .with(headers: { "Authorization" => "token token" })
@@ -49,6 +45,10 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
         headers: { "content-type" => "application/json" }
       )
   end
+
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with a directory" do
     let(:directory) { "/test" }

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
@@ -34,8 +34,6 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     stub_request(:get, "https://example.com/status").to_return(
       status: 200,
@@ -49,6 +47,8 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
       headers: {}
     )
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
     stub_request(:get, url + "Cargo.toml?ref=sha")
       .with(headers: { "Authorization" => "token token" })
@@ -64,6 +60,10 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         headers: json_header
       )
   end
+
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with a lockfile" do
     before do

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -60,9 +60,8 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         body: fixture("github", "contents_cargo_config.json"),
         headers: json_header
       )
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   it_behaves_like "a dependency file fetcher"
 

--- a/cargo/spec/dependabot/cargo/file_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe Dependabot::Cargo::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     stub_request(:get, "https://example.com/status").to_return(
       status: 200,
@@ -44,6 +42,8 @@ RSpec.describe Dependabot::Cargo::MetadataFinder do
       headers: {}
     )
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
   let(:crates_response) { fixture("crates_io_responses", crates_fixture_name) }
   let(:crates_url) { "https://crates.io/api/v1/crates/#{dependency_name}" }
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, crates_url).to_return(status: 200, body: crates_response)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -307,8 +307,6 @@ RSpec.describe Dependabot::FileFetchers::Base do
     context "with a GitHub source" do
       let(:url) { "https://api.github.com/repos/#{repo}/contents/" }
 
-      its(:length) { is_expected.to eq(1) }
-
       before do
         stub_request(:get, url + "requirements.txt?ref=sha")
           .with(headers: { "Authorization" => "token token" })
@@ -316,6 +314,8 @@ RSpec.describe Dependabot::FileFetchers::Base do
                      body: fixture("github", "gemfile_content.json"),
                      headers: { "content-type" => "application/json" })
       end
+
+      its(:length) { is_expected.to eq(1) }
 
       describe "the file" do
         subject(:files_find) { files.find { |file| file.name == "requirements.txt" } }

--- a/composer/spec/dependabot/composer/file_fetcher_spec.rb
+++ b/composer/spec/dependabot/composer/file_fetcher_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe Dependabot::Composer::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   before do
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
@@ -54,6 +52,8 @@ RSpec.describe Dependabot::Composer::FileFetcher do
         headers: { "content-type" => "application/json" }
       )
   end
+
+  it_behaves_like "a dependency file fetcher"
 
   it "fetches the composer.json and composer.lock" do
     expect(file_fetcher_instance.files.map(&:name))

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe Dependabot::Composer::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/composer/spec/dependabot/composer/metadata_finder_spec.rb
+++ b/composer/spec/dependabot/composer/metadata_finder_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     packagist_url = "https://repo.packagist.org/p2/#{dependency_name.downcase}.json"
     stub_request(:get, packagist_url).to_return(status: 200, body: packagist_response)
@@ -50,6 +48,8 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
       headers: {}
     )
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     )
   end
 
-  it_behaves_like "an update checker"
-
   before do
     url = "https://repo.packagist.org/p2/#{dependency_name.downcase}.json"
     stub_request(:get, url).to_return(status: 200, body: packagist_response)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#latest_version" do
     subject(:latest_version) { checker.latest_version }

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with no Dockerfile or Kubernetes YAML file" do
     before do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -49,8 +49,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     )
   end
 
-  it_behaves_like "an update checker"
-
   before do
     auth_url = "https://auth.docker.io/token?service=registry.docker.io"
     stub_request(:get, auth_url)
@@ -59,6 +57,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     stub_request(:get, repo_url + "tags/list")
       .and_return(status: 200, body: registry_tags)
   end
+
+  it_behaves_like "an update checker"
 
   def stub_tag_with_no_digest(tag)
     stub_request(:head, repo_url + "manifests/#{tag}")

--- a/elm/spec/dependabot/elm/file_fetcher_spec.rb
+++ b/elm/spec/dependabot/elm/file_fetcher_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe Dependabot::Elm::FileFetcher do
         body: fixture("github", "contents_elm_package.json"),
         headers: json_header
       )
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   it_behaves_like "a dependency file fetcher"
 

--- a/elm/spec/dependabot/elm/file_fetcher_spec.rb
+++ b/elm/spec/dependabot/elm/file_fetcher_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe Dependabot::Elm::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
     stub_request(:get, url + "?ref=sha")
       .with(headers: { "Authorization" => "token token" })
@@ -47,6 +43,10 @@ RSpec.describe Dependabot::Elm::FileFetcher do
         headers: json_header
       )
   end
+
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with an elm.json" do
     before do

--- a/elm/spec/dependabot/elm/file_updater_spec.rb
+++ b/elm/spec/dependabot/elm/file_updater_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Dependabot::Elm::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
@@ -42,8 +42,6 @@ RSpec.describe Dependabot::GitSubmodules::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     # Not hosted on GitHub Enterprise Server
     stub_request(:get, "https://example.com/status").to_return(
@@ -52,6 +50,8 @@ RSpec.describe Dependabot::GitSubmodules::MetadataFinder do
       headers: {}
     )
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/github_actions/spec/dependabot/github_actions/file_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_fetcher_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Dependabot::GithubActions::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with workflow files" do
     before do

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -252,13 +252,13 @@ RSpec.describe Dependabot::GithubActions::FileParser do
         }]
       end
 
-      its(:length) { is_expected.to eq(4) }
-
       before do
         mock_service_pack_request("docker/setup-qemu-action")
         mock_service_pack_request("docker/setup-buildx-action")
         mock_service_pack_request("docker/login-action")
       end
+
+      its(:length) { is_expected.to eq(4) }
 
       context "when dealing with the first dependency" do
         subject(:dependency) { dependencies.first }

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     )
   end
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, service_pack_url)
       .to_return(
@@ -76,6 +74,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         }
       )
   end
+
+  it_behaves_like "an update checker"
 
   shared_context "with multiple git sources" do
     let(:upload_pack_fixture) { "checkout" }

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     FileUtils.rm_rf(repo_contents_path)
   end
 
-  after { FileUtils.rm_rf(repo_contents_path) }
-
   it_behaves_like "a dependency file fetcher"
 
   it "fetches the go.mod and go.sum" do

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
   let(:branch) { "master" }
   let(:repo) { "dependabot-fixtures/go-modules-lib" }
 
-  it_behaves_like "a dependency file fetcher"
-
-  after { FileUtils.rm_rf(repo_contents_path) }
-
   after do
     FileUtils.rm_rf(repo_contents_path)
   end
+
+  after { FileUtils.rm_rf(repo_contents_path) }
+
+  it_behaves_like "a dependency file fetcher"
 
   it "fetches the go.mod and go.sum" do
     expect(file_fetcher_instance.files.map(&:name))

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Dependabot::GoModules::FileParser do
   let(:files) { [go_mod] }
   let(:parser) { described_class.new(dependency_files: files, source: source, repo_contents_path: repo_contents_path) }
 
-  it_behaves_like "a dependency file parser"
-
   after do
     # Reset to the default go toolchain after each test
     ENV["GOTOOLCHAIN"] = ENV.fetch("GO_LEGACY")
   end
+
+  it_behaves_like "a dependency file parser"
 
   it "requires a go.mod to be present" do
     expect do

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
     )
   end
 
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
   it_behaves_like "a dependency file fetcher"
 
   def stub_content_request(path, fixture)
@@ -45,8 +47,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       .with(headers: { "Authorization" => "token token" })
       .to_return(status: 404)
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   context "with a basic buildfile" do
     before do

--- a/gradle/spec/dependabot/gradle/update_checker_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe Dependabot::Gradle::UpdateChecker do
       "com/google/guava/guava/maven-metadata.xml"
   end
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, maven_central_metadata_url)
       .to_return(status: 200, body: maven_central_releases)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#latest_version" do
     subject { checker.latest_version }

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe Dependabot::Hex::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
     stub_request(:get, url + "?ref=sha")
       .with(headers: { "Authorization" => "token token" })
@@ -56,6 +52,10 @@ RSpec.describe Dependabot::Hex::FileFetcher do
         headers: json_header
       )
   end
+
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   it "fetches the mix.exs and mix.lock" do
     expect(file_fetcher_instance.files.count).to eq(2)

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -52,9 +52,8 @@ RSpec.describe Dependabot::Hex::FileFetcher do
         body: fixture("github", "contents_elixir_lockfile.json"),
         headers: json_header
       )
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   it_behaves_like "a dependency file fetcher"
 

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Dependabot::Hex::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Dependabot::Maven::FileFetcher do
     )
   end
 
+  before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+    stub_request(:get, File.join(url, ".mvn?ref=sha"))
+      .with(headers: { "Authorization" => "token token" })
+      .to_return(
+        status: 404
+      )
+  end
+
   it_behaves_like "a dependency file fetcher"
 
   describe ".required_files_in?" do
@@ -68,16 +78,6 @@ RSpec.describe Dependabot::Maven::FileFetcher do
 
       it { is_expected.to be(false) }
     end
-  end
-
-  before do
-    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
-
-    stub_request(:get, File.join(url, ".mvn?ref=sha"))
-      .with(headers: { "Authorization" => "token token" })
-      .to_return(
-        status: 404
-      )
   end
 
   context "with a basic pom" do

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
     )
   end
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, maven_central_metadata_url)
       .to_return(status: 200, body: maven_central_releases)
     stub_request(:head, maven_central_version_files_url)
       .to_return(status: 200)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#latest_version" do
     subject { checker.latest_version }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   before do
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
@@ -57,6 +55,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         headers: json_header
       )
   end
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with .yarn data stored in git-lfs" do
     let(:source) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -57,11 +57,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before do
     FileUtils.mkdir_p(tmp_path)
   end
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
   let(:registry_base) { "https://registry.npmjs.org" }
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, registry_listing_url)
       .to_return(status: 200, body: registry_response)
     stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
       .to_return(status: 200)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#vulnerable?" do
     context "when the dependency has multiple versions" do

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
@@ -44,6 +40,10 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
         status: 404
       )
   end
+
+  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with a .csproj" do
     before do

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
       .to_return(
         status: 404
       )
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
   end
-
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   it_behaves_like "a dependency file fetcher"
 

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -63,8 +63,6 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before do
     stub_search_results_with_versions_v3("microsoft.extensions.dependencymodel", ["1.0.0", "1.1.1"])
     stub_request(:get, "https://api.nuget.org/v3-flatcontainer/" \
@@ -72,6 +70,8 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
                        "microsoft.extensions.dependencymodel.nuspec")
       .to_return(status: 200, body: fixture("nuspecs", "Microsoft.Extensions.DependencyModel.1.0.0.nuspec"))
   end
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { file_updater_instance.updated_dependency_files }

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -109,6 +109,11 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
         ENV.delete("THIS_VARIABLE_DOES_NOT")
       end
 
+      after do
+        ENV.delete("THIS_VARIBLE_EXISTS")
+        ENV.delete("THIS_VARIABLE_DOES_NOT")
+      end
+
       it "contains the expected values and warns on unavailable" do
         repo = known_repositories[0]
         expect(repo[:url]).to eq("https://nuget.example.com/index.json")
@@ -118,11 +123,6 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
             The variable '%THIS_VARIABLE_DOES_NOT%' could not be expanded in NuGet.Config
           WARN
         )
-      end
-
-      after do
-        ENV.delete("THIS_VARIBLE_EXISTS")
-        ENV.delete("THIS_VARIABLE_DOES_NOT")
       end
     end
   end

--- a/pub/spec/dependabot/pub/file_fetcher_spec.rb
+++ b/pub/spec/dependabot/pub/file_fetcher_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe Dependabot::Pub::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   after do
     FileUtils.rm_rf(repo_contents_path)
   end
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with pubspec.yaml and pubspec.lock" do
     it "fetches the files" do

--- a/pub/spec/dependabot/pub/metadata_finder_spec.rb
+++ b/pub/spec/dependabot/pub/metadata_finder_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe Dependabot::Pub::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     stub_request(:get, "https://pub.dev/api/packages/#{dependency.name}").to_return(
       status: 200,
@@ -50,6 +48,8 @@ RSpec.describe Dependabot::Pub::MetadataFinder do
       )
     end
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     it "finds the repository" do

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -69,20 +69,11 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   let(:sample) { "simple" }
   let(:sample_files) { Dir.glob(File.join("spec", "fixtures", "pub_dev_responses", sample, "*")) }
 
-  it_behaves_like "an update checker"
-
-  before(:all) do
-    # Because we do the networking in dependency_services we have to run an
-    # actual web server.
-    dev_null = WEBrick::Log.new("/dev/null", 7)
-    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
-    Thread.new do
-      @server.start
+  after do
+    sample_files.each do |f|
+      package = File.basename(f, ".json")
+      @server.unmount "/api/packages/#{package}"
     end
-  end
-
-  after(:all) do
-    @server.shutdown
   end
 
   before do
@@ -97,12 +88,21 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     end
   end
 
-  after do
-    sample_files.each do |f|
-      package = File.basename(f, ".json")
-      @server.unmount "/api/packages/#{package}"
+  after(:all) do
+    @server.shutdown
+  end
+
+  before(:all) do
+    # Because we do the networking in dependency_services we have to run an
+    # actual web server.
+    dev_null = WEBrick::Log.new("/dev/null", 7)
+    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
+    Thread.new do
+      @server.start
     end
   end
+
+  it_behaves_like "an update checker"
 
   context "when given an outdated dependency, not requiring unlock" do
     let(:dependency_name) { "collection" }

--- a/python/spec/dependabot/python/file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Dependabot::Python::FileUpdater do
     )
   end
 
-  it_behaves_like "a dependency file updater"
-
   before { FileUtils.mkdir_p(tmp_path) }
+
+  it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/python/spec/dependabot/python/metadata_finder_spec.rb
+++ b/python/spec/dependabot/python/metadata_finder_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe Dependabot::Python::MetadataFinder do
     )
   end
 
-  it_behaves_like "a dependency metadata finder"
-
   before do
     stub_request(:get, "https://example.com/status").to_return(
       status: 200,
@@ -47,6 +45,8 @@ RSpec.describe Dependabot::Python::MetadataFinder do
     stub_request(:get, "https://initd.org/status").to_return(status: 404)
     stub_request(:get, "https://pypi.org/status").to_return(status: 404)
   end
+
+  it_behaves_like "a dependency metadata finder"
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe Dependabot::Python::UpdateChecker do
   let(:pypi_response) { fixture("pypi", "pypi_simple_response.html") }
   let(:pypi_url) { "https://pypi.org/simple/luigi/" }
 
-  it_behaves_like "an update checker"
-
   before do
     stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
   end
+
+  it_behaves_like "an update checker"
 
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }

--- a/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
     )
   end
 
-  it_behaves_like "a dependency file fetcher"
-
   after do
     FileUtils.rm_rf(repo_contents_path)
   end
+
+  it_behaves_like "a dependency file fetcher"
 
   context "with Terraform files" do
     let(:project_name) { "versions_file" }

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -326,6 +326,14 @@ RSpec.describe Dependabot::Terraform::FileParser do
     context "when dealing with hcl2 files" do
       let(:files) { project_dependency_files("hcl2") }
 
+      before do
+        stub_request(:get, "https://unknown-git-repo-example.com/status").to_return(
+          status: 200,
+          body: "Not GHES",
+          headers: {}
+        )
+      end
+
       it "has the right source for the dependency" do
         expect(dependencies[0].requirements).to eq([{
           requirement: nil,
@@ -459,14 +467,6 @@ RSpec.describe Dependabot::Terraform::FileParser do
             }
           }])
         end
-      end
-
-      before do
-        stub_request(:get, "https://unknown-git-repo-example.com/status").to_return(
-          status: 200,
-          body: "Not GHES",
-          headers: {}
-        )
       end
 
       context "with relative path" do


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples

### What are you trying to accomplish?

The RSpec::HooksBeforeExamples rule is disabled.  This PR wil re-enable that Rubocop rule.

### Anything you want to highlight for special attention from reviewers?

Please be aware of conflicting fies.

### How will you know you've accomplished your goal?

The rubocop rule wi be applied to the total ecosystem.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
