### PR TITLE
handle 404 from nuget sources

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
@@ -18,7 +18,8 @@ public class AnalyzeWorkerTestBase
         WorkspaceDiscoveryResult discovery,
         DependencyInfo dependencyInfo,
         ExpectedAnalysisResult expectedResult,
-        MockNuGetPackage[]? packages = null)
+        MockNuGetPackage[]? packages = null,
+        TestFile[]? extraFiles = null)
     {
         var relativeDependencyPath = $"./dependabot/dependency/{dependencyInfo.Name}.json";
 
@@ -27,7 +28,8 @@ public class AnalyzeWorkerTestBase
             (relativeDependencyPath, JsonSerializer.Serialize(dependencyInfo, AnalyzeWorker.SerializerOptions)),
         ];
 
-        var actualResult = await RunAnalyzerAsync(dependencyInfo.Name, files, async directoryPath =>
+        var allFiles = files.Concat(extraFiles ?? []).ToArray();
+        var actualResult = await RunAnalyzerAsync(dependencyInfo.Name, allFiles, async directoryPath =>
         {
             await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -1,3 +1,7 @@
+using System.Text;
+
+using NuGet;
+
 using NuGetUpdater.Core.Analyze;
 
 using Xunit;
@@ -298,6 +302,342 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                 CanUpdate = false,
                 VersionComesFromMultiDependencyProperty = false,
                 UpdatedDependencies = [],
+            }
+        );
+    }
+
+    [Fact]
+    public async Task VersionFinderCanHandle404FromPackageSource_V2()
+    {
+        static (int, byte[]) TestHttpHandler1(string uriString)
+        {
+            // this is a valid nuget package source, but doesn't contain anything
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                "/api/v2/" => (200, Encoding.UTF8.GetBytes($"""
+                    <service xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xml:base="{baseUrl}/api/v2">
+                        <workspace>
+                            <atom:title type="text">Default</atom:title>
+                            <collection href="Packages">
+                                <atom:title type="text">Packages</atom:title>
+                            </collection>
+                        </workspace>
+                    </service>
+                    """)),
+                _ => (404, Encoding.UTF8.GetBytes("{}")), // nothing else is found
+            };
+        }
+        var desktopAppRefPackage = MockNuGetPackage.WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net8.0");
+        (int, byte[]) TestHttpHandler2(string uriString)
+        {
+            // this contains the actual package
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            switch (uri.PathAndQuery)
+            {
+                case "/api/v2/":
+                    return (200, Encoding.UTF8.GetBytes($"""
+                        <service xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xml:base="{baseUrl}/api/v2">
+                            <workspace>
+                                <atom:title type="text">Default</atom:title>
+                                <collection href="Packages">
+                                    <atom:title type="text">Packages</atom:title>
+                                </collection>
+                            </workspace>
+                        </service>
+                        """));
+                case "/api/v2/FindPackagesById()?id='Some.Package'&semVerLevel=2.0.0":
+                    return (200, Encoding.UTF8.GetBytes($"""
+                        <feed xml:base="{baseUrl}/api/v2" xmlns="http://www.w3.org/2005/Atom"
+                            xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                            xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+                            xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+                            <m:count>2</m:count>
+                            <id>http://schemas.datacontract.org/2004/07/</id>
+                            <title />
+                            <updated>{DateTime.UtcNow:O}</updated>
+                            <link rel="self" href="{baseUrl}/api/v2/Packages" />
+                            <entry>
+                                <id>{baseUrl}/api/v2/Packages(Id='Some.Package',Version='1.0.0')</id>
+                                <content type="application/zip" src="{baseUrl}/api/v2/package/Some.Package/1.0.0" />
+                                <m:properties>
+                                    <d:Version>1.0.0</d:Version>
+                                </m:properties>
+                            </entry>
+                            <entry>
+                                <id>{baseUrl}/api/v2/Packages(Id='Some.Package',Version='1.2.3')</id>
+                                <content type="application/zip" src="{baseUrl}/api/v2/package/Some.Package/1.2.3" />
+                                <m:properties>
+                                    <d:Version>1.2.3</d:Version>
+                                </m:properties>
+                            </entry>
+                        </feed>
+                        """));
+                case "/api/v2/Packages(Id='Some.Package',Version='1.2.3')":
+                    return (200, Encoding.UTF8.GetBytes($"""
+                        <entry xml:base="{baseUrl}/api/v2" xmlns="http://www.w3.org/2005/Atom"
+                            xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                            xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+                            xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+                            <id>{baseUrl}/api/v2/Packages(Id='Some.Package',Version='1.2.3')</id>
+                            <updated>{DateTime.UtcNow:O}</updated>
+                            <content type="application/zip" src="{baseUrl}/api/v2/package/Some.Package/1.2.3" />
+                            <m:properties>
+                                <d:Version>1.2.3</d:Version>
+                            </m:properties>
+                        </entry>
+                        """));
+                case "/api/v2/package/Some.Package/1.2.3":
+                    return (200, MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3", "net8.0").GetZipStream().ReadAllBytes());
+                case "/api/v2/FindPackagesById()?id='Microsoft.WindowsDesktop.App.Ref'&semVerLevel=2.0.0":
+                    return (200, Encoding.UTF8.GetBytes($"""
+                        <feed xml:base="{baseUrl}/api/v2" xmlns="http://www.w3.org/2005/Atom"
+                            xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                            xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+                            xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+                            <m:count>1</m:count>
+                            <id>http://schemas.datacontract.org/2004/07/</id>
+                            <title />
+                            <updated>{DateTime.UtcNow:O}</updated>
+                            <link rel="self" href="{baseUrl}/api/v2/Packages" />
+                            <entry>
+                                <id>{baseUrl}/api/v2/Packages(Id='Microsoft.WindowsDesktop.App.Ref',Version='{desktopAppRefPackage.Version}')</id>
+                                <content type="application/zip" src="{baseUrl}/api/v2/package/Microsoft.WindowsDesktop.App.Ref/{desktopAppRefPackage.Version}" />
+                                <m:properties>
+                                    <d:Version>{desktopAppRefPackage.Version}</d:Version>
+                                </m:properties>
+                            </entry>
+                        </feed>
+                        """));
+                default:
+                    if (uri.PathAndQuery == $"/api/v2/package/Microsoft.WindowsDesktop.App.Ref/{desktopAppRefPackage.Version}")
+                    {
+                        return (200, desktopAppRefPackage.GetZipStream().ReadAllBytes());
+                    }
+
+                    // nothing else is found
+                    return (404, Encoding.UTF8.GetBytes("{}"));
+            };
+        }
+        using var http1 = TestHttpServer.CreateTestServer(TestHttpHandler1);
+        using var http2 = TestHttpServer.CreateTestServer(TestHttpHandler2);
+        await TestAnalyzeAsync(
+            extraFiles:
+            [
+                ("NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <clear />
+                        <add key="package_feed_1" value="{http1.BaseUrl.TrimEnd('/')}/api/v2/" allowInsecureConnections="true" />
+                        <add key="package_feed_2" value="{http2.BaseUrl.TrimEnd('/')}/api/v2/" allowInsecureConnections="true" />
+                      </packageSources>
+                    </configuration>
+                    """)
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects =
+                [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies =
+                        [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference),
+                        ]
+                    }
+                ]
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "1.2.3",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies =
+                [
+                    new("Some.Package", "1.2.3", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
+    public async Task VersionFinderCanHandle404FromPackageSource_V3()
+    {
+        static (int, byte[]) TestHttpHandler1(string uriString)
+        {
+            // this is a valid nuget package source, but doesn't contain anything
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                "/index.json" => (200, Encoding.UTF8.GetBytes($$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/query",
+                                "@type": "SearchQueryService"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """)),
+                _ => (404, Encoding.UTF8.GetBytes("{}")), // nothing else is found
+            };
+        }
+        var desktopAppRefPackage = MockNuGetPackage.WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net8.0");
+        (int, byte[]) TestHttpHandler2(string uriString)
+        {
+            // this contains the actual package
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            switch (uri.PathAndQuery)
+            {
+                case "/index.json":
+                    return (200, Encoding.UTF8.GetBytes($$"""
+                        {
+                            "version": "3.0.0",
+                            "resources": [
+                                {
+                                    "@id": "{{baseUrl}}/download",
+                                    "@type": "PackageBaseAddress/3.0.0"
+                                },
+                                {
+                                    "@id": "{{baseUrl}}/query",
+                                    "@type": "SearchQueryService"
+                                },
+                                {
+                                    "@id": "{{baseUrl}}/registrations",
+                                    "@type": "RegistrationsBaseUrl"
+                                }
+                            ]
+                        }
+                        """));
+                case "/registrations/some.package/index.json":
+                    return (200, Encoding.UTF8.GetBytes("""
+                        {
+                            "count": 1,
+                            "items": [
+                                {
+                                    "lower": "1.0.0",
+                                    "upper": "1.2.3",
+                                    "items": [
+                                        {
+                                            "catalogEntry": {
+                                                "listed": true,
+                                                "version": "1.0.0"
+                                            }
+                                        },
+                                        {
+                                            "catalogEntry": {
+                                                "listed": true,
+                                                "version": "1.2.3"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                        """));
+                case "/download/some.package/index.json":
+                    return (200, Encoding.UTF8.GetBytes("""
+                        {
+                            "versions": [
+                                "1.0.0",
+                                "1.2.3"
+                            ]
+                        }
+                        """));
+                case "/download/microsoft.windowsdesktop.app.ref/index.json":
+                    return (200, Encoding.UTF8.GetBytes($$"""
+                        {
+                            "versions": [
+                                "{{desktopAppRefPackage.Version}}"
+                            ]
+                        }
+                        """));
+                case "/download/some.package/1.0.0/some.package.1.0.0.nupkg":
+                    return (200, MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0").GetZipStream().ReadAllBytes());
+                case "/download/some.package/1.2.3/some.package.1.2.3.nupkg":
+                    return (200, MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3", "net8.0").GetZipStream().ReadAllBytes());
+                default:
+                    if (uri.PathAndQuery == $"/download/microsoft.windowsdesktop.app.ref/{desktopAppRefPackage.Version}/microsoft.windowsdesktop.app.ref.{desktopAppRefPackage.Version}.nupkg")
+                    {
+                        return (200, desktopAppRefPackage.GetZipStream().ReadAllBytes());
+                    }
+
+                    // nothing else is found
+                    return (404, Encoding.UTF8.GetBytes("{}"));
+            };
+        }
+        using var http1 = TestHttpServer.CreateTestServer(TestHttpHandler1);
+        using var http2 = TestHttpServer.CreateTestServer(TestHttpHandler2);
+        await TestAnalyzeAsync(
+            extraFiles:
+            [
+                ("NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <clear />
+                        <add key="package_feed_1" value="{http1.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                        <add key="package_feed_2" value="{http2.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                      </packageSources>
+                    </configuration>
+                    """)
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects =
+                [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies =
+                        [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference),
+                        ]
+                    }
+                ]
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "1.2.3",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies =
+                [
+                    new("Some.Package", "1.2.3", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                ],
             }
         );
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -245,7 +245,7 @@ namespace NuGetUpdater.Core.Test
             );
         }
 
-        private Stream GetZipStream()
+        public Stream GetZipStream()
         {
             if (_stream is null)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NuGetUpdater.Core.Test
+{
+    public class TestHttpServer : IDisposable
+    {
+        private readonly Func<string, (int, byte[])> _requestHandler;
+        private readonly HttpListener _listener;
+        private bool _runServer = true;
+
+        public string BaseUrl { get; }
+
+        private TestHttpServer(string baseurl, Func<string, (int, byte[])> requestHandler)
+        {
+            BaseUrl = baseurl;
+            _requestHandler = requestHandler;
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(baseurl);
+        }
+
+        private void Start()
+        {
+            _listener.Start();
+            Task.Factory.StartNew(HandleResponses);
+        }
+
+        public void Dispose()
+        {
+            _runServer = false;
+            _listener.Stop();
+        }
+
+        private async Task HandleResponses()
+        {
+            while (_runServer)
+            {
+                var context = await _listener.GetContextAsync();
+                var (statusCode, response) = _requestHandler(context.Request.Url!.AbsoluteUri);
+                context.Response.StatusCode = statusCode;
+                await context.Response.OutputStream.WriteAsync(response);
+                context.Response.Close();
+            }
+        }
+
+        private static readonly object PortGate = new();
+
+        public static TestHttpServer CreateTestServer(Func<string, (int, byte[])> requestHandler)
+        {
+            // static lock to ensure the port is not recycled after `FindFreePort()` and before we can start the real server
+            lock (PortGate)
+            {
+                var port = FindFreePort();
+                var baseUrl = $"http://localhost:{port}/";
+                var server = new TestHttpServer(baseUrl, requestHandler);
+                server.Start();
+                return server;
+            }
+        }
+
+        private static int FindFreePort()
+        {
+            var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            tcpListener.Start();
+            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+            tcpListener.Stop();
+            return port;
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -143,7 +143,7 @@ internal static class CompatibilityChecker
 
             try
             {
-                // misbehaving v2 apis can throw here
+                // a non-compliant v2 API returning 404 can cause this to throw
                 var exists = await feed.DoesPackageExistAsync(
                     package.Id,
                     package.Version,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -88,7 +88,7 @@ internal record NuGetContext : IDisposable
 
             try
             {
-                // misbehaving v2 apis can throw here
+                // a non-compliant v2 API returning 404 can cause this to throw
                 var existsInFeed = await feed.Exists(
                     packageIdentity,
                     includeUnlisted: false,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -66,15 +66,24 @@ internal static class VersionFinder
                 continue;
             }
 
-            var existsInFeed = await feed.Exists(
-                packageId,
-                includePrerelease,
-                includeUnlisted: false,
-                nugetContext.SourceCacheContext,
-                NullLogger.Instance,
-                cancellationToken);
-            if (!existsInFeed)
+            try
             {
+                // misbehaving v2 apis can throw here
+                var existsInFeed = await feed.Exists(
+                    packageId,
+                    includePrerelease,
+                    includeUnlisted: false,
+                    nugetContext.SourceCacheContext,
+                    NullLogger.Instance,
+                    cancellationToken);
+                if (!existsInFeed)
+                {
+                    continue;
+                }
+            }
+            catch (FatalProtocolException)
+            {
+                // if anything goes wrong here, the package source obviously doesn't contain the requested package
                 continue;
             }
 
@@ -162,15 +171,23 @@ internal static class VersionFinder
                 continue;
             }
 
-            var existsInFeed = await feed.Exists(
-                new PackageIdentity(packageId, version),
-                includeUnlisted: false,
-                nugetContext.SourceCacheContext,
-                NullLogger.Instance,
-                cancellationToken);
-            if (existsInFeed)
+            try
             {
-                return true;
+                // misbehaving v2 apis can throw here
+                var existsInFeed = await feed.Exists(
+                    new PackageIdentity(packageId, version),
+                    includeUnlisted: false,
+                    nugetContext.SourceCacheContext,
+                    NullLogger.Instance,
+                    cancellationToken);
+                if (existsInFeed)
+                {
+                    return true;
+                }
+            }
+            catch (FatalProtocolException)
+            {
+                // if anything goes wrong here, the package source obviously doesn't contain the requested package
             }
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -68,7 +68,7 @@ internal static class VersionFinder
 
             try
             {
-                // misbehaving v2 apis can throw here
+                // a non-compliant v2 API returning 404 can cause this to throw
                 var existsInFeed = await feed.Exists(
                     packageId,
                     includePrerelease,
@@ -173,7 +173,7 @@ internal static class VersionFinder
 
             try
             {
-                // misbehaving v2 apis can throw here
+                // a non-compliant v2 API returning 404 can cause this to throw
                 var existsInFeed = await feed.Exists(
                     new PackageIdentity(packageId, version),
                     includeUnlisted: false,


### PR DESCRIPTION
This feature is behind the `nuget_native_analysis` feature flag.

During a controlled roll out of the feature, a bug was found in the logs.  Misbehaving NuGet package sources could cause uncaught exceptions.  One example was found with Artifactory/JFrog.  This PR catches those exceptions so the analysis can continue.

The bulk of this PR is creating a test-only HTTP server to mimic the necessary `404` responses.