### PR TITLE
Re-enabled NamedSubject RSpec rule which was accidentlaly overwritten

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -127,12 +127,6 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Max: 30
 
-# Offense count: 500
-# Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
-# SupportedStyles: always, named_only
-RSpec/NamedSubject:
-  Enabled: false
-
 # Offense count: 3871
 # Configuration parameters: AllowedGroups.
 RSpec/NestedGroups:

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -960,7 +960,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           end
 
           it "returns an array of commits relevant to the given path" do
-            expect(subject).to contain_exactly({
+            expect(commits).to contain_exactly({
               message: "feat: Custom persister support\n\n" \
                        "* feat: Custom persister support\r\n\r\n" \
                        "* Create a @pollyjs/persister package\r\n" \
@@ -1018,7 +1018,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Added signature for changeset f275e318641f",
             sha: "deae742eacfa985bd20f47a12a8fee6ce2e0447c",
             html_url: "https://bitbucket.org/ged/ruby-pg/commits/" \
@@ -1065,7 +1065,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Merged PR 2: Deleted README.md",
             sha: "9991b4f66def4c0a9ad8f9f27043ece7eddcf1c7",
             html_url: "https://dev.azure.com/fabrikam/SomeGitProject/_git/SampleRepository/commit/" \
@@ -1102,7 +1102,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           end
 
           it "returns an array of commits" do
-            expect(subject).to contain_exactly({
+            expect(commits).to contain_exactly({
               message: "Merged PR 2: Deleted README.md",
               sha: "9991b4f66def4c0a9ad8f9f27043ece7eddcf1c7",
               html_url: "https://dev.azure.com/fabrikam/SomeGitProject/_git/SampleRepository/commit/" \
@@ -1157,7 +1157,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         end
 
         it "returns an array of commits" do
-          expect(subject).to contain_exactly({
+          expect(commits).to contain_exactly({
             message: "Add find command\n",
             sha: "8d7d08fb9a7a439b3e6a1e6a1a34cbdb4273de87",
             html_url: "https://gitlab.com/org/business/commit/" \

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
@@ -258,8 +258,8 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
       let(:requirement_string) { "^1.0.0 || ^2.0.0" }
 
       it do
-        expect(subject).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
-                                           Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
+        expect(reqs).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
+                                        Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
       end
     end
 
@@ -267,8 +267,8 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
       let(:requirement_string) { "(^1.0.0 || ^2.0.0)" }
 
       it do
-        expect(subject).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
-                                           Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
+        expect(reqs).to contain_exactly(Gem::Requirement.new(">= 1.0.0", "< 2.0.0.a"),
+                                        Gem::Requirement.new(">= 2.0.0", "< 3.0.0.a"))
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/dependency_files_builder_spec.rb
@@ -137,16 +137,16 @@ RSpec.describe(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) do
     subject(:test_subject) { builder.lockfiles }
 
     it do
-      expect(subject).to contain_exactly(project_dependency_file("package-lock.json"),
-                                         project_dependency_file("yarn.lock"))
+      expect(test_subject).to contain_exactly(project_dependency_file("package-lock.json"),
+                                              project_dependency_file("yarn.lock"))
     end
 
     context "with shrinkwraps" do
       let(:project_name) { "npm6/shrinkwrap" }
 
       it do
-        expect(subject).to contain_exactly(project_dependency_file("package-lock.json"),
-                                           project_dependency_file("npm-shrinkwrap.json"))
+        expect(test_subject).to contain_exactly(project_dependency_file("package-lock.json"),
+                                                project_dependency_file("npm-shrinkwrap.json"))
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

The NamedSubject Rubocop rule was accidentally disabled after work had been completed on it.  This will re-enable that cop for main so that we can avoid the rebasing issues we have come across

### Anything you want to highlight for special attention from reviewers?

This change is merely putting a named subject in for the generic 'subject' designator.

### How will you know you've accomplished your goal?

Resetting branches to main will include this rule in the enabled ruleset.
### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
