### PR TITLE
fixing rebases not finding the existing pull request due to directory

### DIFF
--- a/silent/tests/testdata/su-basic.txt
+++ b/silent/tests/testdata/su-basic.txt
@@ -2,6 +2,14 @@ dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/depe
 stderr 'created \| dependency-a \( from 1.2.3 to 1.2.4 \)'
 pr-created expected.json
 
+dependabot update -f input-rebase-old.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'updated \| dependency-a \( from 1.2.3 to 1.2.4 \)'
+pr-updated expected.json
+
+dependabot update -f input-rebase-new.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'updated \| dependency-a \( from 1.2.3 to 1.2.4 \)'
+pr-updated expected.json
+
 -- manifest.json --
 {
   "dependency-a": { "version": "1.2.3" },
@@ -55,3 +63,62 @@ job:
       rules:
         patterns:
           - "*"
+
+-- input-rebase-old.yml --
+job:
+  package-manager: "silent"
+  dependencies:
+    - dependency-a
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  security-advisories:
+    - dependency-name: dependency-a
+      affected-versions:
+        - < 1.2.4
+      patched-versions: []
+      unaffected-versions: []
+  security-updates-only: true
+  # If present, groups are ignored
+  dependency-groups:
+    - name: all
+      rules:
+        patterns:
+          - "*"
+  updating-a-pull-request: true
+  existing-pull-requests:
+    - - dependency-name: dependency-a
+        dependency-version: 1.2.4
+
+-- input-rebase-new.yml --
+job:
+  package-manager: "silent"
+  dependencies:
+    - dependency-a
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  security-advisories:
+    - dependency-name: dependency-a
+      affected-versions:
+        - < 1.2.4
+      patched-versions: []
+      unaffected-versions: []
+  security-updates-only: true
+  # If present, groups are ignored
+  dependency-groups:
+    - name: all
+      rules:
+        patterns:
+          - "*"
+  updating-a-pull-request: true
+  existing-pull-requests:
+    - - dependency-name: dependency-a
+        dependency-version: 1.2.4
+        directory: "/"

--- a/silent/tests/testdata/vu-basic.txt
+++ b/silent/tests/testdata/vu-basic.txt
@@ -2,7 +2,11 @@ dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/depe
 stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \)'
 pr-created expected.json
 
-dependabot update -f input-2.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+dependabot update -f input-rebase-old.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+stderr 'updated \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+pr-updated expected.json
+
+dependabot update -f input-rebase-new.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
 stderr 'updated \| dependency-a \( from 1.2.3 to 1.2.5 \)'
 pr-updated expected.json
 
@@ -35,7 +39,7 @@ job:
     api-endpoint: https://example.com/api/v3
     repo: dependabot/smoke-tests
 
--- input-2.yml --
+-- input-rebase-old.yml --
 job:
   package-manager: "silent"
   source:
@@ -50,3 +54,20 @@ job:
   existing-pull-requests:
     - - dependency-name: dependency-a
         dependency-version: 1.2.5
+
+-- input-rebase-new.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests
+  dependencies:
+    - dependency-a
+  updating-a-pull-request: true
+  existing-pull-requests:
+    - - dependency-name: dependency-a
+        dependency-version: 1.2.5
+        directory: "/"

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -200,7 +200,22 @@ module Dependabot
               {
                 "dependency-name" => dep.name,
                 "dependency-version" => dep.version,
-                "dependency-removed" => dep.removed? ? true : nil
+                "dependency-removed" => dep.removed? ? true : nil,
+                "directory" => dep.directory
+              }.compact
+            end
+          )
+
+          existing = job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
+          return existing if existing
+
+          # try the search again without directory
+          new_pr_set = Set.new(
+            updated_dependencies.map do |dep|
+              {
+                "dependency-name" => dep.name,
+                "dependency-version" => dep.version,
+                "dependency-removed" => dep.removed? ? true : nil,
               }.compact
             end
           )

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -215,7 +215,7 @@ module Dependabot
               {
                 "dependency-name" => dep.name,
                 "dependency-version" => dep.version,
-                "dependency-removed" => dep.removed? ? true : nil,
+                "dependency-removed" => dep.removed? ? true : nil
               }.compact
             end
           )

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -205,7 +205,22 @@ module Dependabot
               {
                 "dependency-name" => dep.name,
                 "dependency-version" => dep.version,
-                "dependency-removed" => dep.removed? ? true : nil
+                "dependency-removed" => dep.removed? ? true : nil,
+                "directory" => dep.directory
+              }.compact
+            end
+          )
+
+          existing = job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
+          return existing if existing
+
+          # try the search again without directory
+          new_pr_set = Set.new(
+            updated_dependencies.map do |dep|
+              {
+                "dependency-name" => dep.name,
+                "dependency-version" => dep.version,
+                "dependency-removed" => dep.removed? ? true : nil,
               }.compact
             end
           )

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -220,7 +220,7 @@ module Dependabot
               {
                 "dependency-name" => dep.name,
                 "dependency-version" => dep.version,
-                "dependency-removed" => dep.removed? ? true : nil,
+                "dependency-removed" => dep.removed? ? true : nil
               }.compact
             end
           )


### PR DESCRIPTION
### What are you trying to accomplish?

- fixes #10310

In #10195 we added `directory` to the payload, which then came back in the `existing-pull-requests` data, which made these methods stop working because they didn't take `directory` into account.

The fix is to include it in the comparison, but we also need to support the older data as well so that check is done second.

In the future we can DRY this up, but for now it works!

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Rebases will start working again.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
