### PR TITLE
Solution provided for ignore minor version config is not respected.

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -238,9 +238,9 @@ module Dependabot
 
           # If the original requirement is just a stability flag we append that
           # flag to the requirement
-          return "<=#{latest_allowable_version}#{lower_bound.strip}" if lower_bound.strip.start_with?("@")
+          return "==#{latest_allowable_version}#{lower_bound.strip}" if lower_bound.strip.start_with?("@")
 
-          lower_bound + ", <= #{latest_allowable_version}"
+          lower_bound + ", == #{latest_allowable_version}"
         end
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/AbcSize

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     end
 
     # version constraint: >= 2.0.4, == 3.3.2 (debugging logs)
-    context "when version constraint are set as requirement" do
+    context "when version constraint is set as requirement" do
       let(:project_name) { "php_specified_in_library" }
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
       let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
 
     # combined constraint: >= 2.0.4, == 3.0.0 (debugging logs)
     # But latest allowable version is 3.0.0
-    context "when version constraint are set as requirement, but pushing to latest_allowable_version 3.0.0 now" do
+    context "when version constraint is set as requirement, but pushing to the latest_allowable_version 3.0.0 now" do
       let(:project_name) { "php_specified_in_library" }
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
       let(:latest_allowable_version) { Gem::Version.new("3.0.0") }

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -54,11 +54,69 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
-    context "with a library using a >= PHP constraint" do
+    # version constraint: >= 2.0.4, == 3.3.2 (debugging logs)
+    context "when version constraint are set as requirement" do
       let(:project_name) { "php_specified_in_library" }
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
+    end
+
+    # combined constraint: >= 2.0.4, == 3.0.0 (debugging logs)
+    # But latest allowable version is 3.0.0
+    context "when version constraint are set as requirement, but pushing to latest_allowable_version 3.0.0 now" do
+      let(:project_name) { "php_specified_in_library" }
+      let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:latest_allowable_version) { Gem::Version.new("3.0.0") }
+      let(:dependency_version) { "2.0.4" }
+      let(:string_req) { "2.0.4" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("3.0.0")) }
+    end
+
+    # combined constraint: >= 1.0.1, == 1.1.0 (debugging logs)
+    context "when version constraint are set as dev-requirement" do
+      let(:project_name) { "php_specified_in_library" }
+      let(:dependency_name) { "monolog/monolog" }
+      let(:latest_allowable_version) { Gem::Version.new("1.1.0") }
+      let(:dependency_version) { "1.0.1" }
+      let(:string_req) { "1.0.1" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.1.0")) }
+    end
+
+    # combined constraint: >= 2.0.4 (debugging logs)
+    context "when latest_allowable_version is not set" do
+      let(:project_name) { "php_specified_in_library" }
+      let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:latest_allowable_version) { nil }
+      let(:dependency_version) { "2.0.4" }
+      let(:string_req) { "2.0.4" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
+    end
+
+    # combined constraint: ==3.0.0 (debugging logs) not set to the latest in the registry.
+    context "when version constraint is not set (in existing composer.json)" do
+      let(:project_name) { "php_specified_in_library" }
+      let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:latest_allowable_version) { Gem::Version.new("3.0.0") }
+      let(:dependency_version) { nil }
+      let(:string_req) { nil }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("3.0.0")) }
+    end
+
+    # combined constraint: >= 0
+    context "when both version constraint and latest_allowable_version are not set" do
+      let(:project_name) { "php_specified_in_library" }
+      let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:latest_allowable_version) { nil }
+      let(:dependency_version) { nil }
+      let(:string_req) { nil }
 
       it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
     end
@@ -68,14 +126,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       let(:dependency_name) { "phpdocumentor/reflection-docblock" }
       let(:dependency_version) { "2.0.4" }
       let(:string_req) { "2.0.4" }
+      let(:latest_allowable_version) { Gem::Version.new("3.3.2") }
 
       it { is_expected.to eq(Dependabot::Composer::Version.new("3.3.2")) }
 
-      context "when the minimum version is invalid" do
+      context "when the minimum version is invalid, 3.3.2 is less than 4.2.0" do
         let(:dependency_version) { "4.2.0" }
         let(:string_req) { "4.2.0" }
 
-        it { is_expected.to be >= Dependabot::Composer::Version.new("4.3.1") }
+        it { is_expected.to be_nil }
       end
     end
 
@@ -85,6 +144,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
         let(:dependency_name) { "phpdocumentor/reflection-docblock" }
         let(:dependency_version) { "2.0.4" }
         let(:string_req) { "2.0.4" }
+        let(:latest_allowable_version) { Gem::Version.new("3.2.2") }
 
         it { is_expected.to eq(Dependabot::Composer::Version.new("3.2.2")) }
       end
@@ -107,7 +167,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       let(:dependency_name) { "php-http/client-implementation" }
       let(:dependency_version) { nil }
 
-      it { is_expected.to eq(Dependabot::Composer::Version.new("1.0")) }
+      it { is_expected.to be_nil }
     end
 
     context "with a dependency that uses a stability flag" do

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     end
 
     # combined constraint: >= 1.0.1, == 1.1.0 (debugging logs)
-    context "when version constraint are set as dev-requirement" do
+    context "when version constraint is set as dev-requirement" do
       let(:project_name) { "php_specified_in_library" }
       let(:dependency_name) { "monolog/monolog" }
       let(:latest_allowable_version) { Gem::Version.new("1.1.0") }

--- a/composer/spec/fixtures/projects/php_specified_in_library/composer.json
+++ b/composer/spec/fixtures/projects/php_specified_in_library/composer.json
@@ -5,5 +5,8 @@
     "php": ">=5.6.0",
     "phpdocumentor/reflection-docblock": "2.0.4",
     "illuminate/support": "^5.2.0"
+  },
+  "require-dev": {
+    "monolog/monolog": "1.0.1"
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

provided the solution for ignore minor version not respected issue.

Before we look for the anything `=< latest_allowable_version`. (this cause the issue as some ignored version is part of this range). now we were looking for `=< latest_allowable_version` So it will not select any ignored version. 

As name suggest version_resover.rb checks that given latest_available_version is resolves or not

### Anything you want to highlight for special attention from reviewers?

Changes made on ruby level not in php script now

### How will you know you've accomplished your goal?

Ran all the unit test against the solution and ensured by debugging logs.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
