### PR TITLE
NuGet `FileUpdater.only_deleted_lines?` should ignore white-space lines

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -224,6 +224,7 @@ module Dependabot
         # This prevents false positives when there are trailing empty lines in the original content, for example.
         original_lines = (original_content&.lines || []).map(&:strip).reject(&:empty?)
         updated_lines = updated_content.lines.map(&:strip).reject(&:empty?)
+
         original_lines.count > updated_lines.count
       end
     end

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -223,7 +223,7 @@ module Dependabot
         # Compare the line counts of the original and updated content, but ignore lines only containing white-space.
         # This prevents false positives when there are trailing empty lines in the original content, for example.
         original_lines = (original_content&.lines || []).map(&:strip).reject(&:empty?)
-        updated_lines = (updated_content&.lines || []).map(&:strip).reject(&:empty?)
+        updated_lines = updated_content.lines.map(&:strip).reject(&:empty?)
         original_lines.count > updated_lines.count
       end
     end

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -220,9 +220,10 @@ module Dependabot
 
       sig { params(original_content: T.nilable(String), updated_content: String).returns(T::Boolean) }
       def only_deleted_lines?(original_content, updated_content)
-        original_lines = original_content&.lines || []
-        updated_lines = updated_content.lines
-
+        # Compare the line counts of the original and updated content, but ignore lines only containing white-space.
+        # This prevents false positives when there are trailing empty lines in the original content, for example.
+        original_lines = (original_content&.lines || []).map(&:strip).reject(&:empty?)
+        updated_lines = (updated_content&.lines || []).map(&:strip).reject(&:empty?)
         original_lines.count > updated_lines.count
       end
     end

--- a/nuget/spec/fixtures/projects/file_updater_dotnet_tools_json/.config/dotnet-tools.json
+++ b/nuget/spec/fixtures/projects/file_updater_dotnet_tools_json/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "1.0.0",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/nuget/spec/fixtures/projects/file_updater_dotnet_tools_json/Proj1/Proj1.csproj
+++ b/nuget/spec/fixtures/projects/file_updater_dotnet_tools_json/Proj1/Proj1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### What are you trying to accomplish?

See https://github.com/dependabot/dependabot-core/issues/10323#issuecomment-2260360100 for what has changed and why.
Fixes #10323.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

The following update works without any errors
```bash
bin/dry-run.rb nuget rhyskoedijk/dependabot-nuget-webconfig-assembly-binding-test --dir="/DotNetTools"
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
