### PR TITLE
Centralize Yarn Error Handling for Yarn Update

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -26,7 +26,7 @@ Dependabot::Dependency.register_production_check(
   end
 )
 
-## Define type for creating new error
+## A type used for defining a proc that creates a new error object
 NewErrorProc = T.type_alias do
   T.proc
    .params(message: String, _error: Dependabot::DependabotError, _params: T::Hash[Symbol, T.untyped])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -198,16 +198,6 @@ module Dependabot
         matchfn: nil
       },
       {
-        patterns: [INVALID_PACKAGE_REGEX, SUB_DEP_LOCAL_PATH_TEXT],
-        handler: lambda { |message, _error, params|
-                   dependency_names = params[:dependencies].map(&:name).join(", ")
-                   msg = "Error whilst updating #{dependency_names} in #{params[:yarn_lock].path}:\n#{message}"
-                   raise Dependabot::DependencyFileNotResolvable, msg
-                 },
-        in_usage: false,
-        matchfn: nil
-      },
-      {
         patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
         handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
         in_usage: true,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -66,7 +66,7 @@ module Dependabot
     SUB_DEP_LOCAL_PATH_TEXT = "refers to a non-existing file"
 
     # Used to identify invalid package error when package is not found in registry
-    INVALID_PACKAGE_REGEX = /Can't add ".*?": invalid/
+    INVALID_PACKAGE_REGEX = /Can't add "[\w\-.]+": invalid/
 
     # Used to identify error if package not found in registry
     PACKAGE_NOT_FOUND = "Couldn't find package"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -27,7 +27,7 @@ Dependabot::Dependency.register_production_check(
 )
 
 ## A type used for defining a proc that creates a new error object
-HandleError = T.type_alias do
+ErrorHandler = T.type_alias do
   T.proc
    .params(message: String, error: Dependabot::DependabotError, params: T::Hash[Symbol, T.untyped])
    .returns(Dependabot::DependabotError)
@@ -198,7 +198,7 @@ module Dependabot
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
-      handler: HandleError
+      handler: ErrorHandler
     }])
 
     # Group of patterns to validate error message and raise specific error
@@ -289,7 +289,7 @@ module Dependabot
       }
     ].freeze, T::Array[{
       patterns: T::Array[T.any(String, Regexp)],
-      handler: HandleError,
+      handler: ErrorHandler,
       in_usage: T.nilable(T::Boolean),
       matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
     }])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -280,8 +280,8 @@ module Dependabot
       {
         patterns: [UNREACHABLE_GIT_CHECK_REGEX],
         handler: lambda { |message, _error, _params|
-          dependency_url = message.match(UNREACHABLE_GIT_CHECK_REGEX)
-          .named_captures.fetch(URL_CAPTURE)
+          dependency_url = message.match(UNREACHABLE_GIT_CHECK_REGEX).named_captures.fetch(URL_CAPTURE)
+
           Dependabot::GitDependenciesNotReachable.new(dependency_url)
         },
         in_usage: false,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -66,7 +66,7 @@ module Dependabot
     SUB_DEP_LOCAL_PATH_TEXT = "refers to a non-existing file"
 
     # Used to identify invalid package error when package is not found in registry
-    INVALID_PACKAGE_REGEX = /Can't add "(?<package_req>.*)": invalid/
+    INVALID_PACKAGE_REGEX = /Can't add ".*?": invalid/
 
     # Used to identify error if package not found in registry
     PACKAGE_NOT_FOUND = "Couldn't find package"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -29,7 +29,7 @@ Dependabot::Dependency.register_production_check(
 ## A type used for defining a proc that creates a new error object
 NewErrorProc = T.type_alias do
   T.proc
-   .params(message: String, _error: Dependabot::DependabotError, _params: T::Hash[Symbol, T.untyped])
+   .params(message: String, error: Dependabot::DependabotError, params: T::Hash[Symbol, T.untyped])
    .returns(Dependabot::DependabotError)
 end
 
@@ -110,98 +110,98 @@ module Dependabot
     YARN_ERROR_CODES = T.let({
       "YN0001" => {
         message: "Exception error",
-        new_error: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
       },
       "YN0002" => {
         message: "Missing peer dependency",
-        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) }
       },
       "YN0016" => {
         message: "Remote not found",
-        new_error: ->(message, _error, _params) { Dependabot::GitDependenciesNotReachable.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::GitDependenciesNotReachable.new(message) }
       },
       "YN0020" => {
         message: "Missing lockfile entry",
-        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotFound.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotFound.new(message) }
       },
       "YN0046" => {
         message: "Automerge failed to parse",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0047" => {
         message: "Automerge immutable",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0062" => {
         message: "Incompatible OS",
-        new_error: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
       },
       "YN0063" => {
         message: "Incompatible CPU",
-        new_error: ->(message, _error, _params) { Dependabot::IncompatibleCPU.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::IncompatibleCPU.new(message) }
       },
       "YN0071" => {
         message: "NM can't install external soft link",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0072" => {
         message: "NM preserve symlinks required",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0075" => {
         message: "Prolog instantiation error",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0077" => {
         message: "Ghost architecture",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0080" => {
         message: "Network disabled",
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0081" => {
         message: "Network unsafe HTTP",
-        new_error: ->(message, _error, _params) { Dependabot::NetworkUnsafeHTTP.new(message) }
+        handler: ->(message, _error, _params) { Dependabot::NetworkUnsafeHTTP.new(message) }
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
-      new_error: NewErrorProc
+      handler: NewErrorProc
     }])
 
     # Group of patterns to validate error message and raise specific error
     VALIDATION_GROUP_PATTERNS = T.let([
       {
         patterns: [INVALID_NAME_IN_PACKAGE_JSON],
-        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotParseable.new(message) },
+        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotParseable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [INVALID_PACKAGE_REGEX, SUB_DEP_LOCAL_PATH_TEXT],
-        new_error: lambda { |message, _error, params|
-                     dependency_names = params[:dependencies].map(&:name).join(", ")
-                     msg = "Error whilst updating #{dependency_names} in #{params[:yarn_lock].path}:\n#{message}"
-                     raise Dependabot::DependencyFileNotResolvable, msg
-                   },
+        handler: lambda { |message, _error, params|
+                   dependency_names = params[:dependencies].map(&:name).join(", ")
+                   msg = "Error whilst updating #{dependency_names} in #{params[:yarn_lock].path}:\n#{message}"
+                   raise Dependabot::DependencyFileNotResolvable, msg
+                 },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
-        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
+        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
         in_usage: true,
         matchfn: nil
       },
       {
         patterns: [TARBALL_IS_NOT_IN_NETWORK],
-        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) },
+        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [NODE_VERSION_NOT_SATISFY_REGEX],
-        new_error: lambda { |message, _error, _params|
+        handler: lambda { |message, _error, _params|
           versions = Utils.extract_node_versions(message)
           current_version = versions[:current_version]
           required_version = versions[:required_version]
@@ -215,19 +215,19 @@ module Dependabot
       },
       {
         patterns: [AUTHENTICATION_TOKEN_NOT_PROVIDED, AUTHENTICATION_IS_NOT_CONFIGURED],
-        new_error: ->(message, _error, _params) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
+        handler: ->(message, _error, _params) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [DEPENDENCY_FILE_NOT_RESOLVABLE],
-        new_error: ->(message, _error, _params) { DependencyFileNotResolvable.new(message) },
+        handler: ->(message, _error, _params) { DependencyFileNotResolvable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [ENV_VAR_NOT_RESOLVABLE],
-        new_error: lambda { |message, _error, _params|
+        handler: lambda { |message, _error, _params|
           var = Utils.extract_var(message)
           Dependabot::MissingEnvironmentVariable.new(var, message)
         },
@@ -236,7 +236,7 @@ module Dependabot
       }
     ].freeze, T::Array[{
       patterns: T::Array[T.any(String, Regexp)],
-      new_error: NewErrorProc,
+      handler: NewErrorProc,
       in_usage: T.nilable(T::Boolean),
       matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
     }])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -142,59 +142,87 @@ module Dependabot
     YARN_ERROR_CODES = T.let({
       "YN0001" => {
         message: "Exception error",
-        handler: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependabotError.new(message)
+        }
       },
       "YN0002" => {
         message: "Missing peer dependency",
-        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependencyFileNotResolvable.new(message)
+        }
       },
       "YN0016" => {
         message: "Remote not found",
-        handler: ->(message, _error, _params) { Dependabot::GitDependenciesNotReachable.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::GitDependenciesNotReachable.new(message)
+        }
       },
       "YN0020" => {
         message: "Missing lockfile entry",
-        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotFound.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependencyFileNotFound.new(message)
+        }
       },
       "YN0046" => {
         message: "Automerge failed to parse",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0047" => {
         message: "Automerge immutable",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0062" => {
         message: "Incompatible OS",
-        handler: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependabotError.new(message)
+        }
       },
       "YN0063" => {
         message: "Incompatible CPU",
-        handler: ->(message, _error, _params) { Dependabot::IncompatibleCPU.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::IncompatibleCPU.new(message)
+        }
       },
       "YN0071" => {
         message: "NM can't install external soft link",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0072" => {
         message: "NM preserve symlinks required",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0075" => {
         message: "Prolog instantiation error",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0077" => {
         message: "Ghost architecture",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0080" => {
         message: "Network disabled",
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        }
       },
       "YN0081" => {
         message: "Network unsafe HTTP",
-        handler: ->(message, _error, _params) { Dependabot::NetworkUnsafeHTTP.new(message) }
+        handler: lambda { |message, _error, _params|
+          Dependabot::NetworkUnsafeHTTP.new(message)
+        }
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
@@ -205,7 +233,9 @@ module Dependabot
     VALIDATION_GROUP_PATTERNS = T.let([
       {
         patterns: [INVALID_NAME_IN_PACKAGE_JSON],
-        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotParseable.new(message) },
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependencyFileNotParseable.new(message)
+        },
         in_usage: false,
         matchfn: nil
       },
@@ -226,13 +256,17 @@ module Dependabot
       },
       {
         patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
-        handler: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
+        handler: lambda { |message, _error, _params|
+          Dependabot::MisconfiguredTooling.new("Yarn", message)
+        },
         in_usage: true,
         matchfn: nil
       },
       {
         patterns: [TARBALL_IS_NOT_IN_NETWORK],
-        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) },
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependencyFileNotResolvable.new(message)
+        },
         in_usage: false,
         matchfn: nil
       },
@@ -252,13 +286,17 @@ module Dependabot
       },
       {
         patterns: [AUTHENTICATION_TOKEN_NOT_PROVIDED, AUTHENTICATION_IS_NOT_CONFIGURED],
-        handler: ->(message, _error, _params) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
+        handler: lambda { |message, _error, _params|
+          Dependabot::PrivateSourceAuthenticationFailure.new(message)
+        },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [DEPENDENCY_FILE_NOT_RESOLVABLE],
-        handler: ->(message, _error, _params) { DependencyFileNotResolvable.new(message) },
+        handler: lambda { |message, _error, _params|
+          DependencyFileNotResolvable.new(message)
+        },
         in_usage: false,
         matchfn: nil
       },
@@ -266,6 +304,7 @@ module Dependabot
         patterns: [ENV_VAR_NOT_RESOLVABLE],
         handler: lambda { |message, _error, _params|
           var = Utils.extract_var(message)
+
           Dependabot::MissingEnvironmentVariable.new(var, message)
         },
         in_usage: false,
@@ -273,7 +312,9 @@ module Dependabot
       },
       {
         patterns: [ONLY_PRIVATE_WORKSPACE_TEXT],
-        handler: ->(message, _error, _params) { Dependabot::DependencyFileNotEvaluatable.new(message) },
+        handler: lambda { |message, _error, _params|
+          Dependabot::DependencyFileNotEvaluatable.new(message)
+        },
         in_usage: false,
         matchfn: nil
       },

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -27,7 +27,7 @@ Dependabot::Dependency.register_production_check(
 )
 
 ## A type used for defining a proc that creates a new error object
-NewErrorProc = T.type_alias do
+HandleError = T.type_alias do
   T.proc
    .params(message: String, error: Dependabot::DependabotError, params: T::Hash[Symbol, T.untyped])
    .returns(Dependabot::DependabotError)
@@ -198,7 +198,7 @@ module Dependabot
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
-      handler: NewErrorProc
+      handler: HandleError
     }])
 
     # Group of patterns to validate error message and raise specific error
@@ -289,7 +289,7 @@ module Dependabot
       }
     ].freeze, T::Array[{
       patterns: T::Array[T.any(String, Regexp)],
-      handler: NewErrorProc,
+      handler: HandleError,
       in_usage: T.nilable(T::Boolean),
       matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
     }])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -26,6 +26,13 @@ Dependabot::Dependency.register_production_check(
   end
 )
 
+## Define type for creating new error
+NewErrorProc = T.type_alias do
+  T.proc
+   .params(message: String, _error: Dependabot::DependabotError, _params: T::Hash[Symbol, T.untyped])
+   .returns(Dependabot::DependabotError)
+end
+
 module Dependabot
   module NpmAndYarn
     NODE_VERSION_NOT_SATISFY_REGEX = /The current Node version (?<current_version>v?\d+\.\d+\.\d+) does not satisfy the required version (?<required_version>v?\d+\.\d+\.\d+)\./ # rubocop:disable Layout/LineLength
@@ -36,7 +43,7 @@ module Dependabot
     # Used to check if url is http or https
     HTTP_CHECK_REGEX = %r{https?://}
 
-    # Error message when a package.json name include invalid characters
+    # When package name contains package.json name cannot contain characters like empty string or @.
     INVALID_NAME_IN_PACKAGE_JSON = "Name contains illegal characters"
 
     # Used to identify error messages indicating a package is missing, unreachable,
@@ -103,82 +110,98 @@ module Dependabot
     YARN_ERROR_CODES = T.let({
       "YN0001" => {
         message: "Exception error",
-        new_error: ->(_error, message) { Dependabot::DependabotError.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
       },
       "YN0002" => {
         message: "Missing peer dependency",
-        new_error: ->(_error, message) { Dependabot::DependencyFileNotResolvable.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) }
       },
       "YN0016" => {
         message: "Remote not found",
-        new_error: ->(_error, message) { Dependabot::GitDependenciesNotReachable.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::GitDependenciesNotReachable.new(message) }
       },
       "YN0020" => {
         message: "Missing lockfile entry",
-        new_error: ->(_error, message) { Dependabot::DependencyFileNotFound.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotFound.new(message) }
       },
       "YN0046" => {
         message: "Automerge failed to parse",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0047" => {
         message: "Automerge immutable",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0062" => {
         message: "Incompatible OS",
-        new_error: ->(_error, message) { Dependabot::DependabotError.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::DependabotError.new(message) }
       },
       "YN0063" => {
         message: "Incompatible CPU",
-        new_error: ->(_error, message) { Dependabot::IncompatibleCPU.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::IncompatibleCPU.new(message) }
       },
       "YN0071" => {
         message: "NM can't install external soft link",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0072" => {
         message: "NM preserve symlinks required",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0075" => {
         message: "Prolog instantiation error",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0077" => {
         message: "Ghost architecture",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0080" => {
         message: "Network disabled",
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) }
       },
       "YN0081" => {
         message: "Network unsafe HTTP",
-        new_error: ->(_error, message) { Dependabot::NetworkUnsafeHTTP.new(message) }
+        new_error: ->(message, _error, _params) { Dependabot::NetworkUnsafeHTTP.new(message) }
       }
     }.freeze, T::Hash[String, {
       message: T.any(String, NilClass),
-      new_error: T.proc.params(error: Dependabot::DependabotError, message: String).returns(Dependabot::DependabotError)
+      new_error: NewErrorProc
     }])
 
     # Group of patterns to validate error message and raise specific error
     VALIDATION_GROUP_PATTERNS = T.let([
       {
+        patterns: [INVALID_NAME_IN_PACKAGE_JSON],
+        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotParseable.new(message) },
+        in_usage: false,
+        matchfn: nil
+      },
+      {
+        patterns: [INVALID_PACKAGE_REGEX, SUB_DEP_LOCAL_PATH_TEXT],
+        new_error: lambda { |message, _error, params|
+                     dependency_names = params[:dependencies].map(&:name).join(", ")
+                     msg = "Error whilst updating #{dependency_names} in #{params[:yarn_lock].path}:\n#{message}"
+                     raise Dependabot::DependencyFileNotResolvable, msg
+                   },
+        in_usage: false,
+        matchfn: nil
+      },
+      {
         patterns: [NODE_MODULES_STATE_FILE_NOT_FOUND],
-        new_error: ->(_error, message) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
+        new_error: ->(message, _error, _params) { Dependabot::MisconfiguredTooling.new("Yarn", message) },
         in_usage: true,
         matchfn: nil
       },
       {
         patterns: [TARBALL_IS_NOT_IN_NETWORK],
-        new_error: ->(_error, message) { Dependabot::DependencyFileNotResolvable.new(message) },
+        new_error: ->(message, _error, _params) { Dependabot::DependencyFileNotResolvable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [NODE_VERSION_NOT_SATISFY_REGEX],
-        new_error: lambda { |_error, message|
+        new_error: lambda { |message, _error, _params|
           versions = Utils.extract_node_versions(message)
           current_version = versions[:current_version]
           required_version = versions[:required_version]
@@ -192,19 +215,19 @@ module Dependabot
       },
       {
         patterns: [AUTHENTICATION_TOKEN_NOT_PROVIDED, AUTHENTICATION_IS_NOT_CONFIGURED],
-        new_error: ->(_error, message) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
+        new_error: ->(message, _error, _params) { Dependabot::PrivateSourceAuthenticationFailure.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [DEPENDENCY_FILE_NOT_RESOLVABLE],
-        new_error: ->(_error, message) { DependencyFileNotResolvable.new(message) },
+        new_error: ->(message, _error, _params) { DependencyFileNotResolvable.new(message) },
         in_usage: false,
         matchfn: nil
       },
       {
         patterns: [ENV_VAR_NOT_RESOLVABLE],
-        new_error: lambda { |_error, message|
+        new_error: lambda { |message, _error, _params|
           var = Utils.extract_var(message)
           Dependabot::MissingEnvironmentVariable.new(var, message)
         },
@@ -213,8 +236,7 @@ module Dependabot
       }
     ].freeze, T::Array[{
       patterns: T::Array[T.any(String, Regexp)],
-      new_error: T.proc.params(error: Dependabot::DependabotError,
-                               message: String).returns(Dependabot::DependabotError),
+      new_error: NewErrorProc,
       in_usage: T.nilable(T::Boolean),
       matchfn: T.nilable(T.proc.params(usage: String, message: String).returns(T::Boolean))
     }])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -714,16 +714,21 @@ module Dependabot
         sanitized_name = T.let(nil, T.nilable(String))
 
         if p1
-          package_name = error_message
-                         .match(PACKAGE_NOT_FOUND_PACKAGE_NAME_REGEX)
-                         &.named_captures&.[](PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE)
-                         &.split(PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE_SPLIT_REGEX)&.first
+          package_name =
+            error_message
+            .match(PACKAGE_NOT_FOUND_PACKAGE_NAME_REGEX)
+            &.named_captures
+            &.[](PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE)
+            &.split(PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE_SPLIT_REGEX)
+            &.first
         end
 
         if p2
-          package_name = error_message
-                         .match(PACKAGE_NOT_FOUND2_PACKAGE_NAME_REGEX)
-                         &.named_captures&.[](PACKAGE_NOT_FOUND2_PACKAGE_NAME_CAPTURE)
+          package_name =
+            error_message
+            .match(PACKAGE_NOT_FOUND2_PACKAGE_NAME_REGEX)
+            &.named_captures
+            &.[](PACKAGE_NOT_FOUND2_PACKAGE_NAME_CAPTURE)
         end
 
         raise_resolvability_error(error_message, yarn_lock) unless package_name

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -596,11 +596,13 @@ module Dependabot
       # Main error handling method
       sig { params(error: SharedHelpers::HelperSubprocessFailed, params: T::Hash[Symbol, String]).void }
       def handle_error(error, params)
+        error_message = error.message
+        yarn_lock = params[:yarn_lock]
         # Check if sub dependency is using local path and raise a resolvability error
-        handle_sub_dependency_local_path_error(error.message, params[:yarn_lock])
+        handle_sub_dependency_local_path_error(error_message, yarn_lock)
 
         # Extract the usage error message from the raw error message
-        usage_error_message = find_usage_error(error.message) || ""
+        usage_error_message = find_usage_error(error_message) || ""
 
         # Check if the error message contains any group patterns and raise
         # the corresponding error class

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -231,15 +231,6 @@ module Dependabot
         def handle_yarn_lock_updater_error(error, yarn_lock)
           error_message = error.message
 
-          # Invalid package: When package.json doesn't include a name or version
-          # Local path error: When installing a git dependency which
-          # is using local file paths for sub-dependencies (e.g. unbuilt yarn
-          # workspace project)
-          if error_message.match?(INVALID_PACKAGE_REGEX) ||
-             error_message.include?(SUB_DEP_LOCAL_PATH_TEXT)
-            error_handler.raise_resolvability_error(error_message, yarn_lock)
-          end
-
           error_handler.handle_error(error, {
             yarn_lock: yarn_lock
           })

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -653,7 +653,7 @@ module Dependabot
                                      "[#{code}]: #{error_message}"
                                    end
 
-          raise  create_handler(handler, modified_error_message, error, params)
+          raise  create_error(handler, modified_error_message, error, params)
         end
       end
 
@@ -677,12 +677,12 @@ module Dependabot
 
           message = usage_error_message.empty? ? error_message : usage_error_message
           if in_usage && pattern_in_message(patterns, usage_error_message)
-            raise create_handler(handler, message, error, params)
+            raise create_error(handler, message, error, params)
           elsif !in_usage && pattern_in_message(patterns, error.message)
-            raise create_handler(handler, error.message, error, params)
+            raise create_error(handler, error.message, error, params)
           end
 
-          raise create_handler(handler, message, error, params) if matchfn&.call(usage_error_message, error_message)
+          raise create_error(handler, message, error, params) if matchfn&.call(usage_error_message, error_message)
         end
       end
 
@@ -695,7 +695,7 @@ module Dependabot
           params: T::Hash[Symbol, String]
         ).returns(Dependabot::DependabotError)
       end
-      def create_handler(handler, message, error, params)
+      def create_error(handler, message, error, params)
         handler.call(message, error, {
           dependencies: dependencies,
           dependency_files: dependency_files,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -654,7 +654,7 @@ module Dependabot
       # Creates a new error based on the provided parameters
       sig do
         params(
-          handler: NewErrorProc,
+          handler: ErrorHandler,
           message: String,
           error: SharedHelpers::HelperSubprocessFailed,
           params: T::Hash[Symbol, String]

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -597,15 +597,11 @@ module Dependabot
       sig { params(error: SharedHelpers::HelperSubprocessFailed, params: T::Hash[Symbol, String]).void }
       def handle_error(error, params)
         error_message = error.message
-        yarn_lock = params[:yarn_lock]
-        # Check if sub dependency is using local path and raise a resolvability error
-        handle_sub_dependency_local_path_error(error_message, yarn_lock)
 
         # Extract the usage error message from the raw error message
         usage_error_message = find_usage_error(error_message) || ""
 
-        # Check if the error message contains any group patterns and raise
-        # the corresponding error class
+        # Check if the error message contains any group patterns and raise the corresponding error class
         handle_group_patterns(error, usage_error_message, params)
 
         # Check if defined yarn error codes contained in the error message
@@ -720,13 +716,14 @@ module Dependabot
         ).returns(T::Boolean)
       end
       def pattern_in_message(patterns, message)
-        patterns.any? do |pattern|
+        patterns.each do |pattern|
           if pattern.is_a?(String)
-            return message.include?(pattern)
+            return true if message.include?(pattern)
           elsif pattern.is_a?(Regexp)
-            return message.gsub(/\e\[[\d;]*[A-Za-z]/, "").match?(pattern)
+            return true if message.gsub(/\e\[[\d;]*[A-Za-z]/, "").match?(pattern)
           end
         end
+        false
       end
 
       # Checks if a package is missing from the error message

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -231,6 +231,15 @@ module Dependabot
         def handle_yarn_lock_updater_error(error, yarn_lock)
           error_message = error.message
 
+          # Invalid package: When package.json doesn't include a name or version
+          # Local path error: When installing a git dependency which
+          # is using local file paths for sub-dependencies (e.g. unbuilt yarn
+          # workspace project)
+          if error_message.match?(INVALID_PACKAGE_REGEX) ||
+             error_message.include?(SUB_DEP_LOCAL_PATH_TEXT)
+            error_handler.raise_resolvability_error(error_message, yarn_lock)
+          end
+
           error_handler.handle_error(error, {
             yarn_lock: yarn_lock
           })

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -596,16 +596,16 @@ module Dependabot
       # Main error handling method
       sig { params(error: SharedHelpers::HelperSubprocessFailed, params: T::Hash[Symbol, String]).void }
       def handle_error(error, params)
-        # Check if defined yarn error codes contained in the error message
-        # and raise the corresponding error class
-        handle_yarn_error(error, params)
-
         # Extract the usage error message from the raw error message
         usage_error_message = find_usage_error(error.message) || ""
 
         # Check if the error message contains any group patterns and raise
         # the corresponding error class
         handle_group_patterns(error, usage_error_message, params)
+
+        # Check if defined yarn error codes contained in the error message
+        # and raise the corresponding error class
+        handle_yarn_error(error, params)
       end
 
       # Handles errors with specific to yarn error codes

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -705,15 +705,15 @@ module Dependabot
       end
       def handle_package_not_found(error_message, yarn_lock) # rubocop:disable Metrics/PerceivedComplexity
         # There are 2 different package not found error messages
-        p1 = error_message.include?(PACKAGE_NOT_FOUND)
-        p2 = error_message.match?(PACKAGE_NOT_FOUND2)
+        package_not_found = error_message.include?(PACKAGE_NOT_FOUND)
+        package_not_found2 = error_message.match?(PACKAGE_NOT_FOUND2)
 
         # If non of the patterns are found, return an empty hash
-        return {} unless p1 || p2
+        return {} unless package_not_found || package_not_found2
 
         sanitized_name = T.let(nil, T.nilable(String))
 
-        if p1
+        if package_not_found
           package_name =
             error_message
             .match(PACKAGE_NOT_FOUND_PACKAGE_NAME_REGEX)
@@ -723,7 +723,7 @@ module Dependabot
             &.first
         end
 
-        if p2
+        if package_not_found2
           package_name =
             error_message
             .match(PACKAGE_NOT_FOUND2_PACKAGE_NAME_REGEX)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
   let(:dependencies) { [instance_double(Dependabot::Dependency, name: "test-dependency")] }
   let(:dependency_files) { [instance_double(Dependabot::DependencyFile, path: "path/to/yarn.lock")] }
+  let(:yarn_lock) { dependency_files.first }
   let(:error) { instance_double(Dependabot::SharedHelpers::HelperSubprocessFailed, message: error_message) }
 
   describe "#initialize" do
@@ -27,7 +28,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "YN0002: Missing peer dependency" }
 
       it "raises the corresponding error class with the correct message" do
-        expect { error_handler.handle_error(error) }
+        expect { error_handler.handle_error(error, { yarn_lock: yarn_lock }) }
           .to raise_error(Dependabot::DependencyFileNotResolvable, /YN0002: Missing peer dependency/)
       end
     end
@@ -36,7 +37,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "Here is a recognized error pattern: authentication token not provided" }
 
       it "raises the corresponding error class with the correct message" do
-        expect { error_handler.handle_error(error) }
+        expect { error_handler.handle_error(error, { yarn_lock: yarn_lock }) }
           .to raise_error(Dependabot::PrivateSourceAuthenticationFailure, /authentication token not provided/)
       end
     end
@@ -45,7 +46,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "This is an unrecognized pattern that should not raise an error." }
 
       it "does not raise an error" do
-        expect { error_handler.handle_error(error) }.not_to raise_error
+        expect { error_handler.handle_error(error, { yarn_lock: yarn_lock }) }.not_to raise_error
       end
     end
 
@@ -60,7 +61,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       end
 
       it "does not raise an error" do
-        expect { error_handler.handle_error(error) }.not_to raise_error
+        expect { error_handler.handle_error(error, { yarn_lock: yarn_lock }) }.not_to raise_error
       end
     end
 
@@ -80,7 +81,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises a MisconfiguredTooling error with the correct message" do
         expect do
-          error_handler.handle_yarn_error(error)
+          error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
         end.to raise_error(Dependabot::MisconfiguredTooling, /YN0080: .*The remote server failed/)
       end
     end
@@ -97,7 +98,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises a ToolVersionNotSupported error with the correct versions" do
         expect do
-          error_handler.handle_error(error)
+          error_handler.handle_error(error, { yarn_lock: yarn_lock })
         end.to raise_error(Dependabot::ToolVersionNotSupported) do |e| # rubocop:disable Style/MultilineBlockChain
           expect(e.tool_name).to eq("Yarn")
           expect(e.detected_version).to eq("v20.15.1")
@@ -133,7 +134,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises the corresponding error class with the correct message" do
         expect do
-          error_handler.handle_yarn_error(error)
+          error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
         end.to raise_error(Dependabot::DependencyFileNotResolvable, /YN0002: Missing peer dependency/)
       end
     end
@@ -147,7 +148,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       it "raises the last corresponding error class found with the correct message" do
         expect do
-          error_handler.handle_yarn_error(error)
+          error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
         end.to raise_error(Dependabot::GitDependenciesNotReachable, /YN0016: Remote not found/)
       end
     end
@@ -156,7 +157,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "This message does not contain any known Yarn error codes." }
 
       it "does not raise any errors" do
-        expect { error_handler.handle_yarn_error(error) }.not_to raise_error
+        expect { error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock }) }.not_to raise_error
       end
     end
   end
@@ -169,14 +170,14 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message_with_usage_error) { "#{error_message}\n#{usage_error_message}" }
 
       it "raises the corresponding error class with the correct message" do
-        expect { error_handler.handle_group_patterns(error, usage_error_message) }
+        expect { error_handler.handle_group_patterns(error, usage_error_message, { yarn_lock: yarn_lock }) }
           .to raise_error(Dependabot::PrivateSourceAuthenticationFailure, /authentication token not provided/)
       end
     end
 
     context "when the error message contains a recognized pattern in the error message" do
       it "raises the corresponding error class with the correct message" do
-        expect { error_handler.handle_group_patterns(error, "") }
+        expect { error_handler.handle_group_patterns(error, "", { yarn_lock: yarn_lock }) }
           .to raise_error(Dependabot::PrivateSourceAuthenticationFailure, /authentication token not provided/)
       end
     end
@@ -185,7 +186,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       let(:error_message) { "This is an unrecognized pattern that should not raise an error." }
 
       it "does not raise any errors" do
-        expect { error_handler.handle_group_patterns(error, "") }.not_to raise_error
+        expect { error_handler.handle_group_patterns(error, "", { yarn_lock: yarn_lock }) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to centralize and manage yarn error handling logic within the `YarnErrorHandler` class. This change aims to move error handling from the business logic defined in `YarnLockfileUpdater` into `YarnErrorHandler`, making the code more generalized and maintainable.

### Anything you want to highlight for special attention from reviewers?

This approach was chosen to streamline error handling by separating concerns and improving the maintainability of the codebase. It also aligns with the update in dependabot-core (#10177) for more manageable error handling.

### How will you know you've accomplished your goal?

- If errors are consistently handled by the `YarnErrorHandler` class instead of being scattered across the `YarnLockfileUpdater`.
- By running tests to ensure that all existing error handling scenarios are correctly managed by the new implementation.
- By confirming that the new error handling logic is functionally equivalent to the old logic through extensive testing.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.