### PR TITLE
[python] - Fix for updating lower constraint only for increase strategy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: main
+  SMOKE_TEST_BRANCH: kamil/update_smoke_tests_according_to_10154_PR_changes
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -126,7 +126,7 @@ module Dependabot
               req.fetch(:requirement)
             else
               # But if it's not, update it
-              update_requirements_range(requirement_strings)
+              update_requirements_range(requirement_strings, Requirement::BUMP_VERSIONS_OPS)
             end
 
           req.merge(requirement: new_requirement)
@@ -273,12 +273,12 @@ module Dependabot
             .join(".")
         end
 
-        def update_requirements_range(requirement_strings)
+        def update_requirements_range(requirement_strings, ops = Requirement::OPS)
           ruby_requirements =
             requirement_strings.map { |r| requirement_class.new(r) }
 
           updated_requirement_strings = ruby_requirements.flat_map do |r|
-            next r.to_s if r.satisfied_by?(latest_resolvable_version, Requirement::BUMP_VERSIONS_OPS)
+            next r.to_s if r.satisfied_by?(latest_resolvable_version, ops)
 
             case op = r.requirements.first.first
             when "<"

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
+                its([:requirement]) { is_expected.to eq(">=1.9,<=1.10") }
               end
             end
           end
@@ -569,7 +569,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 context "when needing an update" do
                   let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                  its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+                  its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
                 end
               end
             end

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
@@ -297,7 +297,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_py_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
             end
           end
         end
@@ -399,7 +399,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_cfg_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
             end
           end
         end
@@ -569,7 +569,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 context "when needing an update" do
                   let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                  its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+                  its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
                 end
               end
             end
@@ -739,7 +739,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               context "when needing an update" do
                 let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+                its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
               end
             end
           end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to ensure that the changes for updating version bounds apply only to the "increase" strategy in Dependabot for Python dependencies. The current behavior incorrectly applies these changes to all versioning strategies, which is not intended.

**Why**: The previous fix applied to all versioning strategies, but it should specifically target the "increase" strategy to maintain the correct versioning behavior and avoid unintended changes to other strategies.

**Issues this affects or fixes**:
- This PR addresses the issue where the versioning strategy changes were applied broadly instead of specifically to the "increase" strategy.

### Anything you want to highlight for special attention from reviewers?

I chose this approach to ensure the changes only affect the "increase" strategy, aligning with the intended behavior. This ensures that other strategies remain unaffected and work as expected.

Note that the updating lower constraint will work for other strategies (widen, increase if only necessary) only if latest version is lower than the lower constraint which is unusual. 

### How will you know you've accomplished your goal?

- The updated smoke tests for the "increase" strategy should run successfully.
- Testing on a relevant repository should demonstrate that the changes are applied correctly to the "increase" strategy only.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
