### PR TITLE
Enabling RSpec IndexedLet Rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,25 +51,6 @@ RSpec/FilePath:
     - 'nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb'
     - 'nuget/spec/dependabot/nuget/update_checker/tfm_finder_spec.rb'
 
-# Offense count: 70
-# Configuration parameters: Max, AllowedIdentifiers, AllowedPatterns.
-RSpec/IndexedLet:
-  Exclude:
-    - 'bundler/spec/dependabot/bundler/helper_spec.rb'
-    - 'cargo/spec/dependabot/cargo/file_parser_spec.rb'
-    - 'common/spec/dependabot/dependency_file_spec.rb'
-    - 'common/spec/dependabot/dependency_group_spec.rb'
-    - 'common/spec/dependabot/dependency_spec.rb'
-    - 'common/spec/dependabot/pull_request_creator/message_builder_spec.rb'
-    - 'github_actions/spec/dependabot/github_actions/update_checker_spec.rb'
-    - 'hex/spec/dependabot/hex/file_parser_spec.rb'
-    - 'hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb'
-    - 'hex/spec/dependabot/hex/file_updater_spec.rb'
-    - 'hex/spec/dependabot/hex/update_checker_spec.rb'
-    - 'npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb'
-    - 'python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb'
-    - 'python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb'
-
 # Offense count: 29
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:lockfile_bundled_with_v1) do
+  let(:first_version_lockfile) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -23,7 +23,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:lockfile_bundled_with_v2) do
+  let(:second_version_lockfile) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -55,11 +55,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(lockfile_bundled_with_v1)).to eql("1")
+      expect(described_method(first_version_lockfile)).to eql("1")
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(lockfile_bundled_with_v2)).to eql("2")
+      expect(described_method(second_version_lockfile)).to eql("2")
     end
 
     it "is 2 if it was bundled with a future version" do
@@ -81,11 +81,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(lockfile_bundled_with_v1)).to eql("1")
+      expect(described_method(first_version_lockfile)).to eql("1")
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(lockfile_bundled_with_v2)).to eql("2")
+      expect(described_method(second_version_lockfile)).to eql("2")
     end
 
     it "reports the version if it was bundled with a future version" do

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:first_version_lockfile) do
+  let(:lockfile_bundle_with_version_one) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -23,7 +23,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:second_version_lockfile) do
+  let(:lockfile_bundle_with_version_two) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -55,11 +55,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(first_version_lockfile)).to eql("1")
+      expect(described_method(lockfile_bundle_with_version_one)).to eql("1")
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(second_version_lockfile)).to eql("2")
+      expect(described_method(lockfile_bundle_with_version_two)).to eql("2")
     end
 
     it "is 2 if it was bundled with a future version" do
@@ -81,11 +81,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(first_version_lockfile)).to eql("1")
+      expect(described_method(lockfile_bundle_with_version_one)).to eql("1")
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(second_version_lockfile)).to eql("2")
+      expect(described_method(lockfile_bundle_with_version_two)).to eql("2")
     end
 
     it "reports the version if it was bundled with a future version" do

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -281,8 +281,8 @@ RSpec.describe Dependabot::Cargo::FileParser do
               manifest,
               lockfile,
               workspace_child,
-              workspace_child2,
-              workspace_child3
+              second_workspace_child,
+              third_workspace_child
             ]
           end
           let(:workspace_child) do
@@ -291,19 +291,19 @@ RSpec.describe Dependabot::Cargo::FileParser do
               content: fixture("manifests", "workspace_child")
             )
           end
-          let(:workspace_child2) do
+          let(:second_workspace_child) do
             Dependabot::DependencyFile.new(
               name: "src/sub_crate2/Cargo.toml",
-              content: workspace_child2_body
+              content: second_workspace_child_body
             )
           end
-          let(:workspace_child3) do
+          let(:third_workspace_child) do
             Dependabot::DependencyFile.new(
               name: "src/sub_crate3/Cargo.toml",
-              content: workspace_child2_body
+              content: second_workspace_child_body
             )
           end
-          let(:workspace_child2_body) do
+          let(:second_workspace_child_body) do
             fixture("manifests", "workspace_child_with_path_dependency")
           end
 

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -288,35 +288,35 @@ RSpec.describe Dependabot::DependencyFile do
 
   describe "#==" do
     context "when two dependency files are equal" do
-      let(:file1) { described_class.new(name: "Gemfile", content: "a") }
-      let(:file2) { described_class.new(name: "Gemfile", content: "a") }
+      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
+      let(:second_file) { described_class.new(name: "Gemfile", content: "a") }
 
-      specify { expect(file1).to eq(file2) }
+      specify { expect(first_file).to eq(second_file) }
     end
 
     context "when two dependency files are equal, but one is a support file" do
-      let(:file1) { described_class.new(name: "Gemfile", content: "a") }
-      let(:file2) do
+      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
+      let(:second_file) do
         described_class.new(name: "Gemfile", content: "a", support_file: true)
       end
 
-      specify { expect(file1).to eq(file2) }
+      specify { expect(first_file).to eq(second_file) }
     end
 
     context "when two dependency files are equal, but one is a vendored file" do
-      let(:file1) { described_class.new(name: "Gemfile", content: "a") }
-      let(:file2) do
+      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
+      let(:second_file) do
         described_class.new(name: "Gemfile", content: "a", vendored_file: true)
       end
 
-      specify { expect(file1).to eq(file2) }
+      specify { expect(first_file).to eq(second_file) }
     end
 
     context "when two dependency files are not equal" do
-      let(:file1) { described_class.new(name: "Gemfile", content: "a") }
-      let(:file2) { described_class.new(name: "Gemfile", content: "b") }
+      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
+      let(:second_file) { described_class.new(name: "Gemfile", content: "b") }
 
-      specify { expect(file1).not_to eq(file2) }
+      specify { expect(first_file).not_to eq(second_file) }
     end
   end
 

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -288,35 +288,35 @@ RSpec.describe Dependabot::DependencyFile do
 
   describe "#==" do
     context "when two dependency files are equal" do
-      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
-      let(:second_file) { described_class.new(name: "Gemfile", content: "a") }
+      let(:file_one) { described_class.new(name: "Gemfile", content: "a") }
+      let(:file_two) { described_class.new(name: "Gemfile", content: "a") }
 
-      specify { expect(first_file).to eq(second_file) }
+      specify { expect(file_one).to eq(file_two) }
     end
 
     context "when two dependency files are equal, but one is a support file" do
-      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
-      let(:second_file) do
+      let(:file_one) { described_class.new(name: "Gemfile", content: "a") }
+      let(:file_two) do
         described_class.new(name: "Gemfile", content: "a", support_file: true)
       end
 
-      specify { expect(first_file).to eq(second_file) }
+      specify { expect(file_one).to eq(file_two) }
     end
 
     context "when two dependency files are equal, but one is a vendored file" do
-      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
-      let(:second_file) do
+      let(:file_one) { described_class.new(name: "Gemfile", content: "a") }
+      let(:file_two) do
         described_class.new(name: "Gemfile", content: "a", vendored_file: true)
       end
 
-      specify { expect(first_file).to eq(second_file) }
+      specify { expect(file_one).to eq(file_two) }
     end
 
     context "when two dependency files are not equal" do
-      let(:first_file) { described_class.new(name: "Gemfile", content: "a") }
-      let(:second_file) { described_class.new(name: "Gemfile", content: "b") }
+      let(:file_one) { described_class.new(name: "Gemfile", content: "a") }
+      let(:file_two) { described_class.new(name: "Gemfile", content: "b") }
 
-      specify { expect(first_file).not_to eq(second_file) }
+      specify { expect(file_one).not_to eq(file_two) }
     end
   end
 

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dependabot::DependencyGroup do
   let(:name) { "test_group" }
   let(:rules) { { "patterns" => ["test-*"] } }
 
-  let(:test_dependency1) do
+  let(:test_first_dependency) do
     Dependabot::Dependency.new(
       name: "test-dependency-1",
       package_manager: "bundler",
@@ -27,7 +27,7 @@ RSpec.describe Dependabot::DependencyGroup do
     )
   end
 
-  let(:test_dependency2) do
+  let(:test_second_dependency) do
     Dependabot::Dependency.new(
       name: "test-dependency-2",
       package_manager: "bundler",
@@ -95,12 +95,12 @@ RSpec.describe Dependabot::DependencyGroup do
 
     context "when dependencies have been assigned" do
       before do
-        dependency_group.dependencies << test_dependency1
+        dependency_group.dependencies << test_first_dependency
       end
 
       it "returns the dependencies" do
-        expect(dependency_group.dependencies).to include(test_dependency1)
-        expect(dependency_group.dependencies).not_to include(test_dependency2)
+        expect(dependency_group.dependencies).to include(test_first_dependency)
+        expect(dependency_group.dependencies).not_to include(test_second_dependency)
       end
     end
   end
@@ -117,12 +117,12 @@ RSpec.describe Dependabot::DependencyGroup do
       context "when no dependencies are assigned to the group" do
         it "returns true if the dependency matches a pattern" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency1)).to be(true)
+          expect(dependency_group.contains?(test_first_dependency)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
           expect(dependency_group.dependencies).to eq([])
-          expect(dependency_group.contains?(test_dependency2)).to be(false)
+          expect(dependency_group.contains?(test_second_dependency)).to be(false)
         end
 
         it "returns false if the dependency does not match any patterns" do
@@ -133,21 +133,21 @@ RSpec.describe Dependabot::DependencyGroup do
 
       context "when dependencies are assigned to the group" do
         before do
-          dependency_group.dependencies << test_dependency1
+          dependency_group.dependencies << test_first_dependency
         end
 
         it "returns true if the dependency is in the dependency list" do
-          expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency1)).to be(true)
+          expect(dependency_group.dependencies).to include(test_first_dependency)
+          expect(dependency_group.contains?(test_first_dependency)).to be(true)
         end
 
         it "returns false if the dependency is specifically excluded" do
-          expect(dependency_group.dependencies).to include(test_dependency1)
-          expect(dependency_group.contains?(test_dependency2)).to be(false)
+          expect(dependency_group.dependencies).to include(test_first_dependency)
+          expect(dependency_group.contains?(test_second_dependency)).to be(false)
         end
 
         it "returns false if the dependency is not in the dependency list and does not match a pattern" do
-          expect(dependency_group.dependencies).to include(test_dependency1)
+          expect(dependency_group.dependencies).to include(test_first_dependency)
           expect(dependency_group.contains?(production_dependency)).to be(false)
         end
       end
@@ -165,8 +165,8 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns false if the dependency does not match the specified type" do
-        expect(dependency_group.contains?(test_dependency1)).to be(false)
-        expect(dependency_group.contains?(test_dependency2)).to be(false)
+        expect(dependency_group.contains?(test_first_dependency)).to be(false)
+        expect(dependency_group.contains?(test_second_dependency)).to be(false)
       end
 
       context "when a dependency is specifically excluded" do
@@ -193,7 +193,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns true if the dependency matches the specified type and a pattern" do
-        expect(dependency_group.contains?(test_dependency1)).to be(true)
+        expect(dependency_group.contains?(test_first_dependency)).to be(true)
       end
 
       it "returns false if the dependency only matches the pattern" do
@@ -201,7 +201,7 @@ RSpec.describe Dependabot::DependencyGroup do
       end
 
       it "returns false if the dependency matches the specified type and pattern but is excluded" do
-        expect(dependency_group.contains?(test_dependency2)).to be(false)
+        expect(dependency_group.contains?(test_second_dependency)).to be(false)
       end
     end
   end

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -91,17 +91,17 @@ RSpec.describe Dependabot::Dependency do
     end
 
     context "when two dependencies are equal" do
-      let(:dependency1) { described_class.new(**args) }
-      let(:dependency2) { described_class.new(**args) }
+      let(:first_dependency) { described_class.new(**args) }
+      let(:second_dependency) { described_class.new(**args) }
 
-      specify { expect(dependency1).to eq(dependency2) }
+      specify { expect(first_dependency).to eq(second_dependency) }
     end
 
     context "when two dependencies are not equal" do
-      let(:dependency1) { described_class.new(**args) }
-      let(:dependency2) { described_class.new(**args.merge(name: "dep2")) }
+      let(:first_dependency) { described_class.new(**args) }
+      let(:second_dependency) { described_class.new(**args.merge(name: "dep2")) }
 
-      specify { expect(dependency1).not_to eq(dependency2) }
+      specify { expect(first_dependency).not_to eq(second_dependency) }
     end
   end
 
@@ -327,19 +327,19 @@ RSpec.describe Dependabot::Dependency do
     end
 
     it "isn't utilized by the equality operator" do
-      dependency1 = described_class.new(
+      first_dependency = described_class.new(
         name: "dep",
         requirements: [],
         package_manager: "dummy",
         metadata: { foo: 42 }
       )
-      dependency2 = described_class.new(
+      second_dependency = described_class.new(
         name: "dep",
         requirements: [],
         package_manager: "dummy",
         metadata: { foo: 43 }
       )
-      expect(dependency1).to eq(dependency2)
+      expect(first_dependency).to eq(second_dependency)
     end
   end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.5.0",
@@ -248,7 +248,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           it { is_expected.to eq("Bump business and business2") }
 
@@ -330,7 +330,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies with the same name" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business",
               version: "2.3.0",
@@ -340,13 +340,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           it { is_expected.to eq("Bump business") }
         end
 
         context "with three dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.5.0",
@@ -356,7 +356,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -366,7 +366,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3] }
+          let(:dependencies) { [dependency, second_dependency, third_dependency] }
 
           it { is_expected.to eq("Bump business, business2 and business3") }
         end
@@ -716,7 +716,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.5.0",
@@ -726,7 +726,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           it "includes both dependencies" do
             expect(pr_name)
@@ -735,7 +735,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies with the same name" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business",
               version: "2.3.0",
@@ -745,13 +745,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           it { is_expected.to eq("Update requirements for business") }
         end
 
         context "with three dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.5.0",
@@ -761,7 +761,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -771,7 +771,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3] }
+          let(:dependencies) { [dependency, second_dependency, third_dependency] }
 
           it "includes all three dependencies" do
             expect(pr_name)
@@ -857,7 +857,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0 in the all-the-things group") }
 
       context "with two dependencies" do
-        let(:dependency2) do
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "business2",
             version: "1.5.0",
@@ -867,13 +867,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-        let(:dependencies) { [dependency, dependency2] }
+        let(:dependencies) { [dependency, second_dependency] }
 
         it { is_expected.to eq("Bump the all-the-things group with 2 updates") }
       end
 
       context "with two dependencies with the same name" do
-        let(:dependency2) do
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "business",
             version: "1.5.0",
@@ -883,13 +883,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-        let(:dependencies) { [dependency, dependency2] }
+        let(:dependencies) { [dependency, second_dependency] }
 
         it { is_expected.to eq("Bump the all-the-things group with 1 update") }
       end
 
       context "with three dependencies" do
-        let(:dependency2) do
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "business2",
             version: "1.5.0",
@@ -899,7 +899,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-        let(:dependency3) do
+        let(:third_dependency) do
           Dependabot::Dependency.new(
             name: "business3",
             version: "1.5.0",
@@ -909,7 +909,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-        let(:dependencies) { [dependency, dependency2, dependency3] }
+        let(:dependencies) { [dependency, second_dependency, third_dependency] }
 
         it { is_expected.to eq("Bump the all-the-things group with 3 updates") }
       end
@@ -922,7 +922,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             directory: "directory"
           )
         end
-        let(:dependency2) do
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "business2",
             version: "1.5.0",
@@ -932,7 +932,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-        let(:dependencies) { [dependency, dependency2] }
+        let(:dependencies) { [dependency, second_dependency] }
 
         it "includes the directory" do
           expect(pr_name)
@@ -964,7 +964,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "with two dependencies" do
         let(:metadata) { { directory: "/foo" } }
-        let(:dependency2) do
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "business2",
             version: "1.5.0",
@@ -975,7 +975,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             metadata: { directory: "/bar" }
           )
         end
-        let(:dependencies) { [dependency, dependency2] }
+        let(:dependencies) { [dependency, second_dependency] }
 
         it { is_expected.to eq("Bump the go_modules group across 2 directories with 2 updates") }
       end
@@ -1759,8 +1759,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       context "when updating multiple dependencies" do
-        let(:dependencies) { [dependency, dependency2] }
-        let(:dependency2) do
+        let(:dependencies) { [dependency, second_dependency] }
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "statesman",
             version: "1.7.0",
@@ -1899,7 +1899,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               }]
             )
           end
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "statesman",
               version: "1.5.0",
@@ -2018,7 +2018,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2028,7 +2028,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           before do
             business2_repo_url =
@@ -2097,7 +2097,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies with the same name" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business",
               version: "1.5.0",
@@ -2107,7 +2107,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           it "has the correct message" do
             expect(pr_message).to start_with(
@@ -2118,7 +2118,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with three dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2128,7 +2128,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2138,7 +2138,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3] }
+          let(:dependencies) { [dependency, second_dependency, third_dependency] }
 
           before do
             business2_repo_url =
@@ -2227,7 +2227,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with five or more dependencies" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2237,7 +2237,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2247,7 +2247,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency4) do
+          let(:fourth_dependency) do
             Dependabot::Dependency.new(
               name: "business4",
               version: "2.1.1",
@@ -2257,7 +2257,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency5) do
+          let(:fifth_dependency) do
             Dependabot::Dependency.new(
               name: "business5",
               version: "0.17.0",
@@ -2267,7 +2267,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5] }
+          let(:dependencies) { [dependency, second_dependency, third_dependency, fourth_dependency, fifth_dependency] }
 
           before do
             (2..5).each do |i|
@@ -2326,7 +2326,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with five or more dependencies with same name" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2336,7 +2336,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2346,7 +2346,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency4) do
+          let(:fourth_dependency) do
             Dependabot::Dependency.new(
               name: "business4",
               version: "2.1.1",
@@ -2356,7 +2356,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency5) do
+          let(:fifth_dependency) do
             Dependabot::Dependency.new(
               name: "business5",
               version: "0.17.0",
@@ -2366,7 +2366,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency6) do
+          let(:sixth_dependency) do
             Dependabot::Dependency.new(
               name: "business6",
               version: "0.5.4",
@@ -2377,7 +2377,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) do
-            [dependency, dependency2, dependency3, dependency4, dependency5, dependency5, dependency6]
+            [dependency, second_dependency, third_dependency, fourth_dependency, fifth_dependency, fifth_dependency,
+             sixth_dependency]
           end
 
           before do
@@ -2439,7 +2440,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with five or more dependencies with some duplicates" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2449,7 +2450,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2459,7 +2460,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency4) do
+          let(:fourth_dependency) do
             Dependabot::Dependency.new(
               name: "business4",
               version: "2.1.1",
@@ -2469,7 +2470,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency5) do
+          let(:fifth_dependency) do
             Dependabot::Dependency.new(
               name: "business5",
               version: "0.17.0",
@@ -2479,7 +2480,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency6) do
+          let(:sixth_dependency) do
             Dependabot::Dependency.new(
               name: "business6",
               version: "0.5.4",
@@ -2489,7 +2490,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency7) do
+          let(:seventh_dependency) do
             Dependabot::Dependency.new(
               name: "business6",
               version: "0.5.4",
@@ -2499,7 +2500,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency8) do
+          let(:eighth_dependency) do
             Dependabot::Dependency.new(
               name: "business6",
               version: "1.5.0",
@@ -2510,8 +2511,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) do
-            [dependency, dependency2, dependency3, dependency4, dependency5, dependency5, dependency6, dependency7,
-             dependency8]
+            [dependency, second_dependency, third_dependency, fourth_dependency, fifth_dependency, fifth_dependency,
+             sixth_dependency, seventh_dependency,
+             eighth_dependency]
           end
 
           before do
@@ -2574,7 +2576,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with ignore conditions" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2584,7 +2586,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency3) do
+          let(:third_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2594,7 +2596,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency4) do
+          let(:fourth_dependency) do
             Dependabot::Dependency.new(
               name: "business4",
               version: "2.1.1",
@@ -2604,7 +2606,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency5) do
+          let(:fifth_dependency) do
             Dependabot::Dependency.new(
               name: "business5",
               version: "0.17.0",
@@ -2614,7 +2616,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5] }
+          let(:dependencies) { [dependency, second_dependency, third_dependency, fourth_dependency, fifth_dependency] }
 
           before do
             (2..5).each do |i|
@@ -2690,7 +2692,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business3",
               version: "1.5.0",
@@ -2700,7 +2702,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               previous_requirements: []
             )
           end
-          let(:dependencies) { [dependency1, dependency2] }
+          let(:dependencies) { [dependency1, second_dependency] }
 
           before do
             (2..5).each do |i|
@@ -2800,7 +2802,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies in the same directory" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2811,7 +2813,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               metadata: { directory: "/foo" }
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           before do
             business2_repo_url =
@@ -2862,7 +2864,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies in different directories" do
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -2873,7 +2875,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               metadata: { directory: "/bar" }
             )
           end
-          let(:dependencies) { [dependency, dependency2] }
+          let(:dependencies) { [dependency, second_dependency] }
 
           before do
             business2_repo_url =
@@ -2925,7 +2927,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with table for one directory and no table for the other" do
-          let(:dependencies2) do
+          let(:second_dependencies) do
             (1..5).map do |index|
               Dependabot::Dependency.new(
                 name: "business#{index + 1}",
@@ -2938,7 +2940,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
             end
           end
-          let(:dependencies) { dependencies2 + [dependency] }
+          let(:dependencies) { second_dependencies + [dependency] }
 
           before do
             json_header = { "Content-Type" => "application/json" }
@@ -2987,7 +2989,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             end
 
             before do
-              dependencies2.push(removed_dependency)
+              second_dependencies.push(removed_dependency)
             end
 
             it "lists the dependency as removed in the table" do
@@ -2999,7 +3001,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with table for one directory come first and no table for the other" do
-          let(:dependencies1) do
+          let(:first_dependencies) do
             (1..5).map do |index|
               Dependabot::Dependency.new(
                 name: "business#{index + 1}",
@@ -3012,7 +3014,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
             end
           end
-          let(:dependency2) do
+          let(:second_dependency) do
             Dependabot::Dependency.new(
               name: "business2",
               version: "1.8.0",
@@ -3023,7 +3025,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               metadata: { directory: "/bar" }
             )
           end
-          let(:dependencies) { dependencies1 + [dependency] + [dependency2] }
+          let(:dependencies) { first_dependencies + [dependency] + [second_dependency] }
 
           before do
             json_header = { "Content-Type" => "application/json" }
@@ -3065,7 +3067,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a table for both directories" do
-          let(:dependencies1) do
+          let(:first_dependencies) do
             (1..5).map do |index|
               Dependabot::Dependency.new(
                 name: "business#{index + 1}",
@@ -3078,7 +3080,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
             end
           end
-          let(:dependencies2) do
+          let(:second_dependencies) do
             (1..5).map do |index|
               Dependabot::Dependency.new(
                 name: "business#{index + 1}",
@@ -3091,7 +3093,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
             end
           end
-          let(:dependencies) { dependencies1 + dependencies2 + [dependency] }
+          let(:dependencies) { first_dependencies + second_dependencies + [dependency] }
 
           before do
             json_header = { "Content-Type" => "application/json" }
@@ -3174,8 +3176,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       context "when updating multiple dependencies" do
-        let(:dependencies) { [dependency, dependency2] }
-        let(:dependency2) do
+        let(:dependencies) { [dependency, second_dependency] }
+        let(:second_dependency) do
           Dependabot::Dependency.new(
             name: "statesman",
             version: "1.7.0",

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -159,17 +159,17 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:upload_pack_fixture) { "run-vcpkg" }
 
         context "when there's a branch named like a higher version" do
-          let(:tip_of_v6) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
+          let(:tip_of_version_six) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
 
-          let(:reference) { tip_of_v6 }
+          let(:reference) { tip_of_version_six }
 
           it { is_expected.to be_truthy }
         end
 
         context "when there's no branch named like a higher version" do
-          let(:tip_of_v10) { "34684effe7451ea95f60397e56ba34c06daced68" }
+          let(:tip_of_version_ten) { "34684effe7451ea95f60397e56ba34c06daced68" }
 
-          let(:reference) { tip_of_v10 }
+          let(:reference) { tip_of_version_ten }
 
           it { is_expected.to be_falsey }
         end
@@ -383,17 +383,17 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       let(:upload_pack_fixture) { "run-vcpkg" }
 
       context "when a branch named like a higher version" do
-        let(:tip_of_v6) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
+        let(:tip_of_version_six) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
 
-        let(:reference) { tip_of_v6 }
+        let(:reference) { tip_of_version_six }
 
         it { is_expected.to eq(Gem::Version.new("10.5")) }
       end
 
       context "when no branch named like a higher version" do
-        let(:tip_of_v10) { "34684effe7451ea95f60397e56ba34c06daced68" }
+        let(:tip_of_version_ten) { "34684effe7451ea95f60397e56ba34c06daced68" }
 
-        let(:reference) { tip_of_v10 }
+        let(:reference) { tip_of_version_ten }
 
         it { is_expected.to eq(Gem::Version.new("10.5")) }
       end
@@ -646,11 +646,11 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
     context "when a git commit SHA pointing to the tip of a branch named like a version" do
       let(:upload_pack_fixture) { "run-vcpkg" }
-      let(:tip_of_v6) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
-      let(:tip_of_v10) { "34684effe7451ea95f60397e56ba34c06daced68" }
+      let(:tip_of_version_six) { "205a4bde2b6ddf941a102fb50320ea1aa9338233" }
+      let(:tip_of_version_ten) { "34684effe7451ea95f60397e56ba34c06daced68" }
 
       context "when it's not the latest version" do
-        let(:reference) { tip_of_v6 }
+        let(:reference) { tip_of_version_six }
 
         let(:expected_requirements) do
           [{
@@ -660,7 +660,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             source: {
               type: "git",
               url: "https://github.com/actions/setup-node",
-              ref: tip_of_v10,
+              ref: tip_of_version_ten,
               branch: nil
             },
             metadata: { declaration_string: "actions/setup-node@master" }
@@ -671,7 +671,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
 
       context "when it's also the latest version" do
-        let(:reference) { tip_of_v6 }
+        let(:reference) { tip_of_version_six }
 
         let(:expected_requirements) do
           [{
@@ -681,7 +681,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             source: {
               type: "git",
               url: "https://github.com/actions/setup-node",
-              ref: tip_of_v10,
+              ref: tip_of_version_ten,
               branch: nil
             },
             metadata: { declaration_string: "actions/setup-node@master" }

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -362,18 +362,17 @@ RSpec.describe Dependabot::Hex::FileParser do
     context "with an umbrella app" do
       let(:mixfile_fixture_name) { "umbrella" }
       let(:lockfile_fixture_name) { "umbrella" }
-      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
-      let(:sub_first_mixfile) do
-        Dependabot::DependencyFile.new(
+      let(:files) do
+        sub_mixfile1 = Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
-      end
-      let(:sub_second_mixfile) do
-        Dependabot::DependencyFile.new(
+        sub_mixfile2 = Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")
         )
+
+        [mixfile, lockfile, sub_mixfile1, sub_mixfile2]
       end
 
       it "parses the dependencies correctly" do

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -362,14 +362,14 @@ RSpec.describe Dependabot::Hex::FileParser do
     context "with an umbrella app" do
       let(:mixfile_fixture_name) { "umbrella" }
       let(:lockfile_fixture_name) { "umbrella" }
-      let(:files) { [mixfile, lockfile, sub_mixfile1, sub_mixfile2] }
-      let(:sub_mixfile1) do
+      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
+      let(:sub_first_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
       end
-      let(:sub_mixfile2) do
+      let(:sub_second_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -246,14 +246,14 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
     context "with an umbrella app" do
       let(:mixfile_fixture_name) { "umbrella" }
       let(:lockfile_fixture_name) { "umbrella" }
-      let(:files) { [mixfile, lockfile, sub_mixfile1, sub_mixfile2] }
-      let(:sub_mixfile1) do
+      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
+      let(:sub_first_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
       end
-      let(:sub_mixfile2) do
+      let(:sub_second_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -246,14 +246,14 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
     context "with an umbrella app" do
       let(:mixfile_fixture_name) { "umbrella" }
       let(:lockfile_fixture_name) { "umbrella" }
-      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
-      let(:sub_first_mixfile) do
+      let(:files) { [mixfile, lockfile, sub_mixfile_one, sub_mixfile_two] }
+      let(:sub_mixfile_one) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
       end
-      let(:sub_second_mixfile) do
+      let(:sub_mixfile_two) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -105,21 +105,18 @@ RSpec.describe Dependabot::Hex::FileUpdater do
       context "with an umbrella app" do
         let(:mixfile_fixture_name) { "umbrella" }
         let(:lockfile_fixture_name) { "umbrella" }
-
-        let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
-        let(:sub_first_mixfile) do
-          Dependabot::DependencyFile.new(
+        let(:files) do
+          sub_mixfile1 = Dependabot::DependencyFile.new(
             name: "apps/dependabot_business/mix.exs",
             content: fixture("mixfiles", "dependabot_business")
           )
-        end
-        let(:sub_second_mixfile) do
-          Dependabot::DependencyFile.new(
+          sub_mixfile2 = Dependabot::DependencyFile.new(
             name: "apps/dependabot_web/mix.exs",
             content: fixture("mixfiles", "dependabot_web")
           )
-        end
 
+          [mixfile, lockfile, sub_mixfile1, sub_mixfile2]
+        end
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "plug",

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -106,14 +106,14 @@ RSpec.describe Dependabot::Hex::FileUpdater do
         let(:mixfile_fixture_name) { "umbrella" }
         let(:lockfile_fixture_name) { "umbrella" }
 
-        let(:files) { [mixfile, lockfile, sub_mixfile1, sub_mixfile2] }
-        let(:sub_mixfile1) do
+        let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
+        let(:sub_first_mixfile) do
           Dependabot::DependencyFile.new(
             name: "apps/dependabot_business/mix.exs",
             content: fixture("mixfiles", "dependabot_business")
           )
         end
-        let(:sub_mixfile2) do
+        let(:sub_second_mixfile) do
           Dependabot::DependencyFile.new(
             name: "apps/dependabot_web/mix.exs",
             content: fixture("mixfiles", "dependabot_web")

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -615,14 +615,14 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
     context "with an umbrella application" do
       let(:mixfile_body) { fixture("mixfiles", "umbrella") }
       let(:lockfile_body) { fixture("lockfiles", "umbrella") }
-      let(:files) { [mixfile, lockfile, sub_mixfile1, sub_mixfile2] }
-      let(:sub_mixfile1) do
+      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
+      let(:sub_first_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
       end
-      let(:sub_mixfile2) do
+      let(:sub_second_mixfile) do
         Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -615,20 +615,18 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
     context "with an umbrella application" do
       let(:mixfile_body) { fixture("mixfiles", "umbrella") }
       let(:lockfile_body) { fixture("lockfiles", "umbrella") }
-      let(:files) { [mixfile, lockfile, sub_first_mixfile, sub_second_mixfile] }
-      let(:sub_first_mixfile) do
-        Dependabot::DependencyFile.new(
+      let(:files) do
+        sub_mixfile1 = Dependabot::DependencyFile.new(
           name: "apps/dependabot_business/mix.exs",
           content: fixture("mixfiles", "dependabot_business")
         )
-      end
-      let(:sub_second_mixfile) do
-        Dependabot::DependencyFile.new(
+        sub_mixfile2 = Dependabot::DependencyFile.new(
           name: "apps/dependabot_web/mix.exs",
           content: fixture("mixfiles", "dependabot_web")
         )
-      end
 
+        [mixfile, lockfile, sub_mixfile1, sub_mixfile2]
+      end
       let(:dependency_name) { "plug" }
       let(:version) { "1.3.6" }
       let(:dependency_requirements) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         Dependabot::Dependency.new(
           name: "foo",
           version: "1.0.0",
-          requirements: (foo_first_version.requirements + foo_second_version.requirements).uniq,
+          requirements: (foo_version_one.requirements + foo_version_two.requirements).uniq,
           package_manager: "npm_and_yarn",
-          metadata: { all_versions: [foo_first_version, foo_second_version] }
+          metadata: { all_versions: [foo_version_one, foo_version_two] }
         )
       end
 
-      let(:foo_first_version) do
+      let(:foo_version_one) do
         Dependabot::Dependency.new(
           name: "foo",
           version: "1.0.0",
@@ -91,7 +91,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         )
       end
 
-      let(:foo_second_version) do
+      let(:foo_version_two) do
         Dependabot::Dependency.new(
           name: "foo",
           version: "2.0.0",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         Dependabot::Dependency.new(
           name: "foo",
           version: "1.0.0",
-          requirements: (foo_v1.requirements + foo_v2.requirements).uniq,
+          requirements: (foo_first_version.requirements + foo_second_version.requirements).uniq,
           package_manager: "npm_and_yarn",
-          metadata: { all_versions: [foo_v1, foo_v2] }
+          metadata: { all_versions: [foo_first_version, foo_second_version] }
         )
       end
 
-      let(:foo_v1) do
+      let(:foo_first_version) do
         Dependabot::Dependency.new(
           name: "foo",
           version: "1.0.0",
@@ -91,7 +91,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         )
       end
 
-      let(:foo_v2) do
+      let(:foo_second_version) do
         Dependabot::Dependency.new(
           name: "foo",
           version: "2.0.0",

--- a/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
@@ -398,47 +398,47 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       context "with multiple requirement.in files" do
         let(:dependency_files) do
           [
-            manifest_file, manifest_file2, manifest_file3, manifest_file4,
-            generated_file, generated_file2, generated_file3, generated_file4
+            manifest_file, second_manifest_file, third_manifest_file, fourth_manifest_file,
+            generated_file, second_generated_file, third_generated_file, fourth_generated_file
           ]
         end
 
-        let(:manifest_file2) do
+        let(:second_manifest_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/dev.in",
             content:
               fixture("pip_compile_files", manifest_fixture_name)
           )
         end
-        let(:generated_file2) do
+        let(:second_generated_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/dev.txt",
             content: fixture("requirements", generated_fixture_name)
           )
         end
 
-        let(:manifest_file3) do
+        let(:third_manifest_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/mirror2.in",
             content:
               fixture("pip_compile_files", "imports_mirror.in")
           )
         end
-        let(:generated_file3) do
+        let(:third_generated_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/mirror2.txt",
             content: fixture("requirements", generated_fixture_name)
           )
         end
 
-        let(:manifest_file4) do
+        let(:fourth_manifest_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/mirror.in",
             content:
               fixture("pip_compile_files", "imports_dev.in")
           )
         end
-        let(:generated_file4) do
+        let(:fourth_generated_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/mirror.txt",
             content: fixture("requirements", generated_fixture_name)

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -652,12 +652,12 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
     context "with multiple requirements" do
       let(:requirements) do
         [
-          { file: "req.txt", requirement: req1, groups: [], source: nil },
-          { file: "req2.txt", requirement: req2, groups: [], source: nil }
+          { file: "req.txt", requirement: first_requirement, groups: [], source: nil },
+          { file: "req2.txt", requirement: second_requirement, groups: [], source: nil }
         ]
       end
-      let(:req1) { "~=2.0" }
-      let(:req2) { "<=2.5.0" }
+      let(:first_requirement) { "~=2.0" }
+      let(:second_requirement) { "<=2.5.0" }
       let(:version) { nil }
 
       it { is_expected.to eq(Gem::Version.new("2.5.0")) }

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -149,17 +149,17 @@ RSpec.describe namespace::PipCompileVersionResolver do
 
       context "with multiple requirement.in files" do
         let(:dependency_files) do
-          [manifest_file, manifest_file2, generated_file, generated_file2]
+          [manifest_file, second_manifest_file, generated_file, second_generated_file2]
         end
 
-        let(:manifest_file2) do
+        let(:second_manifest_file) do
           Dependabot::DependencyFile.new(
             name: "requirements/dev.in",
             content:
               fixture("pip_compile_files", manifest_fixture_name2)
           )
         end
-        let(:generated_file2) do
+        let(:second_generated_file2) do
           Dependabot::DependencyFile.new(
             name: "requirements/dev.txt",
             content: fixture("requirements", generated_fixture_name2)


### PR DESCRIPTION
https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecindexedlet

### What are you trying to accomplish?
The RSpec IndexedLet rubocop rule has been disabled.  This PR will re-enable it on the whole ecosystem.

### Anything you want to highlight for special attention from reviewers?

This was essentially a renaming of variables in the rspec files.  It shoud not affect anything.

### How will you know you've accomplished your goal?

This cop just asks us to rename variables.  The tests should run as normal.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
