### PR TITLE
Strict type `github_actions`

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -144,14 +144,14 @@ module Dependabot
       max_local_tag(allowed_version_tags)
     end
 
-    sig { returns(T::Array[T.nilable(T::Hash[Symbol, T.untyped])]) }
+    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def local_tags_for_allowed_versions_matching_existing_precision
-      select_matching_existing_precision(allowed_version_tags).map { |t| to_local_tag(t) }
+      select_matching_existing_precision(allowed_version_tags).filter_map { |t| to_local_tag(t) }
     end
 
-    sig { returns(T::Array[T.nilable(T::Hash[Symbol, T.untyped])]) }
+    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def local_tags_for_allowed_versions
-      allowed_version_tags.map { |t| to_local_tag(t) }
+      allowed_version_tags.filter_map { |t| to_local_tag(t) }
     end
 
     sig { returns(T::Array[Dependabot::GitRef]) }

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -136,7 +136,7 @@ module Dependabot
 
       # Lowest available security fix version not checking resolvability
       # @return [Dependabot::<package manager>::Version, #to_s] version class
-      sig { overridable.returns(Dependabot::Version) }
+      sig { overridable.returns(T.nilable(Dependabot::Version)) }
       def lowest_security_fix_version
         raise NotImplementedError, "#{self.class} must implement #lowest_security_fix_version"
       end
@@ -363,7 +363,7 @@ module Dependabot
       end
 
       # TODO: Should this return Dependabot::Version?
-      sig { returns(T.nilable(Gem::Version)) }
+      sig { returns(T.nilable(Dependabot::Version)) }
       def current_version
         @current_version ||=
           T.let(

--- a/github_actions/.rubocop.yml
+++ b/github_actions/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: ../.rubocop.yml
+
+Sorbet/StrictSigil:
+  Enabled: true

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -15,29 +15,41 @@ module Dependabot
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       extend T::Sig
 
+      sig { override.returns(T.nilable(T.any(String, Gem::Version))) }
       def latest_version
-        @latest_version ||= fetch_latest_version
+        @latest_version ||= T.let(
+          fetch_latest_version,
+          T.nilable(T.any(String, Gem::Version))
+        )
       end
 
+      sig { override.returns(T.nilable(T.any(String, Gem::Version))) }
       def latest_resolvable_version
         # Resolvability isn't an issue for GitHub Actions.
         latest_version
       end
 
+      sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock
         # No concept of "unlocking" for GitHub Actions (since no lockfile)
         dependency.version
       end
 
+      sig { override.returns(T.nilable(Dependabot::Version)) }
       def lowest_security_fix_version
-        @lowest_security_fix_version ||= fetch_lowest_security_fix_version
+        @lowest_security_fix_version ||= T.let(
+          fetch_lowest_security_fix_version,
+          T.nilable(Dependabot::Version)
+        )
       end
 
+      sig { override.returns(T.nilable(Dependabot::Version)) }
       def lowest_resolvable_security_fix_version
         # Resolvability isn't an issue for GitHub Actions.
         lowest_security_fix_version
       end
 
+      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
       def updated_requirements
         dependency.requirements.map do |req|
           source = req[:source]
@@ -61,21 +73,25 @@ module Dependabot
 
       private
 
+      sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
       def active_advisories
         security_advisories.select do |advisory|
           advisory.vulnerable?(version_class.new(git_commit_checker.most_specific_tag_equivalent_to_pinned_ref))
         end
       end
 
+      sig { override.returns(T::Boolean) }
       def latest_version_resolvable_with_full_unlock?
         # Full unlock checks aren't relevant for GitHub Actions
         false
       end
 
+      sig { override.returns(T::Array[Dependabot::Dependency]) }
       def updated_dependencies_after_full_unlock
         raise NotImplementedError
       end
 
+      sig { returns(T.nilable(T.any(Dependabot::Version, String))) }
       def fetch_latest_version
         # TODO: Support Docker sources
         return unless git_dependency?
@@ -83,20 +99,21 @@ module Dependabot
         fetch_latest_version_for_git_dependency
       end
 
+      sig { returns(T.nilable(T.any(Dependabot::Version, String))) }
       def fetch_latest_version_for_git_dependency
         return current_commit unless git_commit_checker.pinned?
 
         # If the dependency is pinned to a tag that looks like a version then
         # we want to update that tag.
         if git_commit_checker.pinned_ref_looks_like_version? && latest_version_tag
-          latest_version = latest_version_tag.fetch(:version)
+          latest_version = latest_version_tag&.fetch(:version)
           return current_version if shortened_semver_eq?(dependency.version, latest_version.to_s)
 
           return latest_version
         end
 
         if git_commit_checker.pinned_ref_looks_like_commit_sha? && latest_version_tag
-          latest_version = latest_version_tag.fetch(:version)
+          latest_version = latest_version_tag&.fetch(:version)
           return latest_commit_for_pinned_ref unless git_commit_checker.local_tag_for_pinned_sha
 
           return latest_version
@@ -107,6 +124,7 @@ module Dependabot
         nil
       end
 
+      sig { returns(T.nilable(Dependabot::Version)) }
       def fetch_lowest_security_fix_version
         # TODO: Support Docker sources
         return unless git_dependency?
@@ -114,23 +132,34 @@ module Dependabot
         fetch_lowest_security_fix_version_for_git_dependency
       end
 
+      sig { returns(T.nilable(Dependabot::Version)) }
       def fetch_lowest_security_fix_version_for_git_dependency
-        lowest_security_fix_version_tag.fetch(:version)
+        lowest_security_fix_version_tag&.fetch(:version)
       end
 
+      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def lowest_security_fix_version_tag
-        @lowest_security_fix_version_tag ||= begin
-          tags_matching_precision = git_commit_checker.local_tags_for_allowed_versions_matching_existing_precision
-          lowest_fixed_version = find_lowest_secure_version(tags_matching_precision)
-          if lowest_fixed_version
-            lowest_fixed_version
-          else
-            tags = git_commit_checker.local_tags_for_allowed_versions
-            find_lowest_secure_version(tags)
-          end
-        end
+        @lowest_security_fix_version_tag ||= T.let(
+          begin
+            tags_matching_precision = git_commit_checker.local_tags_for_allowed_versions_matching_existing_precision
+            lowest_fixed_version = find_lowest_secure_version(tags_matching_precision)
+            if lowest_fixed_version
+              lowest_fixed_version
+            else
+              tags = git_commit_checker.local_tags_for_allowed_versions
+              find_lowest_secure_version(tags)
+            end
+          end,
+          T.nilable(T::Hash[Symbol, String])
+        )
       end
 
+      sig do
+        params(
+          tags: T::Array[T::Hash[Symbol, T.untyped]]
+        )
+          .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+      end
       def find_lowest_secure_version(tags)
         relevant_tags = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(tags, security_advisories)
         relevant_tags = filter_lower_tags(relevant_tags)
@@ -138,40 +167,54 @@ module Dependabot
         relevant_tags.min_by { |tag| tag.fetch(:version) }
       end
 
+      sig { returns(T.nilable(String)) }
       def latest_commit_for_pinned_ref
-        @latest_commit_for_pinned_ref ||= begin
-          head_commit_for_ref_sha = git_commit_checker.head_commit_for_pinned_ref
-          if head_commit_for_ref_sha
-            head_commit_for_ref_sha
-          else
-            url = git_commit_checker.dependency_source_details[:url]
-            source = T.must(Source.from_url(url))
+        @latest_commit_for_pinned_ref ||= T.let(
+          begin
+            head_commit_for_ref_sha = git_commit_checker.head_commit_for_pinned_ref
+            if head_commit_for_ref_sha
+              head_commit_for_ref_sha
+            else
+              url = git_commit_checker.dependency_source_details&.fetch(:url)
+              source = T.must(Source.from_url(url))
 
-            SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-              repo_contents_path = File.join(temp_dir, File.basename(source.repo))
+              SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
+                repo_contents_path = File.join(temp_dir, File.basename(source.repo))
 
-              SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
+                SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
 
-              Dir.chdir(repo_contents_path) do
-                ref_branch = find_container_branch(git_commit_checker.dependency_source_details[:ref])
-                git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
+                Dir.chdir(repo_contents_path) do
+                  ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
+                  git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
+                end
               end
             end
-          end
-        end
+          end,
+          T.nilable(String)
+        )
       end
 
+      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def latest_version_tag
-        @latest_version_tag ||= begin
-          return git_commit_checker.local_tag_for_latest_version if dependency.version.nil?
+        @latest_version_tag ||= T.let(
+          begin
+            return git_commit_checker.local_tag_for_latest_version if dependency.version.nil?
 
-          ref = git_commit_checker.local_ref_for_latest_version_matching_existing_precision
-          return ref if ref && ref.fetch(:version) > current_version
+            ref = git_commit_checker.local_ref_for_latest_version_matching_existing_precision
+            return ref if ref && ref.fetch(:version) > current_version
 
-          git_commit_checker.local_ref_for_latest_version_lower_precision
-        end
+            git_commit_checker.local_ref_for_latest_version_lower_precision
+          end,
+          T.nilable(T::Hash[Symbol, T.untyped])
+        )
       end
 
+      sig do
+        params(
+          tags_array: T::Array[T::Hash[Symbol, T.untyped]]
+        )
+          .returns(T::Array[T::Hash[Symbol, T.untyped]])
+      end
       def filter_lower_tags(tags_array)
         return tags_array unless current_version
 
@@ -179,6 +222,7 @@ module Dependabot
           .select { |tag| tag.fetch(:version) > current_version }
       end
 
+      sig { params(source: T.nilable(T::Hash[Symbol, String])).returns(T.nilable(String)) }
       def updated_ref(source)
         # TODO: Support Docker sources
         return unless git_dependency?
@@ -206,6 +250,7 @@ module Dependabot
         nil
       end
 
+      sig { returns(T.nilable(String)) }
       def latest_commit_sha
         new_tag = latest_version_tag
         return unless new_tag
@@ -217,20 +262,30 @@ module Dependabot
         end
       end
 
+      sig { returns(T.nilable(String)) }
       def current_commit
         git_commit_checker.head_commit_for_current_branch
       end
 
+      sig { returns(T::Boolean) }
       def git_dependency?
         git_commit_checker.git_dependency?
       end
 
+      sig { returns(Dependabot::GitCommitChecker) }
       def git_commit_checker
-        @git_commit_checker ||= git_commit_checker_for(nil)
+        @git_commit_checker ||= T.let(
+          git_commit_checker_for(nil),
+          T.nilable(Dependabot::GitCommitChecker)
+        )
       end
 
+      sig { params(source: T.nilable(T::Hash[Symbol, String])).returns(Dependabot::GitCommitChecker) }
       def git_commit_checker_for(source)
-        @git_commit_checkers ||= {}
+        @git_commit_checkers ||= T.let(
+          {},
+          T.nilable(T::Hash[T.nilable(T::Hash[Symbol, String]), Dependabot::GitCommitChecker])
+        )
 
         @git_commit_checkers[source] ||= Dependabot::GitCommitChecker.new(
           dependency: dependency,
@@ -242,6 +297,7 @@ module Dependabot
         )
       end
 
+      sig { params(base: T.nilable(String), other: String).returns(T::Boolean) }
       def shortened_semver_eq?(base, other)
         return false unless base
 
@@ -252,6 +308,7 @@ module Dependabot
         other_split[0..base_split.length - 1] == base_split
       end
 
+      sig { params(sha: String).returns(T.nilable(String)) }
       def find_container_branch(sha)
         branches_including_ref = SharedHelpers.run_shell_command(
           "git branch --remotes --contains #{sha}",

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -606,9 +606,13 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
   describe "#lowest_resolvable_security_fix_version" do
     subject(:lowest_resolvable_security_fix_version) { checker.lowest_resolvable_security_fix_version }
 
-    before { allow(checker).to receive(:lowest_security_fix_version).and_return("delegate") }
+    before do
+      allow(checker)
+        .to receive(:lowest_security_fix_version)
+        .and_return(Dependabot::GithubActions::Version.new("2.0.0"))
+    end
 
-    it { is_expected.to eq("delegate") }
+    it { is_expected.to eq(Dependabot::GithubActions::Version.new("2.0.0")) }
   end
 
   describe "#updated_requirements" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
Complete Sorbet strict typing of `github_action` and enable `Sorbet/StrictSigil` RuboCop check.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
A couple of minor changes required outside of the `github_actions` directory:
- `Dependabot::UpdateCheckers::Base.lowest_security_fix_version` return type changed from `Dependabot::Version` to `T.nilable(Dependabot::Version)`
  - This makes sense, as not all updates will have a security fix version
- Removed `nil` return values from a couple of methods in `Dependabot::GitCommitChecker` by using `filter_map` instead of just `filter`
  - `nil` array values aren't used, and it makes types in callers simpler

Also, I fixed what I believe to be an incorrect test mock. A string value was being returned where a `Dependabot::Version` was expected. See #9342 for more information about incorrect types in tests.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
