### PR TITLE
Support Go modules with LFS committed files

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -27,3 +27,10 @@ ENV GOTOOLCHAIN="go1.20.10"
 # This pre-installs go 1.20 so that each job doesn't have to do it.
 RUN go version
 ENV GO_LEGACY=$GOTOOLCHAIN
+
+# Enable automatic pulling of files stored with Git LFS.
+# This is crucial for the Go toolchain to correctly compute module hashes in repositories
+# with LFS committed files.
+# This is relevant only for Go Modules embedding (with //go:embed) large files and does not
+# affect repositories that do not commit files to LFS.
+ENV GIT_LFS_SKIP_SMUDGE=1


### PR DESCRIPTION

### What are you trying to accomplish?

My company commits large files using Git LFS which happen to be part of our Go module source tree.
Without `git-lfs` installed, Dependabot's local git installation does not automatically resolve those files, causesing "checksum mismatch" against the committed `go.sum`.

Git LFS support is important when downloading Go modules directly from git repositories. Direct download is more common for private repositories. It is also a valid method to fetch module archives for public repositories, although those are often downloaded from the module-proxy.

### Anything you want to highlight for special attention from reviewers?

While Git LFS may be relevant for other ecosystems, I've been heavily occupied with Go for the past several years. Thus, I'm unable to offer a qualified solution for all ecosystems. Nonetheless, I think this solution is very relevant for companies that rely on GitHub to host their internal codebase.

### How will you know you've accomplished your goal?

While dependabot correctly detects a new version is available, when the repo commits large-files, the generated pull-request contains the wrong module hash, rendering it effectively meaningless.

I've used the following snippets to prove, and consistently test the problem and its solution:

```bash
$ git clone https://github.com/danielorbach/dependabot-go_modules.git lfs-enabled
$ go run github.com/vikyd/go-checksum@latest lfs-enabled github.com/danielorbach/dependabot-go_modules@latest
directory: lfs-enabled
{
        "HashSynthesized": "3abfcf88a6297313f01eb913c7d2a44d3a2302e4c09324bb59b411057f77ed76",
        "HashSynthesizedBase64": "Or/PiKYpcxPwHrkTx9KkTTojAuTAkyS7WbQRBX937XY=",
        "GoCheckSum": "h1:Or/PiKYpcxPwHrkTx9KkTTojAuTAkyS7WbQRBX937XY="
}
```

```bash
$ export GIT_LFS_SKIP_SMUDGE=1 # This env disables the effects of Git LFS
$ git clone https://github.com/danielorbach/dependabot-go_modules.git lfs-disabled
$ go run github.com/vikyd/go-checksum@latest lfs-disabled github.com/danielorbach/dependabot-go_modules@latest
directory: lfs-disabled
{
        "HashSynthesized": "61e260ad4da7812fd89bcaebdcdcc9121098115b05bc97d3c914b25d69aa0588",
        "HashSynthesizedBase64": "YeJgrU2ngS/Ym8rr3NzJEhCYEVsFvJfTyRSyXWmqBYg=",
        "GoCheckSum": "h1:YeJgrU2ngS/Ym8rr3NzJEhCYEVsFvJfTyRSyXWmqBYg="
}
```

We are interested in the value of `GoCheckSum` field because that is the value that gets written to `go.sum`.

Notice how the value changed when Git LFS is disabled.

P.S. I've created `danielorbach/dependabot-go_modules` to demonstrate the scenario. A more elaborate setup can be made to incorporate dependabot.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
