### PR TITLE
Update lower boundary in Python pip pyproject when bumping versions #6631

### DIFF
--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -20,6 +20,11 @@ module Dependabot
         "===" => ->(v, r) { v.to_s == r.to_s }
       )
 
+      # Override the lower bound logic for bump versions strategy.
+      BUMP_VERSIONS_OPS = OPS.merge(
+        ">=" => ->(v, r) { v.to_s == r.to_s }
+      )
+
       quoted = OPS.keys.sort_by(&:length).reverse
                   .map { |k| Regexp.quote(k) }.join("|")
       version_pattern = Python::Version::VERSION_PATTERN
@@ -78,10 +83,10 @@ module Dependabot
         super(requirements)
       end
 
-      def satisfied_by?(version)
+      def satisfied_by?(version, ops = OPS)
         version = Python::Version.new(version.to_s)
 
-        requirements.all? { |op, rv| (OPS[op] || OPS["="]).call(version, rv) }
+        requirements.all? { |op, rv| (ops[op] || ops["="]).call(version, rv) }
       end
 
       def exact?

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -278,14 +278,14 @@ module Dependabot
             requirement_strings.map { |r| requirement_class.new(r) }
 
           updated_requirement_strings = ruby_requirements.flat_map do |r|
-            next r.to_s if r.satisfied_by?(latest_resolvable_version)
+            next r.to_s if r.satisfied_by?(latest_resolvable_version, Requirement::BUMP_VERSIONS_OPS)
 
             case op = r.requirements.first.first
             when "<"
-              "<" + update_greatest_version(r.requirements.first.last, latest_resolvable_version)
-            when "<="
-              "<=" + latest_resolvable_version.to_s
-            when "!=", ">", ">="
+              "#{op}#{update_greatest_version(r.requirements.first.last, latest_resolvable_version)}"
+            when "<=", ">="
+              "#{op}#{latest_resolvable_version}"
+            when "!=", ">"
               raise UnfixableRequirement
             else
               raise "Unexpected op for unsatisfied requirement: #{op}"

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Python::Requirement do
         its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.2.0").to_s) }
       end
 
-      context "when dealing with one digits" do
+      context "when dealing with one digit" do
         let(:requirement_string) { "~1" }
 
         its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0").to_s) }
@@ -185,7 +185,7 @@ RSpec.describe Dependabot::Python::Requirement do
       it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
     end
 
-    context "with a illformed parentheses" do
+    context "with illformed parentheses" do
       let(:requirement_string) { "(== 1.2).1" }
 
       it "raises a helpful error" do
@@ -316,6 +316,52 @@ RSpec.describe Dependabot::Python::Requirement do
             it { is_expected.to be(false) }
           end
         end
+      end
+    end
+  end
+
+  describe "#satisfied_by? with BUMP_VERSIONS_OPS" do
+    subject(:requirement_satisfied_by) { requirement.satisfied_by?(version, described_class::BUMP_VERSIONS_OPS) }
+
+    let(:requirement_string) { ">=1.0.0" }
+
+    context "with a Python::Version" do
+      let(:version) { version_class.new(version_string) }
+
+      context "when dealing with the exact version" do
+        let(:version_string) { "1.0.0" }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when dealing with a different version" do
+        let(:version_string) { "2.0.0" }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when dealing with the latest resolvable version" do
+        let(:version_string) { "1.0.0" }
+
+        it { is_expected.to be(true) }
+
+        context "when the requirement includes a local version" do
+          let(:requirement_string) { ">=1.0.0+gc.1" }
+
+          it { is_expected.to be(false) }
+        end
+
+        context "when the version includes a local version" do
+          let(:version_string) { "1.0.0+gc.1" }
+
+          it { is_expected.to be(false) }
+        end
+      end
+
+      context "when dealing with an out-of-range version" do
+        let(:version_string) { "0.9.0" }
+
+        it { is_expected.to be(false) }
       end
     end
   end

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when requirement version is too high" do
             let(:requirement_txt_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(:unfixable) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0") }
           end
 
           context "when requirement had a local version" do
@@ -146,13 +146,13 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq(">=1.9,<=1.10") }
+                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
               end
             end
           end
@@ -268,7 +268,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when the requirement version is too high" do
             let(:setup_py_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(:unfixable) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0") }
           end
 
           context "with an upper bound" do
@@ -279,7 +279,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_py_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
             end
           end
         end
@@ -370,7 +370,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when the requirement version is too high" do
             let(:setup_cfg_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(:unfixable) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0") }
           end
 
           context "with an upper bound" do
@@ -381,7 +381,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_cfg_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
             end
           end
         end
@@ -504,7 +504,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               context "when the requirement version is too high" do
                 let(:pyproject_req_string) { ">=2.0.0" }
 
-                its([:requirement]) { is_expected.to eq(:unfixable) }
+                its([:requirement]) { is_expected.to eq(">=1.5.0") }
               end
 
               context "when the requirement had a local version" do
@@ -521,7 +521,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 context "when needing an update" do
                   let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                  its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+                  its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
                 end
               end
             end
@@ -650,7 +650,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when the requirement is too high" do
               let(:pyproject_req_string) { ">=2.0.0" }
 
-              its([:requirement]) { is_expected.to eq(:unfixable) }
+              its([:requirement]) { is_expected.to eq(">=1.5.0") }
             end
 
             context "with an upper bound" do
@@ -661,7 +661,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               context "when needing an update" do
                 let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+                its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
               end
             end
           end

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
         end
 
+        context "when a > req was specified" do
+          let(:requirement_txt_req_string) { "> 1.3.0" }
+
+          it { is_expected.to eq(requirement_txt_req) }
+
+          context "when dealing with exactly the version being updated to" do
+            let(:requirement_txt_req_string) { "> 1.5.0" }
+
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+
+          context "when dealing with the version lower than the lower bound" do
+            let(:requirement_txt_req_string) { "> 1.4.0" }
+
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+        end
+
         context "when a range requirement was specified" do
           let(:requirement_txt_req_string) { ">=1.3.0" }
 
@@ -496,6 +514,36 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               it { is_expected.to eq(pyproject_req) }
             end
 
+            context "when a != req was specified" do
+              let(:pyproject_req_string) { "!= 1.3.0" }
+
+              it { is_expected.to eq(pyproject_req) }
+
+              context "when dealing with exactly the version being updated to" do
+                let(:pyproject_req_string) { "!=1.5.0" }
+
+                its([:requirement]) { is_expected.to eq(:unfixable) }
+              end
+            end
+
+            context "when a > req was specified" do
+              let(:pyproject_req_string) { "> 1.3.0" }
+
+              it { is_expected.to eq(pyproject_req) }
+
+              context "when dealing with exactly the version being updated to" do
+                let(:pyproject_req_string) { "> 1.5.0" }
+
+                its([:requirement]) { is_expected.to eq(:unfixable) }
+              end
+
+              context "when dealing with the version lower than the lower bound" do
+                let(:pyproject_req_string) { "> 1.4.0" }
+
+                its([:requirement]) { is_expected.to eq(:unfixable) }
+              end
+            end
+
             context "when a range requirement was specified" do
               let(:pyproject_req_string) { ">=1.3.0" }
 
@@ -634,6 +682,36 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             let(:pyproject_req_string) { "*" }
 
             it { is_expected.to eq(pyproject_req) }
+          end
+
+          context "when a != req was specified" do
+            let(:pyproject_req_string) { "!= 1.3.0" }
+
+            it { is_expected.to eq(pyproject_req) }
+
+            context "when dealing with exactly the version being updated to" do
+              let(:pyproject_req_string) { "!=1.5.0" }
+
+              its([:requirement]) { is_expected.to eq(:unfixable) }
+            end
+          end
+
+          context "when a > req was specified" do
+            let(:pyproject_req_string) { "> 1.3.0" }
+
+            it { is_expected.to eq(pyproject_req) }
+
+            context "when dealing with exactly the version being updated to" do
+              let(:pyproject_req_string) { "> 1.5.0" }
+
+              its([:requirement]) { is_expected.to eq(:unfixable) }
+            end
+
+            context "when dealing with the version lower than the lower bound" do
+              let(:pyproject_req_string) { "> 1.4.0" }
+
+              its([:requirement]) { is_expected.to eq(:unfixable) }
+            end
           end
 
           context "when a range requirement was specified" do

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
 
           context "when dealing with the version lower than the lower bound" do
-            let(:requirement_txt_req_string) { "> 1.4.0" }
+            let(:requirement_txt_req_string) { "> 1.6.0" }
 
             its([:requirement]) { is_expected.to eq(:unfixable) }
           end
@@ -538,7 +538,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               end
 
               context "when dealing with the version lower than the lower bound" do
-                let(:pyproject_req_string) { "> 1.4.0" }
+                let(:pyproject_req_string) { "> 1.6.0" }
 
                 its([:requirement]) { is_expected.to eq(:unfixable) }
               end
@@ -708,7 +708,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             end
 
             context "when dealing with the version lower than the lower bound" do
-              let(:pyproject_req_string) { "> 1.4.0" }
+              let(:pyproject_req_string) { "> 1.6.0" }
 
               its([:requirement]) { is_expected.to eq(:unfixable) }
             end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to correct the behavior of the versioning strategy in Dependabot for Python dependencies. Specifically, when using the "increase" strategy.

**Why:** The current behavior was widening the range (e.g., from `>=8,<9` to `>=8,<10`), which is not the intended behavior. Instead, it should keep lower bound version as the new latest version and just move forward the upper boundary version (e.g., from `>=8,<9` to `>=9,<10`) as mentioned [Documentation for Versioning Strategies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy)

**Issues this affects or fixes:** 
- Addresses the issue reported in #6631.
- First noticed at #6625 (comment).

### Anything you want to highlight for special attention from reviewers?

The changes involve modifying the requirements for the pip ecosystem to ensure correct behavior for the "increase" strategy. Although the issue suggests above major versioning (e.g. >=8,<9), our "increase" strategy mandates that the lower bound is always  to be the latest version (e.g. >=8.0.1,<9). This approach aligns with the guidelines provided in the Dependabot documentation. Therefore, the changes have been made accordingly.

### How will you know you've accomplished your goal?

- Updated smoke tests should run successfully. 
https://github.com/dependabot/smoke-tests/pull/212
- Testing on https://github.com/dsp-testing/dependabot-updates-issues-6631 should create PR according to the changes

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
