### PR TITLE
Enabling ScatteredSetup Rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -176,25 +176,6 @@ RSpec/RepeatedExampleGroupBody:
 RSpec/RepeatedExampleGroupDescription:
   Enabled: false
 
-# Offense count: 36
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/ScatteredSetup:
-  Exclude:
-    - 'bundler/spec/dependabot/bundler/file_fetcher_spec.rb'
-    - 'cargo/spec/dependabot/cargo/file_fetcher_spec.rb'
-    - 'common/spec/dependabot/clients/bitbucket_spec.rb'
-    - 'common/spec/dependabot/git_commit_checker_spec.rb'
-    - 'common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb'
-    - 'composer/spec/dependabot/composer/update_checker_spec.rb'
-    - 'docker/spec/dependabot/docker/file_parser_spec.rb'
-    - 'elm/spec/dependabot/elm/file_fetcher_spec.rb'
-    - 'go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb'
-    - 'gradle/spec/dependabot/gradle/update_checker/multi_dependency_updater_spec.rb'
-    - 'hex/spec/dependabot/hex/file_fetcher_spec.rb'
-    - 'npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb'
-    - 'nuget/spec/dependabot/nuget/file_fetcher_spec.rb'
-    - 'python/spec/dependabot/python/file_fetcher_spec.rb'
-
 # Offense count: 10
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, IgnoreMetadata.
 # Include: **/*_spec.rb

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -30,9 +30,8 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
     stub_request(:get, File.join(url, ".ruby-version?ref=sha"))
       .with(headers: { "Authorization" => "token token" })
       .to_return(

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
     stub_request(:get, url + "Cargo.toml?ref=sha")
       .with(headers: { "Authorization" => "token token" })
       .to_return(

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -66,9 +66,6 @@ RSpec.describe Dependabot::Clients::Bitbucket do
         stub_request(:get, default_reviewers_url)
           .with(headers: { "Authorization" => "Bearer #{access_token}" })
           .to_return(status: 200, body: fixture("bitbucket", "default_reviewers_with_data.json"))
-      end
-
-      before do
         stub_request(:get, current_user_url)
           .with(headers: { "Authorization" => "Bearer #{access_token}" })
           .to_return(status: 401, body: fixture("bitbucket", "current_user_no_access.json"))

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -296,6 +296,14 @@ RSpec.describe Dependabot::GitCommitChecker do
           allow_any_instance_of(DummyPackageManager::MetadataFinder)
             .to receive(:look_up_source)
             .and_return(Dependabot::Source.from_url(source_url))
+          stub_request(:get, service_pack_url)
+            .to_return(
+              status: 200,
+              body: fixture("git", "upload_packs", upload_pack_fixture),
+              headers: {
+                "content-type" => "application/x-git-upload-pack-advertisement"
+              }
+            )
         end
 
         let(:source_url) { "https://bitbucket.org/gocardless/business" }
@@ -307,17 +315,6 @@ RSpec.describe Dependabot::GitCommitChecker do
         let(:bitbucket_url) do
           "https://api.bitbucket.org/2.0/repositories/" \
             "gocardless/business/commits/?exclude=v1.5.0&include=df9f605"
-        end
-
-        before do
-          stub_request(:get, service_pack_url)
-            .to_return(
-              status: 200,
-              body: fixture("git", "upload_packs", upload_pack_fixture),
-              headers: {
-                "content-type" => "application/x-git-upload-pack-advertisement"
-              }
-            )
         end
 
         context "when not included in a release" do

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -180,48 +180,39 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
 
         before do
           allow(builder)
-            .to receive(:fetch_dependency_tags)
-            .and_return(
-              %w(
-                @pollyjs/utils@0.1.0
-                @pollyjs/persister@0.2.0
-                @pollyjs/persister@0.1.0
-                @pollyjs/node-server@0.2.0
-                @pollyjs/node-server@0.1.0
-                @pollyjs/node-server@0.0.2
-                @pollyjs/node-server@0.0.1
-                @pollyjs/ember-cli@0.2.1
-                @pollyjs/ember-cli@0.2.0
-                @pollyjs/ember-cli@0.1.0
-                @pollyjs/ember-cli@0.0.2
-                @pollyjs/ember-cli@0.0.1
-                @pollyjs/ember@0.2.1
-                @pollyjs/ember@0.2.0
-                @pollyjs/ember@0.1.0
-                @pollyjs/ember@0.0.2
-                @pollyjs/ember@0.0.1
-                @pollyjs/core@0.3.0
-                @pollyjs/core@0.2.0
-                @pollyjs/core@0.1.0
-                @pollyjs/core@0.0.2
-                @pollyjs/core@0.0.1
-                @pollyjs/cli@0.1.1
-                @pollyjs/cli@0.1.0
-                @pollyjs/cli@0.0.2
-                @pollyjs/cli@0.0.1
-                @pollyjs/adapter@0.3.0
-                @pollyjs/adapter@0.2.0
-                @pollyjs/adapter@0.1.0
-                @pollyjs/adapter@0.0.2
-                @pollyjs/adapter@0.0.1
-              )
-            )
-        end
-
-        before do
-          allow(builder)
-            .to receive(:reliable_source_directory?)
-            .and_return(true)
+            .to receive_messages(fetch_dependency_tags: %w(
+              @pollyjs/utils@0.1.0
+              @pollyjs/persister@0.2.0
+              @pollyjs/persister@0.1.0
+              @pollyjs/node-server@0.2.0
+              @pollyjs/node-server@0.1.0
+              @pollyjs/node-server@0.0.2
+              @pollyjs/node-server@0.0.1
+              @pollyjs/ember-cli@0.2.1
+              @pollyjs/ember-cli@0.2.0
+              @pollyjs/ember-cli@0.1.0
+              @pollyjs/ember-cli@0.0.2
+              @pollyjs/ember-cli@0.0.1
+              @pollyjs/ember@0.2.1
+              @pollyjs/ember@0.2.0
+              @pollyjs/ember@0.1.0
+              @pollyjs/ember@0.0.2
+              @pollyjs/ember@0.0.1
+              @pollyjs/core@0.3.0
+              @pollyjs/core@0.2.0
+              @pollyjs/core@0.1.0
+              @pollyjs/core@0.0.2
+              @pollyjs/core@0.0.1
+              @pollyjs/cli@0.1.1
+              @pollyjs/cli@0.1.0
+              @pollyjs/cli@0.0.2
+              @pollyjs/cli@0.0.1
+              @pollyjs/adapter@0.3.0
+              @pollyjs/adapter@0.2.0
+              @pollyjs/adapter@0.1.0
+              @pollyjs/adapter@0.0.2
+              @pollyjs/adapter@0.0.1
+            ), reliable_source_directory?: true)
         end
 
         it do
@@ -935,30 +926,18 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
 
           before do
             allow(builder)
-              .to receive(:fetch_dependency_tags)
-              .and_return(
-                %w(
-                  @pollyjs/ember-cli@0.2.1
-                  @pollyjs/ember-cli@0.2.0
-                  @pollyjs/ember-cli@0.1.0
-                  @pollyjs/ember-cli@0.0.2
-                  @pollyjs/ember-cli@0.0.1
-                  @pollyjs/ember@0.2.1
-                  @pollyjs/ember@0.2.0
-                  @pollyjs/ember@0.1.0
-                  @pollyjs/ember@0.0.2
-                  @pollyjs/ember@0.0.1
-                )
-              )
-          end
-
-          before do
-            allow(builder)
-              .to receive(:reliable_source_directory?)
-              .and_return(true)
-          end
-
-          before do
+              .to receive_messages(fetch_dependency_tags: %w(
+                @pollyjs/ember-cli@0.2.1
+                @pollyjs/ember-cli@0.2.0
+                @pollyjs/ember-cli@0.1.0
+                @pollyjs/ember-cli@0.0.2
+                @pollyjs/ember-cli@0.0.1
+                @pollyjs/ember@0.2.1
+                @pollyjs/ember@0.2.0
+                @pollyjs/ember@0.1.0
+                @pollyjs/ember@0.0.2
+                @pollyjs/ember@0.0.1
+              ), reliable_source_directory?: true)
             stub_request(
               :get,
               "https://api.github.com/repos/netflix/pollyjs/commits?" \

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -332,9 +332,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
-      before { `composer clear-cache --quiet` }
-
       before do
+        `composer clear-cache --quiet`
         url = "https://php.fury.io/dependabot-throwaway/packages.json"
         stub_request(:get, url)
           .to_return(status: 200, body: fixture("gemfury_response.json"))

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -141,9 +141,6 @@ RSpec.describe Dependabot::Docker::FileParser do
 
         stub_request(:head, repo_url + "manifests/12.04.5")
           .and_return(status: 200, body: "", headers: digest_headers)
-      end
-
-      before do
         auth_url = "https://auth.docker.io/token?service=registry.docker.io"
         stub_request(:get, auth_url)
           .and_return(status: 200, body: { token: "token" }.to_json)
@@ -248,9 +245,8 @@ RSpec.describe Dependabot::Docker::FileParser do
           fixture("docker", "registry_tags", "small_ubuntu.json")
         end
 
-        before { digest_headers["docker_content_digest"] = "nomatch" }
-
         before do
+          digest_headers["docker_content_digest"] = "nomatch"
           ubuntu_url = "https://registry.hub.docker.com/v2/library/ubuntu/"
           stub_request(:head, /#{Regexp.quote(ubuntu_url)}manifests/)
             .and_return(status: 200, body: "", headers: digest_headers)
@@ -797,9 +793,8 @@ RSpec.describe Dependabot::Docker::FileParser do
           fixture("docker", "registry_tags", "small_ubuntu.json")
         end
 
-        before { digest_headers["docker_content_digest"] = "nomatch" }
-
         before do
+          digest_headers["docker_content_digest"] = "nomatch"
           ubuntu_url = "https://registry.hub.docker.com/v2/library/ubuntu/"
           stub_request(:head, /#{Regexp.quote(ubuntu_url)}manifests/)
             .and_return(status: 200, body: "", headers: digest_headers)

--- a/elm/spec/dependabot/elm/file_fetcher_spec.rb
+++ b/elm/spec/dependabot/elm/file_fetcher_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Dependabot::Elm::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
     stub_request(:get, url + "?ref=sha")
       .with(headers: { "Authorization" => "token token" })
       .to_return(

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  after { FileUtils.rm_rf(repo_contents_path) }
-
   after do
     FileUtils.rm_rf(repo_contents_path)
   end

--- a/gradle/spec/dependabot/gradle/update_checker/multi_dependency_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/multi_dependency_updater_spec.rb
@@ -97,9 +97,6 @@ RSpec.describe namespace::MultiDependencyUpdater do
         status: 200,
         body: fixture("maven_central_metadata", "with_release.xml")
       )
-  end
-
-  before do
     stub_request(:get, jcenter_metadata_url_protoc)
       .to_return(
         status: 200,

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -29,9 +29,8 @@ RSpec.describe Dependabot::Hex::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
     stub_request(:get, url + "?ref=sha")
       .with(headers: { "Authorization" => "token token" })
       .to_return(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -192,9 +192,11 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
     end
 
     context "when the npm link 404s" do
-      before { stub_request(:get, npm_url).to_return(status: 404) }
-      before { stub_request(:get, npm_url + "/latest").to_return(status: 404) }
-      before { stub_request(:get, npm_url + "/latest").to_return(status: 404) }
+      before do
+        stub_request(:get, npm_url).to_return(status: 404)
+        stub_request(:get, npm_url + "/latest").to_return(status: 404)
+        stub_request(:get, npm_url + "/latest").to_return(status: 404)
+      end
 
       let(:npm_latest_version_response) { nil }
       let(:npm_all_versions_response) { fixture("npm_responses", "etag.json") }

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
 
   it_behaves_like "a dependency file fetcher"
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
   before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
     stub_request(:get, File.join(url, ".config?ref=sha"))

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
 
   before do
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
-    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
     stub_request(:get, File.join(url, ".config?ref=sha"))
       .with(headers: { "Authorization" => "token token" })

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -292,9 +292,6 @@ RSpec.describe Dependabot::Python::FileFetcher do
             body: fixture("github", "contents_python_pipfile.json"),
             headers: { "content-type" => "application/json" }
           )
-      end
-
-      before do
         stub_request(:get, url + "Pipfile.lock?ref=sha")
           .with(headers: { "Authorization" => "token token" })
           .to_return(


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/1.10.0/RuboCop/Cop/RSpec/ScatteredSetup

### What are you trying to accomplish?

The ScatteredSetup Rubocop rule has been disabled for some tests.  This PR enables the rule for all of the ecosystem

### Anything you want to highlight for special attention from reviewers?

Autocorrect may create some funky syntax.  Please be alert for such changes.

### How will you know you've accomplished your goal?

The setup for the tests should be much cleaner.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
