### PR TITLE
allow for wildcards in version requirements

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -308,6 +308,50 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
     }
 
     [Fact]
+    public async Task IgnoredVersionsCanHandleWildcardSpecification()
+    {
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"), // initially this
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0"), // should update to this
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.0", "net8.0"), // `IgnoredVersions` should prevent this from being selected
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference),
+                        ],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [Requirement.Parse("> 1.1.*")],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "1.1.0",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies = [
+                    new("Some.Package", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
     public async Task VersionFinderCanHandle404FromPackageSource_V2()
     {
         static (int, byte[]) TestHttpHandler1(string uriString)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
@@ -33,6 +33,8 @@ public class RequirementTests
     [InlineData("1", "~> 1", true)]
     [InlineData("2", "~> 1", false)]
     [InlineData("5.3.8", "< 6, > 5.2.4", true)]
+    [InlineData("1.0-preview", ">= 1.x", false)] // wildcards
+    [InlineData("1.1-preview", ">= 1.x", true)]
     public void IsSatisfiedBy(string versionString, string requirementString, bool expected)
     {
         var version = NuGetVersion.Parse(versionString);
@@ -41,6 +43,18 @@ public class RequirementTests
         var actual = requirement.IsSatisfiedBy(version);
 
         Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("> 1.*", "> 1.0")] // standard wildcard, single digit
+    [InlineData("> 1.2.*", "> 1.2.0")] // standard wildcard, multiple digit
+    [InlineData("> 1.a", "> 1.0")] // alternate wildcard, single digit
+    [InlineData("> 1.2.a", "> 1.2.0")] // alternate wildcard, multiple digit
+    public void Parse_ConvertsWildcardInVersion(string givenRequirementString, string expectedRequirementString)
+    {
+        var parsedRequirement = Requirement.Parse(givenRequirementString);
+        var actualRequirementString = parsedRequirement.ToString();
+        Assert.Equal(expectedRequirementString, actualRequirementString);
     }
 
     [Theory]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
@@ -116,7 +116,14 @@ public class IndividualRequirement : Requirement
             : [requirement[..(splitIndex + 1)].Trim(), requirement[(splitIndex + 1)..].Trim()];
 
         var op = parts.Length == 1 ? "=" : parts[0];
-        var version = NuGetVersion.Parse(parts[^1]);
+        var versionString = parts[^1];
+
+        // allow for single character wildcards; may be asterisk (NuGet-style: 1.*) or a single letter (alternate style: 1.x)
+        var versionParts = versionString.Split('.');
+        var recreatedVersionParts = versionParts.Select(vp => vp.Length == 1 && (vp == "*" || char.IsAsciiLetter(vp[0])) ? "0" : vp).ToArray();
+
+        var rebuiltVersionString = string.Join(".", recreatedVersionParts);
+        var version = NuGetVersion.Parse(rebuiltVersionString);
 
         return new IndividualRequirement(op, version);
     }


### PR DESCRIPTION
Version requirements, particularly `ignore`, can have wildcards, commonly in the form of `> 2.*, < 3`, e.g., to ignore all v2 versions of a package.  The underlying `NuGetVersion` class doesn't allow wildcards, but since we're only doing this for requirements which always have an operator, we can support them.

The new behavior simply splits the version on the `.` character and replaces any single character wildcard with `0`.  For NuGet the only single character wildcard allowed is `*`, but it's not uncommon for a single letter like `a` or `x` to be used, so I added support for that as well.

Issue found during a manual scan of the logs.