### PR TITLE
Bump default PNPM to 9.4.0

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -258,13 +258,16 @@ module Dependabot
       FileUtils.mkdir_p(Utils::BUMP_TMP_DIR_PATH)
 
       previous_config = ENV.fetch("GIT_CONFIG_GLOBAL", nil)
+      previous_terminal_prompt = ENV.fetch("GIT_TERMINAL_PROMPT", nil)
 
       begin
         ENV["GIT_CONFIG_GLOBAL"] = GIT_CONFIG_GLOBAL_PATH
+        ENV["GIT_TERMINAL_PROMPT"] = "false"
         configure_git_to_use_https_with_credentials(credentials, safe_directories)
         yield
       ensure
         ENV["GIT_CONFIG_GLOBAL"] = previous_config
+        ENV["GIT_TERMINAL_PROMPT"] = previous_terminal_prompt
       end
     rescue Errno::ENOSPC => e
       raise Dependabot::OutOfDisk, e.message

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG COREPACK_VERSION=0.24.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=8.15.6
+ARG PNPM_VERSION=9.4.0
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
 ARG YARN_VERSION=4.1.1

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -39,7 +39,8 @@ module Dependabot
 
         IRRESOLVABLE_PACKAGE = "ERR_PNPM_NO_MATCHING_VERSION"
         INVALID_REQUIREMENT = "ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER"
-        UNREACHABLE_GIT = %r{ERR_PNPM_FETCH_404[ [^:print:]]+GET (?<url>https://codeload\.github\.com/[^/]+/[^/]+)/}
+        UNREACHABLE_GIT = %r{Command failed with exit code 128: git ls-remote (?<url>.*github\.com/[^/]+/[^ ]+)}
+        UNREACHABLE_GIT_V8 = %r{ERR_PNPM_FETCH_404[ [^:print:]]+GET (?<url>https://codeload\.github\.com/[^/]+/[^/]+)/}
         FORBIDDEN_PACKAGE = /ERR_PNPM_FETCH_403[ [^:print:]]+GET (?<dependency_url>.*): Forbidden - 403/
         MISSING_PACKAGE = /ERR_PNPM_FETCH_404[ [^:print:]]+GET (?<dependency_url>.*): (?:Not Found)? - 404/
         UNAUTHORIZED_PACKAGE = /ERR_PNPM_FETCH_401[ [^:print:]]+GET (?<dependency_url>.*): Unauthorized - 401/
@@ -95,7 +96,13 @@ module Dependabot
           end
 
           if error_message.match?(UNREACHABLE_GIT)
-            url = error_message.match(UNREACHABLE_GIT).named_captures.fetch("url")
+            url = error_message.match(UNREACHABLE_GIT).named_captures.fetch("url").gsub("git+ssh://git@", "https://").delete_suffix(".git")
+
+            raise Dependabot::GitDependenciesNotReachable, url
+          end
+
+          if error_message.match?(UNREACHABLE_GIT_V8)
+            url = error_message.match(UNREACHABLE_GIT_V8).named_captures.fetch("url").gsub("codeload.", "")
 
             raise Dependabot::GitDependenciesNotReachable, url
           end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -160,7 +160,43 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(error.dependency_urls)
             .to eq(
               [
-                "https://codeload.github.com/Zelcord/electron-context-menu"
+                "https://github.com/Zelcord/electron-context-menu"
+              ]
+            )
+        end
+      end
+    end
+
+    context "with a private git dep we don't have access to in PNPM v8" do
+      let(:dependency_name) { "cross-fetch" }
+      let(:version) { "4.0.0" }
+      let(:previous_version) { "3.1.5" }
+      let(:requirements) do
+        [{
+          file: "package.json",
+          requirement: "^4.0.0",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+      let(:previous_requirements) do
+        [{
+          file: "package.json",
+          requirement: "^3.1.5",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      let(:project_name) { "pnpm/github_dependency_private_v8" }
+
+      it "raises a helpful error" do
+        expect { updated_pnpm_lock_content }
+          .to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+          expect(error.dependency_urls)
+            .to eq(
+              [
+                "https://github.com/Zelcord/electron-context-menu"
               ]
             )
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -3758,8 +3758,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             f.name == "other_package/package.json"
           end
 
-          expect(lockfile.content).to include("/lodash@1.3.1:")
-          expect(lockfile.content).to include("/lodash").once
+          expect(lockfile.content).to include("lodash@1.3.1:\n    resolution").once
 
           expect(package.content).to include('"lodash": "1.3.1"')
           expect(package1.content).to include('"lodash": "^1.3.1"')
@@ -3792,8 +3791,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
               .to match_array(%w(pnpm-lock.yaml packages/package1/package.json))
 
             lockfile = updated_files.find { |f| f.name == "pnpm-lock.yaml" }
-            expect(lockfile.content).to include("/chalk@0.4.0:")
-            expect(lockfile.content).to include("/chalk@0.4.0:").once
+            expect(lockfile.content).to include("chalk@0.4.0:")
+            expect(lockfile.content).to include("chalk@0.4.0:\n    resolution").once
           end
 
           it "does not add the dependency to the top-level workspace" do
@@ -3829,8 +3828,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             root_lockfile = updated_files.find { |f| f.name == "pnpm-lock.yaml" }
             expect(updated_files.map(&:name)). to match_array(%w(pnpm-lock.yaml packages/package1/package.json))
 
-            expect(root_lockfile.content).to include("/etag@1.8.1:")
-            expect(root_lockfile.content).to include("/etag@").once
+            expect(root_lockfile.content).to include("etag@1.8.1:\n    resolution").once
           end
 
           it "updates the existing development declaration" do
@@ -3854,8 +3852,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:previous_requirements) { [] }
 
         it "updates the version" do
-          expect(updated_pnpm_lock.content).to include("/acorn@5.7.3:")
-          expect(updated_pnpm_lock.content).to include("/acorn@").once
+          expect(updated_pnpm_lock.content).to include("acorn@5.7.3:\n    resolution").once
         end
       end
 
@@ -3878,8 +3875,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "updates the resolution, as well as the declaration" do
           expect(updated_package_json.content).to include('"lodash": "3.10.1"')
 
-          expect(updated_pnpm_lock.content).to include("/lodash@3.10.1:")
-          expect(updated_pnpm_lock.content).to include("/lodash@").once
+          expect(updated_pnpm_lock.content).to include("lodash@3.10.1:\n    resolution").once
         end
       end
 
@@ -3902,8 +3898,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "updates the resolution, as well as the declaration" do
           expect(updated_package_json.content).to include('"lodash": "3.10.1"')
 
-          expect(updated_pnpm_lock.content).to include("/lodash@3.10.1:")
-          expect(updated_pnpm_lock.content).to include("/lodash@").once
+          expect(updated_pnpm_lock.content).to include("lodash@3.10.1:\n    resolution").once
         end
       end
 
@@ -3933,8 +3928,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "updates the manifest and lockfile" do
           expect(updated_files.map(&:name)).to match_array(%w(package.json pnpm-lock.yaml))
 
-          expect(updated_pnpm_lock.content).to include("/node-adodb@5.0.3:")
-          expect(updated_pnpm_lock.content).to include("/node-adodb@").once
+          expect(updated_pnpm_lock.content).to include("node-adodb@5.0.3:\n    resolution").once
         end
       end
 
@@ -3950,8 +3944,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "de-duplicates all entries to the same version" do
           expect(updated_files.map(&:name)).to contain_exactly("pnpm-lock.yaml")
 
-          expect(updated_pnpm_lock.content).to include("/js-yaml@3.14.1:")
-          expect(updated_pnpm_lock.content).to include("/js-yaml@").once
+          expect(updated_pnpm_lock.content).to include("js-yaml@3.14.1:\n    resolution").once
         end
       end
 
@@ -3974,8 +3967,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "updates the lockfile" do
           expect(updated_files.map(&:name)).to eq(%w(pnpm-lock.yaml))
 
-          expect(updated_pnpm_lock.content).to include("/typescript@2.1.4:")
-          expect(updated_pnpm_lock.content).to include("/typescript@2.9.1:")
+          expect(updated_pnpm_lock.content).to include("typescript@2.1.4:")
+          expect(updated_pnpm_lock.content).to include("typescript@2.9.1:")
         end
       end
     end

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
@@ -1,28 +1,31 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  cross-fetch:
-    specifier: ^3.1.5
-    version: 3.1.5
-  electron-context-menu:
-    specifier: github:Zelcord/electron-context-menu
-    version: github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32
+importers:
+
+  .:
+    dependencies:
+      cross-fetch:
+        specifier: ^3.1.5
+        version: 3.1.5
+      electron-context-menu:
+        specifier: github:Zelcord/electron-context-menu
+        version: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32
 
 packages:
 
-  /cross-fetch@3.1.5:
+  cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
-    dependencies:
-      node-fetch: 2.6.7
-    transitivePeerDependencies:
-      - encoding
-    dev: false
 
-  /node-fetch@2.6.7:
+  electron-context-menu@https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+    name: electron-context-menu
+    version: 3.5.0
+
+  node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -30,27 +33,35 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+snapshots:
+
+  cross-fetch@3.1.5:
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+
+  electron-context-menu@https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32: {}
+
+  node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
+  tr46@0.0.3: {}
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
+  webidl-conversions@3.0.1: {}
 
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+  whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
-
-  github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32:
-    resolution: {tarball: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
-    name: electron-context-menu
-    version: 3.5.0
-    dev: false

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "Zelcord",
+    "version": "3.3.0",
+    "description": "Zelcord is a custom client designed to enhance your Discord experience while keeping everything lightweight.",
+    "main": "ts-out/main.js",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Zelcord/Zelcord.git"
+    },
+    "author": "smartfrigde",
+    "license": "OSL-3.0",
+    "bugs": {
+        "url": "https://github.com/Zelcord/Zelcord/issues"
+    },
+    "homepage": "https://github.com/Zelcord/Zelcord#readme",
+    "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "electron-context-menu": "github:Zelcord/electron-context-menu"
+    },
+    "packageManager": "pnpm@8.15.6"
+}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
@@ -1,0 +1,56 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  cross-fetch:
+    specifier: ^3.1.5
+    version: 3.1.5
+  electron-context-menu:
+    specifier: github:Zelcord/electron-context-menu
+    version: github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32
+
+packages:
+
+  /cross-fetch@3.1.5:
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
+
+  github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+    name: electron-context-menu
+    version: 3.5.0
+    dev: false


### PR DESCRIPTION
### What are you trying to accomplish?

This is required so that Dependabot works for people using PNPM 9 and not specifying `packageManager` in their `package.json` files.



### Anything you want to highlight for special attention from reviewers?

If `packageManager` is not specified, Dependabot currently uses PNPM 8. When PNPM 8 finds "PNPM 9 lockfiles", it prints a warning like this:

```
 WARN  Ignoring broken lockfile at /home/dependabot/tmp/wJoenn/vue-template: Lockfile /home/dependabot/tmp/wJoenn/vue-template/pnpm-lock.yaml not compatible with current pnpm
```

So it ignores the lockfile and creates a new one from scratch using its own format (lockfileVersion 6), causing the problem reported in https://github.com/dependabot/dependabot-core/issues/9684.

### How will you know you've accomplished your goal?

The problem can be reproduced in a dev shell with

```
$ bin/dry-run.rb npm_and_yarn wJoenn/vue-template --commit eea451a717b4e1f814f840196511fdbef0e1cabb --dep vue
```

With this PR, the lockfile format is no longer reverted to v6.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
