### PR TITLE
Remove the dependency_has_directory feature flag

### DIFF
--- a/silent/tests/testdata/vu-group-multidir-all.txt
+++ b/silent/tests/testdata/vu-group-multidir-all.txt
@@ -120,5 +120,3 @@ job:
         - dependency-name: dependency-c
           version: 3.2.5
           directory: "/bar"
-  experiments:
-    dependency_has_directory: true

--- a/silent/tests/testdata/vu-group-multidir-semver.txt
+++ b/silent/tests/testdata/vu-group-multidir-semver.txt
@@ -77,5 +77,3 @@ job:
         update-types:
           - minor
           - patch
-  experiments:
-    dependency_has_directory: true

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -182,7 +182,7 @@ module Dependabot
           {
             "dependency-name" => dep.name,
             "dependency-version" => dep.version,
-            "directory" => should_consider_directory? ? dep.directory : nil,
+            "directory" => dep.directory,
             "dependency-removed" => dep.removed? ? true : nil
           }.compact
         end
@@ -201,11 +201,6 @@ module Dependabot
       return "" if updated_dependency_files.empty?
 
       T.must(updated_dependency_files.first).directory
-    end
-
-    sig { returns(T::Boolean) }
-    def should_consider_directory?
-      grouped_update? && Dependabot::Experiments.enabled?("dependency_has_directory")
     end
   end
 end

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -153,12 +153,7 @@ module Dependabot
       # If no groups are defined, all dependencies are ungrouped by default.
       return allowed_dependencies unless groups.any?
 
-      if Dependabot::Experiments.enabled?(:dependency_has_directory)
-        return allowed_dependencies.reject { |dep| handled_group_dependencies.include?(dep.name) }
-      end
-
-      # Otherwise return dependencies that haven't been handled during the group update portion.
-      allowed_dependencies.reject { |dep| T.must(@handled_dependencies[@current_directory]).include?(dep.name) }
+      allowed_dependencies.reject { |dep| handled_group_dependencies.include?(dep.name) }
     end
 
     private
@@ -178,13 +173,9 @@ module Dependabot
       @dependencies = T.let({}, T::Hash[String, T::Array[Dependabot::Dependency]])
       directories.each do |dir|
         @current_directory = dir
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependencies = parse_files!
-          dependencies_with_dir = dependencies.each { |dep| dep.directory = dir }
-          @dependencies[dir] = dependencies_with_dir
-        else
-          @dependencies[dir] = parse_files!
-        end
+        dependencies = parse_files!
+        dependencies_with_dir = dependencies.each { |dep| dep.directory = dir }
+        @dependencies[dir] = dependencies_with_dir
       end
 
       @dependency_group_engine = T.let(DependencyGroupEngine.from_job_config(job: job),

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -49,14 +49,10 @@ module Dependabot
         # the DependencyChange.updated_dependencies, we need to add the updated dependencies to the global list
         merge_dependency_changes(dependency_change.updated_dependencies)
 
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          merge_file_and_dependency_changes(
-            dependency_change.updated_dependencies,
-            dependency_change.updated_dependency_files
-          )
-        else
-          merge_file_changes(dependency_change.updated_dependency_files)
-        end
+        merge_file_and_dependency_changes(
+          dependency_change.updated_dependencies,
+          dependency_change.updated_dependency_files
+        )
 
         Dependabot.logger.debug("Dependencies updated:")
         debug_updated_dependencies
@@ -79,33 +75,6 @@ module Dependabot
       # presentation concern.
       def merge_dependency_changes(updated_dependencies)
         @updated_dependencies.concat(updated_dependencies)
-      end
-
-      def merge_file_changes(updated_dependency_files)
-        updated_dependency_files.each do |updated_file|
-          if updated_file.vendored_file?
-            merge_file_to_batch(updated_file, @vendored_dependency_batch)
-          else
-            merge_file_to_batch(updated_file, @dependency_file_batch)
-          end
-        end
-      end
-
-      def merge_file_to_batch(file, batch)
-        change_count = if (existing_file = batch[file.path])
-                         existing_file.fetch(:change_count, 0)
-                       else
-                         # The file is newly encountered
-                         Dependabot.logger.debug("File #{file.operation}d: '#{file.path}'")
-                         0
-                       end
-
-        batch[file.path] = {
-          file: file,
-          updated_dependencies: batch.dig(file.path, :updated_dependencies) || [],
-          changed: true,
-          changes: change_count + 1
-        }
       end
 
       def merge_file_and_dependency_changes(updated_dependencies, updated_dependency_files)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -213,12 +213,8 @@ module Dependabot
 
         # Consider the dependency handled so no individual PR is raised since it is in this group.
         # Even if update is not possible, etc.
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
+                                                              directory: job.source.directory }])
 
         if checker.up_to_date?
           log_up_to_date(dependency)
@@ -239,12 +235,8 @@ module Dependabot
           requirements_to_unlock: requirements_to_unlock
         )
       rescue Dependabot::InconsistentRegistryResponse => e
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
+                                                              directory: job.source.directory }])
         error_handler.log_dependency_error(
           dependency: dependency,
           error: e,
@@ -255,12 +247,8 @@ module Dependabot
       rescue StandardError => e
         # If there was an error we might not be able to determine if the dependency is in this
         # group due to semver grouping, so we consider it handled to avoid raising an individual PR.
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
+                                                              directory: job.source.directory }])
         error_handler.handle_dependency_error(error: e, dependency: dependency, dependency_group: group)
         [] # return an empty set
       end
@@ -467,20 +455,15 @@ module Dependabot
         )
         dependency_snapshot.handled_dependencies << dependency.name
 
-        dependency_params = {
+        Dependabot::Dependency.new(
           name: dependency.name,
           version: dependency.version,
           previous_version: original_dependency.version,
           requirements: dependency.requirements,
           previous_requirements: original_dependency.requirements,
-          package_manager: dependency.package_manager
-        }
-
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_params[:directory] = dependency.directory
-        end
-
-        Dependabot::Dependency.new(**dependency_params)
+          package_manager: dependency.package_manager,
+          directory: dependency.directory
+        ) 
       end
     end
   end

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -114,30 +114,19 @@ module Dependabot
                 "Deferring creation of a new pull request. The existing pull request will update in a separate job."
               )
 
-              if Dependabot::Experiments.enabled?(:dependency_has_directory)
-
-                # A grouped version update gets its directories from user-defined update configs.
-                # A multi-directory grouped update will iterate each group over every directory.
-                # Therefore, we can skip a grouped dependency if it's been updated in *any* directory
-                # add the dependencies in the group so individual updates don't try to update them
-                dependency_snapshot.add_handled_group_dependencies(
-                  dependencies_in_existing_pr_for_group(group)
-                   .map { |d| { name: d["dependency-name"], directory: d["directory"] } }
-                )
-                # also add dependencies that might be in the group, as a rebase would add them;
-                # this avoids individual PR creation that immediately is superseded by a group PR supersede
-                dependency_snapshot.add_handled_group_dependencies(
-                  group.dependencies.map { |d| { name: d.name, directory: d.directory } }
-                )
-              else
-                # add the dependencies in the group so individual updates don't try to update them
-                dependency_snapshot.add_handled_dependencies(
-                  dependencies_in_existing_pr_for_group(group).filter_map { |d| d["dependency-name"] }
-                )
-                # also add dependencies that might be in the group, as a rebase would add them;
-                # this avoids individual PR creation that immediately is superseded by a group PR supersede
-                dependency_snapshot.add_handled_dependencies(group.dependencies.map(&:name))
-              end
+              # A grouped version update gets its directories from user-defined update configs.
+              # A multi-directory grouped update will iterate each group over every directory.
+              # Therefore, we can skip a grouped dependency if it's been updated in *any* directory
+              # add the dependencies in the group so individual updates don't try to update them
+              dependency_snapshot.add_handled_group_dependencies(
+                dependencies_in_existing_pr_for_group(group)
+                 .map { |d| { name: d["dependency-name"], directory: d["directory"] } }
+              )
+              # also add dependencies that might be in the group, as a rebase would add them;
+              # this avoids individual PR creation that immediately is superseded by a group PR supersede
+              dependency_snapshot.add_handled_group_dependencies(
+                group.dependencies.map { |d| { name: d.name, directory: d.directory } }
+              )
 
               next
             end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -269,14 +269,6 @@ RSpec.describe Dependabot::DependencyChange do
   end
 
   describe "#matches_existing_pr?" do
-    before do
-      Dependabot::Experiments.register("dependency_has_directory", true)
-    end
-
-    after do
-      Dependabot::Experiments.reset!
-    end
-
     context "when no existing pull requests are found" do
       let(:job) do
         instance_double(Dependabot::Job,

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -55,15 +55,7 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
       end
     end
 
-    context "when the :dependency_has_directory ff is enabled" do
-      before do
-        Dependabot::Experiments.register(:dependency_has_directory, true)
-      end
-
-      after do
-        Dependabot::Experiments.reset!
-      end
-
+    context "when there are multiple directories" do
       let(:dependency_change) do
         Dependabot::DependencyChange.new(
           job: job,

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -68,15 +68,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       original_bundler_files
     end
 
-    before do
-      stub_rubygems_calls
-      Dependabot::Experiments.register("dependency_has_directory", true)
-    end
-
-    after do
-      Dependabot::Experiments.reset!
-    end
-
     it "updates the existing pull request without errors" do
       expect(mock_service).to receive(:update_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("everything-everywhere-all-at-once")


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the dependency_has_directory feature flag
Used in:
- https://github.com/dependabot/dependabot-core/pull/9988
- https://github.com/dependabot/dependabot-core/pull/9938

### Anything you want to highlight for special attention from reviewers?

The flag was already rolled out to 100% with no new sentry errors.

### How will you know you've accomplished your goal?

No new sentry errors after this deploys.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
