### PR TITLE
Fix security updates in Bundler subdependencies

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: main
+  SMOKE_TEST_BRANCH: deivid-rodriguez/bundler-security-subdep
 jobs:
   discover:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
           cat filtered.json
 
           # Curl the smoke-test tests directory to get a list of tests to run
-          URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests?ref=${{ env.SMOKE_TEST_BRANCH }}
+          URL=https://api.github.com/repos/deivid-rodriguez/smoke-tests/contents/tests?ref=${{ env.SMOKE_TEST_BRANCH }}
           curl $URL > tests.json
 
           # Select the names that match smoke-$test*.yaml, where $test is the .text value from filtered.json
@@ -85,7 +85,7 @@ jobs:
       - name: Download test
         if: steps.cache-smoke-test.outputs.cache-hit != 'true'
         run: |
-          URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/${{ matrix.suite.name }}?ref=${{ env.SMOKE_TEST_BRANCH }}
+          URL=https://api.github.com/repos/deivid-rodriguez/smoke-tests/contents/tests/${{ matrix.suite.name }}?ref=${{ env.SMOKE_TEST_BRANCH }}
           curl $(gh api $URL --jq .download_url) -o smoke.yaml
 
       - name: Cache Smoke Test


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed that #9923 seems to have caused an issue where security updates in Bundler subdependencies no longer succeed.

The new issue seems much worse than the original enhancement (a better error message in an edge case).

So I'm trying to fix it.

Closes https://github.com/dependabot/dependabot-core/pull/10251.

### Anything you want to highlight for special attention from reviewers?

I think ideally we'd add support in upstream Bundler for things like `bundle lock --update foo=<version>`, since right now Bundler only has the capability of updating dependencies to their latest version.

But that's a big feature, so for now I used an approach that creates a `Bundler::Definition` from the Gemfile but adds an extra top level dependency to force the update.

### How will you know you've accomplished your goal?

Hopefully the new smoke test I added to cover this passes.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
