### PR TITLE
Return empty string if index-url not provided to AuthedUrlBuilder

### DIFF
--- a/python/lib/dependabot/python/authed_url_builder.rb
+++ b/python/lib/dependabot/python/authed_url_builder.rb
@@ -7,6 +7,7 @@ module Dependabot
       def self.authed_url(credential:)
         token = credential.fetch("token", nil)
         url = credential.fetch("index-url", nil)
+        return "" unless url
         return url unless token
 
         basic_auth_details =

--- a/python/spec/dependabot/python/authed_url_builder_spec.rb
+++ b/python/spec/dependabot/python/authed_url_builder_spec.rb
@@ -9,6 +9,20 @@ RSpec.describe Dependabot::Python::AuthedUrlBuilder do
   describe ".authed_url" do
     subject(:authed_url) { described_class.authed_url(credential: credential) }
 
+    context "without index-url" do
+      let(:credential) do
+        Dependabot::Credential.new({
+          "type" => "python_index",
+          "replaces-base" => true
+        })
+      end
+
+      it "returns empty string" do
+        expect(authed_url)
+          .to eq("")
+      end
+    end
+
     context "without a token" do
       let(:credential) do
         Dependabot::Credential.new({


### PR DESCRIPTION
### What are you trying to accomplish?

While AuthedUrlBuilder could be provided no index-url, it does not handle this case, making the following line cause an exception:

```
url.sub("://", "://#{basic_auth_details}@")
```

This can happen, for example, when tools like Dependabot for Azure DevOps do not provide index-url generally, as described in this issue:

https://github.com/tinglesoftware/dependabot-azure-devops/issues/1167

### Anything you want to highlight for special attention from reviewers?

Another approach would be to make Dependabot for Azure DevOps provide index-url for Python dependencies in credentials, however this would not fix the general issue of AuthedUrlBuilder not handling a `nil` index-url.

### How will you know you've accomplished your goal?

https://github.com/tinglesoftware/dependabot-azure-devops/issues/1167 will essentially become irrelevant.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
