### PR TITLE
Add deprecation message to the created pull request

### DIFF
--- a/bundler/lib/dependabot/bundler.rb
+++ b/bundler/lib/dependabot/bundler.rb
@@ -12,12 +12,51 @@ require "dependabot/bundler/requirement"
 require "dependabot/bundler/version"
 
 require "dependabot/pull_request_creator/labeler"
+
+module Dependabot
+  module Bundler
+    PACKAGE_MANAGER = "bundler"
+    SUPPORTED_BUNDLER_VERSIONS = T.let(["2"].freeze, T::Array[String])
+    UNSUPPORTED_BUNDLER_VERSIONS = T.let([].freeze, T::Array[String])
+    DEPRECATED_BUNDLER_VERSIONS = T.let(["1"].freeze, T::Array[String])
+
+    class PackageManager < PackageManagerBase
+      extend T::Sig
+      include Helpers
+
+      sig { params(version: String).void }
+      def initialize(version)
+        @version = T.let(version, String)
+        @name = T.let(PACKAGE_MANAGER, String)
+        @deprecated_versions = T.let(DEPRECATED_BUNDLER_VERSIONS, T::Array[String])
+        @unsupported_versions = T.let(UNSUPPORTED_BUNDLER_VERSIONS, T::Array[String])
+        @supported_versions = T.let(SUPPORTED_BUNDLER_VERSIONS, T::Array[String])
+      end
+
+      sig { override.returns(String) }
+      attr_reader :name
+
+      sig { override.returns(String) }
+      attr_reader :version
+
+      sig { override.returns(T::Array[String]) }
+      attr_reader :deprecated_versions
+
+      sig { override.returns(T::Array[String]) }
+      attr_reader :unsupported_versions
+
+      sig { override.returns(T::Array[String]) }
+      attr_reader :supported_versions
+    end
+  end
+end
+
 Dependabot::PullRequestCreator::Labeler
-  .register_label_details("bundler", name: "ruby", colour: "ce2d2d")
+  .register_label_details(Dependabot::Bundler::PACKAGE_MANAGER, name: "ruby", colour: "ce2d2d")
 
 require "dependabot/dependency"
 Dependabot::Dependency.register_production_check(
-  "bundler",
+  Dependabot::Bundler::PACKAGE_MANAGER,
   lambda do |groups|
     return true if groups.empty?
     return true if groups.include?("runtime")

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -8,6 +8,8 @@ require "dependabot/requirements_update_strategy"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 
+require "dependabot/bundler"
+
 module Dependabot
   module Bundler
     class UpdateChecker < Dependabot::UpdateCheckers::Base
@@ -116,7 +118,18 @@ module Dependabot
         )
       end
 
+      sig { returns(PackageManagerBase) }
+      def package_manager
+        bundler_version = Helpers.bundler_version(lockfile)
+        PackageManager.new(bundler_version)
+      end
+
       private
+
+      def lockfile
+        dependency_files.find { |f| f.name == "Gemfile.lock" } ||
+          dependency_files.find { |f| f.name == "gems.locked" }
+      end
 
       def requirements_unlocked?
         dependency.specific_requirements.none?

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -8,6 +8,8 @@ require "dependabot/bundler/update_checker"
 require "dependabot/dependency_file"
 require "dependabot/dependency"
 require "dependabot/requirements_update_strategy"
+require "dependabot/package_manager"
+
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Bundler::UpdateChecker do
@@ -1858,6 +1860,43 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#package_manager" do
+    subject(:package_manager) { checker.package_manager }
+
+    context "when the lockfile specifies Bundler v1" do
+      before do
+        allow(Dependabot::Bundler::Helpers).to receive(:bundler_version).and_return("1")
+      end
+
+      it "returns a PackageManager with the correct version" do
+        expect(package_manager.name).to eq("bundler")
+        expect(package_manager.version).to eq("1")
+      end
+    end
+
+    context "when the lockfile specifies Bundler v2" do
+      before do
+        allow(Dependabot::Bundler::Helpers).to receive(:bundler_version).and_return("2")
+      end
+
+      it "returns a PackageManager with the correct version" do
+        expect(package_manager.name).to eq("bundler")
+        expect(package_manager.version).to eq("2")
+      end
+    end
+
+    context "when the lockfile does not specify a version" do
+      before do
+        allow(Dependabot::Bundler::Helpers).to receive(:bundler_version).and_return("2")
+      end
+
+      it "returns a PackageManager with the default version" do
+        expect(package_manager.name).to eq("bundler")
+        expect(package_manager.version).to eq("2")
+      end
     end
   end
 end

--- a/common/lib/dependabot/package_manager.rb
+++ b/common/lib/dependabot/package_manager.rb
@@ -1,0 +1,38 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class PackageManagerBase
+    extend T::Sig
+    extend T::Helpers
+
+    abstract!
+
+    sig { abstract.returns(String) }
+    def name; end
+
+    sig { abstract.returns(String) }
+    def version; end
+
+    sig { abstract.returns(T.nilable(T::Array[String])) }
+    def deprecated_versions; end
+
+    sig { abstract.returns(T.nilable(T::Array[String])) }
+    def unsupported_versions; end
+
+    sig { abstract.returns(T.nilable(T::Array[String])) }
+    def supported_versions; end
+
+    sig { returns(T::Boolean) }
+    def deprecated
+      deprecated_versions&.include?(version) || false
+    end
+
+    sig { returns(T::Boolean) }
+    def unsupported
+      unsupported_versions&.include?(version) || false
+    end
+  end
+end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2828,7 +2828,8 @@ RSpec.describe Dependabot::Updater do
                 }
               ]
             )
-          ]
+          ],
+          generate_pr_notices: []
         }.merge(stubs)
       )
 


### PR DESCRIPTION
### What are you trying to accomplish?

Implementing a feature to add deprecation messages to the created pull requests. This includes using log levels to match messages shown on the UI, ensuring clear communication of deprecation and other important information.

### What issues does this affect or fix?

This enhancement adds the bundler v1 deprecation warning into the PR description.

### Anything you want to highlight for special attention from reviewers?

- This PR introduces a **generic method to provide informational messages, warnings, and errors in the PR description**. It is also generating bundler v1 `deprecation` warning and attaching it to the pr_notices which can be used to attach to the PR. We are attaching generated notices here: https://github.com/dependabot/dependabot-core/pull/10399. 
- Added `PackageManagerBase` abstract class and created `PackageManager` subclass for bundler to **make the package manager information reachable through `dependabot-core` `updater` and `common` code**. Currently, we are using this class for deprecation and support but it can be used for other purposes as well.

### How will you know you've accomplished your goal?

- **Demonstration**: The specs should successfully run successfully for generated_pr_notices and also should generated deprecation warning and unsupported error properly by the given package manager information. 

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
