### PR TITLE
analyze `global.json` and `dotnet-tools.json`

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -131,19 +131,14 @@ namespace NuGetUpdater.Core.Test
             );
         }
 
-        public static MockNuGetPackage CreateDotNetToolPackage(string id, string version, string targetFramework)
+        public static MockNuGetPackage CreateDotNetToolPackage(string id, string version, string targetFramework, XElement[]? additionalMetadata = null)
         {
+            var packageMetadata = new XElement("packageTypes", new XElement("packageType", new XAttribute("name", "DotnetTool")));
+            var allMetadata = new[] { packageMetadata }.Concat(additionalMetadata ?? []).ToArray();
             return new(
                 id,
                 version,
-                AdditionalMetadata:
-                [
-                    new XElement("packageTypes",
-                        new XElement("packageType",
-                            new XAttribute("name", "DotnetTool")
-                        )
-                    )
-                ],
+                AdditionalMetadata: allMetadata,
                 Files:
                 [
                     ($"tools/{targetFramework}/any/DotnetToolSettings.xml", Encoding.UTF8.GetBytes($"""
@@ -158,8 +153,10 @@ namespace NuGetUpdater.Core.Test
             );
         }
 
-        public static MockNuGetPackage CreateMSBuildSdkPackage(string id, string version, string? sdkPropsContent = null, string? sdkTargetsContent = null)
+        public static MockNuGetPackage CreateMSBuildSdkPackage(string id, string version, string? sdkPropsContent = null, string? sdkTargetsContent = null, XElement[]? additionalMetadata = null)
         {
+            var packageMetadata = new XElement("packageTypes", new XElement("packageType", new XAttribute("name", "MSBuildSdk")));
+            var allMetadata = new[] { packageMetadata }.Concat(additionalMetadata ?? []).ToArray();
             sdkPropsContent ??= """
                 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                 </Project>
@@ -171,14 +168,7 @@ namespace NuGetUpdater.Core.Test
             return new(
                 id,
                 version,
-                AdditionalMetadata:
-                [
-                    new XElement("packageTypes",
-                        new XElement("packageType",
-                            new XAttribute("name", "MSBuildSdk")
-                        )
-                    )
-                ],
+                AdditionalMetadata: additionalMetadata,
                 Files:
                 [
                     ("Sdk/Sdk.props", Encoding.UTF8.GetBytes(sdkPropsContent)),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -51,12 +51,15 @@ public partial class AnalyzeWorker
             => p.Dependencies.Where(d => !d.IsTransitive &&
                 d.EvaluationResult?.RootPropertyName is not null)
             ).ToImmutableArray();
+        var dotnetToolsHasDependency = discovery.DotNetToolsJson?.Dependencies.Any(d => d.Name.Equals(dependencyInfo.Name, StringComparison.OrdinalIgnoreCase)) == true;
+        var globalJsonHasDependency = discovery.GlobalJson?.Dependencies.Any(d => d.Name.Equals(dependencyInfo.Name, StringComparison.OrdinalIgnoreCase)) == true;
 
         bool usesMultiDependencyProperty = false;
         NuGetVersion? updatedVersion = null;
         ImmutableArray<Dependency> updatedDependencies = [];
 
-        bool isUpdateNecessary = IsUpdateNecessary(dependencyInfo, projectsWithDependency);
+        bool isProjectUpdateNecessary = IsUpdateNecessary(dependencyInfo, projectsWithDependency);
+        var isUpdateNecessary = isProjectUpdateNecessary || dotnetToolsHasDependency || globalJsonHasDependency;
         using var nugetContext = new NuGetContext(startingDirectory);
         AnalysisResult result;
         try
@@ -94,16 +97,35 @@ public partial class AnalyzeWorker
                     CancellationToken.None);
 
                 _logger.Log($"  Finding updated peer dependencies.");
-                updatedDependencies = updatedVersion is not null
-                    ? await FindUpdatedDependenciesAsync(
+                if (updatedVersion is null)
+                {
+                    updatedDependencies = [];
+                }
+                else if (isProjectUpdateNecessary)
+                {
+                    updatedDependencies = await FindUpdatedDependenciesAsync(
                         repoRoot,
                         discovery,
                         dependenciesToUpdate,
                         updatedVersion,
                         nugetContext,
                         _logger,
-                        CancellationToken.None)
-                    : [];
+                        CancellationToken.None);
+                }
+                else if (dotnetToolsHasDependency)
+                {
+                    var infoUrl = await nugetContext.GetPackageInfoUrlAsync(dependencyInfo.Name, updatedVersion.ToNormalizedString(), CancellationToken.None);
+                    updatedDependencies = [new Dependency(dependencyInfo.Name, updatedVersion.ToNormalizedString(), DependencyType.DotNetTool, IsDirect: true, InfoUrl: infoUrl)];
+                }
+                else if (globalJsonHasDependency)
+                {
+                    var infoUrl = await nugetContext.GetPackageInfoUrlAsync(dependencyInfo.Name, updatedVersion.ToNormalizedString(), CancellationToken.None);
+                    updatedDependencies = [new Dependency(dependencyInfo.Name, updatedVersion.ToNormalizedString(), DependencyType.MSBuildSdk, IsDirect: true, InfoUrl: infoUrl)];
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unreachable.");
+                }
 
                 //TODO: At this point we should add the peer dependencies to a queue where
                 // we will analyze them one by one to see if they themselves are part of a


### PR DESCRIPTION
When analyzing packages for updates, the current code path only considers projects (e.g., `*.csproj`, etc.)  This PR explicitly analyzes the dependencies of `global.json` and `.config/dotnet-tools.json`.  Since these are top-level items in top-level files, we can directly return the new dependencies array once we've computed the newest available version.

This PR also includes required changes to test code to allow passing in extra metadata when creating mock NuGet packages.