### PR TITLE
Revert "Passing the latest allowable version as package constraints"

### DIFF
--- a/composer/helpers/v2/src/UpdateChecker.php
+++ b/composer/helpers/v2/src/UpdateChecker.php
@@ -8,15 +8,13 @@ use Composer\DependencyResolver\Request;
 use Composer\Factory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
-use Composer\Package\Link;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionParser;
 
 final class UpdateChecker
 {
     public static function getLatestResolvableVersion(array $args): ?string
     {
-        [$workingDirectory, $dependencyName, $gitCredentials, $registryCredentials, $latestAllowableVersion] = $args;
+        [$workingDirectory, $dependencyName, $gitCredentials, $registryCredentials] = $args;
 
         $httpBasicCredentials = [];
 
@@ -50,22 +48,10 @@ final class UpdateChecker
             $io->loadConfiguration($config);
         }
 
-        $package = $composer->getPackage();
-
-        $versionParser = new VersionParser();
-
-        $constraint = $versionParser->parseConstraints($latestAllowableVersion); // your version constraint
-        $packageLink = new Link($package->getName(), $dependencyName, $constraint);
-
-        $requires = $package->getRequires();
-        $requires[$dependencyName] = $packageLink;
-
-        $package->setRequires($requires);
-
         $install = new Installer(
             $io,
             $config,
-            $package,  // @phpstan-ignore-line
+            $composer->getPackage(),  // @phpstan-ignore-line
             $composer->getDownloadManager(),
             $composer->getRepositoryManager(),
             $composer->getLocker(),

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -148,8 +148,7 @@ module Dependabot
                 Dir.pwd,
                 dependency.name.downcase,
                 git_credentials,
-                registry_credentials,
-                @latest_allowable_version.to_s
+                registry_credentials
               ]
             )
           end

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
-      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
 
       it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
     end
@@ -69,14 +68,12 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
-      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
 
       it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
 
       context "when the minimum version is invalid" do
         let(:dependency_version) { "4.2.0" }
         let(:string_req) { "4.2.0" }
-        let(:latest_allowable_version) { Gem::Version.new("4.3.1") }
 
         it { is_expected.to be >= Dependabot::Composer::Version.new("4.3.1") }
       end
@@ -88,7 +85,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
         let(:dependency_name) { "phpdocumentor/reflection-docblock" }
         let(:dependency_version) { "2.0.4" }
         let(:string_req) { "2.0.4" }
-        let(:latest_allowable_version) { Gem::Version.new("3.2.2") }
 
         it { is_expected.to eq(Dependabot::Composer::Version.new("3.2.2")) }
       end
@@ -107,7 +103,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     context "with a dependency that's provided by another dep" do
       let(:project_name) { "provided_dependency" }
       let(:string_req) { "^1.0" }
-      let(:latest_allowable_version) { Gem::Version.new("1.0.0") }
+      let(:latest_allowable_version) { Gem::Version.new("6.0.0") }
       let(:dependency_name) { "php-http/client-implementation" }
       let(:dependency_version) { nil }
 

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -194,12 +194,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { checker.latest_resolvable_version }
 
-    # setting the latest allowable version to 1.22.0
-    before do
-      allow(checker).to receive(:latest_version_from_registry)
-        .and_return(Gem::Version.new("1.22.0"))
-    end
-
     it "returns a non-normalized version, following semver" do
       expect(latest_resolvable_version.segments.count).to eq(3)
     end
@@ -215,7 +209,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.22.0.a, < 4.0"] }
 
-      it { is_expected.to eq(Gem::Version.new("1.22.0")) }
+      it { is_expected.to eq(Gem::Version.new("1.21.0")) }
     end
 
     context "without a lockfile" do
@@ -234,12 +228,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           }]
         end
 
-        # setting the latest allowable version to 4.3.0
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("4.3.0"))
-        end
-
         it { is_expected.to be >= Gem::Version.new("4.3.0") }
       end
 
@@ -256,32 +244,26 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           }]
         end
 
-        # setting the latest allowable version to 5.2.45
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("5.2.45"))
-        end
-
         it { is_expected.to be >= Gem::Version.new("5.2.45") }
 
         context "when as a platform requirement" do
           let(:project_name) { "old_php_platform" }
 
-          it { is_expected.to eq(Gem::Version.new("5.2.45")) }
+          it { is_expected.to eq(Gem::Version.new("5.4.36")) }
 
           context "when an extension is specified that we don't have" do
             let(:project_name) { "missing_extension" }
 
             it "pretends the missing extension is there" do
               expect(latest_resolvable_version)
-                .to eq(Dependabot::Composer::Version.new("5.2.45"))
+                .to eq(Dependabot::Composer::Version.new("5.4.36"))
             end
           end
 
           context "when the platform requirement only specifies an extension" do
             let(:project_name) { "bad_php" }
 
-            it { is_expected.to eq(Gem::Version.new("5.2.45")) }
+            it { is_expected.to eq(Gem::Version.new("5.4.36")) }
           end
         end
       end
@@ -297,12 +279,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
             groups: ["runtime"],
             source: nil
           }]
-        end
-
-        # setting the latest allowable version to 5.2.45
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("5.2.45"))
         end
 
         it { is_expected.to be >= Gem::Version.new("5.2.45") }
@@ -489,8 +465,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         v1_metadata_url = "https://repo.packagist.org/p/#{dependency_name.downcase}.json"
         # v1 url doesn't always return 404 for missing packages
         stub_request(:get, v1_metadata_url).to_return(status: 200, body: '{"error":{"code":404,"message":"Not Found"}}')
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("2.4.2"))
       end
 
       it "is between 2.0.0 and 3.0.0" do
@@ -512,12 +486,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
       let(:ignored_versions) { [">= 2.8.0"] }
-
-      # set latest allowable version from registry to 2.1.7
-      before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("2.1.7"))
-      end
 
       it "is the highest resolvable version" do
         expect(latest_resolvable_version).to eq(Gem::Version.new("2.1.7"))
@@ -586,16 +554,12 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       context "when there is no lockfile" do
         let(:project_name) { "version_conflict_on_update_without_lockfile" }
 
-        it "raises a helpful error" do
-          expect { latest_resolvable_version }.to raise_error(Dependabot::DependencyFileNotResolvable)
-        end
+        it { is_expected.to be_nil }
 
         context "when the conflict comes from a loose PHP version" do
           let(:project_name) { "version_conflict_library" }
 
-          it "raises a helpful error" do
-            expect { latest_resolvable_version }.to raise_error(Dependabot::DependencyFileNotResolvable)
-          end
+          it { is_expected.to be_nil }
         end
       end
     end
@@ -686,12 +650,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
-      # set latest allowable version from registry to 1.3.0
-      before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("1.3.0"))
-      end
-
       # Alternatively, this could raise an error. Either behaviour would be
       # fine - the below is just what we get with Composer at the moment
       # because we disabled downloading the files in
@@ -770,8 +728,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
             status: 200,
             body: fixture("wpackagist_response.json")
           )
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("3.0.2"))
       end
 
       it { is_expected.to be >= Gem::Version.new("3.0.2") }
@@ -790,13 +746,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
-      # set latest allowable version from registry to 5.2.7
-      before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("5.2.7"))
-      end
-
-      it { is_expected.to be >= Gem::Version.new("5.2.7") }
+      it { is_expected.to be >= Gem::Version.new("5.2.30") }
     end
 
     context "when a sub-dependency would block the update" do
@@ -810,12 +760,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           groups: ["runtime"],
           source: nil
         }]
-      end
-
-      # setting the latest allowable version to 5.6.23
-      before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("5.6.23"))
       end
 
       # 5.5.0 series and up require an update to illuminate/contracts


### PR DESCRIPTION
Reverts dependabot/dependabot-core#10018

Based on the comment provided on the https://github.com/dependabot/dependabot-core/pull/10018 I have decided to revert this changes.

Once we resolve all the related issue we will enable this changes again.
