### PR TITLE
retain `msbuild-sdks` property in `global.json` when adding a transitive dependency

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Sdk.cs
@@ -577,6 +577,83 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task TransitiveDependencyCanBeAddedWithCustomMSBuildSdk()
+        {
+            await TestUpdateForProject("Some.Transitive.Package", "1.0.0", "1.0.1", isTransitive: true,
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", [(null, [("Some.Transitive.Package", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Package", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Transitive.Package", "1.0.1", "net8.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Custom.MSBuild.Sdk", "1.2.3"),
+                ],
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFiles:
+                [
+                    ("Directory.Build.props", """
+                        <Project>
+                          <Import Project="Sdk.props" Sdk="Custom.MSBuild.Sdk" />
+                        </Project>
+                        """),
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("global.json", """
+                        {
+                          "sdk": {
+                            "version": "99.99.999" // this version doesn't match anything that's installed
+                          },
+                          "msbuild-sdks": {
+                            "Custom.MSBuild.Sdk": "1.2.3"
+                          }
+                        }
+                        """)
+                ],
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                        <PackageReference Include="Some.Transitive.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFilesExpected:
+                [
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                            <PackageVersion Include="Some.Transitive.Package" Version="1.0.1" />
+                          </ItemGroup>
+                        </Project>
+                        """)
+                ]
+            );
+        }
+
+        [Fact]
         public async Task UpdateVersionAttribute_InProjectFile_ForAnalyzerPackageReferenceInclude()
         {
             // update Some.Analyzer from 3.3.0 to 3.3.4

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -236,7 +236,7 @@ internal static class SdkPackageUpdater
             {
                 logger.Log($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
             }
-        });
+        }, retainMSBuildSdks: true);
     }
 
     /// <summary>


### PR DESCRIPTION
Adding a transitive dependency is accomplished by invoking the CLI tool `dotnet add project.csproj package Some.Transitive.Dependency --version 1.2.3`, but if that project has custom `msbuild-sdks` listed in `global.json` _and_ that SDK is explicitly imported, then adding the package will fail because the `global.json` file is temporarily sidelined (see #10305) to prevent any issues with a .NET SDK mismatch.

The fix is to optionally retain a bare-bones `global.json` with _only_ the `msbuild-sdks` property to allow package installation to proceed.