### PR TITLE
Make `HelperSubprocessFailed` error class configurable in run_helper_subprocess

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -134,13 +134,15 @@ module Dependabot
         args: T.any(T::Array[T.any(String, T::Array[T::Hash[String, T.untyped]])], T::Hash[Symbol, String]),
         env: T.nilable(T::Hash[String, String]),
         stderr_to_stdout: T::Boolean,
-        allow_unsafe_shell_command: T::Boolean
+        allow_unsafe_shell_command: T::Boolean,
+        error_class: T.class_of(HelperSubprocessFailed)
       )
         .returns(T.nilable(T.any(String, T::Hash[String, T.untyped], T::Array[T::Hash[String, T.untyped]])))
     end
     def self.run_helper_subprocess(command:, function:, args:, env: nil,
                                    stderr_to_stdout: false,
-                                   allow_unsafe_shell_command: false)
+                                   allow_unsafe_shell_command: false,
+                                   error_class: HelperSubprocessFailed)
       start = Time.now
       stdin_data = JSON.dump(function: function, args: args)
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
@@ -180,28 +182,29 @@ module Dependabot
         process_termsig: process.termsig
       }
 
-      check_out_of_memory_error(stderr, error_context)
+      check_out_of_memory_error(stderr, error_context, error_class)
 
       begin
         response = JSON.parse(stdout)
         return response["result"] if process.success?
 
-        raise HelperSubprocessFailed.new(
+        raise error_class.new(
           message: response["error"],
           error_class: response["error_class"],
           error_context: error_context,
           trace: response["trace"]
         )
       rescue JSON::ParserError
-        raise handle_json_parse_error(stdout, stderr, error_context)
+        raise handle_json_parse_error(stdout, stderr, error_context, error_class)
       end
     end
 
     sig do
-      params(stdout: String, stderr: String, error_context: T::Hash[Symbol, T.untyped])
-        .returns(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      params(stdout: String, stderr: String, error_context: T::Hash[Symbol, T.untyped],
+             error_class: T.class_of(HelperSubprocessFailed))
+        .returns(HelperSubprocessFailed)
     end
-    def self.handle_json_parse_error(stdout, stderr, error_context)
+    def self.handle_json_parse_error(stdout, stderr, error_context, error_class)
       # If the JSON is invalid, the helper has likely failed
       # We should raise a more helpful error message
       message = if !stdout.strip.empty?
@@ -211,7 +214,7 @@ module Dependabot
                 else
                   "No output from command"
                 end
-      HelperSubprocessFailed.new(
+      error_class.new(
         message: message,
         error_class: "JSON::ParserError",
         error_context: error_context
@@ -219,11 +222,14 @@ module Dependabot
     end
 
     # rubocop:enable Metrics/MethodLength
-    sig { params(stderr: T.nilable(String), error_context: T::Hash[Symbol, String]).void }
-    def self.check_out_of_memory_error(stderr, error_context)
+    sig do
+      params(stderr: T.nilable(String), error_context: T::Hash[Symbol, String],
+             error_class: T.class_of(HelperSubprocessFailed)).void
+    end
+    def self.check_out_of_memory_error(stderr, error_context, error_class)
       return unless stderr&.include?("JavaScript heap out of memory")
 
-      raise HelperSubprocessFailed.new(
+      raise error_class.new(
         message: "JavaScript heap out of memory",
         error_class: "Dependabot::OutOfMemoryError",
         error_context: error_context

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -9,6 +9,9 @@ require "dependabot/shared_helpers"
 require "dependabot/simple_instrumentor"
 require "dependabot/workspace"
 
+# Custom error class for testing
+class EcoSystemHelperSubprocessFailed < Dependabot::SharedHelpers::HelperSubprocessFailed; end
+
 RSpec.describe Dependabot::SharedHelpers do
   let(:spec_root) { File.join(File.dirname(__FILE__), "..") }
   let(:tmp) { Dependabot::Utils::BUMP_TMP_DIR_PATH }

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -138,7 +138,8 @@ RSpec.describe Dependabot::SharedHelpers do
         function: function,
         args: args,
         env: env,
-        stderr_to_stdout: stderr_to_stdout
+        stderr_to_stdout: stderr_to_stdout,
+        error_class: error_class
       )
     end
 
@@ -146,6 +147,7 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:args) { ["foo"] }
     let(:env) { nil }
     let(:stderr_to_stdout) { false }
+    let(:error_class) { Dependabot::SharedHelpers::HelperSubprocessFailed }
 
     context "when the subprocess is successful" do
       it "returns the result" do
@@ -220,9 +222,9 @@ RSpec.describe Dependabot::SharedHelpers do
 
     context "when a custom error class is passed" do
       let(:error_class) { EcoSystemHelperSubprocessFailed }
+      let(:function) { "hard_error" }
 
       it "raises the custom error class" do
-        let(:function) { "hard_error" }
         expect { run_subprocess }
           .to raise_error(EcoSystemHelperSubprocessFailed)
       end
@@ -588,6 +590,7 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:stdout) { "" }
     let(:stderr) { "" }
     let(:error_context) { { command: "test_command", function: "test_function", args: [] } }
+    let(:error_class) { Dependabot::SharedHelpers::HelperSubprocessFailed }
 
     context "when stdout is not empty" do
       let(:stdout) { "Some stdout message" }

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -569,12 +569,13 @@ RSpec.describe Dependabot::SharedHelpers do
 
   describe ".handle_json_parse_error" do
     subject(:handle_json_parse_error) do
-      described_class.handle_json_parse_error(stdout, stderr, error_context)
+      described_class.handle_json_parse_error(stdout, stderr, error_context, error_class)
     end
 
     let(:stdout) { "" }
     let(:stderr) { "" }
     let(:error_context) { { command: "test_command", function: "test_function", args: [] } }
+    let(:error_class) { Dependabot::SharedHelpers::HelperSubprocessFailed }
 
     context "when stdout is not empty" do
       let(:stdout) { "Some stdout message" }

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -214,6 +214,16 @@ RSpec.describe Dependabot::SharedHelpers do
           end)
       end
     end
+
+    context "when a custom error class is passed" do
+      let(:error_class) { EcoSystemHelperSubprocessFailed }
+
+      it "raises the custom error class" do
+        let(:function) { "hard_error" }
+        expect { run_subprocess }
+          .to raise_error(EcoSystemHelperSubprocessFailed)
+      end
+    end
   end
 
   describe ".run_shell_command" do
@@ -575,7 +585,6 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:stdout) { "" }
     let(:stderr) { "" }
     let(:error_context) { { command: "test_command", function: "test_function", args: [] } }
-    let(:error_class) { Dependabot::SharedHelpers::HelperSubprocessFailed }
 
     context "when stdout is not empty" do
       let(:stdout) { "Some stdout message" }
@@ -599,6 +608,16 @@ RSpec.describe Dependabot::SharedHelpers do
       it "raises HelperSubprocessFailed with default message" do
         expect { raise handle_json_parse_error }
           .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, "No output from command")
+      end
+    end
+
+    context "when a custom error class is passed" do
+      let(:stdout) { "Some stdout message" }
+      let(:error_class) { EcoSystemHelperSubprocessFailed }
+
+      it "raises the custom error class with stdout message" do
+        expect { raise handle_json_parse_error }
+          .to raise_error(EcoSystemHelperSubprocessFailed, "Some stdout message")
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR aims to enhance the `run_helper_subprocess` method by making the `HelperSubprocessFailed` error class configurable. This change allows callers to specify a custom error class that extends `HelperSubprocessFailed`, enabling better categorization of errors based on the package manager or other context. This will help to categorize error classes between ecosystems, improving error debugging when using tools like console, Sentry, or other monitoring tools.

### What issues does this affect or fix?

This update addresses the need for more granular error handling and categorization in subprocess executions, improving error transparency and debugging efficiency across different package managers.

### Anything you want to highlight for special attention from reviewers?

The new functionality introduces an optional `error_class` parameter to the `run_helper_subprocess` method. This parameter defaults to `HelperSubprocessFailed` but allows for any subclass of `HelperSubprocessFailed` to be specified. This approach ensures backward compatibility while providing enhanced flexibility.

### How will you know you've accomplished your goal?

- Custom error classes will be used correctly when specified in calls to `run_helper_subprocess`.
- All existing tests will pass without modification, ensuring backward compatibility.
- Additional tests will be added to verify the new functionality, ensuring that custom error classes behave as expected.
- Error debugging will be improved in tools like console, Sentry, or other monitoring tools due to better error categorization.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
