### PR TITLE
ensure ``Dependency::source::source_url`` can be populated from `.nuspec` uRL

### DIFF
--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -12,14 +12,146 @@ module Dependabot
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
 
+      sig do
+        override
+          .params(
+            dependency: Dependabot::Dependency,
+            credentials: T::Array[Dependabot::Credential]
+          )
+          .void
+      end
+      def initialize(dependency:, credentials:)
+        @dependency_nuspec_file = T.let(nil, T.nilable(Nokogiri::XML::Document))
+
+        super
+      end
+
       private
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        source_url = dependency_source_url
-        return Source.from_url(source_url) if source_url
+        return Source.from_url(dependency_source_url) if dependency_source_url
 
+        if dependency_nuspec_file
+          src_repo = look_up_source_in_nuspec(T.must(dependency_nuspec_file))
+          return src_repo if src_repo
+        end
+
+        # Fallback to getting source from the search result's projectUrl or licenseUrl.
+        # GitHub Packages doesn't support getting the `.nuspec`, switch to getting
+        # that instead once it is supported.
+        src_repo_from_project
+      rescue StandardError
+        # At this point in the process the PR is ready to be posted, we tried to gather commit
+        # and release notes, but have encountered an exception. So let's eat it since it's
+        # better to have a PR with no info than error out.
         nil
+      end
+
+      sig { returns(T.nilable(Dependabot::Source)) }
+      def src_repo_from_project
+        source = dependency.requirements.find { |r| r.fetch(:source) }&.fetch(:source)
+        return unless source
+
+        # Query the service index e.g. https://nuget.pkg.github.com/ORG/index.json
+        response = Dependabot::RegistryClient.get(
+          url: source.fetch(:url),
+          headers: { **auth_header, "Accept" => "application/json" }
+        )
+        return unless response.status == 200
+
+        # Extract the query url e.g. https://nuget.pkg.github.com/ORG/query
+        search_base = extract_search_url(response.body)
+        return unless search_base
+
+        response = Dependabot::RegistryClient.get(
+          url: search_base + "?q=#{dependency.name.downcase}&prerelease=true&semVerLevel=2.0.0",
+          headers: { **auth_header, "Accept" => "application/json" }
+        )
+        return unless response.status == 200
+
+        # Find a projectUrl or licenseUrl that look like a source URL
+        extract_source_repo(response.body)
+      rescue JSON::ParserError
+        # Ignored, this is expected for some registries that don't handle these request.
+      end
+
+      sig { params(body: String).returns(T.nilable(String)) }
+      def extract_search_url(body)
+        JSON.parse(body)
+            .fetch("resources", [])
+            .find { |r| r.fetch("@type") == "SearchQueryService" }
+            &.fetch("@id")
+      end
+
+      sig { params(body: String).returns(T.nilable(Dependabot::Source)) }
+      def extract_source_repo(body)
+        JSON.parse(body).fetch("data", []).each do |search_result|
+          next unless search_result["id"].casecmp(dependency.name).zero?
+
+          if search_result.key?("projectUrl")
+            source = Source.from_url(search_result.fetch("projectUrl"))
+            return source if source
+          end
+          if search_result.key?("licenseUrl")
+            source = Source.from_url(search_result.fetch("licenseUrl"))
+            return source if source
+          end
+        end
+        # failed to find a source URL
+        nil
+      end
+
+      sig { params(nuspec: Nokogiri::XML::Document).returns(T.nilable(Dependabot::Source)) }
+      def look_up_source_in_nuspec(nuspec)
+        potential_source_urls = [
+          nuspec.at_css("package > metadata > repository")
+                &.attribute("url")&.value,
+          nuspec.at_css("package > metadata > repository > url")&.content,
+          nuspec.at_css("package > metadata > projectUrl")&.content,
+          nuspec.at_css("package > metadata > licenseUrl")&.content
+        ].compact
+
+        source_url = potential_source_urls.find { |url| Source.from_url(url) }
+        source_url ||= source_from_anywhere_in_nuspec(nuspec)
+
+        Source.from_url(source_url)
+      end
+
+      sig { params(nuspec: Nokogiri::XML::Document).returns(T.nilable(String)) }
+      def source_from_anywhere_in_nuspec(nuspec)
+        github_urls = []
+        nuspec.to_s.force_encoding(Encoding::UTF_8)
+              .scan(Source::SOURCE_REGEX) do
+          github_urls << Regexp.last_match.to_s
+        end
+
+        github_urls.find do |url|
+          repo = T.must(Source.from_url(url)).repo
+          repo.downcase.end_with?(dependency.name.downcase)
+        end
+      end
+
+      sig { returns(T.nilable(Nokogiri::XML::Document)) }
+      def dependency_nuspec_file
+        return @dependency_nuspec_file unless @dependency_nuspec_file.nil?
+
+        return if dependency_nuspec_url.nil?
+
+        response = Dependabot::RegistryClient.get(
+          url: T.must(dependency_nuspec_url),
+          headers: auth_header
+        )
+
+        @dependency_nuspec_file = Nokogiri::XML(response.body)
+      end
+
+      sig { returns(T.nilable(String)) }
+      def dependency_nuspec_url
+        source = dependency.requirements
+                           .find { |r| r.fetch(:source) }&.fetch(:source)
+
+        source.fetch(:nuspec_url) if source&.key?(:nuspec_url)
       end
 
       sig { returns(T.nilable(String)) }
@@ -32,6 +164,32 @@ module Dependabot
 
         source.fetch("source_url")
       end
+
+      # rubocop:disable Metrics/PerceivedComplexity
+      sig { returns(T::Hash[String, String]) }
+      def auth_header
+        source = dependency.requirements
+                           .find { |r| r.fetch(:source) }&.fetch(:source)
+        url = source&.fetch(:url, nil) || source&.fetch("url")
+
+        token = credentials
+                .select { |cred| cred["type"] == "nuget_feed" }
+                .find { |cred| cred["url"] == url }
+                &.fetch("token", nil)
+
+        return {} unless token
+
+        if token.include?(":")
+          encoded_token = Base64.encode64(token).delete("\n")
+          { "Authorization" => "Basic #{encoded_token}" }
+        elsif Base64.decode64(token).ascii_only? &&
+              Base64.decode64(token).include?(":")
+          { "Authorization" => "Basic #{token.delete("\n")}" }
+        else
+          { "Authorization" => "Bearer #{token}" }
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
     end
   end
 end

--- a/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
@@ -26,76 +26,212 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: dependency_version,
-      requirements: requirements,
+      requirements: [{
+        file: "my.csproj",
+        requirement: dependency_version,
+        groups: ["dependencies"],
+        source: source
+      }],
       package_manager: "nuget"
     )
   end
 
-  let(:requirements) do
-    [{
-      file: "my.csproj",
-      requirement: dependency_version,
-      groups: ["dependencies"],
-      source: source
-    }]
-  end
-
   it_behaves_like "a dependency metadata finder"
 
-  describe "#dependency_source_url" do
-    subject(:look_up_source) { finder.send(:dependency_source_url) }
+  describe "#source_url" do
+    subject(:source_url) { finder.source_url }
 
-    context "with a source object with symbol keys" do
+    let(:nuget_url) do
+      "https://api.nuget.org/v3-flatcontainer/" \
+        "microsoft.extensions.dependencymodel/2.1.0/" \
+        "microsoft.extensions.dependencymodel.nuspec"
+    end
+    let(:nuget_response) do
+      fixture(
+        "nuspecs",
+        "Microsoft.Extensions.DependencyModel.nuspec"
+      )
+    end
+
+    before do
+      stub_request(:get, nuget_url).to_return(status: 200, body: nuget_response)
+      stub_request(:get, "https://example.com/status").to_return(
+        status: 200,
+        body: "Not GHES",
+        headers: {}
+      )
+    end
+
+    context "with a source" do
       let(:source) do
         {
-          source_url: "https://nuget.example.com/some.package",
-          type: "nuget_repo"
+          type: "nuget_repo",
+          url: "https://www.myget.org/F/exceptionless/api/v3/index.json",
+          source_url: nil,
+          nuspec_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                      "flatcontainer/microsoft.extensions." \
+                      "dependencymodel/2.1.0/" \
+                      "microsoft.extensions.dependencymodel.nuspec"
         }
       end
 
-      it { is_expected.to eq("https://nuget.example.com/some.package") }
-    end
-
-    context "with a source object with string keys" do
-      let(:source) do
-        {
-          "source_url" => "https://nuget.example.com/some.package",
-          "type" => "nuget_repo"
-        }
+      let(:nuget_url) do
+        "https://www.myget.org/F/exceptionless/api/v3/" \
+          "flatcontainer/microsoft.extensions.dependencymodel/2.1.0/" \
+          "microsoft.extensions.dependencymodel.nuspec"
       end
 
-      it { is_expected.to eq("https://nuget.example.com/some.package") }
-    end
+      it { is_expected.to eq("https://github.com/dotnet/core-setup") }
 
-    context "with a nil source object" do
-      let(:source) { nil }
-
-      it { is_expected.to be_nil }
-    end
-
-    context "with multiple requirements" do
-      let(:requirements) do
-        [{
-          file: "project.csproj",
-          requirement: dependency_version,
-          groups: ["dependencies"],
-          source: nil
-        }, {
-          file: "my.csproj",
-          requirement: dependency_version,
-          groups: ["dependencies"],
-          source: source
-        }]
+      it "caches the call to nuget" do
+        2.times { source_url }
+        expect(WebMock).to have_requested(:get, nuget_url).once
       end
 
-      let(:source) do
-        {
-          source_url: "https://nuget.example.com/some.package",
-          type: "nuget_repo"
-        }
+      context "when nuget repo has a source_url only" do
+        let(:source) do
+          {
+            type: "nuget_repo",
+            url: "https://www.myget.org/F/exceptionless/api/v3/index.json",
+            source_url: "https://github.com/my/repo",
+            nuspec_url: nil
+          }
+        end
+
+        it { is_expected.to eq("https://github.com/my/repo") }
       end
 
-      it { is_expected.to eq("https://nuget.example.com/some.package") }
+      context "when the nuget repo has neither a source_url nor a nuspec_url" do
+        let(:source) do
+          {
+            type: "nuget_repo",
+            url: "https://www.myget.org/F/exceptionless/api/v3/index.json",
+            source_url: nil,
+            nuspec_url: nil
+          }
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with details in the credentials (but no token)" do
+        let(:credentials) do
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }, {
+            "type" => "nuget_feed",
+            "url" => "https://www.myget.org/F/exceptionless/api/v3/" \
+                     "index.json"
+          }]
+        end
+
+        it { is_expected.to eq("https://github.com/dotnet/core-setup") }
+      end
+
+      context "when the registry requires authentication" do
+        before do
+          stub_request(:get, nuget_url).to_return(status: 404)
+          stub_request(:get, nuget_url)
+            .with(basic_auth: %w(my passw0rd))
+            .to_return(status: 200, body: nuget_response)
+        end
+
+        it { is_expected.to be_nil }
+
+        context "with details in the credentials" do
+          let(:credentials) do
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "nuget_feed",
+              "url" => "https://www.myget.org/F/exceptionless/api/v3/" \
+                       "index.json",
+              "token" => "my:passw0rd"
+            }]
+          end
+
+          it { is_expected.to eq("https://github.com/dotnet/core-setup") }
+        end
+      end
+
+      context "when the registry doesn't support .nuspec routes" do
+        before do
+          # registry doesn't support .nuspec route, so returns 404
+          stub_request(:get, nuget_url).to_return(status: 404)
+          # fallback begins by getting the search URL from the index
+          stub_request(:get, "https://www.myget.org/F/exceptionless/api/v3/index.json")
+            .to_return(status: 200, body: fixture("nuspecs", "index.json"))
+          # next query for the package at the search URL returned
+          stub_request(:get, "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=microsoft.extensions.dependencymodel&semVerLevel=2.0.0")
+            .to_return(status: 200, body: fixture("nuspecs", "microsoft.extensions.dependencymodel-results.json"))
+        end
+
+        # data was extracted from the projectUrl in the search results
+        it { is_expected.to eq "https://github.com/dotnet/core-setup" }
+      end
+
+      context "when the index returns XML" do
+        before do
+          # registry doesn't support .nuspec route, so returns 404
+          stub_request(:get, nuget_url).to_return(status: 404)
+          # fallback tries to get the index, but gets a 200 with XML
+          # This might be due to artifactory not supporting index?
+          stub_request(:get, "https://www.myget.org/F/exceptionless/api/v3/index.json")
+            .to_return(status: 200, body: '<?xml version="1.0" encoding="UTF-8"?><hello>world</hello>')
+        end
+
+        # no exceptions
+        it { is_expected.to be_nil }
+      end
+
+      context "when the search results do not contain a projectUrl" do
+        before do
+          # registry doesn't support .nuspec route, so returns 404
+          stub_request(:get, nuget_url).to_return(status: 404)
+          # fallback begins by getting the search URL from the index
+          stub_request(:get, "https://www.myget.org/F/exceptionless/api/v3/index.json")
+            .to_return(status: 200, body: fixture("nuspecs", "index.json"))
+          # the search results have a blank projectUrl field AND missing the licenseUrl field entirely
+          stub_request(:get, "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=microsoft.extensions.dependencymodel&semVerLevel=2.0.0")
+            .to_return(status: 200, body: '{"data":[{"id":"Microsoft.Extensions.DependencyModel","projectUrl":""}]}')
+        end
+
+        # no exceptions
+        it { is_expected.to be_nil }
+      end
+
+      context "when the source url fails to get the index.json" do
+        before do
+          # registry is in a bad state
+          stub_request(:get, nuget_url).to_return(status: 500)
+          # it falls back to get search URL from the index, but it fails too
+          stub_request(:get, "https://www.myget.org/F/exceptionless/api/v3/index.json")
+            .to_return(status: 500, body: "internal server error")
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when it fails to get the search results" do
+        before do
+          # registry doesn't support .nuspec route, so returns 404
+          stub_request(:get, nuget_url).to_return(status: 404)
+          # fallback begins by getting the search URL from the index
+          stub_request(:get, "https://www.myget.org/F/exceptionless/api/v3/index.json")
+            .to_return(status: 200, body: fixture("nuspecs", "index.json"))
+          # oops, we're a little overloaded
+          stub_request(:get, "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=microsoft.extensions.dependencymodel&semVerLevel=2.0.0")
+            .to_return(status: 503, body: "")
+        end
+
+        it { is_expected.to be_nil }
+      end
     end
   end
 end


### PR DESCRIPTION
PR #10025 moved the NuGet package source repository URL finder to native code, but since that feature is behind an experimental flag, the old version of `metadata_finder.rb` and the corresponding tests had to be temporarily restored.  Otherwise no change has been made.

Manually verified with the customer-reported repo.

Fixes #10178.