### PR TITLE
Revert "Combining dependabot core version constraint (latest_allowable_version) with existing composer version constraint"

### DIFF
--- a/composer/helpers/v2/src/UpdateChecker.php
+++ b/composer/helpers/v2/src/UpdateChecker.php
@@ -8,15 +8,13 @@ use Composer\DependencyResolver\Request;
 use Composer\Factory;
 use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
-use Composer\Package\Link;
 use Composer\Package\PackageInterface;
-use Composer\Package\Version\VersionParser;
 
 final class UpdateChecker
 {
     public static function getLatestResolvableVersion(array $args): ?string
     {
-        [$workingDirectory, $dependencyName, $gitCredentials, $registryCredentials, $latestAllowableVersion] = $args;
+        [$workingDirectory, $dependencyName, $gitCredentials, $registryCredentials] = $args;
 
         $httpBasicCredentials = [];
 
@@ -50,36 +48,10 @@ final class UpdateChecker
             $io->loadConfiguration($config);
         }
 
-        $package = $composer->getPackage();
-        $versionParser = new VersionParser();
-        // constraint from dependabot
-        $dependabotConstraint = '==' . $latestAllowableVersion;
-        // combine new dependabot constraints with the existing composer constraints (if exists)
-        if (isset($package->getRequires()[$dependencyName])) {
-            // Root Composer Constraint
-            $composerConstraint = $package->getRequires()[$dependencyName]->getPrettyConstraint();
-            $combinedConstraint = $dependabotConstraint . ' ' . $composerConstraint;
-            $constraint = $versionParser->parseConstraints($combinedConstraint);
-            $link = new Link($package->getName(), $dependencyName, $constraint);
-            $package->setRequires([$dependencyName => $link]);
-        } elseif (isset($package->getDevRequires()[$dependencyName])) {
-            // Dev Composer Constraint
-            $composerConstraint = $package->getDevRequires()[$dependencyName]->getPrettyConstraint();
-            $combinedConstraint = $dependabotConstraint . ' ' . $composerConstraint;
-            $constraint = $versionParser->parseConstraints($combinedConstraint);
-            $link = new Link($package->getName(), $dependencyName, $constraint);
-            $package->setDevRequires([$dependencyName => $link]);
-        } else {
-            // No Composer Constraint
-            $constraint = $versionParser->parseConstraints($dependabotConstraint);
-            $link = new Link($package->getName(), $dependencyName, $constraint);
-            $package->setRequires([$dependencyName => $link]);
-        }
-
         $install = new Installer(
             $io,
             $config,
-            $package,  // @phpstan-ignore-line
+            $composer->getPackage(),  // @phpstan-ignore-line
             $composer->getDownloadManager(),
             $composer->getRepositoryManager(),
             $composer->getLocker(),

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -148,8 +148,7 @@ module Dependabot
                 Dir.pwd,
                 dependency.name.downcase,
                 git_credentials,
-                registry_credentials,
-                @latest_allowable_version.to_s
+                registry_credentials
               ]
             )
           end

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     context "with a library using a >= PHP constraint" do
       let(:project_name) { "php_specified_in_library" }
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
-      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
 
@@ -67,7 +66,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     context "with an application using a >= PHP constraint" do
       let(:project_name) { "php_specified_without_lockfile" }
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
-      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
 
@@ -75,7 +73,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
 
       context "when the minimum version is invalid" do
         let(:dependency_version) { "4.2.0" }
-        let(:latest_allowable_version) { Gem::Version.new("4.3.1") }
         let(:string_req) { "4.2.0" }
 
         it { is_expected.to be >= Dependabot::Composer::Version.new("4.3.1") }
@@ -86,7 +83,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       context "when the minimum version is invalid" do
         let(:project_name) { "php_specified_min_invalid_without_lockfile" }
         let(:dependency_name) { "phpdocumentor/reflection-docblock" }
-        let(:latest_allowable_version) { Gem::Version.new("3.2.2") }
         let(:dependency_version) { "2.0.4" }
         let(:string_req) { "2.0.4" }
 
@@ -107,16 +103,11 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     context "with a dependency that's provided by another dep" do
       let(:project_name) { "provided_dependency" }
       let(:string_req) { "^1.0" }
+      let(:latest_allowable_version) { Gem::Version.new("6.0.0") }
       let(:dependency_name) { "php-http/client-implementation" }
       let(:dependency_version) { nil }
 
-      # Root composer.json requires php-http/client-implementation ==6.0.0 ^1.0, it could not be found in any version,
-      it "raises a Dependabot::DependencyFileNotResolvable error" do
-        expect { resolver.latest_resolvable_version }
-          .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-          expect(error.message).to include("Your requirements could not be resolved to an installable set of packages.")
-        end
-      end
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.0")) }
     end
 
     context "with a dependency that uses a stability flag" do

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -194,12 +194,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { checker.latest_resolvable_version }
 
-    # setting the latest allowable version to 1.22.0
-    before do
-      allow(checker).to receive(:latest_version_from_registry)
-        .and_return(Gem::Version.new("1.22.0"))
-    end
-
     it "returns a non-normalized version, following semver" do
       expect(latest_resolvable_version.segments.count).to eq(3)
     end
@@ -215,7 +209,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.22.0.a, < 4.0"] }
 
-      it { is_expected.to eq(Gem::Version.new("1.22.0")) }
+      it { is_expected.to eq(Gem::Version.new("1.21.0")) }
     end
 
     context "without a lockfile" do
@@ -234,12 +228,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           }]
         end
 
-        # setting the latest allowable version to 4.3.0
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("4.3.0"))
-        end
-
         it { is_expected.to be >= Gem::Version.new("4.3.0") }
       end
 
@@ -256,13 +244,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           }]
         end
 
-        # setting the latest allowable version to 1.22.0
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("5.4.36"))
-        end
-
-        it { is_expected.to be >= Gem::Version.new("5.4.36") }
+        it { is_expected.to be >= Gem::Version.new("5.2.45") }
 
         context "when as a platform requirement" do
           let(:project_name) { "old_php_platform" }
@@ -297,12 +279,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
             groups: ["runtime"],
             source: nil
           }]
-        end
-
-        # setting the latest allowable version to 5.2.45
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("5.2.45"))
         end
 
         it { is_expected.to be >= Gem::Version.new("5.2.45") }
@@ -489,9 +465,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         v1_metadata_url = "https://repo.packagist.org/p/#{dependency_name.downcase}.json"
         # v1 url doesn't always return 404 for missing packages
         stub_request(:get, v1_metadata_url).to_return(status: 200, body: '{"error":{"code":404,"message":"Not Found"}}')
-        # setting the latest allowable version to 2.4.1
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("2.4.1"))
       end
 
       it "is between 2.0.0 and 3.0.0" do
@@ -514,8 +487,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       end
       let(:ignored_versions) { [">= 2.8.0"] }
 
-      it "latest version 1.22.0 cannot be resolved." do
-        expect(latest_resolvable_version).to be_nil
+      it "is the highest resolvable version" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("2.1.7"))
       end
 
       context "when the blocking dependency is a git dependency" do
@@ -543,19 +516,9 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       context "when there is no lockfile" do
         let(:project_name) { "version_conflict_without_lockfile" }
 
-        # setting the latest allowable version to 2.1.7
-        before do
-          allow(checker).to receive(:latest_version_from_registry)
-            .and_return(Gem::Version.new("2.1.7"))
-        end
-
-        # Root composer.json requires monolog/monolog ==2.1.7 1.22.0
         it "raises a resolvability error" do
           expect { latest_resolvable_version }
-            .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-            expect(error.message)
-              .to include("Your requirements could not be resolved to an installable set of packages.")
-          end
+            .to raise_error(Dependabot::DependencyFileNotResolvable)
         end
       end
     end
@@ -591,26 +554,12 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       context "when there is no lockfile" do
         let(:project_name) { "version_conflict_on_update_without_lockfile" }
 
-        # Root composer.json requires longman/telegram-bot ==1.22.0 *
-        it "raises a resolvability error" do
-          expect { latest_resolvable_version }
-            .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-            expect(error.message)
-              .to include("Your requirements could not be resolved to an installable set of packages.")
-          end
-        end
+        it { is_expected.to be_nil }
 
         context "when the conflict comes from a loose PHP version" do
           let(:project_name) { "version_conflict_library" }
 
-          # Root composer.json requires longman/telegram-bot ==1.22.0 *
-          it "raises a resolvability error" do
-            expect { latest_resolvable_version }
-              .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-              expect(error.message)
-                .to include("Your requirements could not be resolved to an installable set of packages.")
-            end
-          end
+          it { is_expected.to be_nil }
         end
       end
     end
@@ -773,10 +722,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
-      # setting the latest allowable version to 3.0.2
       before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("3.0.2"))
         stub_request(:get, "https://wpackagist.org/packages.json")
           .to_return(
             status: 200,
@@ -800,7 +746,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be >= Gem::Version.new("5.2.30") }
     end
 
     context "when a sub-dependency would block the update" do
@@ -814,12 +760,6 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           groups: ["runtime"],
           source: nil
         }]
-      end
-
-      # setting the latest allowable version to 5.6.23
-      before do
-        allow(checker).to receive(:latest_version_from_registry)
-          .and_return(Gem::Version.new("5.6.23"))
       end
 
       # 5.5.0 series and up require an update to illuminate/contracts


### PR DESCRIPTION
Reverts dependabot/dependabot-core#10150

as we found the new approach to fix this.
https://github.com/dependabot/dependabot-core/pull/10182/files

