### PR TITLE
Fix malformed version number error for terraform and github actions

### DIFF
--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -31,7 +31,7 @@ module Dependabot
 
       sig { override.params(version: VersionParameter).returns(T::Boolean) }
       def self.correct?(version)
-        return false if version.to_s.empty?
+        return false if version.to_s.strip.empty?
 
         version = Version.remove_leading_v(version)
         super

--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -31,6 +31,8 @@ module Dependabot
 
       sig { override.params(version: VersionParameter).returns(T::Boolean) }
       def self.correct?(version)
+        return false if version.to_s.empty?
+
         version = Version.remove_leading_v(version)
         super
       end

--- a/github_actions/spec/dependabot/github_actions/version_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/version_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Dependabot::GithubActions::Version do
   semver_without_v = "1.2.3"
 
   describe "#correct?" do
+    it "rejects nil" do
+      expect(described_class.correct?(nil)).to be(false)
+    end
+
     it "accepts semver" do
       expect(described_class.correct?(semver_version)).to be(true)
     end

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -40,7 +40,7 @@ module Dependabot
         version = Version.remove_leading_v(version)
         version = Version.remove_backport(version)
 
-        return false if version.to_s.empty?
+        return false if version.to_s.strip.empty?
 
         super
       end

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,6 +19,9 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
+        version = version.gsub(/^v/, "") if version.is_a?(String)
+        version = version.to_s.split("+").first if version.to_s.include?("+")
+
         super
       end
 
@@ -30,6 +33,15 @@ module Dependabot
       sig { override.returns(String) }
       def to_s
         @version_string
+      end
+
+      sig { override.params(version: VersionParameter).returns(T::Boolean) }
+      def self.correct?(version)
+        version = version.gsub(/^v/, "") if version.is_a?(String)
+        version = version.to_s.split("+").first if version.to_s.include?("+")
+        return false if version.to_s.empty?
+
+        super
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -19,8 +19,8 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s, String)
-        version = version.gsub(/^v/, "") if version.is_a?(String)
-        version = version.to_s.split("+").first if version.to_s.include?("+")
+        version = Version.remove_leading_v(version)
+        version = Version.remove_backport(version)
 
         super
       end
@@ -37,11 +37,26 @@ module Dependabot
 
       sig { override.params(version: VersionParameter).returns(T::Boolean) }
       def self.correct?(version)
-        version = version.gsub(/^v/, "") if version.is_a?(String)
-        version = version.to_s.split("+").first if version.to_s.include?("+")
+        version = Version.remove_leading_v(version)
+        version = Version.remove_backport(version)
+
         return false if version.to_s.empty?
 
         super
+      end
+
+      sig { params(version: VersionParameter).returns(VersionParameter) }
+      def self.remove_leading_v(version)
+        return version.gsub(/^v/, "") if version.is_a?(String)
+
+        version
+      end
+
+      sig { params(version: VersionParameter).returns(VersionParameter) }
+      def self.remove_backport(version)
+        return version.split("+").first if version.is_a?(String) && version.include?("+")
+
+        version
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/version_spec.rb
+++ b/terraform/spec/dependabot/terraform/version_spec.rb
@@ -30,4 +30,26 @@ RSpec.describe Dependabot::Terraform::Version do
       it { is_expected.to eq "1.0.0-pre1" }
     end
   end
+
+  describe "#correct?" do
+    subject { described_class.correct?(version_string) }
+
+    valid = %w(1.0.0 v0.3.2 1.17.2+backport-1)
+    valid.each do |version|
+      context "with version #{version}" do
+        let(:version_string) { version }
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    invalid = ["", nil]
+    invalid.each do |version|
+      context "with version #{version}" do
+        let(:version_string) { version }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
 end

--- a/terraform/spec/dependabot/terraform/version_spec.rb
+++ b/terraform/spec/dependabot/terraform/version_spec.rb
@@ -29,9 +29,39 @@ RSpec.describe Dependabot::Terraform::Version do
 
       it { is_expected.to eq "1.0.0-pre1" }
     end
+
+    context "with a leading v" do
+      let(:version_string) { "v0.3.2" }
+
+      it { is_expected.to eq "v0.3.2" }
+    end
+
+    context "with a backported version" do
+      let(:version_string) { "1.17.2+backport-1" }
+
+      it { is_expected.to eq "1.17.2+backport-1" }
+    end
   end
 
-  describe "#correct?" do
+  describe "#initialize" do
+    subject { version.inspect }
+
+    context "with a leading v" do
+      let(:version_string) { "v0.3.2" }
+      let(:expected) { "#<#{described_class} \"0.3.2\">" }
+
+      it { is_expected.to eq expected }
+    end
+
+    context "with a backported version" do
+      let(:version_string) { "1.17.2+backport-1" }
+      let(:expected) { "#<#{described_class} \"1.17.2\">" }
+
+      it { is_expected.to eq expected }
+    end
+  end
+
+  describe ".correct?" do
     subject { described_class.correct?(version_string) }
 
     valid = %w(1.0.0 v0.3.2 1.17.2+backport-1)


### PR DESCRIPTION
### What are you trying to accomplish?
Stop github actions and terraform updates erroring for version formats like `v3.3.2` and `1.17.2+backport-1`
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
Malformed version number errors in terraform and github actions should stop

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
