### PR TITLE
Improve Yarn Helper Error Handling

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -224,7 +224,7 @@ module Dependabot
         }
       }
     when
-      Dependabot::DependencyConflict,
+      DependencyConflict,
       RequiredVersionIsNotSatisfied,
       AutoMergeParseFailure,
       AutoMergeImmutable,

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -226,17 +226,9 @@ module Dependabot
     when
       DependencyConflict,
       RequiredVersionIsNotSatisfied,
-      AutoMergeParseFailure,
-      AutoMergeImmutable,
       IncompatibleOS,
       IncompatibleCPU,
-      NetworkDisabled,
-      NetworkUnsafeHTTP,
-      NMExternalSoftLink,
-      NMPreserveSymlinksRequired,
-      PrologInstantiationError,
-      GhostArchitecture,
-      StateFileNotFound
+      NetworkUnsafeHTTP
 
       error.get_detail
 
@@ -674,20 +666,6 @@ module Dependabot
     end
   end
 
-  class AutoMergeParseFailure < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("auto_merge_parse_failure", message)
-    end
-  end
-
-  class AutoMergeImmutable < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("auto_merge_immutable", message)
-    end
-  end
-
   class IncompatibleOS < TypedDependabotError
     sig { params(message: T.any(T.nilable(String), MatchData)).void }
     def initialize(message = nil)
@@ -702,52 +680,10 @@ module Dependabot
     end
   end
 
-  class NetworkDisabled < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("network_disabled", message)
-    end
-  end
-
   class NetworkUnsafeHTTP < TypedDependabotError
     sig { params(message: T.any(T.nilable(String), MatchData)).void }
     def initialize(message = nil)
       super("network_unsafe_http", message)
-    end
-  end
-
-  class NMExternalSoftLink < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("nm_external_soft_link", message)
-    end
-  end
-
-  class NMPreserveSymlinksRequired < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("nm_preserve_symlinks_required", message)
-    end
-  end
-
-  class PrologInstantiationError < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("prolog_instantiation_error", message)
-    end
-  end
-
-  class GhostArchitecture < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("ghost_architecture", message)
-    end
-  end
-
-  class StateFileNotFound < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("state_file_not_found", message)
     end
   end
 end

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -230,7 +230,7 @@ module Dependabot
       IncompatibleCPU,
       NetworkUnsafeHTTP
 
-      error.get_detail
+      error.detail
 
     when Dependabot::NotImplemented
       {
@@ -316,15 +316,14 @@ module Dependabot
       super(message || error_type)
     end
 
-    sig { params(detail: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
-    def get_detail(detail = nil)
-      hash = {
+    sig { params(hash: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
+    def detail(hash = nil)
+      {
         "error-type": error_type,
-        "error-detail": detail || {
+        "error-detail": hash || {
           message: message
         }
       }
-      hash
     end
   end
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -226,10 +226,8 @@ module Dependabot
     when
       DependencyConflict,
       RequiredVersionIsNotSatisfied,
-      IncompatibleOS,
       IncompatibleCPU,
       NetworkUnsafeHTTP
-
       error.detail
 
     when Dependabot::NotImplemented
@@ -662,13 +660,6 @@ module Dependabot
     sig { params(message: T.any(T.nilable(String), MatchData)).void }
     def initialize(message = nil)
       super("required_version_not_satisfied", message)
-    end
-  end
-
-  class IncompatibleOS < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("incompatible_os", message)
     end
   end
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -224,8 +224,6 @@ module Dependabot
         }
       }
     when
-      DependencyConflict,
-      RequiredVersionIsNotSatisfied,
       IncompatibleCPU,
       NetworkUnsafeHTTP
       error.detail
@@ -489,13 +487,6 @@ module Dependabot
 
   class DependencyFileNotResolvable < DependabotError; end
 
-  class DependencyConflict < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("dependency_conflict", message)
-    end
-  end
-
   #######################
   # Source level errors #
   #######################
@@ -655,13 +646,6 @@ module Dependabot
 
   # Raised by FileParser if processing may execute external code in the update context
   class UnexpectedExternalCode < DependabotError; end
-
-  class RequiredVersionIsNotSatisfied < TypedDependabotError
-    sig { params(message: T.any(T.nilable(String), MatchData)).void }
-    def initialize(message = nil)
-      super("required_version_not_satisfied", message)
-    end
-  end
 
   class IncompatibleCPU < TypedDependabotError
     sig { params(message: T.any(T.nilable(String), MatchData)).void }

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -223,6 +223,23 @@ module Dependabot
           "go-mod": error.go_mod
         }
       }
+    when
+      Dependabot::DependencyConflict,
+      RequiredVersionIsNotSatisfied,
+      AutoMergeParseFailure,
+      AutoMergeImmutable,
+      IncompatibleOS,
+      IncompatibleCPU,
+      NetworkDisabled,
+      NetworkUnsafeHTTP,
+      NMExternalSoftLink,
+      NMPreserveSymlinksRequired,
+      PrologInstantiationError,
+      GhostArchitecture,
+      StateFileNotFound
+
+      error.get_detail
+
     when Dependabot::NotImplemented
       {
         "error-type": "not_implemented",
@@ -291,6 +308,31 @@ module Dependabot
       string.scan(regex).flatten.compact.reduce(string) do |original_msg, match|
         original_msg.gsub(match, replacement)
       end
+    end
+  end
+
+  class TypedDependabotError < Dependabot::DependabotError
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :error_type
+
+    sig { params(error_type: String, message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(error_type, message = nil)
+      @error_type = T.let(error_type, String)
+
+      super(message || error_type)
+    end
+
+    sig { params(detail: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
+    def get_detail(detail = nil)
+      hash = {
+        "error-type": error_type,
+        "error-detail": detail || {
+          message: message
+        }
+      }
+      hash
     end
   end
 
@@ -458,6 +500,13 @@ module Dependabot
 
   class DependencyFileNotResolvable < DependabotError; end
 
+  class DependencyConflict < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("dependency_conflict", message)
+    end
+  end
+
   #######################
   # Source level errors #
   #######################
@@ -617,4 +666,88 @@ module Dependabot
 
   # Raised by FileParser if processing may execute external code in the update context
   class UnexpectedExternalCode < DependabotError; end
+
+  class RequiredVersionIsNotSatisfied < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("required_version_not_satisfied", message)
+    end
+  end
+
+  class AutoMergeParseFailure < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("auto_merge_parse_failure", message)
+    end
+  end
+
+  class AutoMergeImmutable < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("auto_merge_immutable", message)
+    end
+  end
+
+  class IncompatibleOS < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("incompatible_os", message)
+    end
+  end
+
+  class IncompatibleCPU < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("incompatible_cpu", message)
+    end
+  end
+
+  class NetworkDisabled < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("network_disabled", message)
+    end
+  end
+
+  class NetworkUnsafeHTTP < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("network_unsafe_http", message)
+    end
+  end
+
+  class NMExternalSoftLink < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("nm_external_soft_link", message)
+    end
+  end
+
+  class NMPreserveSymlinksRequired < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("nm_preserve_symlinks_required", message)
+    end
+  end
+
+  class PrologInstantiationError < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("prolog_instantiation_error", message)
+    end
+  end
+
+  class GhostArchitecture < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("ghost_architecture", message)
+    end
+  end
+
+  class StateFileNotFound < TypedDependabotError
+    sig { params(message: T.any(T.nilable(String), MatchData)).void }
+    def initialize(message = nil)
+      super("state_file_not_found", message)
+    end
+  end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -32,63 +32,63 @@ module Dependabot
     YARN_ERROR_CODES = T.let({
       "YN0001" => {
         message: "Exception error",
-        new_error: ->(error) { Dependabot::DependabotError.new(error.message) }
+        new_error: ->(_error, message) { Dependabot::DependabotError.new(message) }
       },
       "YN0002" => {
         message: "Missing peer dependency",
-        new_error: ->(message) { Dependabot::DependencyFileNotResolvable.new(message) }
+        new_error: ->(_error, message) { Dependabot::DependencyFileNotResolvable.new(message) }
       },
       "YN0016" => {
         message: "Remote not found",
-        new_error: ->(message) { Dependabot::GitDependenciesNotReachable.new(message) }
+        new_error: ->(_error, message) { Dependabot::GitDependenciesNotReachable.new(message) }
       },
       "YN0020" => {
         message: "Missing lockfile entry",
-        new_error: ->(message) { Dependabot::DependencyFileNotFound.new(message) }
+        new_error: ->(_error, message) { Dependabot::DependencyFileNotFound.new(message) }
       },
       "YN0046" => {
         message: "Automerge failed to parse",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0047" => {
         message: "Automerge immutable",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0062" => {
         message: "Incompatible OS",
-        new_error: ->(message) { Dependabot::IncompatibleOS.new(message) }
+        new_error: ->(_error, message) { Dependabot::IncompatibleOS.new(message) }
       },
       "YN0063" => {
         message: "Incompatible CPU",
-        new_error: ->(message) { Dependabot::IncompatibleCPU.new(message) }
+        new_error: ->(_error, message) { Dependabot::IncompatibleCPU.new(message) }
       },
       "YN0071" => {
         message: "NM can't install external soft link",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0072" => {
         message: "NM preserve symlinks required",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0075" => {
         message: "Prolog instantiation error",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0077" => {
         message: "Ghost architecture",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0080" => {
         message: "Network disabled",
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0081" => {
         message: "Network unsafe HTTP",
-        new_error: ->(message) { Dependabot::NetworkUnsafeHTTP.new(message) }
+        new_error: ->(_error, message) { Dependabot::NetworkUnsafeHTTP.new(message) }
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
-      new_error: T.proc.params(message: String).returns(Dependabot::DependabotError)
+      new_error: T.proc.params(error: Dependabot::DependabotError, message: String).returns(Dependabot::DependabotError)
     }])
 
     # Used to check if package manager registry is public npm registry
@@ -142,37 +142,38 @@ module Dependabot
     VALIDATION_GROUP_PATTERNS = T.let([
       {
         patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
-        new_error: ->(message) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
+        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
         in_usage: true,
         matchfn: nil
       },
       {
         patterns: [TARBALL_IS_NOT_IN_NETWORK],
-        new_error: ->(message) { Dependabot::DependencyFileNotResolvable.new(message) },
+        new_error: ->(_error, message) { Dependabot::DependencyFileNotResolvable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [NODE_VERSION_NOT_SATISFY_REGEX],
-        new_error: ->(message) { Dependabot::RequiredVersionIsNotSatisfied.new(message) },
+        new_error: ->(_error, message) { Dependabot::RequiredVersionIsNotSatisfied.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [AUTHENTICATION_TOKEN_NOT_PROVIDED, AUTHENTICATION_IS_NOT_CONFIGURED],
-        new_error: ->(message) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
+        new_error: ->(_error, message) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [DEPENDENCY_CONFLICT],
-        new_error: ->(message) { Dependabot::DependencyConflict.new(message) },
+        new_error: ->(_error, message) { Dependabot::DependencyConflict.new(message) },
         in_usage: false,
         matchfn: nil
       }
     ].freeze, T::Array[{
       patterns: T::Array[T.any(String, Regexp)],
-      new_error: T.proc.params(message: String).returns(Dependabot::DependabotError),
+      new_error: T.proc.params(error: Dependabot::DependabotError,
+                               message: String).returns(Dependabot::DependabotError),
       in_usage: T.nilable(T::Boolean),
       matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
     }])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -25,3 +25,111 @@ Dependabot::Dependency.register_production_check(
     groups.include?("dependencies")
   end
 )
+
+module Dependabot
+  module NpmAndYarn
+    YARN_CODE_REGEX = /(YN\d{4})/
+    YARN_ERROR_CODES = T.let({
+      "YN0001" => { message: "Exception error", error_class: Dependabot::DependabotError },
+      "YN0002" => { message: "Missing peer dependency", error_class: Dependabot::DependencyFileNotResolvable },
+      "YN0016" => { message: "Remote not found", error_class: Dependabot::GitDependenciesNotReachable },
+      "YN0020" => { message: "Missing lockfile entry", error_class: Dependabot::DependencyFileNotFound },
+      "YN0046" => { message: "Automerge failed to parse", error_class: Dependabot::AutoMergeParseFailure },
+      "YN0047" => { message: "Automerge immutable", error_class: AutoMergeImmutable },
+      "YN0062" => { message: "Incompatible OS", error_class: Dependabot::IncompatibleOS },
+      "YN0063" => { message: "Incompatible CPU", error_class: Dependabot::IncompatibleCPU },
+      "YN0071" => { message: "NM can't install external soft link", error_class: Dependabot::NMExternalSoftLink },
+      "YN0072" => { message: "NM preserve symlinks required", error_class: Dependabot::NMPreserveSymlinksRequired },
+      "YN0075" => { message: "Prolog instantiation error", error_class: Dependabot::PrologInstantiationError },
+      "YN0077" => { message: "Ghost architecture", error_class: Dependabot::GhostArchitecture },
+      "YN0080" => { message: "Network disabled", error_class: Dependabot::NetworkDisabled },
+      "YN0081" => { message: "Network unsafe HTTP", error_class: Dependabot::NetworkUnsafeHTTP }
+    }.freeze, T::Hash[String, { message: String, error_class: T.class_of(Dependabot::DependabotError) }])
+
+    # Used to check if package manager registry is public npm registry
+    NPM_REGISTRY = "registry.npmjs.org"
+
+    # Used to check if url is http or https
+    HTTP_CHECK_REGEX = %r{https?://}
+
+    # Error message when a package.json name include invalid characters
+    INVALID_NAME_IN_PACKAGE_JSON = "Name contains illegal characters"
+
+    # Used to identify error messages indicating a package is missing, unreachable,
+    # or there are network issues (e.g., ENOBUFS, ETIMEDOUT, registry down).
+    PACKAGE_MISSING_REGEX = /(ENOBUFS|ETIMEDOUT|The registry may be down)/
+
+    # Used to check if error message contains timeout fetching package
+    TIMEOUT_FETCHING_PACKAGE_REGEX = %r{(?<url>.+)/(?<package>[^/]+): ETIMEDOUT}
+
+    # Used to identify git unreachable error
+    UNREACHABLE_GIT_CHECK_REGEX = /ls-remote --tags --heads (?<url>.*)/
+
+    # Used to check if yarn workspace is enabled in non-private workspace
+    ONLY_PRIVATE_WORKSPACE_TEXT = "Workspaces can only be enabled in priva"
+
+    # Used to identify local path error in yarn when installing sub-dependency
+    SUB_DEP_LOCAL_PATH_TEXT = "refers to a non-existing file"
+
+    # Used to identify invalid package error when package is not found in registry
+    INVALID_PACKAGE_REGEX = /Can't add "(?<package_req>.*)": invalid/
+
+    # Used to identify error if node_modules state file not resolved
+    NODE_MODULES_STATE_FILE_NOT_FOUND = "Couldn't find the node_modules state file"
+
+    # Used to find error message in yarn error output
+    YARN_USAGE_ERROR_TEXT = "Usage Error:"
+
+    # Used to identify error if tarball is not in network
+    TARBALL_IS_NOT_IN_NETWORK = "Tarball is not in network and can not be located in cache"
+
+    # Finding errors such as "The current Node version 20.15.1 does not satisfy the required version 20.11.0"
+    NODE_VERSION_NOT_SATISFY_REGEX = /The current .*Node.* version.*does not satisfy the required version/
+
+    # Used to identify if authentication failure error
+    AUTHENTICATION_TOKEN_NOT_PROVIDED = "authentication token not provided"
+    AUTHENTICATION_IS_NOT_CONFIGURED = "No authentication configured for request"
+
+    # Used to identify if error message is related to yarn workspaces
+    DEPENDENCY_CONFLICT = "conflicts with direct dependency"
+
+    # Group of patterns to validate error message and raise specific error
+    VALIDATION_GROUP_PATTERNS = T.let([
+      {
+        patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
+        error_class: Dependabot::StateFileNotFound,
+        in_usage: true,
+        matchfn: nil
+      },
+      {
+        patterns: [TARBALL_IS_NOT_IN_NETWORK],
+        error_class: Dependabot::DependencyFileNotResolvable,
+        in_usage: false,
+        matchfn: nil
+      },
+      {
+        patterns: [NODE_VERSION_NOT_SATISFY_REGEX],
+        error_class: Dependabot::RequiredVersionIsNotSatisfied,
+        in_usage: false,
+        matchfn: nil
+      },
+      {
+        patterns: [AUTHENTICATION_TOKEN_NOT_PROVIDED, AUTHENTICATION_IS_NOT_CONFIGURED],
+        error_class: Dependabot::PrivateSourceAuthenticationFailure,
+        in_usage: false,
+        matchfn: nil
+      },
+      {
+        patterns: [DEPENDENCY_CONFLICT],
+        error_class: Dependabot::DependencyConflict,
+        in_usage: false,
+        matchfn: nil
+      }
+    ].freeze, T::Array[{
+      patterns: T::Array[T.any(String, Regexp)],
+      error_class: T.class_of(Dependabot::DependabotError),
+      in_usage: T.nilable(T::Boolean),
+      matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
+    }])
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -56,7 +56,7 @@ module Dependabot
       },
       "YN0062" => {
         message: "Incompatible OS",
-        new_error: ->(_error, message) { Dependabot::IncompatibleOS.new(message) }
+        new_error: ->(_error, message) { Dependabot::DependabotError.new(message) }
       },
       "YN0063" => {
         message: "Incompatible CPU",

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -650,7 +650,7 @@ module Dependabot
           next unless new_error
 
           modified_error_message = if message
-                                     "[#{code}]: #{message}, detail: #{error_message}"
+                                     "[#{code}]: #{message}, Detail: #{error_message}"
                                    else
                                      "[#{code}]: #{error_message}"
                                    end
@@ -676,13 +676,14 @@ module Dependabot
 
           next unless (patterns || matchfn) && new_error
 
+          message = usage_error_message.empty? ? error_message : usage_error_message
           if in_usage && pattern_in_message(patterns, usage_error_message)
-            raise new_error.call(usage_error_message)
+            raise new_error.call(error, message)
           elsif !in_usage && pattern_in_message(patterns, error_message)
             raise new_error.call(error, error.message)
           end
 
-          raise new_error.call(usage_error_message) if matchfn&.call(usage_error_message, error_message)
+          raise new_error.call(error, message) if matchfn&.call(usage_error_message, error_message)
         end
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       end
 
       it "raises a NetworkDisabled error" do
-        expect {
+        expect do
           error_handler.handle_yarn_error(error_message)
-        }.to raise_error(Dependabot::NetworkDisabled)
+        end.to raise_error(Dependabot::NetworkDisabled)
       end
     end
 
@@ -127,9 +127,9 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "YN0002: Missing peer dependency" }
 
       it "raises the corresponding error class" do
-        expect {
+        expect do
           error_handler.handle_yarn_error(error_message)
-        }.to raise_error(Dependabot::DependencyFileNotResolvable)
+        end.to raise_error(Dependabot::DependencyFileNotResolvable)
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
           "➤ YN0000: Failed with errors in 1s 234ms"
       end
 
-      it "raises a NetworkDisabled error" do
+      it "raises a MisconfiguredTooling error" do
         expect do
           error_handler.handle_yarn_error(error_message)
-        end.to raise_error(Dependabot::NetworkDisabled)
+        end.to raise_error(Dependabot::MisconfiguredTooling)
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises a MisconfiguredTooling error" do
         expect do
-          error_handler.handle_yarn_error(error_message)
+          error_handler.handle_yarn_error(error)
         end.to raise_error(Dependabot::MisconfiguredTooling)
       end
     end
@@ -128,7 +128,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises the corresponding error class" do
         expect do
-          error_handler.handle_yarn_error(error_message)
+          error_handler.handle_yarn_error(error)
         end.to raise_error(Dependabot::DependencyFileNotResolvable)
       end
     end
@@ -137,7 +137,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "This message does not contain any known Yarn error codes." }
 
       it "does not raise any errors" do
-        expect { error_handler.handle_yarn_error(error_message) }.not_to raise_error
+        expect { error_handler.handle_yarn_error(error) }.not_to raise_error
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -1,0 +1,164 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/shared_helpers"
+require "dependabot/errors"
+
+RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
+  subject(:error_handler) { described_class.new(dependencies: dependencies, dependency_files: dependency_files) }
+
+  let(:dependencies) { [instance_double(Dependabot::Dependency, name: "test-dependency")] }
+  let(:dependency_files) { [instance_double(Dependabot::DependencyFile, path: "path/to/yarn.lock")] }
+  let(:error) { instance_double(Dependabot::SharedHelpers::HelperSubprocessFailed, message: error_message) }
+
+  describe "#initialize" do
+    it "initializes with dependencies and dependency files" do
+      expect(error_handler.send(:dependencies)).to eq(dependencies)
+      expect(error_handler.send(:dependency_files)).to eq(dependency_files)
+    end
+  end
+
+  describe "#handle_error" do
+    context "when the error message contains a yarn error code that is mapped" do
+      let(:error_message) { "YN0002: Missing peer dependency" }
+
+      it "raises the corresponding error class" do
+        expect { error_handler.handle_error(error) }.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
+    context "when the error message contains a recognized pattern" do
+      let(:error_message) { "Here is a recognized error pattern: authentication token not provided " }
+
+      it "raises the corresponding error class" do
+        expect { error_handler.handle_error(error) }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+      end
+    end
+
+    context "when the error message contains unrecognized patterns" do
+      let(:error_message) { "This is an unrecognized pattern that should not raise an error." }
+
+      it "does not raise an error" do
+        expect { error_handler.handle_error(error) }.not_to raise_error
+      end
+    end
+
+    context "when not recognized yarn error code, patterns" do
+      let(:error_message) do
+        "➤ YN0000: ┌ Resolution step\n" \
+          "➤ YN0000: ┌ Fetch step\n" \
+          "➤ YN0099: │ some-dummy-package@npm:1.0.0 can't be found\n" \
+          "➤ YN0099: │ some-dummy-package@npm:1.0.0: The remote server failed\n" \
+          "➤ YN0000: └ Completed\n" \
+          "➤ YN0000: Failed with errors in 1s 234ms"
+      end
+
+      it "does not raise an error" do
+        expect { error_handler.handle_error(error) }.not_to raise_error
+      end
+    end
+
+    context "when the error message contains a recognized yarn error code in multiple yarn error codes" do
+      let(:error_message) do
+        "➤ YN0000: ┌ Resolution step\n" \
+          "➤ YN0002: │ dummy-package@npm:1.2.3 doesn't provide dummy (p1a2b3)\n" \
+          "➤ YN0060: │ dummy-package@workspace:. provides dummy-tool (p4b5c6)\n" \
+          "➤ YN0002: │ another-dummy-package@npm:4.5.6 doesn't provide dummy (p7d8e9)\n" \
+          "➤ YN0000: └ Completed in 0s 123ms\n" \
+          "➤ YN0000: ┌ Fetch step\n" \
+          "➤ YN0080: │ some-dummy-package@npm:1.0.0 can't be found\n" \
+          "➤ YN0080: │ some-dummy-package@npm:1.0.0: The remote server failed\n" \
+          "➤ YN0000: └ Completed\n" \
+          "➤ YN0000: Failed with errors in 1s 234ms"
+      end
+
+      it "raises a NetworkDisabled error" do
+        expect {
+          error_handler.handle_yarn_error(error_message)
+        }.to raise_error(Dependabot::NetworkDisabled)
+      end
+    end
+
+    context "when the error contains multiple not recognized yarn error codes" do
+      let(:error_message) do
+        "➤ YN0000: ┌ Resolution step\n" \
+          "➤ YN0000: ┌ Fetch step\n" \
+          "➤ YN0013: │ some-dummy-package@npm:1.0.0 can't be found\n" \
+          "➤ YN0035: │ some-dummy-package@npm:1.0.0: The remote server failed\n" \
+          "➤ YN0035: │   Response Code: 404 (Not Found)\n" \
+          "➤ YN0035: │   Request Method: GET\n" \
+          "➤ YN0035: │   Request URL: https://dummy.artifactory...\n" \
+          "➤ YN0000: └ Completed\n" \
+          "➤ YN0000: Failed with errors in 1s 234ms"
+      end
+
+      it "does not raise an error" do
+        expect { error_handler.handle_error(error) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#find_usage_error" do
+    context "when there is a usage error in the message" do
+      let(:error_message) { "Some initial text. Usage Error: This is a specific usage error.\nERROR" }
+
+      it "returns the usage error text" do
+        usage_error = error_handler.find_usage_error(error_message)
+        expect(usage_error).to include("Usage Error: This is a specific usage error.\nERROR")
+      end
+    end
+
+    context "when there is no usage error in the message" do
+      let(:error_message) { "This message does not contain a usage error." }
+
+      it "returns nil" do
+        usage_error = error_handler.find_usage_error(error_message)
+        expect(usage_error).to be_nil
+      end
+    end
+  end
+
+  describe "#handle_yarn_error" do
+    context "when the error message contains yarn error codes" do
+      let(:error_message) { "YN0002: Missing peer dependency" }
+
+      it "raises the corresponding error class" do
+        expect {
+          error_handler.handle_yarn_error(error_message)
+        }.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
+    context "when the error message does not contain Yarn error codes" do
+      let(:error_message) { "This message does not contain any known Yarn error codes." }
+
+      it "does not raise any errors" do
+        expect { error_handler.handle_yarn_error(error_message) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#pattern_in_message" do
+    let(:patterns) { ["pattern1", /pattern2/] }
+
+    context "when the message contains one of the patterns" do
+      let(:message) { "This message contains pattern1 and pattern2." }
+
+      it "returns true" do
+        expect(error_handler.pattern_in_message(patterns, message)).to be(true)
+      end
+    end
+
+    context "when the message does not contain any of the patterns" do
+      let(:message) { "This message does not contain the patterns." }
+
+      it "returns false" do
+        expect(error_handler.pattern_in_message(patterns, message)).to be(false)
+      end
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
     end
 
     context "when the error message contains a recognized pattern" do
-      let(:error_message) { "Here is a recognized error pattern: authentication token not provided " }
+      let(:error_message) { "Here is a recognized error pattern: authentication token not provided" }
 
       it "raises the corresponding error class" do
         expect { error_handler.handle_error(error) }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
@@ -47,7 +47,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       end
     end
 
-    context "when not recognized yarn error code, patterns" do
+    context "when the error message contains unrecognized yarn error codes and patterns" do
       let(:error_message) do
         "➤ YN0000: ┌ Resolution step\n" \
           "➤ YN0000: ┌ Fetch step\n" \
@@ -62,7 +62,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       end
     end
 
-    context "when the error message contains a recognized yarn error code in multiple yarn error codes" do
+    context "when the error message contains a recognized yarn error code among multiple yarn error codes" do
       let(:error_message) do
         "➤ YN0000: ┌ Resolution step\n" \
           "➤ YN0002: │ dummy-package@npm:1.2.3 doesn't provide dummy (p1a2b3)\n" \
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       end
     end
 
-    context "when the error contains multiple not recognized yarn error codes" do
+    context "when the error contains multiple unrecognized yarn error codes" do
       let(:error_message) do
         "➤ YN0000: ┌ Resolution step\n" \
           "➤ YN0000: ┌ Fetch step\n" \


### PR DESCRIPTION
### What are you trying to accomplish?

We are trying to reduce unknown_errors to change them into defined_errors that will improve support and provide clean error to customer. Followings are implemented to achieve that:

- Enhance the error handling for `npm_and_yarn` module by mapping `unknown_errrors` into defined errors.
- Handling errors through yarn error code. 
- Handling custom errors by using a systematic way to check patterns in error message  

Yarn Error Codes: https://yarnpkg.com/advanced/error-codes

### What issues does this affect or fix?

Issue aiming to fix unknown_errors especially related to with missing dependencies and network errors during Yarn helper runs, reducing unknown errors. Also we changed the error structure to make it easy new specified errors for developers. 

### Anything you want to highlight for special attention from reviewers?

Focus on core `common/lib/dependabot/errors.rb` changes since all defined errors and structure will be used for all eco-system in future. Also the approach regarding custom errors taken in the yarn_error_handler can be generalized to handle all other eco-systems errors as well. It can be improved to handle most of the unknown errors. 

### How will you know you've accomplished your goal?

The Yarn helper should provide clear error messages for mapped yarn error code mapped errors and pattern mapped custom errors instead of unknown_errors. 

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.