### PR TITLE
support multi-part requirements

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
@@ -32,6 +32,7 @@ public class RequirementTests
     [InlineData("2.0", "~> 1.0", false)]
     [InlineData("1", "~> 1", true)]
     [InlineData("2", "~> 1", false)]
+    [InlineData("5.3.8", "< 6, > 5.2.4", true)]
     public void IsSatisfiedBy(string versionString, string requirementString, bool expected)
     {
         var version = NuGetVersion.Parse(versionString);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
@@ -12,62 +12,9 @@ namespace NuGetUpdater.Core.Analyze;
 /// See Gem::Version for a description on how versions and requirements work
 /// together in RubyGems.
 /// </remarks>
-public class Requirement
+public abstract class Requirement
 {
-    private static readonly ImmutableDictionary<string, Func<NuGetVersion, NuGetVersion, bool>> Operators = new Dictionary<string, Func<NuGetVersion, NuGetVersion, bool>>()
-    {
-        ["="] = (v, r) => v == r,
-        ["!="] = (v, r) => v != r,
-        [">"] = (v, r) => v > r,
-        ["<"] = (v, r) => v < r,
-        [">="] = (v, r) => v >= r,
-        ["<="] = (v, r) => v <= r,
-        ["~>"] = (v, r) => v >= r && v.Version < Bump(r),
-    }.ToImmutableDictionary();
-
-    public static Requirement Parse(string requirement)
-    {
-        var splitIndex = requirement.LastIndexOfAny(['=', '>', '<']);
-
-        // Throw if the requirement is all operator and no version.
-        if (splitIndex == requirement.Length - 1)
-        {
-            throw new ArgumentException($"`{requirement}` is a invalid requirement string", nameof(requirement));
-        }
-
-        string[] parts = splitIndex == -1
-            ? [requirement.Trim()]
-            : [requirement[..(splitIndex + 1)].Trim(), requirement[(splitIndex + 1)..].Trim()];
-
-        var op = parts.Length == 1 ? "=" : parts[0];
-        var version = NuGetVersion.Parse(parts[^1]);
-
-        return new Requirement(op, version);
-    }
-
-    public string Operator { get; }
-    public NuGetVersion Version { get; }
-
-    public Requirement(string op, NuGetVersion version)
-    {
-        if (!Operators.ContainsKey(op))
-        {
-            throw new ArgumentException("Invalid operator", nameof(op));
-        }
-
-        Operator = op;
-        Version = version;
-    }
-
-    public override string ToString()
-    {
-        return $"{Operator} {Version}";
-    }
-
-    public bool IsSatisfiedBy(NuGetVersion version)
-    {
-        return Operators[Operator](version, Version);
-    }
+    public abstract bool IsSatisfiedBy(NuGetVersion version);
 
     private static readonly Dictionary<string, Version> BumpMap = [];
     /// <summary>
@@ -101,5 +48,101 @@ public class Requirement
         BumpMap[version.OriginalVersion!] = bumpedVersion;
 
         return bumpedVersion;
+    }
+
+    public static Requirement Parse(string requirement)
+    {
+        var specificParts = requirement.Split(',');
+        if (specificParts.Length == 1)
+        {
+            return IndividualRequirement.ParseIndividual(requirement);
+        }
+
+        var specificRequirements = specificParts.Select(IndividualRequirement.ParseIndividual).ToArray();
+        return new MultiPartRequirement(specificRequirements);
+    }
+}
+
+
+public class IndividualRequirement : Requirement
+{
+    private static readonly ImmutableDictionary<string, Func<NuGetVersion, NuGetVersion, bool>> Operators = new Dictionary<string, Func<NuGetVersion, NuGetVersion, bool>>()
+    {
+        ["="] = (v, r) => v == r,
+        ["!="] = (v, r) => v != r,
+        [">"] = (v, r) => v > r,
+        ["<"] = (v, r) => v < r,
+        [">="] = (v, r) => v >= r,
+        ["<="] = (v, r) => v <= r,
+        ["~>"] = (v, r) => v >= r && v.Version < Bump(r),
+    }.ToImmutableDictionary();
+
+    public string Operator { get; }
+    public NuGetVersion Version { get; }
+
+    public IndividualRequirement(string op, NuGetVersion version)
+    {
+        if (!Operators.ContainsKey(op))
+        {
+            throw new ArgumentException("Invalid operator", nameof(op));
+        }
+
+        Operator = op;
+        Version = version;
+    }
+
+    public override string ToString()
+    {
+        return $"{Operator} {Version}";
+    }
+
+    public override bool IsSatisfiedBy(NuGetVersion version)
+    {
+        return Operators[Operator](version, Version);
+    }
+
+    public static IndividualRequirement ParseIndividual(string requirement)
+    {
+        var splitIndex = requirement.LastIndexOfAny(['=', '>', '<']);
+
+        // Throw if the requirement is all operator and no version.
+        if (splitIndex == requirement.Length - 1)
+        {
+            throw new ArgumentException($"`{requirement}` is a invalid requirement string", nameof(requirement));
+        }
+
+        string[] parts = splitIndex == -1
+            ? [requirement.Trim()]
+            : [requirement[..(splitIndex + 1)].Trim(), requirement[(splitIndex + 1)..].Trim()];
+
+        var op = parts.Length == 1 ? "=" : parts[0];
+        var version = NuGetVersion.Parse(parts[^1]);
+
+        return new IndividualRequirement(op, version);
+    }
+}
+
+public class MultiPartRequirement : Requirement
+{
+    public ImmutableArray<IndividualRequirement> Parts { get; }
+
+    public MultiPartRequirement(IndividualRequirement[] parts)
+    {
+        if (parts.Length <= 1)
+        {
+            throw new ArgumentException("At least two parts are required", nameof(parts));
+        }
+
+        Parts = parts.ToImmutableArray();
+    }
+
+    public override string ToString()
+    {
+        return string.Join(", ", Parts);
+    }
+
+    public override bool IsSatisfiedBy(NuGetVersion version)
+    {
+        return Parts.All(part => part.IsSatisfiedBy(version));
     }
 }


### PR DESCRIPTION
Requirements passed to an update operation (e.g., as a part of the `ignored_versions` property) can have multiple parts separated by a comma.  These are interpreted as the `AND` combination of each individual requirement.  The NuGet updater doesn't support this, so this PR adds that functionality.

The `Requirement` class was made abstract with two concrete classes inheriting from it; `IndividualRequirement` and `MultiPartRequirement`.

`IndividualRequirement` is exactly the same as the original `Requirement` class, modulo moving some common code into the base class.

`MultiPartRequirement` simply contains multiple `IndividualRequirement`s and when checking for version compatibility, returns the `AND` combination of all parts via the LINQ method `All()`.