### PR TITLE
Add `#directory` to Dependabot::Dependency

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -165,6 +165,7 @@ module Dependabot
         "requirements" => requirements,
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,
+        "directory" => directory,
         "package_manager" => package_manager,
         "subdependency_metadata" => subdependency_metadata,
         "removed" => removed? ? true : nil

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -79,6 +79,9 @@ module Dependabot
     sig { returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
     attr_reader :previous_requirements
 
+    sig { returns(T.nilable(String)) }
+    attr_accessor :directory
+
     sig { returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
     attr_reader :subdependency_metadata
 
@@ -96,13 +99,14 @@ module Dependabot
         version: T.nilable(T.any(String, Dependabot::Version)),
         previous_version: T.nilable(String),
         previous_requirements: T.nilable(T::Array[T::Hash[T.any(Symbol, String), T.untyped]]),
+        directory: T.nilable(String),
         subdependency_metadata: T.nilable(T::Array[T::Hash[T.any(Symbol, String), String]]),
         removed: T::Boolean,
         metadata: T.nilable(T::Hash[T.any(Symbol, String), String])
       ).void
     end
     def initialize(name:, requirements:, package_manager:, version: nil,
-                   previous_version: nil, previous_requirements: nil,
+                   previous_version: nil, previous_requirements: nil, directory: nil,
                    subdependency_metadata: [], removed: false, metadata: {})
       @name = name
       @version = T.let(
@@ -121,6 +125,7 @@ module Dependabot
         T.nilable(T::Array[T::Hash[Symbol, T.untyped]])
       )
       @package_manager = package_manager
+      @directory = directory
       unless top_level? || subdependency_metadata == []
         @subdependency_metadata = T.let(
           subdependency_metadata&.map { |h| symbolize_keys(h) },

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -239,6 +239,27 @@ RSpec.describe Dependabot::Dependency do
         expect(to_h).to eq(expected)
       end
     end
+
+    context "when a directory is specified" do
+      let(:dependency_args) do
+        {
+          name: "dep",
+          requirements: [],
+          package_manager: "dummy",
+          directory: "/home"
+        }
+      end
+
+      it do
+        expected = {
+          "name" => "dep",
+          "package_manager" => "dummy",
+          "requirements" => [],
+          "directory" => "/home"
+        }
+        expect(to_h).to eq(expected)
+      end
+    end
   end
 
   describe "#subdependency_metadata" do


### PR DESCRIPTION
### What are you trying to accomplish?

This is a concept which has been deemed to be missing. The effect of this is that when a pull request exists for a group, without there being knowledge of a directory, individual pull requests are then created. By adding `#directory` to Dependabot::Dependency, we'll be able to prevent this.

We'll need to start setting `#directory` in future changes. By leaving it in its current state, it will be available to the updater (for said future changes), and to consumers of the library.

### Anything you want to highlight for special attention from reviewers?

While this change adds an `attr_accessor`, `#directory` is not being written or read anywhere yet.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
