### PR TITLE
write dependency info JSON to log

### DIFF
--- a/nuget/lib/dependabot/nuget/native_update_checker/native_update_checker.rb
+++ b/nuget/lib/dependabot/nuget/native_update_checker/native_update_checker.rb
@@ -134,6 +134,7 @@ module Dependabot
           nil?
         end
 
+        Dependabot.logger.info("Writing dependency info: #{dependency_info}")
         File.write(dependency_file_path, dependency_info)
       end
 


### PR DESCRIPTION
Examining the logs showed some instances of the NuGet dependency info file failing to parse, but not much more information than that.  This PR logs the file's content to make later debugging easier.  We already report the discovery JSON file as well as the analyze JSON result, so this is in line with our current behavior.