### PR TITLE
Fix Docker Requirement initializer type

### DIFF
--- a/docker/lib/dependabot/docker/requirement.rb
+++ b/docker/lib/dependabot/docker/requirement.rb
@@ -27,10 +27,10 @@ module Dependabot
 
       # Patches Gem::Requirement to make it accept requirement strings like
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
-      sig { params(requirements: String).void }
+      sig { params(requirements: T.any(T.nilable(String), T::Array[T.nilable(String)])).void }
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",").map(&:strip)
+          req_string.to_s.split(",").map(&:strip)
         end
 
         super(requirements)

--- a/docker/spec/dependabot/docker/requirement_spec.rb
+++ b/docker/spec/dependabot/docker/requirement_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Dependabot::Docker::Requirement do
 
       it { is_expected.to eq(Gem::Requirement.new("> 20.8.1.alpine3.18", "< 20.9")) }
     end
+
+    context "with a collection of strings" do
+      let(:requirement_string) { [">= 1.0.0", "< 2.0.0"] }
+
+      it { is_expected.to eq(Gem::Requirement.new(">= 1.0.0", "< 2.0.0")) }
+    end
   end
 
   describe "#satisfied_by?" do


### PR DESCRIPTION
### What are you trying to accomplish?

The signature takes a splatted argument, but it's been typed as a String. I'm updating this so that it is compatible with current uses of Docker Requirement in the service 👇 

```plaintext
TypeError:Parameter 'requirements': Expected type String, got type Array with value [">= 2.0.20230809182251.a", "< 2.0.20230809182252"]
Caller: /home/dependabot/.local/share/gem/ruby/gems/sorbet-runtime-0.5.11430/lib/types/private/methods/call_validation.rb:133
Definition: /home/dependabot/.local/share/gem/ruby/gems/dependabot-docker-0.261.0/lib/dependabot/docker/requirement.rb:31 (Dependabot::Docker::Requirement#initialize)
```

### Anything you want to highlight for special attention from reviewers?

No, but I do see that `Requirement.requirement_string` accepts a `T.nilable(String)` and immediately uses `T.must(requirement_string)`. This does not seem to be intentional, but is outside the scope of what I need to do here.

### How will you know you've accomplished your goal?

Sorbet compilation is successful.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
