### PR TITLE
Enabling the RSpec BeforeAfterAll Rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,14 +22,6 @@ RSpec/AnyInstance:
     - 'updater/spec/dependabot/dependency_change_builder_spec.rb'
     - 'updater/spec/dependabot/file_fetcher_command_spec.rb'
 
-# Offense count: 7
-RSpec/BeforeAfterAll:
-  Exclude:
-    - 'nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb'
-    - 'pub/spec/dependabot/pub/file_updater_spec.rb'
-    - 'pub/spec/dependabot/pub/infer_sdk_versions_spec.rb'
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
-
 # Offense count: 1286
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -127,12 +127,6 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Max: 30
 
-# Offense count: 500
-# Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
-# SupportedStyles: always, named_only
-RSpec/NamedSubject:
-  Enabled: false
-
 # Offense count: 3871
 # Configuration parameters: AllowedGroups.
 RSpec/NestedGroups:

--- a/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
@@ -1,10 +1,11 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "pathname"
 require "parser/current"
 require "dependabot/bundler/file_fetcher"
 require "dependabot/errors"
+require "sorbet-runtime"
 
 module Dependabot
   module Bundler
@@ -12,32 +13,38 @@ module Dependabot
       # Finds the paths of any Gemfiles declared using `eval_gemfile` in the
       # passed Gemfile.
       class ChildGemfileFinder
+        extend T::Sig
+
+        sig { params(gemfile: Dependabot::DependencyFile).void }
         def initialize(gemfile:)
           @gemfile = gemfile
         end
 
+        sig { returns(T::Array[String]) }
         def child_gemfile_paths
-          ast = Parser::CurrentRuby.parse(gemfile.content)
+          ast = Parser::CurrentRuby.parse(gemfile&.content)
           find_child_gemfile_paths(ast)
         rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+          raise Dependabot::DependencyFileNotParseable, T.must(gemfile&.path)
         end
 
         private
 
+        sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :gemfile
 
+        sig { params(node: T.untyped).returns(T::Array[String]) }
         def find_child_gemfile_paths(node)
           return [] unless node.is_a?(Parser::AST::Node)
 
           if declares_eval_gemfile?(node)
             path_node = node.children[2]
             unless path_node.type == :str
-              path = gemfile.path
+              path = gemfile&.path
               msg = "Dependabot only supports uninterpolated string arguments " \
                     "to eval_gemfile. Got " \
                     "`#{path_node.loc.expression.source}`"
-              raise Dependabot::DependencyFileNotParseable.new(path, msg)
+              raise Dependabot::DependencyFileNotParseable.new(T.must(path), msg)
             end
 
             path = path_node.loc.expression.source.gsub(/['"]/, "")
@@ -50,12 +57,14 @@ module Dependabot
           end
         end
 
+        sig { returns(T.nilable(String)) }
         def current_dir
-          @current_dir ||= gemfile.name.rpartition("/").first
+          @current_dir ||= T.let(gemfile&.name&.rpartition("/")&.first, T.nilable(String))
           @current_dir = nil if @current_dir == ""
           @current_dir
         end
 
+        sig { params(node: Parser::AST::Node).returns(T::Boolean) }
         def declares_eval_gemfile?(node)
           return false unless node.is_a?(Parser::AST::Node)
 

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -960,7 +960,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           end
 
           it "returns an array of commits relevant to the given path" do
-            expect(subject).to contain_exactly({
+            expect(commits).to contain_exactly({
               message: "feat: Custom persister support\n\n" \
                        "* feat: Custom persister support\r\n\r\n" \
                        "* Create a @pollyjs/persister package\r\n" \
@@ -1018,7 +1018,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Added signature for changeset f275e318641f",
             sha: "deae742eacfa985bd20f47a12a8fee6ce2e0447c",
             html_url: "https://bitbucket.org/ged/ruby-pg/commits/" \
@@ -1065,7 +1065,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Merged PR 2: Deleted README.md",
             sha: "9991b4f66def4c0a9ad8f9f27043ece7eddcf1c7",
             html_url: "https://dev.azure.com/fabrikam/SomeGitProject/_git/SampleRepository/commit/" \
@@ -1102,7 +1102,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           end
 
           it "returns an array of commits" do
-            expect(subject).to contain_exactly({
+            expect(commits).to contain_exactly({
               message: "Merged PR 2: Deleted README.md",
               sha: "9991b4f66def4c0a9ad8f9f27043ece7eddcf1c7",
               html_url: "https://dev.azure.com/fabrikam/SomeGitProject/_git/SampleRepository/commit/" \
@@ -1157,7 +1157,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Add find command\n",
             sha: "8d7d08fb9a7a439b3e6a1e6a1a34cbdb4273de87",
             html_url: "https://gitlab.com/org/business/commit/" \

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
@@ -258,8 +258,8 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
       let(:requirement_string) { "^1.0.0 || ^2.0.0" }
 
       it do
-        expect(subject).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
-                                           Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
+        expect(reqs).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
+                                        Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
       end
     end
 
@@ -267,8 +267,8 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
       let(:requirement_string) { "(^1.0.0 || ^2.0.0)" }
 
       it do
-        expect(subject).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
-                                           Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
+        expect(reqs).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
+                                        Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
@@ -137,16 +137,16 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
     subject(:test_subject) { builder.lockfiles }
 
     it do
-      expect(subject).to contain_exactly(project_dependency_file("package-lock.json"),
-                                         project_dependency_file("yarn.lock"))
+      expect(test_subject).to contain_exactly(project_dependency_file("package-lock.json"),
+                                              project_dependency_file("yarn.lock"))
     end
 
     context "with shrinkwraps" do
       let(:project_name) { "npm6/shrinkwrap" }
 
       it do
-        expect(subject).to contain_exactly(project_dependency_file("package-lock.json"),
-                                           project_dependency_file("npm-shrinkwrap.json"))
+        expect(test_subject).to contain_exactly(project_dependency_file("package-lock.json"),
+                                                project_dependency_file("npm-shrinkwrap.json"))
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
   end
 
   # Can get transitive dependencies
+
   describe "#transitive_dependencies", :vcr do
     subject(:transitive_dependencies) { finder.transitive_dependencies }
 
@@ -57,21 +58,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
   context "when the api.nuget.org is not hit due to absence in the NuGet.Config" do
     subject(:transitive_dependencies) { finder.transitive_dependencies }
 
-    let(:dependency_version) { "42.42.42" }
-    let(:nuget_config_body) { fixture("configs", "example.com_nuget.config") }
-    let(:nuget_config) { Dependabot::DependencyFile.new(name: "NuGet.Config", content: nuget_config_body) }
-    let(:dependency_files) { [csproj, nuget_config] }
-
-    def create_nupkg(nuspec_name, nuspec_fixture_path)
-      content = Zip::OutputStream.write_buffer do |zio|
-        zio.put_next_entry("#{nuspec_name}.nuspec")
-        zio.write(fixture("nuspecs", nuspec_fixture_path))
-      end
-      content.rewind
-      content.sysread
-    end
-
-    before(:context) do
+    before do
       disallowed_urls = %w(
         https://api.nuget.org/v3/index.json
         https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.nuspec
@@ -91,6 +78,20 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
       stub_request(:get, "https://api.example.com/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.43.43.43.nupkg")
         .to_return(status: 200, body: create_nupkg("Microsoft.NETCore.Platforms",
                                                    "Microsoft.NETCore.Platforms_43.43.43_faked.nuspec"))
+    end
+
+    let(:dependency_version) { "42.42.42" }
+    let(:nuget_config_body) { fixture("configs", "example.com_nuget.config") }
+    let(:nuget_config) { Dependabot::DependencyFile.new(name: "NuGet.Config", content: nuget_config_body) }
+    let(:dependency_files) { [csproj, nuget_config] }
+
+    def create_nupkg(nuspec_name, nuspec_fixture_path)
+      content = Zip::OutputStream.write_buffer do |zio|
+        zio.put_next_entry("#{nuspec_name}.nuspec")
+        zio.write(fixture("nuspecs", nuspec_fixture_path))
+      end
+      content.rewind
+      content.sysread
     end
 
     # this test doesn't really care about the dependency count, we just need to ensure that `api.nuget.org` wasn't hit

--- a/pub/spec/dependabot/pub/file_updater_spec.rb
+++ b/pub/spec/dependabot/pub/file_updater_spec.rb
@@ -43,28 +43,22 @@ RSpec.describe Dependabot::Pub::FileUpdater do
       package = File.basename(f, ".json")
       @server.unmount "/api/packages/#{package}"
     end
-  end
-
-  before do
-    sample_files.each do |f|
-      package = File.basename(f, ".json")
-      @server.mount_proc "/api/packages/#{package}" do |_req, res|
-        res.body = File.read(File.join("..", "..", "..", f))
-      end
-    end
-  end
-
-  after(:all) do
     @server.shutdown
   end
 
-  before(:all) do
+  before do
     # Because we do the networking in dependency_services we have to run an
     # actual web server.
     dev_null = WEBrick::Log.new("/dev/null", 7)
     @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
     Thread.new do
       @server.start
+    end
+    sample_files.each do |f|
+      package = File.basename(f, ".json")
+      @server.mount_proc "/api/packages/#{package}" do |_req, res|
+        res.body = File.read(File.join("..", "..", "..", f))
+      end
     end
   end
 

--- a/pub/spec/dependabot/pub/infer_sdk_versions_spec.rb
+++ b/pub/spec/dependabot/pub/infer_sdk_versions_spec.rb
@@ -8,7 +8,7 @@ require "dependabot/pub/helpers"
 require "webrick"
 
 RSpec.describe "Helpers" do
-  before(:all) do
+  before do
     # Because we do the networking in infer_sdk_versions we have to run an
     # actual web server.
     dev_null = WEBrick::Log.new("/dev/null", 7)
@@ -16,16 +16,13 @@ RSpec.describe "Helpers" do
     Thread.new do
       @server.start
     end
-  end
-
-  after(:all) do
-    @server.shutdown
-  end
-
-  before do
     @server.mount_proc "/flutter_releases.json" do |_req, res|
       res.body = File.read(File.join(__dir__, "..", "..", "fixtures", "flutter_releases.json"))
     end
+  end
+
+  after do
+    @server.shutdown
   end
 
   let(:inferred_result) do

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -74,9 +74,17 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       package = File.basename(f, ".json")
       @server.unmount "/api/packages/#{package}"
     end
+    @server.shutdown
   end
 
   before do
+    # Because we do the networking in dependency_services we have to run an
+    # actual web server.
+    dev_null = WEBrick::Log.new("/dev/null", 7)
+    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
+    Thread.new do
+      @server.start
+    end
     sample_files.each do |f|
       package = File.basename(f, ".json")
       @server.mount_proc "/api/packages/#{package}" do |_req, res|
@@ -85,20 +93,6 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     end
     @server.mount_proc "/flutter_releases.json" do |_req, res|
       res.body = File.read(File.join(__dir__, "..", "..", "fixtures", "flutter_releases.json"))
-    end
-  end
-
-  after(:all) do
-    @server.shutdown
-  end
-
-  before(:all) do
-    # Because we do the networking in dependency_services we have to run an
-    # actual web server.
-    dev_null = WEBrick::Log.new("/dev/null", 7)
-    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
-    Thread.new do
-      @server.start
     end
   end
 


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/1.15.0/RuboCop/Cop/RSpec/BeforeAfterAll

### What are you trying to accomplish?

The BeforeAfterAll RSpec rule was disabled in some parts of the ecosystme.  This PR will enable and fix those scenarios it identifies.

### Anything you want to highlight for special attention from reviewers?

Please watch for code duplications or conflicts.

### How will you know you've accomplished your goal?

The Rubocop rule will work and the tests will not fai afterwards.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
