### PR TITLE
trim whitespace from package names

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -60,6 +60,54 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task TestDependencyWithTrailingSpacesInAttribute()
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+            ],
+            workspacePath: "src",
+            files: new[]
+            {
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageReference Include=" Some.Package    " Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            },
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        ReferencedProjectPaths = [],
+                        ExpectedDependencyCount = 2,
+                        Dependencies = [
+                            new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
+                        ],
+                        Properties = [
+                            new("SomePackageVersion", "9.0.1", "src/project.csproj"),
+                            new("TargetFramework", "net8.0", "src/project.csproj"),
+                        ]
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
     public async Task TestPackageConfig()
     {
         await TestDiscoveryAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -2903,6 +2903,38 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task UpdatePackageWithWhitespaceInTheXMLAttributeValue()
+        {
+            await TestUpdateForProject("Some.Package", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0"),
+                ],
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include=" Some.Package    " Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include=" Some.Package    " Version="1.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
+        }
+
+        [Fact]
         public async Task ReportsPrivateSourceAuthenticationFailure()
         {
             static (int, string) TestHttpHandler(string uriString)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/ProjectBuildFile.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/ProjectBuildFile.cs
@@ -93,11 +93,11 @@ internal sealed class ProjectBuildFile : XmlBuildFile
     {
         var isUpdate = false;
 
-        var name = element.GetAttributeOrSubElementValue("Include", StringComparison.OrdinalIgnoreCase);
+        var name = element.GetAttributeOrSubElementValue("Include", StringComparison.OrdinalIgnoreCase)?.Trim();
         if (name is null)
         {
             isUpdate = true;
-            name = element.GetAttributeOrSubElementValue("Update", StringComparison.OrdinalIgnoreCase);
+            name = element.GetAttributeOrSubElementValue("Update", StringComparison.OrdinalIgnoreCase)?.Trim();
         }
 
         if (name is null || name.StartsWith("@("))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -595,7 +595,7 @@ internal static class SdkPackageUpdater
         string packageName)
         => buildFile.PackageItemNodes.Where(e =>
             string.Equals(
-                e.GetAttributeOrSubElementValue("Include", StringComparison.OrdinalIgnoreCase) ?? e.GetAttributeOrSubElementValue("Update", StringComparison.OrdinalIgnoreCase),
+                (e.GetAttributeOrSubElementValue("Include", StringComparison.OrdinalIgnoreCase) ?? e.GetAttributeOrSubElementValue("Update", StringComparison.OrdinalIgnoreCase))?.Trim(),
                 packageName,
                 StringComparison.OrdinalIgnoreCase) &&
             (e.GetAttributeOrSubElementValue("Version", StringComparison.OrdinalIgnoreCase) ?? e.GetAttributeOrSubElementValue("VersionOverride", StringComparison.OrdinalIgnoreCase)) is not null);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -185,8 +185,9 @@ internal static partial class MSBuildHelper
                 var versionSpecification = packageItem.Metadata.FirstOrDefault(m => m.Name.Equals("Version", StringComparison.OrdinalIgnoreCase))?.Value
                                            ?? packageItem.Metadata.FirstOrDefault(m => m.Name.Equals("VersionOverride", StringComparison.OrdinalIgnoreCase))?.Value
                                            ?? string.Empty;
-                foreach (var attributeValue in new[] { packageItem.Include, packageItem.Update })
+                foreach (var rawAttributeValue in new[] { packageItem.Include, packageItem.Update })
                 {
+                    var attributeValue = rawAttributeValue?.Trim();
                     if (!string.IsNullOrWhiteSpace(attributeValue))
                     {
                         if (packageInfo.TryGetValue(attributeValue, out var existingInfo))


### PR DESCRIPTION
It's valid MSBuild to have leading and trailing whitespace in a package name in a `PackageReference` element so we need to explicitly handle that during reporting and updating.

Examining the logs showed that an attempt was made to fetch a URL like `https://<some-nuget-source>/some.package  /index.json` and this is because there was trailing whitespace in the project file of the form:

``` xml
...
<PackageReference Include="Some.Package   " Version="1.2.3" />
...
```

A normal `dotnet restore` and `dotnet build` call can handle this, so we must, too.  The fix was to call `?.Trim()` at a few key locations.