### PR TITLE
Adds exception to handle nil buildfile issue

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -71,8 +71,8 @@ module Dependabot
 
           # Exception raised to handle issue that arises when buildfiles function (see this file)
           # removes the build file that contains the dependency itself. So no build file exists to
-          # update dependency, This behaviour is erratic and happens for extremely small number of users
-          # can be handled once a permanent solution is found.
+          # update dependency, This behaviour is evident for only extremely small number of users
+          # that have added separate repos as sub-modules in parent projects
 
           raise "No files changed!" if buildfile.nil?
 

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -73,7 +73,7 @@ module Dependabot
           # update dependency, This behaviour is evident for extremely small number of users
           # that have added separate repos as sub-modules in parent projects
 
-          raise DependencyFileNotFound.new(nil, "No build file found to update the dependency") if buildfile.nil?
+          raise DependencyFileNotResolvable, "No build file found to update the dependency" if buildfile.nil?
 
           if new_req.dig(:metadata, :property_name)
             files = update_files_for_property_change(files, old_req, new_req)

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -71,10 +71,10 @@ module Dependabot
 
           # Exception raised to handle issue that arises when buildfiles function (see this file)
           # removes the build file that contains the dependency itself. So no build file exists to
-          # update dependency, This behaviour is erratic and happens for exteremely small number of users
+          # update dependency, This behaviour is erratic and happens for extremely small number of users
           # can be handled once a permanent solution is found.
 
-          raise "No files have changed!" if buildfile.nil?
+          raise "No files changed!" if buildfile.nil?
 
           if new_req.dig(:metadata, :property_name)
             files = update_files_for_property_change(files, old_req, new_req)

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -69,6 +69,13 @@ module Dependabot
 
           buildfile = files.find { |f| f.name == new_req.fetch(:file) }
 
+          # Exception raised to handle issue that arises when buildfiles function (see this file)
+          # removes the build file that contains the dependency itself. So no build file exists to
+          # update dependency, This behaviour is erratic and happens for exteremely small number of users
+          # can be handled once a permanent solution is found.
+
+          raise "No files have changed!" if buildfile.nil?
+
           if new_req.dig(:metadata, :property_name)
             files = update_files_for_property_change(files, old_req, new_req)
           elsif new_req.dig(:metadata, :dependency_set)

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -65,6 +65,7 @@ module Dependabot
         reqs.each do |new_req, old_req|
           raise "Bad req match" unless new_req[:file] == old_req[:file]
           next if new_req[:requirement] == old_req[:requirement]
+
           buildfile = files.find { |f| f.name == new_req.fetch(:file) }
 
           # Exception raised to handle issue that arises when buildfiles function (see this file)
@@ -72,9 +73,7 @@ module Dependabot
           # update dependency, This behaviour is evident for extremely small number of users
           # that have added separate repos as sub-modules in parent projects
 
-          if buildfile.nil?
-            raise DependencyFileNotFound.new(nil, "No build file found to update the dependency")
-          end
+          raise DependencyFileNotFound.new(nil, "No build file found to update the dependency") if buildfile.nil?
 
           if new_req.dig(:metadata, :property_name)
             files = update_files_for_property_change(files, old_req, new_req)

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -309,6 +309,59 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
         end
       end
 
+      context "with multiple sub module buildfiles" do
+        let(:dependency_files) { [buildfile, subproject_buildfile] }
+        let(:subproject_buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "submodule/build.gradle",
+            content: fixture("buildfiles", buildfile_fixture_name)
+          )
+        end
+
+        context "when trying to update buildfiles" do
+          let(:dependency) do
+            Dependabot::Dependency.new(
+              name: "co.aikar:acf-paper",
+              version: "0.5.0-SNAPSHOT",
+              requirements: [{
+                file: "build.gradle",
+                requirement: "0.6.0-SNAPSHOT",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }, {
+                file: "app/build.gradle",
+                requirement: "0.6.0-SNAPSHOT",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }],
+              previous_requirements: [{
+                file: "build.gradle",
+                requirement: "0.5.0-SNAPSHOT",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }, {
+                file: "app/build.gradle",
+                requirement: "0.5.0-SNAPSHOT",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }],
+              package_manager: "gradle"
+            )
+          end
+
+          describe "updates the submodule/build.gradle file" do
+            it "raises a DependencyFileNotFound error" do
+              expect { updated_files.find { |f| f.name == "submodule/build.gradle" } }
+                .to raise_error(Dependabot::DependencyFileNotFound)
+            end
+          end
+        end
+      end
+
       context "with a dependency name defined by a property" do
         let(:buildfile_fixture_name) { "name_property.gradle" }
 

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
           end
 
           describe "updates the submodule/build.gradle file" do
-            it "raises a DependencyFileNotFound error" do
+            it "raises a DependencyFileNotResolvable error" do
               expect { updated_files.find { |f| f.name == "submodule/build.gradle" } }
                 .to raise_error(Dependabot::DependencyFileNotResolvable)
             end

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
           describe "updates the submodule/build.gradle file" do
             it "raises a DependencyFileNotFound error" do
               expect { updated_files.find { |f| f.name == "submodule/build.gradle" } }
-                .to raise_error(Dependabot::DependencyFileNotFound)
+                .to raise_error(Dependabot::DependencyFileNotResolvable)
             end
           end
         end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes following issue:

`NoMethodError: undefined method 'content' for nil:NilClass`

```
  original_content = buildfile.content.dup
                              ^^^^^^^^
  gradle/lib/dependabot/gradle/file_updater.rb:116:in `update_version_in_buildfile'
  gradle/lib/dependabot/gradle/file_updater.rb:74:in `block in update_buildfiles_for_dependency'
  gradle/lib/dependabot/gradle/file_updater.rb:62:in `each'
  gradle/lib/dependabot/gradle/file_updater.rb:62:in `update_buildfiles_for_dependency'
  gradle/lib/dependabot/gradle/file_updater.rb:28:in `block in updated_dependency_files'
...
(27 additional frame(s) were not displayed)
```

**Preface:** 

When managing a large project with several sub-modules, user can work with different configurations. user can create a single repo with all the submodules as part of single project. In this way, all sub modules can be handled as part of single repository.

Another approach would be to manage the submodules in separate repos. Submodules can be added to a parent project via `git submodule add https://github.com/<user>/repo repo` This way each project (main and sub modules) can be managed differently from each other, this is helpful in cases when a project is intended to be used a sub module in several projects. an example snapshot of a sub module is as following. Here, **blockmiui** and **xtoast** are added as submodules to a project. These submodules are managed from their own separate repos.

![image](https://github.com/dependabot/dependabot-core/assets/167903774/ef412af5-f251-4684-8216-b4e89ea178c4)

**Issue:** This issue exists when :dependabot: makes an update to a _gradle_ project. It is observed that dependabot is parsing the files in submodules and treating the files as part of a single repo. This is evident when file_fetcher also treats files ( build.gradle, build.gradle.kts ) from submodules eligible for update. Incidentally, when the file_updater module runs, the submodule project files are not parsed. So in this scenario, a dependency from a submodule while found to be eligible to update, does not have a valid file where it can be updated as submodule files are filtered out in file_updater stage. So no relevant build file is found at `original_content = buildfile.content.dup` in `update_version_in_buildfile`. 

**Fix:** Raise "No files changed!" exception if file_updater is not able to find a valid build file eligible for update.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

If Build file update is not successful, a new exception with message "No files changed!" will be raised.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
