### PR TITLE
Remove redundant call from `mixfile`

### DIFF
--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -42,7 +42,6 @@ module Dependabot
       sig { returns(T.nilable(DependencyFile)) }
       def mixfile
         @mixfile ||= T.let(fetch_file_from_host("mix.exs"), T.nilable(Dependabot::DependencyFile))
-        fetch_file_from_host("mix.exs")
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
Remove a redundant call to `fetch_file_from_host` in `mixfile`. This was called out in the original review by @landongrindheim, but never addressed[^1]. Thank you @jeffwidman for pointing this out.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
N/A

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
Sorbet checks and tests pass.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

[^1]: https://github.com/dependabot/dependabot-core/pull/9990/files#r1648045378