### PR TITLE
use unique directory for temp nuget packages

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -390,6 +390,8 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                             </m:properties>
                         </entry>
                         """));
+                case "/api/v2/package/Some.Package/1.0.0":
+                    return (200, MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0").GetZipStream().ReadAllBytes());
                 case "/api/v2/package/Some.Package/1.2.3":
                     return (200, MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3", "net8.0").GetZipStream().ReadAllBytes());
                 case "/api/v2/FindPackagesById()?id='Microsoft.WindowsDesktop.App.Ref'&semVerLevel=2.0.0":

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -63,11 +63,6 @@ public partial class AnalyzeWorker
         {
             if (isUpdateNecessary)
             {
-                if (!Directory.Exists(nugetContext.TempPackageDirectory))
-                {
-                    Directory.CreateDirectory(nugetContext.TempPackageDirectory);
-                }
-
                 _logger.Log($"  Determining multi-dependency property.");
                 var multiDependencies = DetermineMultiDependencyDetails(
                     discovery,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -37,12 +37,23 @@ internal record NuGetContext : IDisposable
             .Where(p => p.IsEnabled)
             .ToImmutableArray();
         Logger = logger ?? NullLogger.Instance;
-        TempPackageDirectory = Path.Combine(Path.GetTempPath(), ".dependabot", "packages");
+        TempPackageDirectory = Path.Combine(Path.GetTempPath(), $"dependabot-packages_{Guid.NewGuid():d}");
+        Directory.CreateDirectory(TempPackageDirectory);
     }
 
     public void Dispose()
     {
         SourceCacheContext.Dispose();
+        if (Directory.Exists(TempPackageDirectory))
+        {
+            try
+            {
+                Directory.Delete(TempPackageDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
     }
 
     private readonly Dictionary<PackageIdentity, string?> _packageInfoUrlCache = new();


### PR DESCRIPTION
Some CI runs fail due to a corrupted temporary NuGet package.  I can't get this to fail locally, but it seems to have a~30% failure rate in CI.  The temp directory is re-used between tests and I'm exploring a theory that one test writes a corrupt package and the next test reads that.  This PR uses a unique directory each time.  I'll be running CI repeatedly to see if I can get it to fail.

I've run the NuGet leg of the CI 10 times with no failures.  I'm good to call this ready.