### PR TITLE
DependencyGroupChangeBatch tracks updated dependencies per file

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "dependabot/errors"
+require "dependabot/pull_request_creator/message_builder"
 
 # This class describes a change to the project's Dependencies which has been
 # determined by a Dependabot operation.

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -129,7 +129,6 @@ module Dependabot
       updated_dependencies.map { |x| x.name.downcase }.uniq.sort != T.must(job.dependencies).map(&:downcase).uniq.sort
     end
 
-    # Now that updated_dependency_files can store the updated_dependencies too, we need to make sure they don't get lost
     sig { params(dependency_changes: T::Array[DependencyChange]).void }
     def merge_changes!(dependency_changes)
       dependency_changes.each do |dependency_change|
@@ -175,7 +174,7 @@ module Dependabot
 
     private
 
-    # FIXME: this needs to be updated to also consider the directory once it's in teh existing-group-pull-requests repsonse
+    # FIXME: this needs to be updated to also consider the directory once it's in existing-group-pull-requests
     sig { returns(T::Set[T::Hash[String, T.any(String, T::Boolean)]]) }
     def updated_dependencies_set
       Set.new(

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -174,7 +174,6 @@ module Dependabot
 
     private
 
-    # FIXME: this needs to be updated to also consider the directory once it's in existing-group-pull-requests
     sig { returns(T::Set[T::Hash[String, T.any(String, T::Boolean)]]) }
     def updated_dependencies_set
       Set.new(

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -129,6 +129,7 @@ module Dependabot
       updated_dependencies.map { |x| x.name.downcase }.uniq.sort != T.must(job.dependencies).map(&:downcase).uniq.sort
     end
 
+    # Now that updated_dependency_files can store the updated_dependencies too, we need to make sure they don't get lost
     sig { params(dependency_changes: T::Array[DependencyChange]).void }
     def merge_changes!(dependency_changes)
       dependency_changes.each do |dependency_change|
@@ -174,6 +175,7 @@ module Dependabot
 
     private
 
+    # FIXME: this needs to be updated to also consider the directory once it's in teh existing-group-pull-requests repsonse
     sig { returns(T::Set[T::Hash[String, T.any(String, T::Boolean)]]) }
     def updated_dependencies_set
       Set.new(

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -120,7 +120,7 @@ module Dependabot
                          0
                        end
 
-        updated_dependencies_list = batch[file.path][updated_dependencies] + updated_dependencies
+        updated_dependencies_list = batch[file.path][updated_dependencies].concat(updated_dependencies)
         batch[file.path] =
           { file: file, updated_dependencies: updated_dependencies_list, changed: true, changes: change_count + 1 }
       end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -104,9 +104,9 @@ module Dependabot
       def merge_file_and_dependency_changes(updated_dependencies, updated_dependency_files)
         updated_dependency_files.each do |updated_file|
           if updated_file.vendored_file?
-            merge_file_to_batch(updated_file, @vendored_dependency_batch, updated_dependencies)
+            merge_file_and_dependency_changes_to_batch(updated_file, @vendored_dependency_batch, updated_dependencies)
           else
-            merge_file_to_batch(updated_file, @dependency_file_batch, updated_dependencies)
+            merge_file_and_dependency_changes_to_batch(updated_file, @dependency_file_batch, updated_dependencies)
           end
         end
       end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -100,8 +100,12 @@ module Dependabot
                          0
                        end
 
-        # We explicitly keep updated_dependencies as an empty list if the :dependency_has_directory ff is not enabled
-        batch[file.path] = { file: file, updated_dependencies: [], changed: true, changes: change_count + 1 }
+        batch[file.path] = {
+          file: file,
+          updated_dependencies: batch[file.path][:updated_dependencies] || [],
+          changed: true,
+          changes: change_count + 1
+        }
       end
 
       def merge_file_and_dependency_changes(updated_dependencies, updated_dependency_files)

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -46,6 +46,10 @@ module Dependabot
 
       def merge(dependency_change)
         if Dependabot::Experiments.enabled?(:dependency_has_directory)
+          # FIXME: we shouldn't have to rely on this but because CreateGroupUpdatePullRequest explicitly checks
+          # the DependencyChange.updated_dependencies, we need to add the updated dependencies to the global list
+          merge_dependency_changes(dependency_change.updated_dependencies)
+
           merge_file_and_dependency_changes(
             dependency_change.updated_dependencies,
             dependency_change.updated_dependency_files
@@ -122,6 +126,7 @@ module Dependabot
 
         previous_updated_dependencies = batch[file.path][updated_dependencies] || []
         updated_dependencies_list = previous_updated_dependencies.concat(updated_dependencies)
+
         batch[file.path] =
           { file: file, updated_dependencies: updated_dependencies_list, changed: true, changes: change_count + 1 }
       end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -97,7 +97,8 @@ module Dependabot
                          0
                        end
 
-        batch[file.path] = { file: file, changed: true, changes: change_count + 1 }
+        # We explicitly keep updated_dependencies as an empty list if the :dependency_has_directory ff is not enabled
+        batch[file.path] = { file: file, updated_dependencies: [], changed: true, changes: change_count + 1 }
       end
 
       def merge_file_and_dependency_changes(updated_dependencies, updated_dependency_files)

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -47,7 +47,7 @@ module Dependabot
       def merge(dependency_change)
         if Dependabot::Experiments.enabled?(:dependency_has_directory)
           merge_file_and_dependency_changes(
-            dependency_change.updated_dependencies, 
+            dependency_change.updated_dependencies,
             dependency_change.updated_dependency_files
           )
         else
@@ -121,7 +121,8 @@ module Dependabot
                        end
 
         updated_dependencies_list = batch[file.path][updated_dependencies] + updated_dependencies
-        batch[file.path] = { file: file, updated_dependencies: updated_dependencies_list, changed: true, changes: change_count + 1 }
+        batch[file.path] =
+          { file: file, updated_dependencies: updated_dependencies_list, changed: true, changes: change_count + 1 }
       end
 
       def debug_updated_dependencies

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -123,7 +123,7 @@ module Dependabot
                          0
                        end
 
-        previous_updated_dependencies = batch[file.path][updated_dependencies] || []
+        previous_updated_dependencies = batch[file.path][:updated_dependencies] || []
         updated_dependencies_list = previous_updated_dependencies.concat(updated_dependencies)
 
         batch[file.path] =

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -45,17 +45,16 @@ module Dependabot
       end
 
       def merge(dependency_change)
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          # FIXME: we shouldn't have to rely on this but because CreateGroupUpdatePullRequest explicitly checks
-          # the DependencyChange.updated_dependencies, we need to add the updated dependencies to the global list
-          merge_dependency_changes(dependency_change.updated_dependencies)
+        # FIXME: we shouldn't have to rely on this but because CreateGroupUpdatePullRequest explicitly checks
+        # the DependencyChange.updated_dependencies, we need to add the updated dependencies to the global list
+        merge_dependency_changes(dependency_change.updated_dependencies)
 
+        if Dependabot::Experiments.enabled?(:dependency_has_directory)
           merge_file_and_dependency_changes(
             dependency_change.updated_dependencies,
             dependency_change.updated_dependency_files
           )
         else
-          merge_dependency_changes(dependency_change.updated_dependencies)
           merge_file_changes(dependency_change.updated_dependency_files)
         end
 

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -120,7 +120,8 @@ module Dependabot
                          0
                        end
 
-        updated_dependencies_list = batch[file.path][updated_dependencies].concat(updated_dependencies)
+        previous_updated_dependencies = batch[file.path][updated_dependencies] || []
+        updated_dependencies_list = previous_updated_dependencies.concat(updated_dependencies)
         batch[file.path] =
           { file: file, updated_dependencies: updated_dependencies_list, changed: true, changes: change_count + 1 }
       end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -102,7 +102,7 @@ module Dependabot
 
         batch[file.path] = {
           file: file,
-          updated_dependencies: batch[file.path][:updated_dependencies] || [],
+          updated_dependencies: batch.dig(file.path, :updated_dependencies) || [],
           changed: true,
           changes: change_count + 1
         }

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -89,12 +89,6 @@ module Dependabot
         sig { returns(Dependabot::DependencyGroup) }
         attr_reader :group
 
-        # FIXME:
-        # - every time the directory changes we lose track of the updated_dependencies from the previous directory
-        # for a grouped udpate
-        # - we want to list the updated dependencies under each updated_dependency_file. We will have to keep the current list
-        # of updated dependencies for backwards compatibility for now. We lose the list of updated dependencies for each directory
-        # after the dependency_change.merge_changes! call.
         sig { returns(T.nilable(Dependabot::DependencyChange)) }
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -89,6 +89,12 @@ module Dependabot
         sig { returns(Dependabot::DependencyGroup) }
         attr_reader :group
 
+        # FIXME:
+        # - every time the directory changes we lose track of the updated_dependencies from the previous directory
+        # for a grouped udpate
+        # - we want to list the updated dependencies under each updated_dependency_file. We will have to keep the current list
+        # of updated dependencies for backwards compatibility for now. We lose the list of updated dependencies for each directory
+        # after the dependency_change.merge_changes! call.
         sig { returns(T.nilable(Dependabot::DependencyChange)) }
         def dependency_change
           return @dependency_change if defined?(@dependency_change)

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -126,10 +126,10 @@ module Dependabot
           end
 
           groups_without_pr.each do |group|
-            result = run_update_for(group)
-            if result
+            grouped_update_result = run_grouped_update_for(group)
+            if grouped_update_result
               # Add the actual updated dependencies to the handled list so they don't get updated individually.
-              dependency_snapshot.add_handled_dependencies(result.updated_dependencies.map(&:name))
+              dependency_snapshot.add_handled_dependencies(grouped_update_result.updated_dependencies.map(&:name))
             else
               # The update failed, add the suspected dependencies to the handled list so they don't update individually.
               dependency_snapshot.add_handled_dependencies(group.dependencies.map(&:name))
@@ -138,7 +138,7 @@ module Dependabot
         end
 
         sig { params(group: Dependabot::DependencyGroup).returns(T.nilable(Dependabot::DependencyChange)) }
-        def run_update_for(group)
+        def run_grouped_update_for(group)
           Dependabot::Updater::Operations::CreateGroupUpdatePullRequest.new(
             service: service,
             job: job,

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -69,56 +69,61 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
           job: job,
           updated_dependency_files: updated_dependency_files,
           updated_dependencies: updated_dependencies,
-          dependency_group: group,
+          dependency_group: group
         )
       end
 
       let(:updated_dependency_files) do
         [
-          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-updated-gemfile", directory: "/"),
-          Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-updated-gemfile-lock", directory: "/hello/.."),
-          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-updated-package-json", directory: "/elsewhere"),
-          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown"),
-          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob")
+          Dependabot::DependencyFile.new(
+            name: "Gemfile", content: "mock-updated-gemfile", directory: "/"
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Gemfile.lock", content: "mock-updated-gemfile-lock", directory: "/hello/.."
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Gemfile", content: "mock-updated-package-json", directory: "/elsewhere"
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Gemfile", content: "mock-package-json", directory: "unknown"
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Gemfile", content: "mock-package-json", directory: "../../oob"
+          )
         ]
       end
 
-      let(:test_dependency1) do
-        Dependabot::Dependency.new(
-          name: "test-dependency-1",
-          package_manager: "bundler",
-          version: "1.1.0",
-          requirements: [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.1.0",
-              groups: ["test"],
-              source: nil
-            }
-          ],
-          directory: "/"
-        )
-      end
-
-      let(:test_dependency2) do
-        Dependabot::Dependency.new(
-          name: "test-dependency-2",
-          package_manager: "bundler",
-          version: "1.1.0",
-          requirements: [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.1.0",
-              groups: ["test"],
-              source: nil
-            }
-          ],
-          directory: "/hello/.."
-        )
-      end
-
       let(:updated_dependencies) do
-        [test_dependency1, test_dependency2]
+        [
+          Dependabot::Dependency.new(
+            name: "test-dependency-1",
+            package_manager: "bundler",
+            version: "1.1.0",
+            requirements: [
+              {
+                file: "Gemfile",
+                requirement: "~> 1.1.0",
+                groups: ["test"],
+                source: nil
+              }
+            ],
+            directory: "/"
+          ),
+          Dependabot::Dependency.new(
+            name: "test-dependency-2",
+            package_manager: "bundler",
+            version: "1.1.0",
+            requirements: [
+              {
+                file: "Gemfile",
+                requirement: "~> 1.1.0",
+                groups: ["test"],
+                source: nil
+              }
+            ],
+            directory: "/hello/.."
+          )
+        ]
       end
 
       let(:group) do
@@ -143,10 +148,9 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
         # Eventually this should be narrowed down so that only the files that were modified
         # by the newly merged dependency_change have their updated_dependencies updated.
         dependency_file_batch = batch.instance_variable_get(:@dependency_file_batch)
-        expect(dependency_file_batch["/Gemfile"][:updated_dependencies]).to include(test_dependency1)
-        expect(dependency_file_batch["/Gemfile"][:updated_dependencies]).to include(test_dependency2)
-        expect(dependency_file_batch["/Gemfile.lock"][:updated_dependencies]).to include(test_dependency1)
-        expect(dependency_file_batch["/Gemfile.lock"][:updated_dependencies]).to include(test_dependency2)
+        expect(dependency_file_batch["/Gemfile"][:updated_dependencies]).to eq(updated_dependencies)
+        expect(dependency_file_batch["/Gemfile.lock"][:updated_dependencies]).to eq(updated_dependencies)
+        expect(dependency_file_batch["/unknown/Gemfile"][:updated_dependencies]).to eq(updated_dependencies)
       end
     end
   end

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -54,5 +54,100 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
           .current_dependency_files(job).map(&:name)).to eq(%w(Gemfile Gemfile.lock))
       end
     end
+
+    context "when the :dependency_has_directory ff is enabled" do
+      before do
+        Dependabot::Experiments.register(:dependency_has_directory, true)
+      end
+
+      after do
+        Dependabot::Experiments.reset!
+      end
+
+      let(:dependency_change) do
+        Dependabot::DependencyChange.new(
+          job: job,
+          updated_dependency_files: updated_dependency_files,
+          updated_dependencies: updated_dependencies,
+          dependency_group: group,
+        )
+      end
+
+      let(:updated_dependency_files) do
+        [
+          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-updated-gemfile", directory: "/"),
+          Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "mock-updated-gemfile-lock", directory: "/hello/.."),
+          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-updated-package-json", directory: "/elsewhere"),
+          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "unknown"),
+          Dependabot::DependencyFile.new(name: "Gemfile", content: "mock-package-json", directory: "../../oob")
+        ]
+      end
+
+      let(:test_dependency1) do
+        Dependabot::Dependency.new(
+          name: "test-dependency-1",
+          package_manager: "bundler",
+          version: "1.1.0",
+          requirements: [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.1.0",
+              groups: ["test"],
+              source: nil
+            }
+          ],
+          directory: "/"
+        )
+      end
+
+      let(:test_dependency2) do
+        Dependabot::Dependency.new(
+          name: "test-dependency-2",
+          package_manager: "bundler",
+          version: "1.1.0",
+          requirements: [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.1.0",
+              groups: ["test"],
+              source: nil
+            }
+          ],
+          directory: "/hello/.."
+        )
+      end
+
+      let(:updated_dependencies) do
+        [test_dependency1, test_dependency2]
+      end
+
+      let(:group) do
+        Dependabot::DependencyGroup.new(
+          name: "test",
+          rules: { patterns: ["test-*"] }
+        )
+      end
+
+      it "still tracks the updated_dependencies in the global list" do
+        batch = described_class.new(initial_dependency_files: files)
+        batch.merge(dependency_change)
+
+        expect(batch.updated_dependencies).to eq(updated_dependencies)
+      end
+
+      it "tracks the updated dependencies in the appropriate updated_dependency_files" do
+        batch = described_class.new(initial_dependency_files: files)
+        batch.merge(dependency_change)
+
+        # FIXME: All of the files in the dependency_file_batch will contain a copy of the updated dependencies.
+        # Eventually this should be narrowed down so that only the files that were modified
+        # by the newly merged dependency_change have their updated_dependencies updated.
+        dependency_file_batch = batch.instance_variable_get(:@dependency_file_batch)
+        expect(dependency_file_batch["/Gemfile"][:updated_dependencies]).to include(test_dependency1)
+        expect(dependency_file_batch["/Gemfile"][:updated_dependencies]).to include(test_dependency2)
+        expect(dependency_file_batch["/Gemfile.lock"][:updated_dependencies]).to include(test_dependency1)
+        expect(dependency_file_batch["/Gemfile.lock"][:updated_dependencies]).to include(test_dependency2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Requires https://github.com/dependabot/dependabot-core/pull/9982

Now that a `Dependabot::Dependency` can have a directory, we should use it to track which dependencies are updated in each `updated_dependency_file` in a `DependencyGroupChangeBatch`. This will allow us to keep track of every dependency update across every file.

A `DependencyGroupChangeBatch` is used to hold and consolidate the `DependencyChanges` when [updating a group](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/updater/group_update_creation.rb#L50). For a multi-directory PR, the `DependencyGroupChangeBatch` represents updating a group across every directory. 

Prior to this change, the `DependencyGroupChangeBatch` would overwrite the `updated_dependencies` from the previous directory. This meant that if a dependency was updated in both, we would only keep the changes from the later update.

By tracking dependencies per file, we ensure we keep track of every dependency update across every file and don't miss any updates for a group.

### Anything you want to highlight for special attention from reviewers?

This PR makes use of the feature flag `:dependency_has_directory` which is passed in to the job definition from the API

### How will you know you've accomplished your goal?

This PR only adds `updated_dependencies` to the `updated_dependency_files` but it is not yet used.

A follow up PR that switches the DependencyGroupChangeBatch over to reading from the `updated_dependency_file[updated_dependencies]` field would affect PR creation and will be implemented in a follow-up. For now this PR should have no effect, even when the feature flag is toggled.

We have a test repo where we can compare the changes of this PR before and after toggling the feature flag to confirm.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
