### PR TITLE
removing more of dependency_has_directory feature flag

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -112,17 +112,6 @@ module Dependabot
       @handled_dependencies[@current_directory] = set
     end
 
-    sig { params(dependencies: T::Array[{ name: T.nilable(String), directory: T.nilable(String) }]).void }
-    def add_handled_group_dependencies(dependencies)
-      raise "Current directory not set" if @current_directory == ""
-
-      dependencies.group_by { |d| d[:directory] }.each do |dir, dependency_hash|
-        set = @handled_dependencies[dir] || Set.new
-        set.merge(dependency_hash.map { |d| d[:name] })
-        @handled_dependencies[dir] = set
-      end
-    end
-
     sig { returns(T::Set[String]) }
     def handled_dependencies
       raise "Current directory not set" if @current_directory == ""
@@ -178,13 +167,7 @@ module Dependabot
       @dependencies = T.let({}, T::Hash[String, T::Array[Dependabot::Dependency]])
       directories.each do |dir|
         @current_directory = dir
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependencies = parse_files!
-          dependencies_with_dir = dependencies.each { |dep| dep.directory = dir }
-          @dependencies[dir] = dependencies_with_dir
-        else
-          @dependencies[dir] = parse_files!
-        end
+        @dependencies[dir] = parse_files!
       end
 
       @dependency_group_engine = T.let(DependencyGroupEngine.from_job_config(job: job),

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -121,7 +121,7 @@ module Dependabot
 
     # rubocop:disable Performance/Sum
     sig { returns(T::Set[String]) }
-    def handled_group_dependencies
+    def handled_dependencies_all_directories
       T.must(@handled_dependencies.values.reduce(&:+))
     end
     # rubocop:enable Performance/Sum
@@ -143,11 +143,11 @@ module Dependabot
       return allowed_dependencies unless groups.any?
 
       if Dependabot::Experiments.enabled?(:dependency_has_directory)
-        return allowed_dependencies.reject { |dep| handled_group_dependencies.include?(dep.name) }
+        return allowed_dependencies.reject { |dep| handled_dependencies_all_directories.include?(dep.name) }
       end
 
       # Otherwise return dependencies that haven't been handled during the group update portion.
-      allowed_dependencies.reject { |dep| T.must(@handled_dependencies[@current_directory]).include?(dep.name) }
+      allowed_dependencies.reject { |dep| handled_dependencies.include?(dep.name) }
     end
 
     private

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -54,7 +54,7 @@ module Dependabot
 
         Dependabot.logger.info("Updating the #{job.source.directory} directory.")
         group.dependencies.each do |dependency|
-          # We check dependency_snapshot.handled_dependencies instead of handled_group_dependencies here
+          # We check dependency_snapshot.handled_dependencies instead of handled_dependencies_all_directories here
           # because we still want to update a dependency if it's been updated in another manifest files,
           # but we should skip it if it's been updated in _the same_ manifest file
           if dependency_snapshot.handled_dependencies.include?(dependency.name)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -189,7 +189,6 @@ module Dependabot
       #
       # This method **must** must return an Array when it errors
       #
-      # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       sig do
         params(
           dependency: Dependabot::Dependency,
@@ -213,12 +212,7 @@ module Dependabot
 
         # Consider the dependency handled so no individual PR is raised since it is in this group.
         # Even if update is not possible, etc.
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_dependencies(dependency.name)
 
         if checker.up_to_date?
           log_up_to_date(dependency)
@@ -239,12 +233,7 @@ module Dependabot
           requirements_to_unlock: requirements_to_unlock
         )
       rescue Dependabot::InconsistentRegistryResponse => e
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_dependencies(dependency.name)
         error_handler.log_dependency_error(
           dependency: dependency,
           error: e,
@@ -255,16 +244,10 @@ module Dependabot
       rescue StandardError => e
         # If there was an error we might not be able to determine if the dependency is in this
         # group due to semver grouping, so we consider it handled to avoid raising an individual PR.
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_snapshot.add_handled_group_dependencies([{ name: dependency.name,
-                                                                directory: job.source.directory }])
-        else
-          dependency_snapshot.add_handled_dependencies(dependency.name)
-        end
+        dependency_snapshot.add_handled_dependencies(dependency.name)
         error_handler.handle_dependency_error(error: e, dependency: dependency, dependency_group: group)
         [] # return an empty set
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
       sig { params(dependency: Dependabot::Dependency).void }
       def log_up_to_date(dependency)
@@ -475,10 +458,6 @@ module Dependabot
           previous_requirements: original_dependency.requirements,
           package_manager: dependency.package_manager
         }
-
-        if Dependabot::Experiments.enabled?(:dependency_has_directory)
-          dependency_params[:directory] = dependency.directory
-        end
 
         Dependabot::Dependency.new(**dependency_params)
       end

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -99,7 +99,7 @@ module Dependabot
         sig { returns(Dependabot::Updater::ErrorHandler) }
         attr_reader :error_handler
 
-        # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize
         sig { returns(T::Array[Dependabot::DependencyGroup]) }
         def run_grouped_dependency_updates
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")
@@ -114,31 +114,13 @@ module Dependabot
                 "Deferring creation of a new pull request. The existing pull request will update in a separate job."
               )
 
-              if Dependabot::Experiments.enabled?(:dependency_has_directory)
-
-                # A grouped version update gets its directories from user-defined update configs.
-                # A multi-directory grouped update will iterate each group over every directory.
-                # Therefore, we can skip a grouped dependency if it's been updated in *any* directory
-                # add the dependencies in the group so individual updates don't try to update them
-                dependency_snapshot.add_handled_group_dependencies(
-                  dependencies_in_existing_pr_for_group(group)
-                   .map { |d| { name: d["dependency-name"], directory: d["directory"] } }
-                )
-                # also add dependencies that might be in the group, as a rebase would add them;
-                # this avoids individual PR creation that immediately is superseded by a group PR supersede
-                dependency_snapshot.add_handled_group_dependencies(
-                  group.dependencies.map { |d| { name: d.name, directory: d.directory } }
-                )
-              else
-                # add the dependencies in the group so individual updates don't try to update them
-                dependency_snapshot.add_handled_dependencies(
-                  dependencies_in_existing_pr_for_group(group).filter_map { |d| d["dependency-name"] }
-                )
-                # also add dependencies that might be in the group, as a rebase would add them;
-                # this avoids individual PR creation that immediately is superseded by a group PR supersede
-                dependency_snapshot.add_handled_dependencies(group.dependencies.map(&:name))
-              end
-
+              # add the dependencies in the group so individual updates don't try to update them
+              dependency_snapshot.add_handled_dependencies(
+                dependencies_in_existing_pr_for_group(group).filter_map { |d| d["dependency-name"] }
+              )
+              # also add dependencies that might be in the group, as a rebase would add them;
+              # this avoids individual PR creation that immediately is superseded by a group PR supersede
+              dependency_snapshot.add_handled_dependencies(group.dependencies.map(&:name))
               next
             end
 

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -138,7 +138,7 @@ module Dependabot
             end
           end
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/AbcSize
 
         sig { params(group: Dependabot::DependencyGroup).returns(T.nilable(Dependabot::DependencyChange)) }
         def run_grouped_update_for(group)

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -140,6 +140,59 @@ RSpec.describe Dependabot::DependencySnapshot do
     end
   end
 
+  describe "::handled_dependencies_all_directories" do
+    subject(:create_dependency_snapshot) do
+      described_class.create_from_job_definition(
+        job: job,
+        job_definition: job_definition
+      )
+    end
+
+    let(:job_definition) do
+      {
+        "base_commit_sha" => base_commit_sha,
+        "base64_dependency_files" => encode_dependency_files(dependency_files)
+      }
+    end
+
+    it "handles dependencies" do
+      snapshot = create_dependency_snapshot
+      snapshot.add_handled_dependencies(%w(a b))
+      expect(snapshot.handled_dependencies_all_directories).to eq(Set.new(%w(a b)))
+    end
+
+    context "when there are multiple directories" do
+      let(:directory) { nil }
+      let(:directories) { %w(/foo /bar) }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "Gemfile",
+            content: fixture("bundler/original/Gemfile"),
+            directory: "/foo"
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Gemfile",
+            content: fixture("bundler/original/Gemfile"),
+            directory: "/bar"
+          )
+        ]
+      end
+
+      it "is agnostic of the current directory" do
+        snapshot = create_dependency_snapshot
+        snapshot.current_directory = "/foo"
+        snapshot.add_handled_dependencies("a")
+        snapshot.current_directory = "/bar"
+        snapshot.add_handled_dependencies("b")
+
+        expect(snapshot.handled_dependencies_all_directories).to eq(Set.new(%w(a b)))
+        snapshot.current_directory = "/bar"
+        expect(snapshot.handled_dependencies_all_directories).to eq(Set.new(%w(a b)))
+      end
+    end
+  end
+
   describe "::create_from_job_definition" do
     subject(:create_dependency_snapshot) do
       described_class.create_from_job_definition(
@@ -194,7 +247,8 @@ RSpec.describe Dependabot::DependencySnapshot do
 
         expect(snapshot.ungrouped_dependencies.length).to be(2)
 
-        snapshot.add_handled_dependencies(group.dependencies.find { |d| d.name == "dummy-pkg-a" }.name)
+        snapshot.current_directory = directory
+        snapshot.add_handled_dependencies("dummy-pkg-a")
         expect(snapshot.ungrouped_dependencies.first.name).to eql("dummy-pkg-b")
 
         Dependabot::Experiments.reset!


### PR DESCRIPTION
### What are you trying to accomplish?

This reverts the addition of `add_handled_group_dependencies` in #9938 because it's functionally equivalent to the existing `add_handled_dependencies`.

PR #8963 added support for multi-dir handling of dependencies. The way our update works, and how DependencySnapshot keeps track of the directory can be described with this pseudocode:

```
for each group {
  for each directory {
    dependency_snapshot.current_directory = directory
    do_the_update(dependency_snapshot)
  }
}
for each ungrouped_dependency {
  for each directory {
    dependency_snapshot.current_directory = directory
    do_the_update(dependency_snapshot)
  }
}
```

So anytime `add_handled_dependencies` is called, it uses the `@current_directory` which was set earlier. It has context of which directory is currently being updated.

`add_handled_group_dependencies` does the same thing differently by passing in an array of hashes which has the dependency name and the current directory, but it results in the same outcome.

To further illustrate that, I've kept the existing tests and replaced the calls to `add_handled_group_dependencies` with calls to `add_handled_dependencies` (and setting the `current_directory`) which still passes.

Additionally I have renamed `handled_group_dependencies` to `handled_dependencies_all_directories` to reflect what it returns.

### How will you know you've accomplished your goal?

Again, there should be no functional difference here.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
