### PR TITLE
Attach generated_pr_notices into the PR description

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -64,6 +64,9 @@ module Dependabot
       sig { returns(T::Array[T::Hash[String, String]]) }
       attr_reader :ignore_conditions
 
+      sig { returns(T.nilable(T::Array[T::Hash[T.any(String, Symbol), T.untyped]])) }
+      attr_reader :notices
+
       TRUNCATED_MSG = "...\n\n_Description has been truncated_"
 
       sig do
@@ -80,7 +83,8 @@ module Dependabot
           dependency_group: T.nilable(Dependabot::DependencyGroup),
           pr_message_max_length: T.nilable(Integer),
           pr_message_encoding: T.nilable(Encoding),
-          ignore_conditions: T::Array[T::Hash[String, String]]
+          ignore_conditions: T::Array[T::Hash[String, String]],
+          notices: T.nilable(T::Array[T::Hash[T.any(String, Symbol), T.untyped]])
         )
           .void
       end
@@ -88,7 +92,8 @@ module Dependabot
                      pr_message_header: nil, pr_message_footer: nil,
                      commit_message_options: {}, vulnerabilities_fixed: {},
                      github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,
-                     dependency_group: nil, pr_message_max_length: nil, pr_message_encoding: nil, ignore_conditions: [])
+                     dependency_group: nil, pr_message_max_length: nil, pr_message_encoding: nil,
+                     ignore_conditions: [], notices: nil)
         @dependencies               = dependencies
         @files                      = files
         @source                     = source
@@ -102,6 +107,7 @@ module Dependabot
         @pr_message_max_length      = pr_message_max_length
         @pr_message_encoding        = pr_message_encoding
         @ignore_conditions          = ignore_conditions
+        @notices                    = notices
       end
 
       sig { params(pr_message_max_length: Integer).returns(Integer) }
@@ -119,7 +125,8 @@ module Dependabot
 
       sig { returns(String) }
       def pr_message
-        msg = "#{suffixed_pr_message_header}" \
+        msg = "#{pr_notices}" \
+              "#{suffixed_pr_message_header}" \
               "#{commit_message_intro}" \
               "#{metadata_cascades}" \
               "#{ignore_conditions_table}" \
@@ -129,6 +136,19 @@ module Dependabot
       rescue StandardError => e
         suppress_error("PR message", e)
         suffixed_pr_message_header + prefixed_pr_message_footer
+      end
+
+      sig { returns(T.nilable(String)) }
+      def pr_notices
+        notices = @notices || []
+        unique_messages = notices.filter_map do |notice|
+          notice_details = notice[:details] if notice
+          markdown = notice_details[:markdown] if notice_details
+          markdown unless markdown.nil? || markdown.empty?
+        end.uniq
+
+        message = unique_messages.join("\n\n")
+        message.empty? ? nil : message
       end
 
       # Truncate PR message as determined by the pr_message_max_length and pr_message_encoding instance variables
@@ -315,6 +335,8 @@ module Dependabot
       sig { returns(String) }
       def suffixed_pr_message_header
         return "" unless pr_message_header
+
+        return "#{pr_message_header}\n\n" if notices
 
         "#{pr_message_header}\n\n"
       end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       vulnerabilities_fixed: vulnerabilities_fixed,
       github_redirection_service: github_redirection_service,
       dependency_group: dependency_group,
-      ignore_conditions: ignore_conditions
+      ignore_conditions: ignore_conditions,
+      notices: notices
     )
   end
 
@@ -50,6 +51,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   let(:commit_message_options) { { signoff_details: signoff_details, trailers: trailers } }
   let(:signoff_details) { nil }
   let(:trailers) { nil }
+  let(:notices) { [] }
   let(:vulnerabilities_fixed) { { "business" => [] } }
   let(:github_redirection_service) { "redirect.github.com" }
   let(:dependency_group) { nil }
@@ -3313,6 +3315,94 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       it "doesn't include git trailer" do
         expect(pr_message).not_to include("Changelog: dependency")
+      end
+    end
+
+    context "with generated single notices" do
+      let(:notices) do
+        [{
+          mode: "WARN",
+          type: "bundler_deprecated_warn",
+          package_manager_name: "bundler",
+          details: {
+            message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                     "Please upgrade to one of the following versions: v2, v3.",
+            current_version: "v1",
+            markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n\n" \
+                      "> Please upgrade to one of the following versions: v2, v3."
+          }
+        }]
+      end
+
+      it do
+        expect(pr_message).to start_with(notices[0][:details][:markdown])
+      end
+    end
+
+    context "with generated multiple notices" do
+      let(:notices) do
+        [{
+          mode: "WARN",
+          type: "bundler_deprecated_warn",
+          package_manager_name: "bundler",
+          details: {
+            message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                     "Please upgrade to one of the following versions: v2, v3.",
+            current_version: "v1",
+            markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n\n" \
+                      "> Please upgrade to one of the following versions: v2, v3."
+          }
+        }, {
+          mode: "INFO",
+          type: "bundler_nosupport_due_info",
+          package_manager_name: "bundler",
+          details: {
+            message: "The support for bundler v1 is due 30th of August!" \
+                     "Please upgrade the bundler to one of the following versions soon!: v2, v3.",
+            current_version: "v1",
+            markdown: "> [!INFO]\n> The support for bundler v1 is due 30th of August!\n\n" \
+                      "> Please upgrade the bundler to one of the following versions soon!: v2, v3."
+          }
+        }]
+      end
+
+      it do
+        expect(pr_message).to start_with(
+          "#{notices[0][:details][:markdown]}\n\n#{notices[1][:details][:markdown]}"
+        )
+      end
+    end
+
+    context "with duplicate notices" do
+      let(:notices) do
+        [{
+          mode: "WARN",
+          type: "bundler_deprecated_warn",
+          package_manager_name: "bundler",
+          details: {
+            message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                     "Please upgrade to one of the following versions: v2, v3.",
+            current_version: "v1",
+            markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n\n" \
+                      "> Please upgrade to one of the following versions: v2, v3."
+          }
+        }, {
+          mode: "WARN",
+          type: "bundler_deprecated_warn",
+          package_manager_name: "bundler",
+          details: {
+            message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                     "Please upgrade to one of the following versions: v2, v3.",
+            current_version: "v1",
+            markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n\n" \
+                      "> Please upgrade to one of the following versions: v2, v3."
+          }
+        }]
+      end
+
+      it "returns a unique message" do
+        expect(pr_message).to start_with(notices[0][:details][:markdown])
+        expect(pr_message.scan(notices[0][:details][:markdown]).count).to eq(1)
       end
     end
   end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -45,15 +45,19 @@ module Dependabot
     sig { returns(T.nilable(Dependabot::DependencyGroup)) }
     attr_reader :dependency_group
 
+    sig { returns(T::Array[T::Hash[T.any(String, Symbol), T.untyped]]) }
+    attr_reader :notices
+
     sig do
       params(
         job: Dependabot::Job,
         updated_dependencies: T::Array[Dependabot::Dependency],
         updated_dependency_files: T::Array[Dependabot::DependencyFile],
-        dependency_group: T.nilable(Dependabot::DependencyGroup)
+        dependency_group: T.nilable(Dependabot::DependencyGroup),
+        notices: T::Array[T::Hash[T.any(String, Symbol), T.untyped]]
       ).void
     end
-    def initialize(job:, updated_dependencies:, updated_dependency_files:, dependency_group: nil)
+    def initialize(job:, updated_dependencies:, updated_dependency_files:, dependency_group: nil, notices: [])
       @job = job
       @updated_dependencies = updated_dependencies
       @updated_dependency_files = updated_dependency_files
@@ -61,6 +65,7 @@ module Dependabot
 
       @pr_message = T.let(nil, T.nilable(Dependabot::PullRequestCreator::Message))
       ensure_dependencies_have_directories
+      @notices = notices
     end
 
     sig { returns(Dependabot::PullRequestCreator::Message) }
@@ -90,7 +95,8 @@ module Dependabot
         dependency_group: dependency_group,
         pr_message_max_length: pr_message_max_length,
         pr_message_encoding: pr_message_encoding,
-        ignore_conditions: job.ignore_conditions
+        ignore_conditions: job.ignore_conditions,
+        notices: notices
       ).message
 
       @pr_message = message

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -30,15 +30,17 @@ module Dependabot
         job: Dependabot::Job,
         dependency_files: T::Array[Dependabot::DependencyFile],
         updated_dependencies: T::Array[Dependabot::Dependency],
-        change_source: T.any(Dependabot::Dependency, Dependabot::DependencyGroup)
+        change_source: T.any(Dependabot::Dependency, Dependabot::DependencyGroup),
+        notices: T::Array[T::Hash[T.any(String, Symbol), T.untyped]]
       ).returns(Dependabot::DependencyChange)
     end
-    def self.create_from(job:, dependency_files:, updated_dependencies:, change_source:)
+    def self.create_from(job:, dependency_files:, updated_dependencies:, change_source:, notices: [])
       new(
         job: job,
         dependency_files: dependency_files,
         updated_dependencies: updated_dependencies,
-        change_source: change_source
+        change_source: change_source,
+        notices: notices
       ).run
     end
 
@@ -47,10 +49,11 @@ module Dependabot
         job: Dependabot::Job,
         dependency_files: T::Array[Dependabot::DependencyFile],
         updated_dependencies: T::Array[Dependabot::Dependency],
-        change_source: T.any(Dependabot::Dependency, Dependabot::DependencyGroup)
+        change_source: T.any(Dependabot::Dependency, Dependabot::DependencyGroup),
+        notices: T::Array[T::Hash[T.any(String, Symbol), T.untyped]]
       ).void
     end
-    def initialize(job:, dependency_files:, updated_dependencies:, change_source:)
+    def initialize(job:, dependency_files:, updated_dependencies:, change_source:, notices: [])
       @job = job
 
       dir = Pathname.new(job.source.directory).cleanpath
@@ -61,6 +64,7 @@ module Dependabot
 
       @updated_dependencies = updated_dependencies
       @change_source = change_source
+      @notices = notices
     end
 
     sig { returns(Dependabot::DependencyChange) }
@@ -84,7 +88,8 @@ module Dependabot
         job: job,
         updated_dependencies: updated_deps,
         updated_dependency_files: updated_files,
-        dependency_group: source_dependency_group
+        dependency_group: source_dependency_group,
+        notices: notices
       )
     end
 
@@ -101,6 +106,9 @@ module Dependabot
 
     sig { returns(T.any(Dependabot::Dependency, Dependabot::DependencyGroup)) }
     attr_reader :change_source
+
+    sig { returns(T::Array[T::Hash[T.any(String, Symbol), T.untyped]]) }
+    attr_reader :notices
 
     sig { returns(T.nilable(String)) }
     def source_dependency_name

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe Dependabot::DependencyChange do
           dependency_group: nil,
           pr_message_encoding: nil,
           pr_message_max_length: 65_535,
-          ignore_conditions: []
+          ignore_conditions: [],
+          notices: []
         )
 
       expect(dependency_change.pr_message.pr_message).to eql("Hello World!")
@@ -141,7 +142,8 @@ RSpec.describe Dependabot::DependencyChange do
             dependency_group: group,
             pr_message_encoding: nil,
             pr_message_max_length: 65_535,
-            ignore_conditions: []
+            ignore_conditions: [],
+            notices: []
           )
 
         expect(dependency_change.pr_message&.pr_message).to eql("Hello World!")


### PR DESCRIPTION
### What are you trying to accomplish?

Implementing a feature to attach generated PR notices into the PR description. This includes using log levels to match messages shown on the UI, ensuring clear communication of deprecation and other important information.

### What issues does this affect or fix?

This PR adds the generated `bundler v1 deprecation warning into` alongside with other generated PR notices into PR description. 

### Anything you want to highlight for special attention from reviewers?

- This PR introduces a **generic method to provide informational messages, warnings, and errors in the PR description**. Currently, it is used to show bundler v1 `deprecation` warning in this PR but can also be used to show other kinds of information, warnings, and errors.

### How will you know you've accomplished your goal?

- **Demonstration**: The deprecation alert and other generated PR notices should appear in the PR description as intended.

<img width="682" alt="Screenshot 2024-08-07 at 9 56 18 AM" src="https://github.com/user-attachments/assets/23ec226e-e15c-4391-89f3-1d5e6fcc4a85">

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.