### PR TITLE
report missing nuget files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 
 using NuGetUpdater.Core.Updater;
 
@@ -1723,6 +1724,62 @@ public partial class UpdateWorkerTests
                   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
                 </packages>
                 """);
+        }
+
+        [Fact]
+        public async Task MissingTargetsAreReported()
+        {
+            using var temporaryDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+                [
+                    ("project.csproj", """
+                        <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <Import Project="this.file.does.not.exist.targets" />
+                          <PropertyGroup>
+                            <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
+                          <ItemGroup>
+                            <Reference Include="Some.Package, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                              <HintPath>packages\Some.Package.1.0.0\lib\net45\Some.Package.dll</HintPath>
+                              <Private>True</Private>
+                            </Reference>
+                          </ItemGroup>
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """),
+                    ("packages.config", """
+                        <packages>
+                          <package id="Some.Package" version="1.0.0" targetFramework="net45" />
+                        </packages>
+                        """),
+                    ("NuGet.Config", """
+                        <configuration>
+                          <packageSources>
+                            <clear />
+                            <add key="private_feed" value="packages" />
+                          </packageSources>
+                        </configuration>
+                        """)
+                ]
+            );
+            MockNuGetPackage[] packages =
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net45"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net45"),
+            ];
+            await MockNuGetPackagesInDirectory(packages, Path.Combine(temporaryDirectory.DirectoryPath, "packages"));
+            var resultOutputPath = Path.Combine(temporaryDirectory.DirectoryPath, "result.json");
+
+            var worker = new UpdaterWorker(new Logger(verbose: true));
+            await worker.RunAsync(temporaryDirectory.DirectoryPath, "project.csproj", "Some.Package", "1.0.0", "1.1.0", isTransitive: false, resultOutputPath: resultOutputPath);
+
+            var resultContents = await File.ReadAllTextAsync(resultOutputPath);
+            var result = JsonSerializer.Deserialize<UpdateOperationResult>(resultContents, UpdaterWorker.SerializerOptions)!;
+            Assert.Equal(ErrorType.MissingFile, result.ErrorType);
+            Assert.Equal(Path.Combine(temporaryDirectory.DirectoryPath, "this.file.does.not.exist.targets"), result.ErrorDetails);
         }
 
         [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
@@ -5,4 +5,5 @@ public enum ErrorType
     // TODO: add `Unknown` option to track all other failure types
     None,
     AuthenticationFailure,
+    MissingFile,
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/MissingFileException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/MissingFileException.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core;
+
+internal class MissingFileException : Exception
+{
+    public string FilePath { get; }
+
+    public MissingFileException(string filePath)
+    {
+        FilePath = filePath;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -146,6 +146,7 @@ internal static class PackagesConfigUpdater
                 }
 
                 MSBuildHelper.ThrowOnUnauthenticatedFeed(fullOutput);
+                MSBuildHelper.ThrowOnMissingFile(fullOutput);
                 throw new Exception(fullOutput);
             }
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -73,6 +73,14 @@ public class UpdaterWorker
                 ErrorDetails = "(" + string.Join("|", NuGetContext.GetPackageSourceUrls(workspacePath)) + ")",
             };
         }
+        catch (MissingFileException ex)
+        {
+            result = new()
+            {
+                ErrorType = ErrorType.MissingFile,
+                ErrorDetails = ex.FilePath,
+            };
+        }
 
         _processedProjectPaths.Clear();
         if (resultOutputPath is { })

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -620,6 +620,16 @@ internal static partial class MSBuildHelper
         }
     }
 
+    internal static void ThrowOnMissingFile(string output)
+    {
+        var missingFilePattern = new Regex(@"The imported project \""(?<FilePath>.*)\"" was not found");
+        var match = missingFilePattern.Match(output);
+        if (match.Success)
+        {
+            throw new MissingFileException(match.Groups["FilePath"].Value);
+        }
+    }
+
     internal static bool TryGetGlobalJsonPath(string repoRootPath, string workspacePath, [NotNullWhen(returnValue: true)] out string? globalJsonPath)
     {
         globalJsonPath = PathHelper.GetFileInDirectoryOrParent(workspacePath, repoRootPath, "global.json", caseSensitive: false);

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -261,6 +261,8 @@ module Dependabot
           # no issue
         when "AuthenticationFailure"
           raise PrivateSourceAuthenticationFailure, error_details
+        when "MissingFile"
+          raise DependencyFileNotFound, error_details
         else
           raise "Unexpected error type from native tool: #{error_type}: #{error_details}"
         end


### PR DESCRIPTION
During a restore of a project with a `packages.config` file, a missing targets/project file will fail the restore.  I saw instances in the logs of this resulting in `unknown_error` but in this case we know exactly what the problem is, so we scan the restore log for a well-known message and surface it appropriately.