### PR TITLE
Including Sentry meta tag for security updates

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -17,6 +17,7 @@ module Dependabot
     DEPENDENCY_GROUPS = "job-dependency-groups"
     JOB_ID            = "job-id"
     PACKAGE_MANAGER   = "package-manager"
+    SECURITY_UPDATE   = "security-update"
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -129,7 +129,7 @@ module Dependabot
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
         ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups,
-        ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only?
+        ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only ? "true" : "false"
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
     end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -128,7 +128,8 @@ module Dependabot
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
-        ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups
+        ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups,
+        ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only?
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
     end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -129,7 +129,7 @@ module Dependabot
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
         ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups,
-        ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only ? "true" : "false"
+        ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only?
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
     end

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => [],
-            Dependabot::ErrorAttributes::SECURITY_UPDATE => "false"
+            Dependabot::ErrorAttributes::SECURITY_UPDATE => false
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -163,7 +163,8 @@ RSpec.describe Dependabot::FileFetcherCommand do
             Dependabot::ErrorAttributes::CLASS => "StandardError",
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
-            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => []
+            Dependabot::ErrorAttributes::DEPENDENCY_GROUPS => [],
+            Dependabot::ErrorAttributes::SECURITY_UPDATE => "false"
           }
         )
         expect(api_client).to receive(:mark_job_as_processed)

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -371,6 +371,24 @@ RSpec.describe Dependabot::Service do
         )
     end
 
+    it "extracts information from a job if provided" do
+      job = OpenStruct.new(id: 1234, package_manager: "npm_and_yarn", repo_private?: false, repo_owner: "foo", security_update:true)
+      service.capture_exception(error: error, job: job)
+
+      expect(mock_client)
+        .to have_received(:record_update_job_unknown_error)
+        .with(
+          error_type: "unknown_error",
+          error_details: hash_including(
+            Dependabot::ErrorAttributes::CLASS => "Dependabot::DependabotError",
+            Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
+            Dependabot::ErrorAttributes::JOB_ID => job.id,
+            Dependabot::ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
+            Dependabot::ErrorAttributes::SECURITY_UPDATE => job.security_updates_only?
+          )
+        )
+    end
+
     it "extracts information from a dependency_group if provided" do
       dependency_group = OpenStruct.new(name: "all-the-things")
       allow(dependency_group).to receive(:is_a?).with(Dependabot::DependencyGroup).and_return(true)

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -371,8 +371,9 @@ RSpec.describe Dependabot::Service do
         )
     end
 
-    it "extracts information from a job if provided" do
-      job = OpenStruct.new(id: 1234, package_manager: "npm_and_yarn", repo_private?: false, repo_owner: "foo", security_update:true)
+    it "extracts information from a security job if provided" do
+      job = OpenStruct.new(id: 1234, package_manager: "npm_and_yarn", repo_private?: false, repo_owner: "foo",
+                           security_updates_only: "true")
       service.capture_exception(error: error, job: job)
 
       expect(mock_client)
@@ -384,7 +385,7 @@ RSpec.describe Dependabot::Service do
             Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
             Dependabot::ErrorAttributes::JOB_ID => job.id,
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
-            Dependabot::ErrorAttributes::SECURITY_UPDATE => job.security_updates_only?
+            Dependabot::ErrorAttributes::SECURITY_UPDATE => "true"
           )
         )
     end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe Dependabot::Service do
 
     it "extracts information from a security job if provided" do
       job = OpenStruct.new(id: 1234, package_manager: "npm_and_yarn", repo_private?: false, repo_owner: "foo",
-                           security_updates_only: "true")
+                           security_updates_only?: true)
       service.capture_exception(error: error, job: job)
 
       expect(mock_client)
@@ -385,7 +385,7 @@ RSpec.describe Dependabot::Service do
             Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
             Dependabot::ErrorAttributes::JOB_ID => job.id,
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
-            Dependabot::ErrorAttributes::SECURITY_UPDATE => "true"
+            Dependabot::ErrorAttributes::SECURITY_UPDATE => true
           )
         )
     end


### PR DESCRIPTION
### What are you trying to accomplish?

**Preface:** When there is Security update related exception in NPM and YARN ecosystem, the error response is generic ("No files were updated!") which is not very useful in Sentry analysis. The fix adds a new tag to Sentry to better isolate the issues related with Security Update failures.

**Fix:** Include "security-update" tag with :dependabot: jobs. tag will assert to true if job is of type security update and false if regular update. 

<!-- What issues does this affect or fix? -->

Process to fix https://github.com/github/dependabot-updates/issues/6133 issues related with NPM and Yarn package manager. The change is to isolate security updates from regular updates so that these issues can be analyzed in a separate bucket for fixes.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

This fix was followed up after discussion here: https://github.com/github/dependabot-updates/issues/6254

### How will you know you've accomplished your goal?

Security update jobs should have a tag called `security-update : true `

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
