### PR TITLE
remove glob experiment since glob support is released

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -28,7 +28,7 @@ module Dependabot
         file
       end
 
-      if Dependabot::Experiments.enabled?(:globs) && job.source.directories
+      if job.source.directories
         # The job.source.directory may contain globs, so we use the directories from the fetched files
         job.source.directories = decoded_dependency_files.flat_map(&:directory).uniq
       end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -100,19 +100,8 @@ module Dependabot
     end
 
     def dependency_files_for_multi_directories
-      if Dependabot::Experiments.enabled?(:globs)
-        return @dependency_files_for_multi_directories ||= dependency_files_for_globs
-      end
+      return @dependency_files_for_multi_directories if defined?(@dependency_files_for_multi_directories)
 
-      @dependency_files_for_multi_directories ||= job.source.directories.flat_map do |dir|
-        ff = with_retries { file_fetcher_for_directory(dir) }
-        files = ff.files
-        post_ecosystem_versions(ff) if should_record_ecosystem_versions?
-        files
-      end
-    end
-
-    def dependency_files_for_globs
       has_glob = T.let(false, T::Boolean)
       directories = Dir.chdir(job.repo_contents_path) do
         job.source.directories.map do |dir|
@@ -124,7 +113,7 @@ module Dependabot
         end.flatten
       end.uniq
 
-      directories.flat_map do |dir|
+      @dependency_files_for_multi_directories = directories.flat_map do |dir|
         ff = with_retries { file_fetcher_for_directory(dir) }
 
         begin


### PR DESCRIPTION
### What are you trying to accomplish?

We put glob support behind a feature flag so it could be rolled out and tested. 

The feature is now released, we can remove this code.

### Anything you want to highlight for special attention from reviewers?

Nope, I just got rid of `dependency_files_for_globs` and pulled the implementation up into `dependency_files_for_multi_directories` so the diff looks complicated.

### How will you know you've accomplished your goal?

Removing code that is no longer being run, so we shouldn't see any change. 

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
