### PR TITLE
Fix Dependabot::Nuget::FileUpdater file content normalization

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -164,13 +164,15 @@ module Dependabot
       sig { params(dependency_file: Dependabot::DependencyFile, updated_content: String).returns(String) }
       def normalize_content(dependency_file, updated_content)
         # Fix up line endings
-        if dependency_file.content&.include?("\r\n") && updated_content.match?(/(?<!\r)\n/)
+        if dependency_file.content&.include?("\r\n")
           # The original content contain windows style newlines.
-          # Ensure the updated content also uses windows style newlines.
-          updated_content = updated_content.gsub(/(?<!\r)\n/, "\r\n")
-          puts "Fixing mismatched Windows line endings for [#{dependency_file.name}]."
+          if updated_content.match?(/(?<!\r)\n/)
+            # Ensure the updated content also uses windows style newlines.
+            updated_content = updated_content.gsub(/(?<!\r)\n/, "\r\n")
+            puts "Fixing mismatched Windows line endings for [#{dependency_file.name}]."
+          end
         elsif updated_content.include?("\r\n")
-          # The original content does not contain windows style newlines.
+          # The original content does not contain windows style newlines, but the updated content does.
           # Ensure the updated content uses unix style newlines.
           updated_content = updated_content.gsub("\r\n", "\n")
           puts "Fixing mismatched Unix line endings for [#{dependency_file.name}]."


### PR DESCRIPTION
### What are you trying to accomplish?

Fix Dependabot::Nuget::FileUpdater file content normalization (line-endings) as the current logic replaces CRLF line-endings of source file with LF.

Related to #8642
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
