### PR TITLE
Enabling RSpec InstanceVariable Rubocop rule.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,9 +77,9 @@ RSpec/InstanceVariable:
     - 'bundler/helpers/v2/spec/ruby_version_spec.rb'
     - 'common/spec/dependabot/clients/azure_spec.rb'
     - 'go_modules/spec/dependabot/go_modules/file_updater_spec.rb'
-    - 'pub/spec/dependabot/pub/file_updater_spec.rb'
-    - 'pub/spec/dependabot/pub/infer_sdk_versions_spec.rb'
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
+ #   - 'pub/spec/dependabot/pub/file_updater_spec.rb'
+ #   - 'pub/spec/dependabot/pub/infer_sdk_versions_spec.rb'
+  #  - 'pub/spec/dependabot/pub/update_checker_spec.rb'
 
 # Offense count: 22
 RSpec/IteratedExpectation:

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   let(:updated_dependencies) do
     checker.updated_dependencies(requirements_to_unlock: requirements_to_unlock).map(&:to_h)
   end
+  let(:dev_null) { WEBrick::Log.new("/dev/null", 7) }
+  let(:server) { WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null }) }
   let(:can_update) { checker.can_update?(requirements_to_unlock: requirements_to_unlock) }
   let(:directory) { nil }
   let(:project) { "can_update" }
@@ -22,7 +24,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     files = project_dependency_files(project)
     files.each do |file|
       # Simulate that the lockfile was from localhost:
-      file.content.gsub!("https://pub.dartlang.org", "http://localhost:#{@server[:Port]}")
+      file.content.gsub!("https://pub.dartlang.org", "http://localhost:#{server[:Port]}")
       if defined?(git_dir)
         file.content.gsub!("$GIT_DIR", git_dir)
         file.content.gsub!("$REF", dependency_version)
@@ -58,8 +60,8 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       }],
       ignored_versions: ignored_versions,
       options: {
-        pub_hosted_url: "http://localhost:#{@server[:Port]}",
-        flutter_releases_url: "http://localhost:#{@server[:Port]}/flutter_releases.json"
+        pub_hosted_url: "http://localhost:#{server[:Port]}",
+        flutter_releases_url: "http://localhost:#{server[:Port]}/flutter_releases.json"
       },
       raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories,
@@ -72,33 +74,31 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
   after do
     sample_files.each do |f|
       package = File.basename(f, ".json")
-      @server.unmount "/api/packages/#{package}"
+      server.unmount "/api/packages/#{package}"
     end
   end
 
   before do
     sample_files.each do |f|
       package = File.basename(f, ".json")
-      @server.mount_proc "/api/packages/#{package}" do |_req, res|
+      server.mount_proc "/api/packages/#{package}" do |_req, res|
         res.body = File.read(File.join("..", "..", "..", f))
       end
     end
-    @server.mount_proc "/flutter_releases.json" do |_req, res|
+    server.mount_proc "/flutter_releases.json" do |_req, res|
       res.body = File.read(File.join(__dir__, "..", "..", "fixtures", "flutter_releases.json"))
     end
   end
 
   after(:all) do
-    @server.shutdown
+    server.shutdown
   end
 
   before(:all) do
     # Because we do the networking in dependency_services we have to run an
     # actual web server.
-    dev_null = WEBrick::Log.new("/dev/null", 7)
-    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
     Thread.new do
-      @server.start
+      server.start
     end
   end
 
@@ -527,7 +527,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       WebMock.allow_net_connect!
       # To find the vulnerable versions we do a package listing before invoking the helper.
       # Stub this out here:
-      stub_request(:get, "http://localhost:#{@server[:Port]}/api/packages/#{dependency.name}").to_return(
+      stub_request(:get, "http://localhost:#{server[:Port]}/api/packages/#{dependency.name}").to_return(
         status: 200,
         body: fixture("pub_dev_responses/simple/#{dependency.name}.json"),
         headers: {}
@@ -601,7 +601,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       WebMock.allow_net_connect!
       # To find the vulnerable versions we do a package listing before invoking the helper.
       # Stub this out here:
-      stub_request(:get, "http://localhost:#{@server[:Port]}/api/packages/#{dependency.name}").to_return(
+      stub_request(:get, "http://localhost:#{server[:Port]}/api/packages/#{dependency.name}").to_return(
         status: 200,
         body: fixture("pub_dev_responses/simple/#{dependency.name}.json"),
         headers: {}


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
### What are you trying to accomplish?

Enabling the RSpec/InstanceVariable Rubocop rule
### Anything you want to highlight for special attention from reviewers?

Currenty, this is a draft PR.  The first fix I made makes the test hang.  I need to make more fixes but cannot proceed until I have this one working.

### How will you know you've accomplished your goal?

Rubocop rules wil be enforced and the changes will be transparent on testing.


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
