### PR TITLE
Set Dependency#directory when parsing files

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -67,6 +67,7 @@ module Dependabot
                   source: dep.fetch("source")&.transform_keys(&:to_sym),
                   file: file.name
                 }],
+                directory: source&.directory,
                 package_manager: "bundler"
               )
           end
@@ -102,6 +103,7 @@ module Dependabot
                   source: dependency.fetch("source")&.transform_keys(&:to_sym),
                   file: gemspec.name
                 }],
+                directory: source&.directory,
                 package_manager: "bundler"
               )
             end
@@ -129,6 +131,7 @@ module Dependabot
               name: dependency.name,
               version: dependency_version(dependency.name)&.to_s,
               requirements: [],
+              directory: source&.directory,
               package_manager: "bundler",
               subdependency_metadata: [{
                 production: production_dep_names.include?(dependency.name)

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -111,7 +111,8 @@ module Dependabot
             file: file.name,
             groups: [type],
             source: source_from_declaration(requirement)
-          }]
+          }],
+          directory: source&.directory,
         )
       end
 

--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -75,6 +75,7 @@ module Dependabot
             ),
             groups: [keys[:group]]
           }],
+          directory: source&.directory,
           package_manager: "composer"
         )
       end
@@ -112,6 +113,7 @@ module Dependabot
           name: name,
           version: version,
           requirements: [],
+          directory: source&.directory,
           package_manager: "composer",
           subdependency_metadata: [{
             production: keys.fetch(:group) != "development"

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -65,7 +65,8 @@ module Dependabot
                 groups: [],
                 file: dockerfile.name,
                 source: source_from(parsed_from_line)
-              ]
+              ],
+              directory: source&.directory,
             )
           end
         end

--- a/elm/lib/dependabot/elm/file_parser.rb
+++ b/elm/lib/dependabot/elm/file_parser.rb
@@ -69,6 +69,7 @@ module Dependabot
           name: name,
           version: version_for(requirement)&.to_s,
           requirements: direct ? requirements : [],
+          directory: source&.directory,
           package_manager: "elm"
         )
       end

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -73,6 +73,7 @@ module Dependabot
           name: details["Path"],
           version: version,
           requirements: details["Indirect"] ? [] : reqs,
+          directory: source&.directory,
           package_manager: "go_modules"
         )
       end

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -292,6 +292,7 @@ module Dependabot
             groups: groups,
             metadata: dependency_metadata(details_hash, in_dependency_set)
           }],
+          directory: source&.directory,
           package_manager: "gradle"
         )
       end

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -34,6 +34,7 @@ module Dependabot
                 source: dep["source"] && symbolize_keys(dep["source"]),
                 file: dep["from"]
               }],
+              directory: source&.directory,
               package_manager: "hex"
             )
         end

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -123,7 +123,8 @@ module Dependabot
               packaging_type: packaging_type(pom, dependency_node),
               classifier: dependency_classifier(dependency_node, pom)
             }.merge(property_details).compact
-          }]
+          }],
+          directory: source&.directory,
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -160,7 +160,8 @@ module Dependabot
             file: file.name,
             groups: [type],
             source: source_for(name, requirement, lockfile_details)
-          }]
+          }],
+          directory: source&.directory,
         )
       end
 

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -257,6 +257,7 @@ module Dependabot
           name: json["name"],
           version: json["version"],
           package_manager: "pub",
+          directory: source&.directory,
           requirements: []
         }
 

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -99,7 +99,8 @@ module Dependabot
               name: normalised_name(name, dep["extras"]),
               version: version&.include?("*") ? nil : version,
               requirements: requirements,
-              package_manager: "pip"
+              package_manager: "pip",
+              directory: source&.directory,
             )
         end
         dependencies

--- a/silent/lib/dependabot/silent/file_parser.rb
+++ b/silent/lib/dependabot/silent/file_parser.rb
@@ -34,6 +34,7 @@ module SilentPackageManager
         name: name,
         version: info["version"],
         package_manager: "silent",
+        directory: source&.directory,
         requirements: [{
           requirement: info["version"],
           file: T.must(dependency_files.first).name,

--- a/swift/lib/dependabot/swift/file_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser.rb
@@ -26,6 +26,7 @@ module Dependabot
               version: dep.version,
               package_manager: dep.package_manager,
               requirements: requirements,
+              directory: source&.directory,
               metadata: dep.metadata
             )
           else

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -105,7 +105,8 @@ module Dependabot
             groups: [],
             file: file.name,
             source: source
-          ]
+          ],
+          directory: source&.directory,
         )
       end
 
@@ -130,7 +131,8 @@ module Dependabot
               registry_hostname: hostname,
               module_identifier: "#{namespace}/#{name}"
             }
-          ]
+          ],
+          directory: source&.directory,
         )
       end
 

--- a/updater/spec/support/dummy_package_manager/file_parser.rb
+++ b/updater/spec/support/dummy_package_manager/file_parser.rb
@@ -25,7 +25,8 @@ module DummyPackageManager
               groups: [],
               file: dependency_file.name,
               source: nil
-            ]
+            ],
+            directory: source&.directory,
           )
         end
       end


### PR DESCRIPTION
This doesn't encapsulate all of the file parsers, but all of those which seem straightforward to update. Others (such as Devcontainers and Nuget) build their dependency sets outside the parser which inherits from FileParser::Base. I'll update those in separate commits.

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
