### PR TITLE
Make it easier to upgrade Bundler & RubyGems in sync (take 2)

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -110,16 +110,18 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
+# RubyGems & Bundler should be bumped together following these steps:
+# * Bump RubyGems version below. That will also automatically update the default Bundler version.
+# * Regenerate `updater/Gemfile.lock` via `BUNDLE_GEMFILE=updater/Gemfile bundle lock --update --bundler`.
+# * Regenerate `Gemfile.lock` via `bundle lock --update --bundler`.
+#
+# Note that RubyGems & Bundler versions are currently released in sync, but
+# RubyGems version is one major ahead. So when bumping to RubyGems 3.y.z, Bundler
+# version will jump to 2.y.z
 ARG RUBYGEMS_VERSION=3.5.14
 RUN gem update --system $RUBYGEMS_VERSION
 
-# When bumping Bundler, need to also:
-# * Regenerate `updater/Gemfile.lock` via `BUNDLE_GEMFILE=updater/Gemfile bundle lock --update --bundler`
-# * Regenerate `Gemfile.lock` via `bundle lock --update --bundler`.
-ARG BUNDLER_V2_VERSION=2.5.14
-
-RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
- bundle config set --global build.psych --with-libyaml-source-dir=$DEPENDABOT_HOME/src/libyaml/yaml-$LIBYAML_VERSION && \
+RUN bundle config set --global build.psych --with-libyaml-source-dir=$DEPENDABOT_HOME/src/libyaml/yaml-$LIBYAML_VERSION && \
  bundle config set --local path 'vendor' && \
  bundle config set --local frozen 'true' && \
  bundle config set --local without 'development' && \

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -119,7 +119,6 @@ RUN gem update --system $RUBYGEMS_VERSION
 ARG BUNDLER_V2_VERSION=2.5.14
 
 RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
- rm -rf /var/lib/gems/*/cache/* && \
  bundle config set --global build.psych --with-libyaml-source-dir=$DEPENDABOT_HOME/src/libyaml/yaml-$LIBYAML_VERSION && \
  bundle config set --local path 'vendor' && \
  bundle config set --local frozen 'true' && \


### PR DESCRIPTION
### What are you trying to accomplish?

This is a fresh copy of https://github.com/dependabot/dependabot-core/pull/9979, as requested in https://github.com/dependabot/dependabot-core/pull/9979#issuecomment-2187693088.

Even if Bundler is tested against multiple versions of RubyGems, it's best if both are upgraded together.

Also, upgrading RubyGems installs an upgraded copy of Bundler as a default gem, so I believe it's unnecessary to install Bundler explicitly. It should result in a slightly thinner image.

### Anything you want to highlight for special attention from reviewers?

No.

### How will you know you've accomplished your goal?

Everything still works smoothly in production after deploying this.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
