### PR TITLE
Fix sorbet typing for `current_name` parameter

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -800,8 +800,8 @@ module Dependabot
 
         sig do
           params(
-            current_name: String,
-            original_name: String,
+            current_name: T.any(String, NilClass),
+            original_name: T.any(String, NilClass),
             updated_lockfile_content: String
           )
             .returns(String)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -801,7 +801,7 @@ module Dependabot
         sig do
           params(
             current_name: T.any(String, NilClass),
-            original_name: T.any(String, NilClass),
+            original_name: String,
             updated_lockfile_content: String
           )
             .returns(String)


### PR DESCRIPTION
### What are you trying to accomplish?

The goal is to resolve a type error that occurs when the `current_name` parameter receives `nil` values. This parameter is being read from a map that is `T.untyped`, which means it can sometimes be `nil`. Changing its type to `T.any(String, NilClass)` will prevent the `Dependabot::Sorbet::Runtime::InformationalError`.

### Anything you want to highlight for special attention from reviewers?

By changing the type to `T.any(String, NilClass)`, we accommodate the possibility of `nil` values, which aligns with the behavior of the map from which this parameter is read. This approach ensures that the function can handle all potential input types without causing runtime errors.

### How will you know you've accomplished your goal?

- The error should no longer appear in the logs.
- Running the test suite should pass without errors related to this type issue.
- Any additional tests should confirm that the function handles both `String` and `nil` values appropriately.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
