### PR TITLE
Include `directory` when serializing dependencies

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -181,7 +181,7 @@ module Dependabot
           {
             "dependency-name" => dep.name,
             "dependency-version" => dep.version,
-            "directory" => grouped_update? ? dep.directory : nil,
+            "directory" => should_consider_directory? ? dep.directory : nil,
             "dependency-removed" => dep.removed? ? true : nil
           }.compact
         end
@@ -200,6 +200,10 @@ module Dependabot
       return "" if updated_dependency_files.empty?
 
       updated_dependency_files.first.directory
+    end
+
+    def should_consider_directory?
+      grouped_update? && Dependabot::Experiments.enabled?("dependency_has_directory")
     end
   end
 end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -199,9 +199,10 @@ module Dependabot
     def directory
       return "" if updated_dependency_files.empty?
 
-      updated_dependency_files.first.directory
+      T.must(updated_dependency_files.first).directory
     end
 
+    sig { returns(T::Boolean) }
     def should_consider_directory?
       grouped_update? && Dependabot::Experiments.enabled?("dependency_has_directory")
     end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -59,6 +59,7 @@ module Dependabot
       @dependency_group = dependency_group
 
       @pr_message = T.let(nil, T.nilable(Dependabot::PullRequestCreator::Message))
+      ensure_dependencies_have_directories
     end
 
     sig { returns(Dependabot::PullRequestCreator::Message) }
@@ -180,10 +181,25 @@ module Dependabot
           {
             "dependency-name" => dep.name,
             "dependency-version" => dep.version,
+            "directory" => grouped_update? ? dep.directory : nil,
             "dependency-removed" => dep.removed? ? true : nil
           }.compact
         end
       )
+    end
+
+    sig { returns(T::Array[Dependabot::Dependency]) }
+    def ensure_dependencies_have_directories
+      updated_dependencies.each do |dep|
+        dep.directory = directory
+      end
+    end
+
+    sig { returns(String) }
+    def directory
+      return "" if updated_dependency_files.empty?
+
+      updated_dependency_files.first.directory
     end
   end
 end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -269,6 +269,14 @@ RSpec.describe Dependabot::DependencyChange do
   end
 
   describe "#matches_existing_pr?" do
+    before do
+      Dependabot::Experiments.register("dependency_has_directory", true)
+    end
+
+    after do
+      Dependabot::Experiments.reset!
+    end
+
     context "when no existing pull requests are found" do
       let(:job) do
         instance_double(Dependabot::Job,

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Dependabot::Service do
 
     let(:dependency_files) do
       [
-        { name: "Gemfile", content: "some gems" }
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "some gems")
       ]
     end
 
@@ -138,7 +138,7 @@ RSpec.describe Dependabot::Service do
 
     let(:dependency_files) do
       [
-        { name: "Gemfile", content: "some gems" }
+        Dependabot::DependencyFile.new(name: "Gemfile", content: "some gems")
       ]
     end
 

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
 
     before do
       stub_rubygems_calls
+      Dependabot::Experiments.register("dependency_has_directory", true)
+    end
+
+    after do
+      Dependabot::Experiments.reset!
     end
 
     it "updates the existing pull request without errors" do

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
@@ -15,6 +15,7 @@ job:
       dependencies:
         - dependency-name: dummy-pkg-b
           dependency-version: 1.2.0
+          directory: "/"
   updating-a-pull-request: true
   lockfile-only: false
   update-subdependencies: false


### PR DESCRIPTION
### What are you trying to accomplish?

Currently, when Dependabot attempts to do a multi-directory update, it doesn't consider the directory of the dependencies in existing pull requests. This results in ungrouped pull requests being created for the dependencies which are already in a grouped pull request. By considering the directory of existing dependencies, we can avoid this issue.

## Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

I've created a (private) repository which is impacted by the existing behavior. Once this pull request is merged, I'll re-run Dependabot on that repository and confirm that the grouped updates are correctly grouped and single-dependency pull requests are not created.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
