### PR TITLE
Fix `ArgumentError` in `original_package_update_available?` when `latest_version` is `nil`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -309,6 +309,8 @@ module Dependabot
 
           latest_version = latest_version_finder(original_package).latest_version_from_registry
 
+          # If the latest version is within the scope of the current requirements,
+          # latest_version will be nil. In such cases, there is no update available.
           return false if latest_version.nil?
 
           original_package_version < latest_version

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -309,6 +309,8 @@ module Dependabot
 
           latest_version = latest_version_finder(original_package).latest_version_from_registry
 
+          return false if latest_version.nil?
+
           original_package_version < latest_version
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?

The goal is to fix an `ArgumentError` that occurs when the `latest_version` is `nil` in the `original_package_update_available?` method. Instead of performing a comparison when `latest_version` is `nil`, the method will return `false`. This will prevent the error and ensure the function handles the `nil` case gracefully.

### Anything you want to highlight for special attention from reviewers?

By returning `false` when `latest_version` is `nil`, we avoid the `ArgumentError` that occurs due to the comparison with `nil`. This approach ensures that the method functions correctly even when the `latest_version` is not available.

### How will you know you've accomplished your goal?

- The error should no longer appear in the logs.
- Running the test suite should pass without errors related to this issue.
- Any additional tests should confirm that the function handles `nil` values for `latest_version` appropriately.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.