### PR TITLE
Handle Errors Coded with YN0035 Yarn Error Code

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -175,7 +175,7 @@ module Dependabot
           YN0035.each do |(_yn0035_key, yn0035_regex)|
             if (match_data = message.match(yn0035_regex)) && (package_req = match_data[:package_req])
               return Dependabot::DependencyNotFound.new(
-                "#{package_req} -> Detail: #{message}"
+                "#{package_req} Detail: #{message}"
               )
             end
           end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -74,6 +74,11 @@ module Dependabot
     PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE = "package_req"
     PACKAGE_NOT_FOUND_PACKAGE_NAME_CAPTURE_SPLIT_REGEX = /(?<=\w)\@/
 
+    YN0035 = T.let({
+      PACKAGE_NOT_FOUND: %r{(?<package_req>@[\w-]+\/[\w-]+@\S+): Package not found},
+      FAILED_TO_RETRIEVE: %r{(?<package_req>@[\w-]+\/[\w-]+@\S+): The remote server failed to provide the requested resource} # rubocop:disable Layout/LineLength
+    }.freeze, T::Hash[String, Regexp])
+
     PACKAGE_NOT_FOUND2 = %r{/[^/]+: Not found}
     PACKAGE_NOT_FOUND2_PACKAGE_NAME_REGEX = %r{/(?<package_name>[^/]+): Not found}
     PACKAGE_NOT_FOUND2_PACKAGE_NAME_CAPTURE = "package_name"
@@ -162,6 +167,19 @@ module Dependabot
         message: "Missing lockfile entry",
         handler: lambda { |message, _error, _params|
           Dependabot::DependencyFileNotFound.new(message)
+        }
+      },
+      "YN0035" => {
+        message: "Package not found",
+        handler: lambda { |message, _error, _params|
+          YN0035.each do |(_yn0035_key, yn0035_regex)|
+            if (match_data = message.match(yn0035_regex)) && (package_req = match_data[:package_req])
+              return Dependabot::DependencyNotFound.new(
+                "#{package_req} -> Detail: #{message}"
+              )
+            end
+          end
+          Dependabot::DependencyNotFound.new(message)
         }
       },
       "YN0046" => {

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -596,7 +596,8 @@ module Dependabot
       # Handles errors with specific to yarn error codes
       sig { params(error: SharedHelpers::HelperSubprocessFailed, params: T::Hash[Symbol, String]).void }
       def handle_yarn_error(error, params)
-        error_message = error.message
+        ## Clean error message from ANSI escape codes
+        error_message = error.message.gsub(/\e\[\d+(;\d+)*m/, "")
         matches = error_message.scan(YARN_CODE_REGEX)
         return if matches.empty?
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
             error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
           end.to raise_error(
             Dependabot::DependencyNotFound,
-            %r{The following dependency could not be found : @dummy-scope/dummy-package@npm:\^1.2.3 ->}
+            %r{The following dependency could not be found : @dummy-scope/dummy-package@npm:\^1.2.3}
           )
         end
       end
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
             error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
           end.to raise_error(
             Dependabot::DependencyNotFound,
-            %r{The following dependency could not be found : @dummy-scope/dummy-fixture@npm:\^1.0.0 ->}
+            %r{The following dependency could not be found : @dummy-scope/dummy-fixture@npm:\^1.0.0}
           )
         end
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -214,17 +214,19 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
       context "when error message matches with YN0035.PACKAGE_NOT_FOUND" do
         let(:error_message) do
           "[94m➤[39m YN0000: · Yarn 4.2.2\n" \
-            "[94m➤[39m [90mYN0000[39m: ┌ Resolution step\n" \
-            "::group::Resolution step\n" \
-            "[91m➤[39m YN0035: │ [38;5;166m@dummy-scope/[39m[38;5;173mdummy-package[39m[38;5;37m@[39m[38;5;37mnpm:^1.2.3[39m: Package not found\n" \
+            "[94m➤[39m [90mYN0000[39m: ┌ Resolution step\n::group::Resolution step\n" \
+            "[91m➤[39m YN0035: │ [38;5;166m@dummy-scope/[39m[38;5;173mdummy-package" \
+            "[39m[38;5;37m@[39m[38;5;37mnpm:^1.2.3[39m: Package not found\n" \
             "[91m➤[39m YN0035: │   [38;5;111mResponse Code[39m: [38;5;220m404[39m (Not Found)\n" \
             "[91m➤[39m YN0035: │   [38;5;111mRequest Method[39m: GET\n" \
-            "[91m➤[39m YN0035: │   [38;5;111mRequest URL[39m: [38;5;170mhttps://registry.yarnpkg.com/@dummy-scope%2fdummy-package[39m\n" \
-            "::endgroup::\n" \
-            "[91m➤[39m YN0035: [38;5;166m@dummy-scope/[39m[38;5;173mdummy-package[39m[38;5;37m@[39m[38;5;37mnpm:^1.2.3[39m: Package not found\n" \
+            "[91m➤[39m YN0035: │   [38;5;111mRequest URL[39m: [38;5;" \
+            "170mhttps://registry.yarnpkg.com/@dummy-scope%2fdummy-package[39m\n::endgroup::\n" \
+            "[91m➤[39m YN0035: [38;5;166m@dummy-scope/[39m[38;5;173mdummy-package" \
+            "[39m[38;5;37m@[39m[38;5;37mnpm:^1.2.3[39m: Package not found\n" \
             "[91m➤[39m YN0035:   [38;5;111mResponse Code[39m: [38;5;220m404[39m (Not Found)\n" \
             "[91m➤[39m YN0035:   [38;5;111mRequest Method[39m: GET\n" \
-            "[91m➤[39m YN0035:   [38;5;111mRequest URL[39m: [38;5;170mhttps://registry.yarnpkg.com/@dummy-scope%2fdummy-package[39m\n" \
+            "[91m➤[39m YN0035:   [38;5;111mRequest URL[39m: [38;5;" \
+            "170mhttps://registry.yarnpkg.com/@dummy-scope%2fdummy-package[39m\n" \
             "[94m➤[39m [90mYN0000[39m: └ Completed in 0s 291ms\n" \
             "[91m➤[39m YN0000: · Failed with errors in 0s 303ms"
         end
@@ -241,21 +243,20 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
 
       context "when error message matches with YN0035.FAILED_TO_RETRIEVE" do
         let(:error_message) do
-          "Dependabot::SharedHelpers::HelperSubprocessFailed: [94m➤[39m [90mYN0000[39m: ┌ Project validation\n" \
-            "::group::Project validation\n" \
-            "[93m➤[39m YN0057: │ [38;5;166m@dummy-scope/[39m[38;5;173mdummy-connect[39m: Resolutions field will be ignored\n" \
-            "[93m➤[39m YN0057: │ [38;5;166m@dummy-scope/[39m[38;5;173mdummy-js[39m: Resolutions field will be ignored\n" \
-            "::endgroup::\n" \
-            "[94m➤[39m [90mYN0000[39m: └ Completed\n" \
-            "[94m➤[39m [90mYN0000[39m: ┌ Resolution step\n" \
-            "::group::Resolution step\n" \
-            "[91m➤[39m YN0035: │ [38;5;166m@dummy-scope/[39m[38;5;173mdummy-fixture[39m[38;5;37m@[39m[38;5;37mnpm:^1.0.0[39m: The remote server failed to provide the requested resource\n" \
-            "[91m➤[39m YN0035: │   [38;5;111mResponse Code[39m: [38;5;220m404[39m (Not Found)\n" \
-            "[91m➤[39m YN0035: │   [38;5;111mRequest Method[39m: GET\n" \
-            "[91m➤[39m YN0035: │   [38;5;111mRequest URL[39m: [38;5;170mhttps://registry.yarnpkg.com/@dummy-scope%2fdummy-fixture\n" \
-            "::endgroup::\n" \
-            "[94m➤[39m [90mYN0000[39m: └ Completed in 0s 566ms\n" \
-            "[91m➤[39m YN0000: Failed with errors in 0s 571ms"
+          "Dependabot::SharedHelpers::HelperSubprocessFailed: [94m➤[39m[90mYN0000" \
+            "[39m: ┌ Project validation\n::group::Project validation\n[93m➤[39m YN0057: │ " \
+            "[38;5;166m@dummy-scope/[39m[38;5;173mdummy-connect[39m: Resolutions field" \
+            " will be ignored\n[93m➤[39m YN0057: │ [38;5;166m@dummy-scope/[39m[38;5;" \
+            "173mdummy-js[39m: Resolutions field will be ignored\n::endgroup::\n[94m➤" \
+            "[39m [90mYN0000[39m: └ Completed\n[94m➤[39m [90mYN0000[39m: ┌ Resolution" \
+            " step\n::group::Resolution step\n[91m➤[39m YN0035: │ [38;5;166m@dummy-scope/" \
+            "[39m[38;5;173mdummy-fixture[39m[38;5;37m@[39m[38;5;37mnpm:^1.0.0[39m: " \
+            "The remote server failed to provide the requested resource\n[91m➤[39m YN0035: " \
+            "│   [38;5;111mResponse Code[39m: [38;5;220m404[39m (Not Found)\n[91m➤" \
+            "[39m YN0035: │   [38;5;111mRequest Method[39m: GET\n[91m➤[39m YN0035: │  " \
+            " [38;5;111mRequest URL[39m: [38;5;170m" \
+            "https://registry.yarnpkg.com/@dummy-scope%2fdummy-fixture\n::endgroup::\n" \
+            "[94m➤[39m [90mYN0000[39m: └ Completed in 0s 566ms\n[91m➤[39m YN0000: Failed with errors in 0s 571ms"
         end
 
         it "raises error with captured `package_req`" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_error_handler_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Dependabot::NpmAndYarn::YarnErrorHandler do
             "➤ YN0000: · Failed with errors in 0s 683ms"
         end
 
-        it "raises" do
+        it "raises error with the raw message" do
           expect do
             error_handler.handle_yarn_error(error, { yarn_lock: yarn_lock })
           end.to raise_error(


### PR DESCRIPTION
### What are you trying to accomplish?

This PR aims to reduce the number of unknown errors by creating specific, related error messages for the YN0035 error code. The YN0035 error occurs when the remote server fails to provide the requested resource for a package. By capturing and handling this error, we can provide more informative error messages.

This change addresses the need for better error handling in scenarios where packages cannot be retrieved due to server issues, which is crucial for maintaining the reliability and usability of the package management process.

### Anything you want to highlight for special attention from reviewers?

The main focus of this PR is to ensure that the error messages are specific and helpful, significantly aiding in diagnosing issues during package retrieval.

### How will you know you've accomplished your goal?

- If an error occurs with YN0035, the error handler will capture it and provide a detailed error message indicating the package that could not be retrieved.
- I have added tests to verify that the new error handling logic works as expected.
- The error handler's behavior has been verified by running the complete test suite and ensuring that all tests pass successfully.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
