### PR TITLE
feat: add option to overwrite Docker read and open timeout values

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -300,15 +300,28 @@ module Dependabot
         "library/#{dependency.name}"
       end
 
+      # Defaults from https://github.com/deitch/docker_registry2/blob/bfde04144f0b7fd63c156a1aca83efe19ee78ffd/lib/registry/registry.rb#L26-L27
+      DEFAULT_DOCKER_OPEN_TIMEOUT_IN_SECONDS = 2
+      DEFAULT_DOCKER_READ_TIMEOUT_IN_SECONDS = 5
+
       def docker_registry_client
         @docker_registry_client ||=
           DockerRegistry2::Registry.new(
             "https://#{registry_hostname}",
             user: registry_credentials&.fetch("username", nil),
             password: registry_credentials&.fetch("password", nil),
-            read_timeout: 10,
+            read_timeout: docker_read_timeout_in_seconds,
+            open_timeout: docker_open_timeout_in_seconds,
             http_options: { proxy: ENV.fetch("HTTPS_PROXY", nil) }
           )
+      end
+
+      def docker_open_timeout_in_seconds
+        ENV.fetch("DEPENDABOT_DOCKER_OPEN_TIMEOUT_IN_SECONDS", DEFAULT_DOCKER_OPEN_TIMEOUT_IN_SECONDS).to_i
+      end
+
+      def docker_read_timeout_in_seconds
+        ENV.fetch("DEPENDABOT_DOCKER_READ_TIMEOUT_IN_SECONDS", DEFAULT_DOCKER_READ_TIMEOUT_IN_SECONDS).to_i
       end
 
       def sort_tags(candidate_tags, version_tag)

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1433,6 +1433,40 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
+  describe ".docker_read_timeout_in_seconds" do
+    context "when DEPENDABOT_DOCKER_READ_TIMEOUT_IN_SECONDS is set" do
+      it "returns the provided value" do
+        override_value = 10
+        stub_const("ENV", ENV.to_hash.merge("DEPENDABOT_DOCKER_READ_TIMEOUT_IN_SECONDS" => override_value))
+        expect(checker.send(:docker_read_timeout_in_seconds)).to eq(override_value)
+      end
+    end
+
+    context "when ENV does not provide an override" do
+      it "falls back to a default value" do
+        expect(checker.send(:docker_read_timeout_in_seconds))
+          .to eq(Dependabot::Docker::UpdateChecker::DEFAULT_DOCKER_READ_TIMEOUT_IN_SECONDS)
+      end
+    end
+  end
+
+  describe ".docker_open_timeout_in_seconds" do
+    context "when DEPENDABOT_DOCKER_OPEN_TIMEOUT_IN_SECONDS is set" do
+      it "returns the provided value" do
+        override_value = 10
+        stub_const("ENV", ENV.to_hash.merge("DEPENDABOT_DOCKER_OPEN_TIMEOUT_IN_SECONDS" => override_value))
+        expect(checker.send(:docker_open_timeout_in_seconds)).to eq(override_value)
+      end
+    end
+
+    context "when ENV does not provide an override" do
+      it "falls back to a default value" do
+        expect(checker.send(:docker_open_timeout_in_seconds))
+          .to eq(Dependabot::Docker::UpdateChecker::DEFAULT_DOCKER_OPEN_TIMEOUT_IN_SECONDS)
+      end
+    end
+  end
+
   private
 
   def stub_same_sha_for(*tags)


### PR DESCRIPTION
### What are you trying to accomplish?

Allows overwriting the read and open timeout values for interactions with the docker registry using two separate environment variables

###  What issues does this affect or fix? 

I do not have any issue in the tracker, but I noticed this need while using `dependabot-core` with slow private registries

###   If there were multiple ways to approach the problem, why did you pick this one? 

Initially, I considered using the existing environment variables defined here : 

https://github.com/dependabot/dependabot-core/blob/c95a0fcfe208bc516441aa0b15e17401ac08a1b6/common/lib/dependabot/clients/github_with_retries.rb#L13-L14

But I noticed that the default values there are different and I figured that separate environment properties may be better

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
