### PR TITLE
Revert PR #10060: Fix Versioning Strategy for Python Dependencies

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: main
+  SMOKE_TEST_BRANCH: revert-212-kamil/update_smoke_test_for_updated_pip_increase_strategy
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: revert-212-kamil/update_smoke_test_for_updated_pip_increase_strategy
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -20,11 +20,6 @@ module Dependabot
         "===" => ->(v, r) { v.to_s == r.to_s }
       )
 
-      # Override the lower bound logic for bump versions strategy.
-      BUMP_VERSIONS_OPS = OPS.merge(
-        ">=" => ->(v, r) { v.to_s == r.to_s }
-      )
-
       quoted = OPS.keys.sort_by(&:length).reverse
                   .map { |k| Regexp.quote(k) }.join("|")
       version_pattern = Python::Version::VERSION_PATTERN
@@ -83,10 +78,10 @@ module Dependabot
         super(requirements)
       end
 
-      def satisfied_by?(version, ops = OPS)
+      def satisfied_by?(version)
         version = Python::Version.new(version.to_s)
 
-        requirements.all? { |op, rv| (ops[op] || ops["="]).call(version, rv) }
+        requirements.all? { |op, rv| (OPS[op] || OPS["="]).call(version, rv) }
       end
 
       def exact?

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -278,14 +278,14 @@ module Dependabot
             requirement_strings.map { |r| requirement_class.new(r) }
 
           updated_requirement_strings = ruby_requirements.flat_map do |r|
-            next r.to_s if r.satisfied_by?(latest_resolvable_version, Requirement::BUMP_VERSIONS_OPS)
+            next r.to_s if r.satisfied_by?(latest_resolvable_version)
 
             case op = r.requirements.first.first
             when "<"
-              "#{op}#{update_greatest_version(r.requirements.first.last, latest_resolvable_version)}"
-            when "<=", ">="
-              "#{op}#{latest_resolvable_version}"
-            when "!=", ">"
+              "<" + update_greatest_version(r.requirements.first.last, latest_resolvable_version)
+            when "<="
+              "<=" + latest_resolvable_version.to_s
+            when "!=", ">", ">="
               raise UnfixableRequirement
             else
               raise "Unexpected op for unsatisfied requirement: #{op}"

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Python::Requirement do
         its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.2.0").to_s) }
       end
 
-      context "when dealing with one digit" do
+      context "when dealing with one digits" do
         let(:requirement_string) { "~1" }
 
         its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0").to_s) }
@@ -185,7 +185,7 @@ RSpec.describe Dependabot::Python::Requirement do
       it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
     end
 
-    context "with illformed parentheses" do
+    context "with a illformed parentheses" do
       let(:requirement_string) { "(== 1.2).1" }
 
       it "raises a helpful error" do
@@ -316,52 +316,6 @@ RSpec.describe Dependabot::Python::Requirement do
             it { is_expected.to be(false) }
           end
         end
-      end
-    end
-  end
-
-  describe "#satisfied_by? with BUMP_VERSIONS_OPS" do
-    subject(:requirement_satisfied_by) { requirement.satisfied_by?(version, described_class::BUMP_VERSIONS_OPS) }
-
-    let(:requirement_string) { ">=1.0.0" }
-
-    context "with a Python::Version" do
-      let(:version) { version_class.new(version_string) }
-
-      context "when dealing with the exact version" do
-        let(:version_string) { "1.0.0" }
-
-        it { is_expected.to be(true) }
-      end
-
-      context "when dealing with a different version" do
-        let(:version_string) { "2.0.0" }
-
-        it { is_expected.to be(false) }
-      end
-
-      context "when dealing with the latest resolvable version" do
-        let(:version_string) { "1.0.0" }
-
-        it { is_expected.to be(true) }
-
-        context "when the requirement includes a local version" do
-          let(:requirement_string) { ">=1.0.0+gc.1" }
-
-          it { is_expected.to be(false) }
-        end
-
-        context "when the version includes a local version" do
-          let(:version_string) { "1.0.0+gc.1" }
-
-          it { is_expected.to be(false) }
-        end
-      end
-
-      context "when dealing with an out-of-range version" do
-        let(:version_string) { "0.9.0" }
-
-        it { is_expected.to be(false) }
       end
     end
   end

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -121,24 +121,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
         end
 
-        context "when a > req was specified" do
-          let(:requirement_txt_req_string) { "> 1.3.0" }
-
-          it { is_expected.to eq(requirement_txt_req) }
-
-          context "when dealing with exactly the version being updated to" do
-            let(:requirement_txt_req_string) { "> 1.5.0" }
-
-            its([:requirement]) { is_expected.to eq(:unfixable) }
-          end
-
-          context "when dealing with the version lower than the lower bound" do
-            let(:requirement_txt_req_string) { "> 1.4.0" }
-
-            its([:requirement]) { is_expected.to eq(:unfixable) }
-          end
-        end
-
         context "when a range requirement was specified" do
           let(:requirement_txt_req_string) { ">=1.3.0" }
 
@@ -514,36 +496,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               it { is_expected.to eq(pyproject_req) }
             end
 
-            context "when a != req was specified" do
-              let(:pyproject_req_string) { "!= 1.3.0" }
-
-              it { is_expected.to eq(pyproject_req) }
-
-              context "when dealing with exactly the version being updated to" do
-                let(:pyproject_req_string) { "!=1.5.0" }
-
-                its([:requirement]) { is_expected.to eq(:unfixable) }
-              end
-            end
-
-            context "when a > req was specified" do
-              let(:pyproject_req_string) { "> 1.3.0" }
-
-              it { is_expected.to eq(pyproject_req) }
-
-              context "when dealing with exactly the version being updated to" do
-                let(:pyproject_req_string) { "> 1.5.0" }
-
-                its([:requirement]) { is_expected.to eq(:unfixable) }
-              end
-
-              context "when dealing with the version lower than the lower bound" do
-                let(:pyproject_req_string) { "> 1.4.0" }
-
-                its([:requirement]) { is_expected.to eq(:unfixable) }
-              end
-            end
-
             context "when a range requirement was specified" do
               let(:pyproject_req_string) { ">=1.3.0" }
 
@@ -682,36 +634,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             let(:pyproject_req_string) { "*" }
 
             it { is_expected.to eq(pyproject_req) }
-          end
-
-          context "when a != req was specified" do
-            let(:pyproject_req_string) { "!= 1.3.0" }
-
-            it { is_expected.to eq(pyproject_req) }
-
-            context "when dealing with exactly the version being updated to" do
-              let(:pyproject_req_string) { "!=1.5.0" }
-
-              its([:requirement]) { is_expected.to eq(:unfixable) }
-            end
-          end
-
-          context "when a > req was specified" do
-            let(:pyproject_req_string) { "> 1.3.0" }
-
-            it { is_expected.to eq(pyproject_req) }
-
-            context "when dealing with exactly the version being updated to" do
-              let(:pyproject_req_string) { "> 1.5.0" }
-
-              its([:requirement]) { is_expected.to eq(:unfixable) }
-            end
-
-            context "when dealing with the version lower than the lower bound" do
-              let(:pyproject_req_string) { "> 1.4.0" }
-
-              its([:requirement]) { is_expected.to eq(:unfixable) }
-            end
           end
 
           context "when a range requirement was specified" do

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when requirement version is too high" do
             let(:requirement_txt_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(">=1.5.0") }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
           end
 
           context "when requirement had a local version" do
@@ -146,13 +146,13 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
+                its([:requirement]) { is_expected.to eq(">=1.9,<=1.10") }
               end
             end
           end
@@ -268,7 +268,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when the requirement version is too high" do
             let(:setup_py_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(">=1.5.0") }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
           end
 
           context "with an upper bound" do
@@ -279,7 +279,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_py_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
             end
           end
         end
@@ -370,7 +370,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when the requirement version is too high" do
             let(:setup_cfg_req_string) { ">=2.0.0" }
 
-            its([:requirement]) { is_expected.to eq(">=1.5.0") }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
           end
 
           context "with an upper bound" do
@@ -381,7 +381,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when needing an update" do
               let(:setup_cfg_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
             end
           end
         end
@@ -504,7 +504,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               context "when the requirement version is too high" do
                 let(:pyproject_req_string) { ">=2.0.0" }
 
-                its([:requirement]) { is_expected.to eq(">=1.5.0") }
+                its([:requirement]) { is_expected.to eq(:unfixable) }
               end
 
               context "when the requirement had a local version" do
@@ -521,7 +521,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 context "when needing an update" do
                   let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                  its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+                  its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
                 end
               end
             end
@@ -650,7 +650,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             context "when the requirement is too high" do
               let(:pyproject_req_string) { ">=2.0.0" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0") }
+              its([:requirement]) { is_expected.to eq(:unfixable) }
             end
 
             context "with an upper bound" do
@@ -661,7 +661,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               context "when needing an update" do
                 let(:pyproject_req_string) { ">=1.3.0, <1.5" }
 
-                its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+                its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
               end
             end
           end

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
 
           context "when dealing with the version lower than the lower bound" do
-            let(:requirement_txt_req_string) { "> 1.6.0" }
+            let(:requirement_txt_req_string) { "> 1.4.0" }
 
             its([:requirement]) { is_expected.to eq(:unfixable) }
           end
@@ -538,7 +538,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               end
 
               context "when dealing with the version lower than the lower bound" do
-                let(:pyproject_req_string) { "> 1.6.0" }
+                let(:pyproject_req_string) { "> 1.4.0" }
 
                 its([:requirement]) { is_expected.to eq(:unfixable) }
               end
@@ -708,7 +708,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
             end
 
             context "when dealing with the version lower than the lower bound" do
-              let(:pyproject_req_string) { "> 1.6.0" }
+              let(:pyproject_req_string) { "> 1.4.0" }
 
               its([:requirement]) { is_expected.to eq(:unfixable) }
             end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to revert a previous change that modified the behavior of the versioning strategy in Dependabot for Python dependencies. The reverted PR aimed to correct the behavior of the "increase" strategy but has introduced a bug. The versioning strategy needs to be re-planned and re-implemented correctly.

**Why:** The changes in the reverted PR caused unintended behavior that needs to be fixed. We will re-implement the correct versioning strategy after careful planning.

### Anything you want to highlight for special attention from reviewers?

This reversion is necessary because the previous changes have introduced bugs in the versioning strategy. We need to re-evaluate and properly plan the versioning strategy before re-implementing it to avoid similar issues in the future.

### How will you know you've accomplished your goal?

The reversion will restore the previous behavior of the versioning strategy. Future PRs will focus on correctly implementing the desired changes with appropriate testing and validation.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.