### PR TITLE
Enabling RSpec/BeforeAfterAll Rubocop rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,14 +22,6 @@ RSpec/AnyInstance:
     - 'updater/spec/dependabot/dependency_change_builder_spec.rb'
     - 'updater/spec/dependabot/file_fetcher_command_spec.rb'
 
-# Offense count: 7
-RSpec/BeforeAfterAll:
-  Exclude:
-    - 'nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb'
-    - 'pub/spec/dependabot/pub/file_updater_spec.rb'
-    - 'pub/spec/dependabot/pub/infer_sdk_versions_spec.rb'
-    - 'pub/spec/dependabot/pub/update_checker_spec.rb'
-
 # Offense count: 1286
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:

--- a/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/dependency_finder_spec.rb
@@ -62,16 +62,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
     let(:nuget_config) { Dependabot::DependencyFile.new(name: "NuGet.Config", content: nuget_config_body) }
     let(:dependency_files) { [csproj, nuget_config] }
 
-    def create_nupkg(nuspec_name, nuspec_fixture_path)
-      content = Zip::OutputStream.write_buffer do |zio|
-        zio.put_next_entry("#{nuspec_name}.nuspec")
-        zio.write(fixture("nuspecs", nuspec_fixture_path))
-      end
-      content.rewind
-      content.sysread
-    end
-
-    before(:context) do
+    before do
       disallowed_urls = %w(
         https://api.nuget.org/v3/index.json
         https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencymodel/42.42.42/microsoft.extensions.dependencymodel.nuspec
@@ -91,6 +82,15 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::DependencyFinder do
       stub_request(:get, "https://api.example.com/v3-flatcontainer/microsoft.netcore.platforms/43.43.43/microsoft.netcore.platforms.43.43.43.nupkg")
         .to_return(status: 200, body: create_nupkg("Microsoft.NETCore.Platforms",
                                                    "Microsoft.NETCore.Platforms_43.43.43_faked.nuspec"))
+    end
+
+    def create_nupkg(nuspec_name, nuspec_fixture_path)
+      content = Zip::OutputStream.write_buffer do |zio|
+        zio.put_next_entry("#{nuspec_name}.nuspec")
+        zio.write(fixture("nuspecs", nuspec_fixture_path))
+      end
+      content.rewind
+      content.sysread
     end
 
     # this test doesn't really care about the dependency count, we just need to ensure that `api.nuget.org` wasn't hit

--- a/pub/spec/dependabot/pub/file_updater_spec.rb
+++ b/pub/spec/dependabot/pub/file_updater_spec.rb
@@ -43,28 +43,22 @@ RSpec.describe Dependabot::Pub::FileUpdater do
       package = File.basename(f, ".json")
       @server.unmount "/api/packages/#{package}"
     end
-  end
-
-  before do
-    sample_files.each do |f|
-      package = File.basename(f, ".json")
-      @server.mount_proc "/api/packages/#{package}" do |_req, res|
-        res.body = File.read(File.join("..", "..", "..", f))
-      end
-    end
-  end
-
-  after(:all) do
     @server.shutdown
   end
 
-  before(:all) do
+  before do
     # Because we do the networking in dependency_services we have to run an
     # actual web server.
     dev_null = WEBrick::Log.new("/dev/null", 7)
     @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
     Thread.new do
       @server.start
+    end
+    sample_files.each do |f|
+      package = File.basename(f, ".json")
+      @server.mount_proc "/api/packages/#{package}" do |_req, res|
+        res.body = File.read(File.join("..", "..", "..", f))
+      end
     end
   end
 

--- a/pub/spec/dependabot/pub/infer_sdk_versions_spec.rb
+++ b/pub/spec/dependabot/pub/infer_sdk_versions_spec.rb
@@ -8,7 +8,7 @@ require "dependabot/pub/helpers"
 require "webrick"
 
 RSpec.describe "Helpers" do
-  before(:all) do
+  before do
     # Because we do the networking in infer_sdk_versions we have to run an
     # actual web server.
     dev_null = WEBrick::Log.new("/dev/null", 7)
@@ -16,16 +16,13 @@ RSpec.describe "Helpers" do
     Thread.new do
       @server.start
     end
-  end
-
-  after(:all) do
-    @server.shutdown
-  end
-
-  before do
     @server.mount_proc "/flutter_releases.json" do |_req, res|
       res.body = File.read(File.join(__dir__, "..", "..", "fixtures", "flutter_releases.json"))
     end
+  end
+
+  after do
+    @server.shutdown
   end
 
   let(:inferred_result) do

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -74,9 +74,17 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       package = File.basename(f, ".json")
       @server.unmount "/api/packages/#{package}"
     end
+    @server.shutdown
   end
 
   before do
+    # Because we do the networking in dependency_services we have to run an
+    # actual web server.
+    dev_null = WEBrick::Log.new("/dev/null", 7)
+    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
+    Thread.new do
+      @server.start
+    end
     sample_files.each do |f|
       package = File.basename(f, ".json")
       @server.mount_proc "/api/packages/#{package}" do |_req, res|
@@ -85,20 +93,6 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     end
     @server.mount_proc "/flutter_releases.json" do |_req, res|
       res.body = File.read(File.join(__dir__, "..", "..", "fixtures", "flutter_releases.json"))
-    end
-  end
-
-  after(:all) do
-    @server.shutdown
-  end
-
-  before(:all) do
-    # Because we do the networking in dependency_services we have to run an
-    # actual web server.
-    dev_null = WEBrick::Log.new("/dev/null", 7)
-    @server = WEBrick::HTTPServer.new({ Port: 0, AccessLog: [], Logger: dev_null })
-    Thread.new do
-      @server.start
     end
   end
 


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop-rspec/1.15.0/RuboCop/Cop/RSpec/BeforeAfterAll

What are you trying to accomplish?
The BeforeAfterAll RSpec rule was disabled in some parts of the ecosystme. This PR will enable and fix those scenarios it identifies.

Anything you want to highlight for special attention from reviewers?
Please watch for code duplications or conflicts.

How will you know you've accomplished your goal?
The Rubocop rule will work and the tests will not fai afterwards.

Checklist
 I have run the complete test suite to ensure all tests and linters pass.
 I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
 I have written clear and descriptive commit messages.
 I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
 I have ensured that the code is well-documented and easy to understand.