### PR TITLE
surface authentication errors from native tool

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/UpdateCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/UpdateCommand.cs
@@ -1,6 +1,4 @@
-using System;
 using System.CommandLine;
-using System.IO;
 
 using NuGetUpdater.Core;
 
@@ -15,6 +13,7 @@ internal static class UpdateCommand
     internal static readonly Option<string> PreviousVersionOption = new("--previous-version") { IsRequired = true };
     internal static readonly Option<bool> IsTransitiveOption = new("--transitive", getDefaultValue: () => false);
     internal static readonly Option<bool> VerboseOption = new("--verbose", getDefaultValue: () => false);
+    internal static readonly Option<string?> ResultOutputPathOption = new("--result-output-path", getDefaultValue: () => null);
 
     internal static Command GetCommand(Action<int> setExitCode)
     {
@@ -26,17 +25,18 @@ internal static class UpdateCommand
             NewVersionOption,
             PreviousVersionOption,
             IsTransitiveOption,
-            VerboseOption
+            VerboseOption,
+            ResultOutputPathOption
         };
 
         command.TreatUnmatchedTokensAsErrors = true;
 
-        command.SetHandler(async (repoRoot, solutionOrProjectFile, dependencyName, newVersion, previousVersion, isTransitive, verbose) =>
+        command.SetHandler(async (repoRoot, solutionOrProjectFile, dependencyName, newVersion, previousVersion, isTransitive, verbose, resultOutputPath) =>
         {
             var worker = new UpdaterWorker(new Logger(verbose));
-            await worker.RunAsync(repoRoot.FullName, solutionOrProjectFile.FullName, dependencyName, previousVersion, newVersion, isTransitive);
+            await worker.RunAsync(repoRoot.FullName, solutionOrProjectFile.FullName, dependencyName, previousVersion, newVersion, isTransitive, resultOutputPath);
             setExitCode(0);
-        }, RepoRootOption, SolutionOrProjectFileOption, DependencyNameOption, NewVersionOption, PreviousVersionOption, IsTransitiveOption, VerboseOption);
+        }, RepoRootOption, SolutionOrProjectFileOption, DependencyNameOption, NewVersionOption, PreviousVersionOption, IsTransitiveOption, VerboseOption, ResultOutputPathOption);
 
         return command;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
@@ -52,6 +52,8 @@ public class AnalyzeWorkerTestBase
         Assert.Equal(expectedResult.VersionComesFromMultiDependencyProperty, actualResult.VersionComesFromMultiDependencyProperty);
         ValidateDependencies(expectedResult.UpdatedDependencies, actualResult.UpdatedDependencies);
         Assert.Equal(expectedResult.ExpectedUpdatedDependenciesCount ?? expectedResult.UpdatedDependencies.Length, actualResult.UpdatedDependencies.Length);
+        Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
+        Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
 
         return;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -40,6 +40,8 @@ public class DiscoveryWorkerTestBase
         ValidateResultWithDependencies(expectedResult.DotNetToolsJson, actualResult.DotNetToolsJson);
         ValidateProjectResults(expectedResult.Projects, actualResult.Projects);
         Assert.Equal(expectedResult.ExpectedProjectCount ?? expectedResult.Projects.Length, actualResult.Projects.Length);
+        Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
+        Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
 
         return;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+
+using NuGetUpdater.Core.Discover;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Discover;
@@ -319,6 +323,102 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         new("dotnetsay", "2.1.3", DependencyType.DotNetTool),
                     ]
                 }
+            }
+        );
+    }
+
+    [Fact]
+    public async Task ResultFileHasCorrectShapeForAuthenticationFailure()
+    {
+        using var temporaryDirectory = await TemporaryDirectory.CreateWithContentsAsync([]);
+        var discoveryResultPath = Path.Combine(temporaryDirectory.DirectoryPath, DiscoveryWorker.DiscoveryResultFileName);
+        await DiscoveryWorker.WriteResultsAsync(temporaryDirectory.DirectoryPath, discoveryResultPath, new()
+        {
+            ErrorType = ErrorType.AuthenticationFailure,
+            ErrorDetails = "<some package feed>",
+            Path = "/",
+            Projects = [],
+        });
+        var discoveryContents = await File.ReadAllTextAsync(discoveryResultPath);
+
+        // raw result file should look like this:
+        // {
+        //   ...
+        //   "ErrorType": "AuthenticationFailure",
+        //   "ErrorDetails": "<some package feed>",
+        //   ...
+        // }
+        var jsonDocument = JsonDocument.Parse(discoveryContents);
+        var errorType = jsonDocument.RootElement.GetProperty("ErrorType");
+        var errorDetails = jsonDocument.RootElement.GetProperty("ErrorDetails");
+
+        Assert.Equal("AuthenticationFailure", errorType.GetString());
+        Assert.Equal("<some package feed>", errorDetails.GetString());
+    }
+
+    [Fact]
+    public async Task ReportsPrivateSourceAuthenticationFailure()
+    {
+        static (int, string) TestHttpHandler(string uriString)
+        {
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                // initial request is good
+                "/index.json" => (200, $$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/query",
+                                "@type": "SearchQueryService"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """),
+                // all other requests are unauthorized
+                _ => (401, "{}"),
+            };
+        }
+        using var http = TestHttpServer.CreateTestStringServer(TestHttpHandler);
+        await TestDiscoveryAsync(
+            workspacePath: "",
+            files:
+            [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.2.3" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <clear />
+                        <add key="private_feed" value="{http.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                      </packageSources>
+                    </configuration>
+                    """),
+            ],
+            expectedResult: new()
+            {
+                ErrorType = ErrorType.AuthenticationFailure,
+                ErrorDetails = $"({http.BaseUrl.TrimEnd('/')}/index.json)",
+                Path = "",
+                Projects = [],
             }
         );
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -4,7 +4,7 @@ using NuGetUpdater.Core.Discover;
 
 namespace NuGetUpdater.Core.Test.Discover;
 
-public record ExpectedWorkspaceDiscoveryResult
+public record ExpectedWorkspaceDiscoveryResult : NativeResult
 {
     public required string Path { get; init; }
     public bool IsSuccess { get; init; } = true;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 
 namespace NuGetUpdater.Core.Test
 {
@@ -56,6 +57,16 @@ namespace NuGetUpdater.Core.Test
                 server.Start();
                 return server;
             }
+        }
+
+        public static TestHttpServer CreateTestStringServer(Func<string, (int, string)> requestHandler)
+        {
+            Func<string, (int, byte[])> bytesRequestHandler = url =>
+            {
+                var (statusCode, response) = requestHandler(url);
+                return (statusCode, Encoding.UTF8.GetBytes(response));
+            };
+            return CreateTestServer(bytesRequestHandler);
         }
 
         private static int FindFreePort()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+
+using NuGetUpdater.Core.Updater;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -88,7 +92,8 @@ public abstract class UpdateWorkerTestBase : TestBase
         TestFile[]? additionalFiles = null,
         TestFile[]? additionalFilesExpected = null,
         MockNuGetPackage[]? packages = null,
-        string projectFilePath = "test-project.csproj")
+        string projectFilePath = "test-project.csproj",
+        UpdateOperationResult? expectedResult = null)
         => TestUpdateForProject(
             dependencyName,
             oldVersion,
@@ -98,7 +103,8 @@ public abstract class UpdateWorkerTestBase : TestBase
             isTransitive,
             additionalFiles,
             additionalFilesExpected,
-            packages);
+            packages,
+            expectedResult);
 
     protected static async Task TestUpdateForProject(
         string dependencyName,
@@ -109,7 +115,8 @@ public abstract class UpdateWorkerTestBase : TestBase
         bool isTransitive = false,
         TestFile[]? additionalFiles = null,
         TestFile[]? additionalFilesExpected = null,
-        MockNuGetPackage[]? packages = null)
+        MockNuGetPackage[]? packages = null,
+        UpdateOperationResult? expectedResult = null)
     {
         additionalFiles ??= [];
         additionalFilesExpected ??= [];
@@ -130,16 +137,29 @@ public abstract class UpdateWorkerTestBase : TestBase
             // run update
             var worker = new UpdaterWorker(new Logger(verbose: true));
             var projectPath = placeFilesInSrc ? $"src/{projectFilePath}" : projectFilePath;
-            await worker.RunAsync(temporaryDirectory, projectPath, dependencyName, oldVersion, newVersion, isTransitive);
+            var updateResultFile = Path.Combine(temporaryDirectory, "update-result.json");
+            await worker.RunAsync(temporaryDirectory, projectPath, dependencyName, oldVersion, newVersion, isTransitive, updateResultFile);
+            var actualResultContents = await File.ReadAllTextAsync(updateResultFile);
+            var actualResult = JsonSerializer.Deserialize<UpdateOperationResult>(actualResultContents, UpdaterWorker.SerializerOptions);
+            if (expectedResult is { })
+            {
+                ValidateUpdateOperationResult(expectedResult, actualResult!);
+            }
         });
 
-        var expectedResult = additionalFilesExpected.Prepend((projectFilePath, expectedProjectContents)).ToArray();
+        var expectedResultFiles = additionalFilesExpected.Prepend((projectFilePath, expectedProjectContents)).ToArray();
         if (placeFilesInSrc)
         {
-            expectedResult = expectedResult.Select(er => ($"src/{er.Item1}", er.Item2)).ToArray();
+            expectedResultFiles = expectedResultFiles.Select(er => ($"src/{er.Item1}", er.Item2)).ToArray();
         }
 
-        AssertContainsFiles(expectedResult, actualResult);
+        AssertContainsFiles(expectedResultFiles, actualResult);
+    }
+
+    protected static void ValidateUpdateOperationResult(UpdateOperationResult expectedResult, UpdateOperationResult actualResult)
+    {
+        Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
+        Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
     }
 
     protected static Task TestNoChangeforSolution(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+
+using NuGetUpdater.Core.Updater;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
@@ -6,6 +10,34 @@ public partial class UpdateWorkerTests
 {
     public class Mixed : UpdateWorkerTestBase
     {
+        [Fact]
+        public async Task ResultFileHasCorrectShapeForAuthenticationFailure()
+        {
+            using var temporaryDirectory = await TemporaryDirectory.CreateWithContentsAsync([]);
+            var result = new UpdateOperationResult()
+            {
+                ErrorType = ErrorType.AuthenticationFailure,
+                ErrorDetails = "<some package feed>",
+            };
+            var resultFilePath = Path.Combine(temporaryDirectory.DirectoryPath, "update-result.json");
+            await UpdaterWorker.WriteResultFile(result, resultFilePath, new Logger(false));
+            var resultContent = await File.ReadAllTextAsync(resultFilePath);
+
+            // raw result file should look like this:
+            // {
+            //   ...
+            //   "ErrorType": "AuthenticationFailure",
+            //   "ErrorDetails": "<some package feed>",
+            //   ...
+            // }
+            var jsonDocument = JsonDocument.Parse(resultContent);
+            var errorType = jsonDocument.RootElement.GetProperty("ErrorType");
+            var errorDetails = jsonDocument.RootElement.GetProperty("ErrorDetails");
+
+            Assert.Equal("AuthenticationFailure", errorType.GetString());
+            Assert.Equal("<some package feed>", errorDetails.GetString());
+        }
+
         [Fact]
         public async Task ForPackagesProject_UpdatePackageReference_InBuildProps()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -1,5 +1,8 @@
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+
+using NuGetUpdater.Core.Updater;
 
 using Xunit;
 
@@ -2896,6 +2899,59 @@ public partial class UpdateWorkerTests
                       </ItemGroup>
                     </Project>
                     """
+            );
+        }
+
+        [Fact]
+        public async Task ReportsPrivateSourceAuthenticationFailure()
+        {
+            static (int, string) TestHttpHandler(string uriString)
+            {
+                var uri = new Uri(uriString, UriKind.Absolute);
+                var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+                return uri.PathAndQuery switch
+                {
+                    _ => (401, "{}"), // everything is unauthorized
+                };
+            }
+            using var http = TestHttpServer.CreateTestStringServer(TestHttpHandler);
+            await TestUpdateForProject("Some.Package", "1.0.0", "1.1.0",
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFiles:
+                [
+                    ("NuGet.Config", $"""
+                        <configuration>
+                          <packageSources>
+                            <clear />
+                            <add key="private_feed" value="{http.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                          </packageSources>
+                        </configuration>
+                        """)
+                ],
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                expectedResult: new()
+                {
+                    ErrorType = ErrorType.AuthenticationFailure,
+                    ErrorDetails = $"({http.BaseUrl.TrimEnd('/')}/index.json)",
+                }
             );
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalysisResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalysisResult.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 
 namespace NuGetUpdater.Core.Analyze;
 
-public record AnalysisResult
+public record AnalysisResult : NativeResult
 {
     public required string UpdatedVersion { get; init; }
     public bool CanUpdate { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -1,8 +1,8 @@
 using System.Collections.Immutable;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
@@ -57,70 +57,87 @@ public partial class AnalyzeWorker
         ImmutableArray<Dependency> updatedDependencies = [];
 
         bool isUpdateNecessary = IsUpdateNecessary(dependencyInfo, projectsWithDependency);
-        if (isUpdateNecessary)
+        using var nugetContext = new NuGetContext(startingDirectory);
+        AnalysisResult result;
+        try
         {
-            var nugetContext = new NuGetContext(startingDirectory);
-            if (!Directory.Exists(nugetContext.TempPackageDirectory))
+            if (isUpdateNecessary)
             {
-                Directory.CreateDirectory(nugetContext.TempPackageDirectory);
-            }
+                if (!Directory.Exists(nugetContext.TempPackageDirectory))
+                {
+                    Directory.CreateDirectory(nugetContext.TempPackageDirectory);
+                }
 
-            _logger.Log($"  Determining multi-dependency property.");
-            var multiDependencies = DetermineMultiDependencyDetails(
-                discovery,
-                dependencyInfo.Name,
-                propertyBasedDependencies);
-
-            usesMultiDependencyProperty = multiDependencies.Any(md => md.DependencyNames.Count > 1);
-            var dependenciesToUpdate = usesMultiDependencyProperty
-                ? multiDependencies
-                    .SelectMany(md => md.DependencyNames)
-                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
-                : [dependencyInfo.Name];
-            var applicableTargetFrameworks = usesMultiDependencyProperty
-                ? multiDependencies
-                    .SelectMany(md => md.TargetFrameworks)
-                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
-                    .Select(NuGetFramework.Parse)
-                    .ToImmutableArray()
-                : projectFrameworks;
-
-            _logger.Log($"  Finding updated version.");
-            updatedVersion = await FindUpdatedVersionAsync(
-                startingDirectory,
-                dependencyInfo,
-                dependenciesToUpdate,
-                applicableTargetFrameworks,
-                nugetContext,
-                _logger,
-                CancellationToken.None);
-
-            _logger.Log($"  Finding updated peer dependencies.");
-            updatedDependencies = updatedVersion is not null
-                ? await FindUpdatedDependenciesAsync(
-                    repoRoot,
+                _logger.Log($"  Determining multi-dependency property.");
+                var multiDependencies = DetermineMultiDependencyDetails(
                     discovery,
+                    dependencyInfo.Name,
+                    propertyBasedDependencies);
+
+                usesMultiDependencyProperty = multiDependencies.Any(md => md.DependencyNames.Count > 1);
+                var dependenciesToUpdate = usesMultiDependencyProperty
+                    ? multiDependencies
+                        .SelectMany(md => md.DependencyNames)
+                        .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
+                    : [dependencyInfo.Name];
+                var applicableTargetFrameworks = usesMultiDependencyProperty
+                    ? multiDependencies
+                        .SelectMany(md => md.TargetFrameworks)
+                        .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
+                        .Select(NuGetFramework.Parse)
+                        .ToImmutableArray()
+                    : projectFrameworks;
+
+                _logger.Log($"  Finding updated version.");
+                updatedVersion = await FindUpdatedVersionAsync(
+                    startingDirectory,
+                    dependencyInfo,
                     dependenciesToUpdate,
-                    updatedVersion,
+                    applicableTargetFrameworks,
                     nugetContext,
                     _logger,
-                    CancellationToken.None)
-                : [];
+                    CancellationToken.None);
 
-            //TODO: At this point we should add the peer dependencies to a queue where
-            // we will analyze them one by one to see if they themselves are part of a
-            // multi-dependency property. Basically looping this if-body until we have
-            // emptied the queue and have a complete list of updated dependencies. We
-            // should track the dependenciesToUpdate as they have already been analyzed.
+                _logger.Log($"  Finding updated peer dependencies.");
+                updatedDependencies = updatedVersion is not null
+                    ? await FindUpdatedDependenciesAsync(
+                        repoRoot,
+                        discovery,
+                        dependenciesToUpdate,
+                        updatedVersion,
+                        nugetContext,
+                        _logger,
+                        CancellationToken.None)
+                    : [];
+
+                //TODO: At this point we should add the peer dependencies to a queue where
+                // we will analyze them one by one to see if they themselves are part of a
+                // multi-dependency property. Basically looping this if-body until we have
+                // emptied the queue and have a complete list of updated dependencies. We
+                // should track the dependenciesToUpdate as they have already been analyzed.
+            }
+
+            result = new AnalysisResult
+            {
+                UpdatedVersion = updatedVersion?.ToNormalizedString() ?? dependencyInfo.Version,
+                CanUpdate = updatedVersion is not null,
+                VersionComesFromMultiDependencyProperty = usesMultiDependencyProperty,
+                UpdatedDependencies = updatedDependencies,
+            };
         }
-
-        var result = new AnalysisResult
+        catch (HttpRequestException ex)
+        when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {
-            UpdatedVersion = updatedVersion?.ToNormalizedString() ?? dependencyInfo.Version,
-            CanUpdate = updatedVersion is not null,
-            VersionComesFromMultiDependencyProperty = usesMultiDependencyProperty,
-            UpdatedDependencies = updatedDependencies,
-        };
+            // TODO: consolidate this error handling between AnalyzeWorker, DiscoveryWorker, and UpdateWorker
+            result = new AnalysisResult
+            {
+                ErrorType = ErrorType.AuthenticationFailure,
+                ErrorDetails = "(" + string.Join("|", nugetContext.PackageSources.Select(s => s.Source)) + ")",
+                UpdatedVersion = string.Empty,
+                CanUpdate = false,
+                UpdatedDependencies = [],
+            };
+        }
 
         await WriteResultsAsync(analysisDirectory, dependencyInfo.Name, result, _logger);
 
@@ -312,27 +329,6 @@ public partial class AnalyzeWorker
         }
 
         return true;
-    }
-
-    internal static async Task<ImmutableDictionary<NuGetFramework, ImmutableArray<Dependency>>> GetDependenciesAsync(
-        string workspacePath,
-        string projectPath,
-        IEnumerable<NuGetFramework> frameworks,
-        Dependency package,
-        Logger logger)
-    {
-        var result = ImmutableDictionary.CreateBuilder<NuGetFramework, ImmutableArray<Dependency>>();
-        foreach (var framework in frameworks)
-        {
-            var dependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
-                workspacePath,
-                projectPath,
-                framework.ToString(),
-                [package],
-                logger);
-            result.Add(framework, [.. dependencies]);
-        }
-        return result.ToImmutable();
     }
 
     internal static async Task<ImmutableArray<Dependency>> FindUpdatedDependenciesAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -47,6 +47,13 @@ internal record NuGetContext : IDisposable
 
     private readonly Dictionary<PackageIdentity, string?> _packageInfoUrlCache = new();
 
+    public static string[] GetPackageSourceUrls(string currentDirectory)
+    {
+        using var context = new NuGetContext(currentDirectory);
+        var sourceUrls = context.PackageSources.Select(s => s.Source).ToArray();
+        return sourceUrls;
+    }
+
     public async Task<string?> GetPackageInfoUrlAsync(string packageId, string packageVersion, CancellationToken cancellationToken)
     {
         var packageIdentity = new PackageIdentity(packageId, NuGetVersion.Parse(packageVersion));

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 
 namespace NuGetUpdater.Core.Discover;
 
-public sealed record WorkspaceDiscoveryResult
+public sealed record WorkspaceDiscoveryResult : NativeResult
 {
     public required string Path { get; init; }
     public bool IsSuccess { get; init; } = true;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
@@ -1,0 +1,8 @@
+namespace NuGetUpdater.Core;
+
+public enum ErrorType
+{
+    // TODO: add `Unknown` option to track all other failure types
+    None,
+    AuthenticationFailure,
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NativeResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NativeResult.cs
@@ -1,0 +1,8 @@
+namespace NuGetUpdater.Core;
+
+public record NativeResult
+{
+    // TODO: nullable not required, `ErrorType.None` is the default anyway
+    public ErrorType? ErrorType { get; init; }
+    public string? ErrorDetails { get; init; }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -228,6 +228,7 @@ internal static class SdkPackageUpdater
 
         // see https://learn.microsoft.com/nuget/consume-packages/install-use-packages-dotnet-cli
         var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}", workingDirectory: Path.GetDirectoryName(projectPath));
+        MSBuildHelper.ThrowOnUnauthenticatedFeed(stdout);
         if (exitCode != 0)
         {
             logger.Log($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationResult.cs
@@ -1,0 +1,5 @@
+namespace NuGetUpdater.Core.Updater;
+
+public record UpdateOperationResult : NativeResult
+{
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -1,3 +1,10 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Updater;
+
 namespace NuGetUpdater.Core;
 
 public class UpdaterWorker
@@ -5,48 +12,81 @@ public class UpdaterWorker
     private readonly Logger _logger;
     private readonly HashSet<string> _processedProjectPaths = new(StringComparer.OrdinalIgnoreCase);
 
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
     public UpdaterWorker(Logger logger)
     {
         _logger = logger;
     }
 
-    public async Task RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
+    public async Task RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive, string? resultOutputPath = null)
     {
         MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, repoRootPath);
+        UpdateOperationResult result;
 
         if (!Path.IsPathRooted(workspacePath) || !File.Exists(workspacePath))
         {
             workspacePath = Path.GetFullPath(Path.Join(repoRootPath, workspacePath));
         }
 
-        if (!isTransitive)
+        try
         {
-            await DotNetToolsJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
-            await GlobalJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
-        }
+            if (!isTransitive)
+            {
+                await DotNetToolsJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
+                await GlobalJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
+            }
 
-        var extension = Path.GetExtension(workspacePath).ToLowerInvariant();
-        switch (extension)
+            var extension = Path.GetExtension(workspacePath).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".sln":
+                    await RunForSolutionAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                    break;
+                case ".proj":
+                    await RunForProjFileAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                    break;
+                case ".csproj":
+                case ".fsproj":
+                case ".vbproj":
+                    await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                    break;
+                default:
+                    _logger.Log($"File extension [{extension}] is not supported.");
+                    break;
+            }
+
+            result = new(); // all ok
+            _logger.Log("Update complete.");
+        }
+        catch (HttpRequestException ex)
+        when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {
-            case ".sln":
-                await RunForSolutionAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
-                break;
-            case ".proj":
-                await RunForProjFileAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
-                break;
-            case ".csproj":
-            case ".fsproj":
-            case ".vbproj":
-                await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
-                break;
-            default:
-                _logger.Log($"File extension [{extension}] is not supported.");
-                break;
+            // TODO: consolidate this error handling between AnalyzeWorker, DiscoveryWorker, and UpdateWorker
+            result = new()
+            {
+                ErrorType = ErrorType.AuthenticationFailure,
+                ErrorDetails = "(" + string.Join("|", NuGetContext.GetPackageSourceUrls(workspacePath)) + ")",
+            };
         }
-
-        _logger.Log("Update complete.");
 
         _processedProjectPaths.Clear();
+        if (resultOutputPath is { })
+        {
+            await WriteResultFile(result, resultOutputPath, _logger);
+        }
+    }
+
+    internal static async Task WriteResultFile(UpdateOperationResult result, string resultOutputPath, Logger logger)
+    {
+        logger.Log($"  Writing update result to [{resultOutputPath}].");
+
+        var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
+        await File.WriteAllTextAsync(resultOutputPath, resultJson);
     }
 
     private async Task RunForSolutionAsync(

--- a/nuget/lib/dependabot/nuget/analysis/dependency_analysis.rb
+++ b/nuget/lib/dependabot/nuget/analysis/dependency_analysis.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/nuget/version"
+require "dependabot/nuget/native_helpers"
 require "sorbet-runtime"
 
 module Dependabot
@@ -11,6 +12,8 @@ module Dependabot
 
       sig { params(json: T::Hash[String, T.untyped]).returns(DependencyAnalysis) }
       def self.from_json(json)
+        Dependabot::Nuget::NativeHelpers.ensure_no_errors(json)
+
         updated_version = T.let(json.fetch("UpdatedVersion"), String)
         can_update = T.let(json.fetch("CanUpdate"), T::Boolean)
         version_comes_from_multi_dependency_property = T.let(json.fetch("VersionComesFromMultiDependencyProperty"),

--- a/nuget/lib/dependabot/nuget/native_discovery/native_workspace_discovery.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_workspace_discovery.rb
@@ -4,6 +4,7 @@
 require "dependabot/nuget/native_discovery/native_dependency_file_discovery"
 require "dependabot/nuget/native_discovery/native_directory_packages_props_discovery"
 require "dependabot/nuget/native_discovery/native_project_discovery"
+require "dependabot/nuget/native_helpers"
 require "sorbet-runtime"
 
 module Dependabot
@@ -13,6 +14,8 @@ module Dependabot
 
       sig { params(json: T::Hash[String, T.untyped]).returns(NativeWorkspaceDiscovery) }
       def self.from_json(json)
+        Dependabot::Nuget::NativeHelpers.ensure_no_errors(json)
+
         path = T.let(json.fetch("Path"), String)
         path = "/" + path unless path.start_with?("/")
         projects = T.let(json.fetch("Projects"), T::Array[T::Hash[String, T.untyped]]).filter_map do |project|

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -169,11 +169,12 @@ module Dependabot
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       sig do
         params(repo_root: String, proj_path: String, dependency: Dependency,
-               is_transitive: T::Boolean).returns([String, String])
+               is_transitive: T::Boolean, result_output_path: String).returns([String, String])
       end
-      def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency:, is_transitive:)
+      def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency:, is_transitive:, result_output_path:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command_parts = [
           exe_path,
@@ -189,6 +190,8 @@ module Dependabot
           "--previous-version",
           dependency.previous_version,
           is_transitive ? "--transitive" : nil,
+          "--result-output-path",
+          result_output_path,
           "--verbose"
         ].compact
 
@@ -208,10 +211,18 @@ module Dependabot
           "--previous-version",
           "<previous-version>",
           is_transitive ? "--transitive" : nil,
+          "--result-output-path",
+          "<result-output-path>",
           "--verbose"
         ].compact.join(" ")
 
         [command, fingerprint]
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      sig { returns(String) }
+      def self.update_result_file_path
+        File.join(Dir.tmpdir, "update-result.json")
       end
 
       sig do
@@ -225,13 +236,33 @@ module Dependabot
       end
       def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)
         (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
-                                                                dependency: dependency, is_transitive: is_transitive)
+                                                                dependency: dependency, is_transitive: is_transitive,
+                                                                result_output_path: update_result_file_path)
 
         puts "running NuGet updater:\n" + command
 
         NuGetConfigCredentialHelpers.patch_nuget_config_for_action(credentials) do
           output = SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, fingerprint: fingerprint)
           puts output
+
+          result_contents = File.read(update_result_file_path)
+          Dependabot.logger.info("update result: #{result_contents}")
+          result_json = T.let(JSON.parse(result_contents), T::Hash[String, T.untyped])
+          ensure_no_errors(result_json)
+        end
+      end
+
+      sig { params(json: T::Hash[String, T.untyped]).void }
+      def self.ensure_no_errors(json)
+        error_type = T.let(json.fetch("ErrorType", nil), T.nilable(String))
+        error_details = T.let(json.fetch("ErrorDetails", nil), T.nilable(String))
+        case error_type
+        when "None", nil
+          # no issue
+        when "AuthenticationFailure"
+          raise PrivateSourceAuthenticationFailure, error_details
+        else
+          raise "Unexpected error type from native tool: #{error_type}: #{error_details}"
         end
       end
     end

--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -68,6 +68,9 @@ module Dependabot
         add_credentials_to_nuget_config(credentials)
         begin
           yield
+        rescue DependabotError
+          # forward these
+          raise
         rescue StandardError => e
           log_message =
             <<~LOG_MESSAGE

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -303,6 +303,40 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         end
       end
     end
+
+    context "with a private source authentication failure" do
+      let(:dependency_name) { "Nuke.Common" }
+      let(:dependency_requirements) { [] }
+      let(:dependency_version) { "2.0.0" }
+
+      before do
+        intercept_native_tools(
+          discovery_content_hash: {
+            Path: "",
+            IsSuccess: false,
+            Projects: [],
+            DirectoryPackagesProps: nil,
+            GlobalJson: nil,
+            DotNetToolsJson: nil
+          },
+          dependency_name: "Nuke.Common",
+          analysis_content_hash: {
+            UpdatedVersion: "",
+            CanUpdate: false,
+            VersionComesFromMultiDependencyProperty: false,
+            UpdatedDependencies: [],
+            ErrorType: "AuthenticationFailure",
+            ErrorDetails: "the-error-details"
+          }
+        )
+      end
+
+      it "raises the correct error" do
+        run_analyze_test do |checker|
+          expect { checker.up_to_date? }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+        end
+      end
+    end
   end
 
   describe "#latest_resolvable_version" do


### PR DESCRIPTION
With most of the update work being performed in C#, we need a mechanism to surface errors encountered.  This PR adds 2 fields to the output JSON, `ErrorType` and `ErrorDetails`.  Those values are then examined when the output JSON is processed and the relevant error is raised.

The bulk of this PR can be described in two changes:

1. Wrap calls to NuGet APIs and catch `HttpRequestException` with codes `401` or `403` and set the appropriate fields.
    1. When we're starting an external process, we instead scrape the output for a known string and turn that into `HttpRequestException` to be caught further up the call stack.
2. Any time the Ruby code processes an output JSON file, check for `ErrorType` and raise, otherwise continue execution as normal.

The design allows future work of detecting and surfacing other error types, but for now only `PrivateSourceAuthenticationFailure` is handled, because that's a really common one.