### PR TITLE
Revert "v0.268.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: bundler
   specs:
-    dependabot-bundler (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-bundler (0.267.0)
+      dependabot-common (= 0.267.0)
       parallel (~> 1.24)
 
 PATH
   remote: cargo
   specs:
-    dependabot-cargo (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-cargo (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: common
   specs:
-    dependabot-common (0.268.0)
+    dependabot-common (0.267.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -37,107 +37,107 @@ PATH
 PATH
   remote: composer
   specs:
-    dependabot-composer (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-composer (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: devcontainers
   specs:
-    dependabot-devcontainers (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-devcontainers (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: docker
   specs:
-    dependabot-docker (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-docker (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: elm
   specs:
-    dependabot-elm (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-elm (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: git_submodules
   specs:
-    dependabot-git_submodules (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-git_submodules (0.267.0)
+      dependabot-common (= 0.267.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: github_actions
   specs:
-    dependabot-github_actions (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-github_actions (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: go_modules
   specs:
-    dependabot-go_modules (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-go_modules (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: gradle
   specs:
-    dependabot-gradle (0.268.0)
-      dependabot-common (= 0.268.0)
-      dependabot-maven (= 0.268.0)
+    dependabot-gradle (0.267.0)
+      dependabot-common (= 0.267.0)
+      dependabot-maven (= 0.267.0)
 
 PATH
   remote: hex
   specs:
-    dependabot-hex (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-hex (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: maven
   specs:
-    dependabot-maven (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-maven (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-npm_and_yarn (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: nuget
   specs:
-    dependabot-nuget (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-nuget (0.267.0)
+      dependabot-common (= 0.267.0)
       rubyzip (>= 2.3.2, < 3.0)
 
 PATH
   remote: pub
   specs:
-    dependabot-pub (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-pub (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: python
   specs:
-    dependabot-python (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-python (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: silent
   specs:
-    dependabot-silent (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-silent (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: swift
   specs:
-    dependabot-swift (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-swift (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: terraform
   specs:
-    dependabot-terraform (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-terraform (0.267.0)
+      dependabot-common (= 0.267.0)
 
 GEM
   remote: https://rubygems.org/

--- a/common/lib/dependabot.rb
+++ b/common/lib/dependabot.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.268.0"
+  VERSION = "0.267.0"
 end

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: ../bundler
   specs:
-    dependabot-bundler (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-bundler (0.267.0)
+      dependabot-common (= 0.267.0)
       parallel (~> 1.24)
 
 PATH
   remote: ../cargo
   specs:
-    dependabot-cargo (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-cargo (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../common
   specs:
-    dependabot-common (0.268.0)
+    dependabot-common (0.267.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -37,107 +37,107 @@ PATH
 PATH
   remote: ../composer
   specs:
-    dependabot-composer (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-composer (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../devcontainers
   specs:
-    dependabot-devcontainers (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-devcontainers (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../docker
   specs:
-    dependabot-docker (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-docker (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../elm
   specs:
-    dependabot-elm (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-elm (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../git_submodules
   specs:
-    dependabot-git_submodules (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-git_submodules (0.267.0)
+      dependabot-common (= 0.267.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: ../github_actions
   specs:
-    dependabot-github_actions (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-github_actions (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../go_modules
   specs:
-    dependabot-go_modules (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-go_modules (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../gradle
   specs:
-    dependabot-gradle (0.268.0)
-      dependabot-common (= 0.268.0)
-      dependabot-maven (= 0.268.0)
+    dependabot-gradle (0.267.0)
+      dependabot-common (= 0.267.0)
+      dependabot-maven (= 0.267.0)
 
 PATH
   remote: ../hex
   specs:
-    dependabot-hex (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-hex (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../maven
   specs:
-    dependabot-maven (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-maven (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-npm_and_yarn (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../nuget
   specs:
-    dependabot-nuget (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-nuget (0.267.0)
+      dependabot-common (= 0.267.0)
       rubyzip (>= 2.3.2, < 3.0)
 
 PATH
   remote: ../pub
   specs:
-    dependabot-pub (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-pub (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../python
   specs:
-    dependabot-python (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-python (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../silent
   specs:
-    dependabot-silent (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-silent (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../swift
   specs:
-    dependabot-swift (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-swift (0.267.0)
+      dependabot-common (= 0.267.0)
 
 PATH
   remote: ../terraform
   specs:
-    dependabot-terraform (0.268.0)
-      dependabot-common (= 0.268.0)
+    dependabot-terraform (0.267.0)
+      dependabot-common (= 0.267.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Reverts dependabot/dependabot-core#10335

As it is not showing up in https://rubygems.org/gems/dependabot-common/versions/0.245.0