### PR TITLE
ensure every project is compatible with the `Any,Version=v0.0` framework

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/CompatibilityCheckerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/CompatibilityCheckerTests.cs
@@ -142,4 +142,27 @@ public class CompatibilityCheckerTests
 
         Assert.False(result);
     }
+
+    [Theory]
+    [InlineData("netstandard2.0")]
+    [InlineData("net472")]
+    [InlineData("net6.0")]
+    [InlineData("net7.0")]
+    [InlineData("net8.0")]
+    public void EverythingIsCompatibleWithAnyVersion0Framework(string projectFramework)
+    {
+        var package = new PackageIdentity("Dependency", NuGetVersion.Parse("1.0.0"));
+        ImmutableArray<NuGetFramework> projectFrameworks = [NuGetFramework.Parse(projectFramework)];
+        var isDevDependency = false;
+        ImmutableArray<NuGetFramework> packageFrameworks = [NuGetFramework.Parse("Any,Version=v0.0")];
+
+        var result = CompatibilityChecker.PerformCheck(
+            package,
+            projectFrameworks,
+            isDevDependency,
+            packageFrameworks,
+            new Logger(verbose: false));
+
+        Assert.True(result);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -54,6 +54,11 @@ internal static class CompatibilityChecker
 
         var compatibilityService = new FrameworkCompatibilityService();
         var compatibleFrameworks = compatibilityService.GetCompatibleFrameworks(packageFrameworks);
+        var packageSupportsAny = compatibleFrameworks.Any(f => f.IsAny);
+        if (packageSupportsAny)
+        {
+            return true;
+        }
 
         var incompatibleFrameworks = projectFrameworks.Where(f => !compatibleFrameworks.Contains(f)).ToArray();
         if (incompatibleFrameworks.Length > 0)


### PR DESCRIPTION
If a NuGet package doesn't list any dependency groups and has no assemblies in the `lib/` directory, it is assumed to be compatible with everything and according to NuGet and .NET Framework rules its framework is reported as `Any,Version=v0.0`.  This value needs to be special-cased in the compatibility checker; before we were doing straight equality checking, which isn't strictly correct.

This fixes an issue found in the logs during a controlled rollout of recent NuGet changes.