### PR TITLE
don't waste quota on main since branch was up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: Specs
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - "main"
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,8 +2,6 @@
 name: Codespell
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,8 +3,6 @@ name: Smoke
 
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  push:
-    branches: ["main"]
   pull_request:
     paths-ignore:
       - docs/**

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -1,8 +1,5 @@
 name: Sorbet
 on: # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - "main"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
### What are you trying to accomplish?

Lately we have been running out of API quota because the CI and smoke tests use tokens for testing.

Since we require branches to be up-to-date before merging, running these things on main is kind of pointless. So we can save quota by not running them again.

I know some of these workflows that I removed the main run from don't use the token, but again I don't see the point in running them on main if the branch was up-to-date.

### Anything you want to highlight for special attention from reviewers?

Is my assumption above correct?

### How will you know you've accomplished your goal?

Maybe we'll run out of quota less often.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
