### PR TITLE
Support for NuGet feed credentials with only username/password in `repository_finder` and `metadata_finder`

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -253,7 +253,18 @@ module Dependabot
           T.let(
             credentials
             .select { |cred| cred["type"] == "nuget_feed" && cred["url"] }
-            .map { |c| { url: c.fetch("url"), token: c["token"] } },
+            .map do |c|
+              {
+                url: c.fetch("url"),
+                # Private NuGet repository credentials could be any of:
+                #  - `token` only (e.g. access token or basic access auth)
+                #  - `password` only (e.g. GitHub PAT or Azure DevOps PAT, username is not significant)
+                #  - `username` and `password` (e.g. MyGet, Artifactory, https://nuget.telerik.com, etc)
+                # The raw token should always take priority over username/password, if both are provided for some reason
+                # When only username/password is provided, convert them to a basic access auth token
+                token: c["token"] || (c["password"] ? "#{c['username']}:#{c['password']}" : nil)
+              }
+            end,
             T.nilable(T::Array[T::Hash[Symbol, String]])
           )
       end

--- a/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
@@ -243,77 +243,84 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
     subject(:auth_header) { finder.send(:auth_header) }
 
     context "when credentials token is `nil`" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://api.nuget.org/v3/index.json" }]
-      }
-      it {
-        is_expected.to eq({})
-      }
+      end
+
+      it "returns an empty auth header" do
+        expect(auth_header).to eq({})
+      end
     end
 
     context "when credentials token is `nil`, username is `nil`, and password is non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "password" => "github_pat_secret" }]
-      }
-      it {
-        is_expected.to eq(
+      end
+
+      it "returns a basic access auth header" do
+        expect(auth_header).to eq(
           "Authorization" => "Basic #{Base64.encode64(':github_pat_secret').delete("\n")}"
         )
-      }
+      end
     end
 
     context "when credentials token is `nil`, username and password are non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "username" => "user",
            "password" => "password" }]
-      }
-      it {
-        is_expected.to eq(
+      end
+
+      it "returns a basic access auth header" do
+        expect(auth_header).to eq(
           "Authorization" => "Basic #{Base64.encode64('user:password').delete("\n")}"
         )
-      }
+      end
     end
 
     context "when credentials token, username, and password are all non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret",
            "username" => "user", "password" => "password" }]
-      }
-      it {
-        is_expected.to eq(
+      end
+
+      it "returns a bearer token auth header" do
+        expect(auth_header).to eq(
           "Authorization" => "Bearer github_pat_secret"
         )
-      }
+      end
     end
 
     context "when credentials token is access token" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret" }]
-      }
-      it {
-        is_expected.to eq(
+      end
+
+      it "returns a bearer token auth header" do
+        expect(auth_header).to eq(
           "Authorization" => "Bearer github_pat_secret"
         )
-      }
+      end
     end
 
     context "when credentials token is basic access auth" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "user:password" }]
-      }
-      it {
-        is_expected.to eq(
+      end
+
+      it "returns a basic access auth header" do
+        expect(auth_header).to eq(
           "Authorization" => "Basic #{Base64.encode64('user:password').delete("\n")}"
         )
-      }
+      end
     end
 
     context "when credentials token is basic access auth with no username" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => ":password_only" }]
-      }
+      end
+
       it {
-        is_expected.to eq(
+        expect(auth_header).to eq(
           "Authorization" => "Basic #{Base64.encode64(':password_only').delete("\n")}"
         )
       }

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -6,7 +6,7 @@ require "dependabot/nuget/update_checker/repository_finder"
 
 RSpec.describe Dependabot::Nuget::RepositoryFinder do
   describe "#credential_repositories" do
-    subject(:result) {
+    subject(:credential_repositories) do
       described_class.new(
         dependency: Dependabot::Dependency.new(
           name: "Microsoft.Extensions.DependencyModel",
@@ -17,85 +17,92 @@ RSpec.describe Dependabot::Nuget::RepositoryFinder do
         credentials: credentials,
         config_files: []
       ).send(:credential_repositories)
-    }
+    end
 
     context "when credentials token is `nil`" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://api.nuget.org/v3/index.json" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://api.nuget.org/v3/index.json", :token => nil }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://api.nuget.org/v3/index.json", token: nil }]
         )
-      }
+      end
     end
 
     context "when credentials token is `nil`, username is `nil`, and password is non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "password" => "github_pat_secret" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => ":github_pat_secret" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: ":github_pat_secret" }]
         )
-      }
+      end
     end
 
     context "when credentials token is `nil`, username and password are non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "username" => "user",
            "password" => "password" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => "user:password" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: "user:password" }]
         )
-      }
+      end
     end
 
     context "when credentials token, username, and password are all non-empty" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret",
            "username" => "user", "password" => "password" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => "github_pat_secret" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: "github_pat_secret" }]
         )
-      }
+      end
     end
 
     context "when credentials token is access token" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => "github_pat_secret" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: "github_pat_secret" }]
         )
-      }
+      end
     end
 
     context "when credentials token is basic access auth" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "user:password" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => "user:password" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: "user:password" }]
         )
-      }
+      end
     end
 
     context "when credentials token is basic access auth with no username" do
-      let(:credentials) {
+      let(:credentials) do
         [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => ":password_only" }]
-      }
-      it {
-        is_expected.to eq(
-          [{ :url => "https://my.nuget.com/v3/index.json", :token => ":password_only" }]
+      end
+
+      it "returns the repository with credentials as a token" do
+        expect(credential_repositories).to eq(
+          [{ url: "https://my.nuget.com/v3/index.json", token: ":password_only" }]
         )
-      }
+      end
     end
   end
 end

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -1,0 +1,101 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/dependency"
+require "dependabot/nuget/update_checker/repository_finder"
+
+RSpec.describe Dependabot::Nuget::RepositoryFinder do
+  describe "#credential_repositories" do
+    subject(:result) {
+      described_class.new(
+        dependency: Dependabot::Dependency.new(
+          name: "Microsoft.Extensions.DependencyModel",
+          version: "1.0.0",
+          requirements: [],
+          package_manager: "nuget"
+        ),
+        credentials: credentials,
+        config_files: []
+      ).send(:credential_repositories)
+    }
+
+    context "when credentials token is `nil`" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://api.nuget.org/v3/index.json" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://api.nuget.org/v3/index.json", :token => nil }]
+        )
+      }
+    end
+
+    context "when credentials token is `nil`, username is `nil`, and password is non-empty" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "password" => "github_pat_secret" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => ":github_pat_secret" }]
+        )
+      }
+    end
+
+    context "when credentials token is `nil`, username and password are non-empty" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "username" => "user",
+           "password" => "password" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => "user:password" }]
+        )
+      }
+    end
+
+    context "when credentials token, username, and password are all non-empty" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret",
+           "username" => "user", "password" => "password" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => "github_pat_secret" }]
+        )
+      }
+    end
+
+    context "when credentials token is access token" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "github_pat_secret" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => "github_pat_secret" }]
+        )
+      }
+    end
+
+    context "when credentials token is basic access auth" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => "user:password" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => "user:password" }]
+        )
+      }
+    end
+
+    context "when credentials token is basic access auth with no username" do
+      let(:credentials) {
+        [{ "type" => "nuget_feed", "url" => "https://my.nuget.com/v3/index.json", "token" => ":password_only" }]
+      }
+      it {
+        is_expected.to eq(
+          [{ :url => "https://my.nuget.com/v3/index.json", :token => ":password_only" }]
+        )
+      }
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fix #10357.

When running the updater outside of the GitHub environment, the following should work without throwing 401 errors:
```bash
LOCAL_CONFIG_VARIABLES='[{"type":"nuget_feed","password":"*****","url":"https://pkgs.dev.azure.com/rhyskoedijk/Dependabot/_packaging/Private-NuGet/nuget/v3/index.json"},{"type":"nuget_feed","username":"*****","password":"*****","url":"https://nuget.telerik.com/v3/index.json"}]'
bin/dry-run.rb nuget rhyskoedijk/dependabot-tests --dir="/NetFx-PrivateFeeds" --dep="Telerik.Reporting"
```
```yml
version: 2
registries:
  private-devops:
    type: nuget-feed
    url: https://pkgs.dev.azure.com/rhyskoedijk/Dependabot/_packaging/Private-NuGet/nuget/v3/index.json
    password: ${{secrets.PRIVATE_AZURE_DEVOPS_FEED_PAT}}
  telerik:
    type: nuget-feed
    url: https://nuget.telerik.com/v3/index.json
    username: ${{secrets.TELERIK_USERNAME}}
    password: ${{secrets.TELERIK_PASSWORD}}
updates:
  - package-ecosystem: "nuget"
    directory: "/NetFx-PrivateFeeds"
    registries: "*"
```

Documentation on [configuration options for private registries](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-private-registries) and https://github.com/dependabot/dependabot-core/pull/8927#issuecomment-1959913787 suggest nuget-feed registries using username/password should work, but they don't; See #10357 for detailed logs.

I understand that there might be some magic sauce happening within the GitHub environment and maybe I'm missing something obvious here. Other package mangers currently consider username/password in registry auth, but not NuGet. e.g.

- [Docker registry auth with username/password](https://github.com/dependabot/dependabot-core/blob/c95a0fcfe208bc516441aa0b15e17401ac08a1b6/docker/lib/dependabot/docker/update_checker.rb#L307-L308)
- [Maven registry auth with username/password](https://github.com/dependabot/dependabot-core/blob/c95a0fcfe208bc516441aa0b15e17401ac08a1b6/maven/lib/dependabot/maven/utils/auth_headers_finder.rb#L30)

### Anything you want to highlight for special attention from reviewers?

Is there is a better way to pass username/password auth to the updater? If yes, can it be used when running dependabot-core outside of the GitHub environment?

I'm not very experienced with RSpec, so any advice on the unit tests would be appreciated.

### How will you know you've accomplished your goal?

The above configuration doesn't throw 401 errors during updates.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
