### PR TITLE
Guard against possible nil before the actual nil inevitably stops execution

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -89,6 +89,8 @@ module Dependabot
             dep.name.casecmp(dependency.name)&.zero?
           end
 
+          next unless lead_dependency
+
           dependency_change = create_change_for(T.must(lead_dependency), updated_dependencies, dependency_files, group)
 
           # Move on to the next dependency using the existing files if we


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

This commit addresses type issue that the introduction of type has brought about.

The PR #9929 has introduced a regression in which the type check stops execution. It is apparently unexpected as the final message results in "unknown_error" and the backtrace appended to this message is the only clue to debug with.

However once you take a look inside the root of the error is rather expectable so let's not overwhelm those who might encounter from this time on.

```
2024/08/09 12:24:28 INFO Checking if faraday-httpclient 1.0.1 needs updating
2024/08/09 12:24:28 INFO Latest version is 2.0.1
2024/08/09 12:24:39 INFO Requirements to unlock all
2024/08/09 12:24:39 INFO Requirements update strategy bump_versions
2024/08/09 12:24:39 ERROR Passed `nil` into T.must
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/_types.rb:222:in `must'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:92:in `block in compile_all_dependency_changes_for'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:56:in `each'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:56:in `compile_all_dependency_changes_for'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:968:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:968:in `block in create_validator_method_medium1'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:97:in `dependency_change'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:919:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:919:in `block in create_validator_method_medium0'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:61:in `perform'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:919:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:919:in `block in create_validator_method_medium0'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:117:in `run_grouped_update_for'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:968:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation_2_7.rb:968:in `block in create_validator_method_medium1'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:103:in `block in run_grouped_dependency_updates'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:102:in `each'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:102:in `run_grouped_dependency_updates'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation.rb:270:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation.rb:270:in `validate_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:64:in `perform'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation.rb:270:in `bind_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/call_validation.rb:270:in `validate_call'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11444/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:45:in `run'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:44:in `block in perform_job'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/opentelemetry-api-1.2.3/lib/opentelemetry/trace/tracer.rb:37:in `block in in_span'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/opentelemetry-api-1.2.3/lib/opentelemetry/trace.rb:70:in `block in with_span'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/opentelemetry-api-1.2.3/lib/opentelemetry/context.rb:87:in `with_value'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/opentelemetry-api-1.2.3/lib/opentelemetry/trace.rb:70:in `with_span'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/opentelemetry-api-1.2.3/lib/opentelemetry/trace/tracer.rb:37:in `in_span'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:18:in `perform_job'
2024/08/09 12:24:39 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:37:in `run'
2024/08/09 12:24:39 ERROR bin/update_files.rb:46:in `<main>'
2024/08/09 12:24:39 INFO Results:
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+---------------+
|    Errors     |
+---------------+
| unknown_error |
+---------------+
```

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Feeding the consistent job description file to dependabot-cli, the problem was reproducible and fixable. Thanks for providing the great tools to make things easier! 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
