### PR TITLE
convert test to not require the network

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryEnvironment.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryEnvironment.cs
@@ -1,0 +1,23 @@
+namespace NuGetUpdater.Core.Test;
+
+public class TemporaryEnvironment : IDisposable
+{
+    private readonly List<(string Name, string? Value)> _originalVariables = new();
+
+    public TemporaryEnvironment((string Name, string Value)[] variables)
+    {
+        foreach (var (name, value) in variables)
+        {
+            _originalVariables.Add((name, Environment.GetEnvironmentVariable(name)));
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (name, value) in _originalVariables)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+}


### PR DESCRIPTION
When #9694 was created to force unit tests to not hit the network, there was one case where we didn't yet have the test infrastructure, because one particular test _requires_ network access, but now we have the appropriate test helpers to hit `localhost`.  This PR simply converts this remaining test from using real packages from nuget.org to using test-only packages and a `localhost` NuGet feed.

I've manually confirmed that we hit the same codepath.