### PR TITLE
fix PR matching code for both directory and no directory cases

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -166,23 +166,27 @@ module Dependabot
         # We only want PRs for the same group that have the same versions
         job.existing_group_pull_requests.any? do |pr|
           pr["dependency-group-name"] == dependency_group&.name &&
-            Set.new(pr["dependencies"]) == updated_dependencies_set
+            Set.new(pr["dependencies"]) == updated_dependencies_set(should_consider_directory: !!pr["directory"])
         end
       else
-        job.existing_pull_requests.any? { |pr| Set.new(pr) == updated_dependencies_set }
+        job.existing_pull_requests.any? do |pr|
+          Set.new(pr) == updated_dependencies_set(should_consider_directory: !!pr.first&.key?("directory"))
+        end
       end
     end
 
     private
 
-    sig { returns(T::Set[T::Hash[String, T.any(String, T::Boolean)]]) }
-    def updated_dependencies_set
+    # Older PRs will not have a directory key, in that case do not consider directory in the comparison. This will
+    # allow rebases to continue working for those, but for multi-directory configs we do compare with the directory.
+    sig { params(should_consider_directory: T::Boolean).returns(T::Set[T::Hash[String, T.any(String, T::Boolean)]]) }
+    def updated_dependencies_set(should_consider_directory:)
       Set.new(
         updated_dependencies.map do |dep|
           {
             "dependency-name" => dep.name,
             "dependency-version" => dep.version,
-            "directory" => should_consider_directory? ? dep.directory : nil,
+            "directory" => should_consider_directory ? dep.directory : nil,
             "dependency-removed" => dep.removed? ? true : nil
           }.compact
         end
@@ -201,11 +205,6 @@ module Dependabot
       return "" if updated_dependency_files.empty?
 
       T.must(updated_dependency_files.first).directory
-    end
-
-    sig { returns(T::Boolean) }
-    def should_consider_directory?
-      grouped_update? && Dependabot::Experiments.enabled?("dependency_has_directory")
     end
   end
 end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -165,12 +165,16 @@ module Dependabot
       if grouped_update?
         # We only want PRs for the same group that have the same versions
         job.existing_group_pull_requests.any? do |pr|
+          directories_in_use = pr["dependencies"].all? { |dep| dep["directory"] }
+
           pr["dependency-group-name"] == dependency_group&.name &&
-            Set.new(pr["dependencies"]) == updated_dependencies_set(should_consider_directory: !!pr["directory"])
+            Set.new(pr["dependencies"]) == updated_dependencies_set(should_consider_directory: directories_in_use)
         end
       else
         job.existing_pull_requests.any? do |pr|
-          Set.new(pr) == updated_dependencies_set(should_consider_directory: !!pr.first&.key?("directory"))
+          directories_in_use = pr.all? { |dep| dep["directory"] }
+
+          Set.new(pr) == updated_dependencies_set(should_consider_directory: directories_in_use)
         end
       end
     end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -300,8 +300,7 @@ RSpec.describe Dependabot::DependencyChange do
           updated_dependencies.map do |dep|
             { "dependency-name" => dep.name,
               "dependency-version" => dep.version,
-              "directory" => dep.directory
-            }
+              "directory" => dep.directory }
           end
         ]
       end
@@ -317,7 +316,7 @@ RSpec.describe Dependabot::DependencyChange do
         expect(dependency_change.matches_existing_pr?).to be true
       end
 
-      context "and there's no directory in an existing PR that otherwise matches" do
+      context "when there's no directory in an existing PR that otherwise matches" do
         let(:existing_pull_requests) do
           [
             updated_dependencies.map do |dep|
@@ -343,11 +342,10 @@ RSpec.describe Dependabot::DependencyChange do
         [
           { "dependency-group-name" => "foo",
             "dependencies" => updated_dependencies.map do |dep|
-                { "dependency-name" => dep.name.to_s,
-                  "dependency-version" => dep.version.to_s,
-                  "directory" => dep.directory.to_s }
-              end
-            }
+                                { "dependency-name" => dep.name.to_s,
+                                  "dependency-version" => dep.version.to_s,
+                                  "directory" => dep.directory.to_s }
+                              end }
         ]
       end
 
@@ -361,19 +359,17 @@ RSpec.describe Dependabot::DependencyChange do
       end
 
       it "returns true" do
-        expect(dependency_change.matches_existing_pr?).to be false
+        expect(dependency_change.matches_existing_pr?).to be true
       end
 
-      context "and there's no directory in a PR that otherwise matches" do
+      context "when there's no directory in a PR that otherwise matches" do
         let(:existing_group_pull_requests) do
           [
             { "dependency-group-name" => "foo",
               "dependencies" => updated_dependencies.map do |dep|
-                  { "dependency-name" => dep.name.to_s,
-                    "dependency-version" => dep.version.to_s,
-                  }
-                end
-              }
+                                  { "dependency-name" => dep.name.to_s,
+                                    "dependency-version" => dep.version.to_s }
+                                end }
           ]
         end
 
@@ -393,11 +389,10 @@ RSpec.describe Dependabot::DependencyChange do
         [
           { "dependency-group-name" => "foo",
             "dependencies" => updated_dependencies.map do |dep|
-                { "dependency-name" => dep.name.to_s,
-                  "dependency-version" => dep.version.to_s,
-                  "directory" => "/foo" }
-              end
-            }
+                                { "dependency-name" => dep.name.to_s,
+                                  "dependency-version" => dep.version.to_s,
+                                  "directory" => "/foo" }
+                              end }
         ]
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

I took this change out of https://github.com/dependabot/dependabot-core/pull/10195 to make it easier to review.

This fixes rebases not working in the absence of directories in the existing PR job data, but also keeps the behavior for PRs that do have directories. Rather than considering the state of the experiment, we instead consider whether the directory is in the data we're about to compare. This way the data will work in either state.

Additionally I found that the tests for grouped updates were invalid as they had the wrong shape. The dependency array was wrapped in another redundant array. A proper type with Sorbet enforcement would be helpful here.

### Anything you want to highlight for special attention from reviewers?

By treating the data itself as the feature flag, we can handle older PRs as well as new ones.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

There's no way to validate with directory in the PR data yet because that data isn't propagated yet, however I will manually test a rebase to validate it still works without.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
