### PR TITLE
Support for NuGet feed credentials with only username/password in `nuget.config`

### DIFF
--- a/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+++ b/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
@@ -27,32 +27,66 @@ module Dependabot
         return if nuget_credentials.empty?
 
         File.rename(user_nuget_config_path, temporary_nuget_config_path)
+        File.write(
+          user_nuget_config_path,
+          <<~NUGET_XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                #{nuget_config_package_source_xml_lines(nuget_credentials).join("\n    ").strip}
+              </packageSources>
+              <packageSourceCredentials>
+                #{nuget_config_package_source_credential_xml_lines(nuget_credentials).join("\n    ").strip}
+              </packageSourceCredentials>
+            </configuration>
+          NUGET_XML
+        )
+      end
 
-        package_sources = []
-        package_source_credentials = []
-        nuget_credentials.each_with_index do |c, i|
-          source_name = "nuget_source_#{i + 1}"
-          package_sources << "    <add key=\"#{source_name}\" value=\"#{c['url']}\" />"
-          next unless c["token"]
-
-          package_source_credentials << "    <#{source_name}>"
-          package_source_credentials << "      <add key=\"Username\" value=\"user\" />"
-          package_source_credentials << "      <add key=\"ClearTextPassword\" value=\"#{c['token']}\" />"
-          package_source_credentials << "    </#{source_name}>"
+      sig { params(credentials: T::Array[Dependabot::Credential]).returns(T::Array[String]) }
+      def self.nuget_config_package_source_xml_lines(credentials)
+        credentials.each_with_index.filter_map do |c, i|
+          source_key = "nuget_source_#{i + 1}"
+          "<add key=\"#{source_key}\" value=\"#{c['url']}\" />"
         end
+      end
 
-        nuget_config = <<~NUGET_XML
-          <?xml version="1.0" encoding="utf-8"?>
-          <configuration>
-            <packageSources>
-          #{package_sources.join("\n")}
-            </packageSources>
-            <packageSourceCredentials>
-          #{package_source_credentials.join("\n")}
-            </packageSourceCredentials>
-          </configuration>
-        NUGET_XML
-        File.write(user_nuget_config_path, nuget_config)
+      sig { params(credentials: T::Array[Dependabot::Credential]).returns(T::Array[String]) }
+      def self.nuget_config_package_source_credential_xml_lines(credentials)
+        credentials.each_with_index.flat_map do |c, i|
+          source_key = "nuget_source_#{i + 1}"
+
+          # Ignore public sources, as they don't require credentials
+          next unless c["token"] || c["password"]
+
+          # Extract username and password from the token. If the username is empty, assume it's not significant
+          # e.g. token "PAT:12345" --> { username: "PAT", password: "12345" }
+          #            ":12345"    --> { username: "unused", password: "12345" }
+          #            "12345"     --> { username: "unused", password: "12345" }
+          source_token_parts = extract_token_parts_from_credential(c)
+          source_username = source_token_parts.count > 1 ? source_token_parts.first : "unused"
+          source_password = source_token_parts.last
+          [
+            "<#{source_key}>",
+            "  <add key=\"Username\" value=\"#{source_username}\" />",
+            "  <add key=\"ClearTextPassword\" value=\"#{source_password}\" />",
+            "</#{source_key}>"
+          ]
+        end
+      end
+
+      sig { params(credential: T::Hash[String, T.untyped]).returns(T::Array[String]) }
+      def self.extract_token_parts_from_credential(credential)
+        # Private NuGet repository credentials could be any of:
+        #  - `token` only (e.g. access token or basic access auth)
+        #  - `password` only (e.g. GitHub PAT or Azure DevOps PAT, username is not significant)
+        #  - `username` and `password` (e.g. MyGet, Artifactory, https://nuget.telerik.com, etc)
+        # The raw token should always take priority over username/password, if both are provided for some reason
+        # When only username/password is provided, convert them to a basic access auth token
+        token = credential["token"] || "#{credential['username']}:#{credential['password']}"
+        # If token is base64 encoded basic access auth, decode it so that we can extract the username/password
+        token = Base64.decode64(token) if Base64.decode64(token).ascii_only? && Base64.decode64(token).include?(":")
+        token&.split(":", 2)&.reject(&:empty?) || []
       end
 
       sig { void }

--- a/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/nuget_config_credential_helpers_spec.rb
@@ -33,10 +33,24 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
     context "with non-empty credential set" do
       let(:credentials) do
         [
-          { "type" => "nuget_feed", "url" => "https://private.nuget.example.com/index.json",
-            "token" => "secret_token" },
-          { "type" => "nuget_feed", "url" => "https://public.nuget.example.com/index.json" },
-          { "type" => "not_nuget", "some_other_field" => "some other value" }
+          { "type" => "not_nuget", "some_other_field" => "some other value" },
+          { "type" => "nuget_feed", "url" => "https://public1.nuget.example.com/index.json" },
+          { "type" => "nuget_feed", "url" => "https://private2.nuget.example.com/index.json",
+            "username" => "user", "password" => "secret" },
+          { "type" => "nuget_feed", "url" => "https://private3.nuget.example.com/index.json",
+            "password" => "secret" },
+          { "type" => "nuget_feed", "url" => "https://private4.nuget.example.com/index.json",
+            "token" => "PAT:12345" },
+          { "type" => "nuget_feed", "url" => "https://private5.nuget.example.com/index.json",
+            "token" => ":12345" },
+          { "type" => "nuget_feed", "url" => "https://private6.nuget.example.com/index.json",
+            "token" => "12345" },
+          { "type" => "nuget_feed", "url" => "https://private7.nuget.example.com/index.json",
+            "token" => Base64.encode64("PAT:12345").delete("\n") },
+          { "type" => "nuget_feed", "url" => "https://private8.nuget.example.com/index.json",
+            "token" => Base64.encode64(":12345").delete("\n") },
+          { "type" => "nuget_feed", "url" => "https://private9.nuget.example.com/index.json",
+            "token" => Base64.encode64("12345").delete("\n") }
         ]
       end
 
@@ -47,14 +61,49 @@ RSpec.describe Dependabot::Nuget::NuGetConfigCredentialHelpers do
               <?xml version="1.0" encoding="utf-8"?>
               <configuration>
                 <packageSources>
-                  <add key="nuget_source_1" value="https://private.nuget.example.com/index.json" />
-                  <add key="nuget_source_2" value="https://public.nuget.example.com/index.json" />
+                  <add key="nuget_source_1" value="https://public1.nuget.example.com/index.json" />
+                  <add key="nuget_source_2" value="https://private2.nuget.example.com/index.json" />
+                  <add key="nuget_source_3" value="https://private3.nuget.example.com/index.json" />
+                  <add key="nuget_source_4" value="https://private4.nuget.example.com/index.json" />
+                  <add key="nuget_source_5" value="https://private5.nuget.example.com/index.json" />
+                  <add key="nuget_source_6" value="https://private6.nuget.example.com/index.json" />
+                  <add key="nuget_source_7" value="https://private7.nuget.example.com/index.json" />
+                  <add key="nuget_source_8" value="https://private8.nuget.example.com/index.json" />
+                  <add key="nuget_source_9" value="https://private9.nuget.example.com/index.json" />
                 </packageSources>
                 <packageSourceCredentials>
-                  <nuget_source_1>
+                  <nuget_source_2>
                     <add key="Username" value="user" />
-                    <add key="ClearTextPassword" value="secret_token" />
-                  </nuget_source_1>
+                    <add key="ClearTextPassword" value="secret" />
+                  </nuget_source_2>
+                  <nuget_source_3>
+                    <add key="Username" value="unused" />
+                    <add key="ClearTextPassword" value="secret" />
+                  </nuget_source_3>
+                  <nuget_source_4>
+                    <add key="Username" value="PAT" />
+                    <add key="ClearTextPassword" value="12345" />
+                  </nuget_source_4>
+                  <nuget_source_5>
+                    <add key="Username" value="unused" />
+                    <add key="ClearTextPassword" value="12345" />
+                  </nuget_source_5>
+                  <nuget_source_6>
+                    <add key="Username" value="unused" />
+                    <add key="ClearTextPassword" value="12345" />
+                  </nuget_source_6>
+                  <nuget_source_7>
+                    <add key="Username" value="PAT" />
+                    <add key="ClearTextPassword" value="12345" />
+                  </nuget_source_7>
+                  <nuget_source_8>
+                    <add key="Username" value="unused" />
+                    <add key="ClearTextPassword" value="12345" />
+                  </nuget_source_8>
+                  <nuget_source_9>
+                    <add key="Username" value="unused" />
+                    <add key="ClearTextPassword" value="MTIzNDU=" />
+                  </nuget_source_9>
                 </packageSourceCredentials>
               </configuration>
             XML


### PR DESCRIPTION
### What are you trying to accomplish?

Fix #9098; specifically, https://github.com/dependabot/dependabot-core/issues/9098#issuecomment-2254896548
Fix #8914; specifically, https://github.com/dependabot/dependabot-core/issues/8914#issuecomment-2012966293

When dependabot uses NuGet.exe to perform the update, it injects registry credentials to `nuget.config`. If a registry requires basic access auth (username/password), there is no way to set the username as it is always hard-coded to "user".

For example, when using configuration:
```yml
version: 2
registries:
  private-devops:
    type: nuget-feed
    url: https://pkgs.dev.azure.com/rhyskoedijk/Dependabot/_packaging/Private-NuGet/nuget/v3/index.json
    password: 1234567890
  telerik:
    type: nuget-feed
    url: https://nuget.telerik.com/v3/index.json
    username: user@company.com
    password: secret
updates:
  - package-ecosystem: "nuget"
    directory: "/NetFx-PrivateFeeds"
    registries: "*"
```

`nuget.config` would be:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <add key="nuget_source_1" value="https://pkgs.dev.azure.com/rhyskoedijk/Dependabot/_packaging/Private-NuGet/nuget/v3/index.json" />
    <add key="nuget_source_2" value="https://nuget.telerik.com/v3/index.json" />
  </packageSources>
  <packageSourceCredentials>
    <nuget_source_1>
      <add key="Username" value="user" />
      <add key="ClearTextPassword" value="" /><!-- EXPECTED: '1234567890' -->
    </nuget_source_1>
    <nuget_source_2>
      <add key="Username" value="user" /><!-- EXPECTED: 'user@company.com' -->
      <add key="ClearTextPassword" value="" /><!-- EXPECTED: 'secret' -->
    </nuget_source_2>
  </packageSourceCredentials>
</configuration>
```

Changing the `dependabot.yml` config to use a basic access auth formatted `token` for the registry does not fix the issue. The `nuget.config` becomes:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <add key="nuget_source_1" value="https://pkgs.dev.azure.com/rhyskoedijk/Dependabot/_packaging/Private-NuGet/nuget/v3/index.json" />
    <add key="nuget_source_2" value="https://nuget.telerik.com/v3/index.json" />
  </packageSources>
  <packageSourceCredentials>
    <nuget_source_1>
      <add key="Username" value="user" />
      <add key="ClearTextPassword" value=":1234567890" /><!-- EXPECTED: '1234567890' -->
    </nuget_source_1>
    <nuget_source_2>
      <add key="Username" value="user" /><!-- EXPECTED: 'user@company.com' -->
      <add key="ClearTextPassword" value="user@company.com:secret" /><!-- EXPECTED: 'secret' -->
    </nuget_source_2>
  </packageSourceCredentials>
</configuration>
```

There appears to be no way to influence the value of `Username`; Without this, NuGet feeds secured with basic access auth cannot be used if the username is a significant part of the credentials (e.g. nuget.telerik.com)

### Anything you want to highlight for special attention from reviewers?

There was an existing unit test for this which I've just added more scenarios too.
Should I break this out in to individual tests?

### How will you know you've accomplished your goal?

The `nuget.config` has the expected values (see above).

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
