### PR TITLE
Disabling the RSpec IndexedLet Rubocop rule due to its negligible benefit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -231,6 +231,8 @@ Performance/UnfreezeString:
   Enabled: true
 Performance/UriDefaultParser:
   Enabled: true
+RSpec/IndexedLet:
+  Enabled: false
 Style/AccessorGrouping:
   EnforcedStyle: 'separated'
 Style/ArgumentsForwarding:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,25 +51,6 @@ RSpec/FilePath:
     - 'nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb'
     - 'nuget/spec/dependabot/nuget/update_checker/tfm_finder_spec.rb'
 
-# Offense count: 70
-# Configuration parameters: Max, AllowedIdentifiers, AllowedPatterns.
-RSpec/IndexedLet:
-  Exclude:
-    - 'bundler/spec/dependabot/bundler/helper_spec.rb'
-    - 'cargo/spec/dependabot/cargo/file_parser_spec.rb'
-    - 'common/spec/dependabot/dependency_file_spec.rb'
-    - 'common/spec/dependabot/dependency_group_spec.rb'
-    - 'common/spec/dependabot/dependency_spec.rb'
-    - 'common/spec/dependabot/pull_request_creator/message_builder_spec.rb'
-    - 'github_actions/spec/dependabot/github_actions/update_checker_spec.rb'
-    - 'hex/spec/dependabot/hex/file_parser_spec.rb'
-    - 'hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb'
-    - 'hex/spec/dependabot/hex/file_updater_spec.rb'
-    - 'hex/spec/dependabot/hex/update_checker_spec.rb'
-    - 'npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb'
-    - 'python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb'
-    - 'python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb'
-
 # Offense count: 29
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:


### PR DESCRIPTION
https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecindexedlet

<h2 id="rspecindexedlet" style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; color: rgb(25, 25, 25); font-weight: 400; hyphens: none; line-height: 1.3; margin: 1rem -1rem 0px; border-bottom: 1px solid rgb(225, 225, 225); padding: 0.4rem 1rem 0.1rem; font-family: Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">RSpec/IndexedLet</h2><div class="sectionbody" style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; color: rgb(51, 51, 51); font-family: Roboto, sans-serif; font-size: 16.9999px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
-- | -- | -- | -- | --
Enabled | Yes | No | 2.20 | 2.23
<p>Do not set up test data using indexes (e.g., item_1, item_2).

<p>It makes reading the test harder because it’s not clear what exactly is tested by this particular example.

<p>The configurable options AllowedIdentifiers and AllowedPatterns will also read those set in Naming/VariableNumber.
<h3 id="references-49" style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; color: rgb(25, 25, 25); font-weight: 600; hyphens: none; line-height: 1.3; margin: 1rem 0px 0px;"><a class="anchor" href="https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#references-49" style="box-sizing: inherit; text-decoration: none; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; color: rgb(21, 101, 192); position: absolute; width: 1.75ex; margin-left: -1.5ex; visibility: hidden; font-size: 0.8em; font-weight: 400; padding-top: 0.05em;"></a>References</h3><div class="ulist" style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; margin: 1rem 0px 0px;"><ul style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; margin: 0px; padding: 0px 0px 0px 2rem;"><li style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent;"><p style="box-sizing: inherit; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; margin: 0px;"><a href="https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IndexedLet" class="bare" style="box-sizing: inherit; text-decoration: none; scrollbar-width: thin; scrollbar-color: rgb(193, 193, 193) transparent; color: rgb(21, 101, 192); hyphens: none;">https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IndexedLet</a></p></li></ul>

### What are you trying to accomplish?

During today's standup, we decided that this rule does not make significant improvements to the readability of the code, as it is intended.  In response, we are disabling this rule with the caveat that developers should endeavor to use meaningful names for variables in rspec files and code where possible.  As a result, PR https://github.com/dependabot/dependabot-core/pull/10024 will be unlinked and closed and a new PR will be generated.

### Anything you want to highlight for special attention from reviewers?

This disables the rule on the whole ecosystem. 

### How will you know you've accomplished your goal?

this rule will not file.  For sanity sake, it will be on the developer and code reviewers not to use names which are abstract like "file1" or "dependency4" where they are not descriptive of the functionality.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
