### PR TITLE
Add PR notices into the PR description created by `CreateSecurityUpdatePullRequest ` operation

### DIFF
--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -42,7 +42,7 @@ module Dependabot
           @dependency_snapshot = dependency_snapshot
           @error_handler = error_handler
           # TODO: Collect @created_pull_requests on the Job object?
-          @created_pull_requests = T.let([], T::Array[T::Array[T::Hash[String, String]]])
+          @created_pull_requests = T.let([], T::Array[T::Array[T::Hash[String, T.untyped]]])
         end
 
         # TODO: We currently tolerate multiple dependencies for this operation
@@ -74,7 +74,7 @@ module Dependabot
         attr_reader :dependency_snapshot
         sig { returns(Dependabot::Updater::ErrorHandler) }
         attr_reader :error_handler
-        sig { returns(T::Array[T::Array[T::Hash[String, String]]]) }
+        sig { returns(T::Array[T::Array[T::Hash[String, T.untyped]]]) }
         attr_reader :created_pull_requests
 
         sig { params(dependency: Dependabot::Dependency).void }
@@ -169,7 +169,8 @@ module Dependabot
             job: job,
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
-            change_source: checker.dependency
+            change_source: checker.dependency,
+            notices: checker.generate_pr_notices
           )
 
           create_pull_request(dependency_change)


### PR DESCRIPTION
### Description

### What are you trying to accomplish?

Implementing a feature, https://github.com/dependabot/dependabot-core/pull/10399 to include generated PR notices into the PR which are created by the `CreateSecurityUpdatePullRequest` operation. This ensures that important messages, warnings, and deprecations are clearly communicated in the PR description.

### What issues does this affect or fix?

This enhancement adds the ability to pass generated PR notices into the PR message for security updates, ensuring that relevant information is prominently displayed in the PR description. Currently, this includes the bundler v1 deprecation warning.

### Anything you want to highlight for special attention from reviewers?

- This PR extends the functionality of the `CreateSecurityUpdatePullRequest` operation to include generated PR notices in the PR description.
- The generated PR notices can include various types of messages such as informational messages, warnings, and errors to provide a comprehensive overview of the updates.
- Since we generated bundler v1 deprecation warning, currently it is aiming to add this warning into the PR for bundler eco-system when PR is generated by bundler v1

### How will you know you've accomplished your goal?

- **Demonstration**: The generated PR notices, including the bundler v1 deprecation warning, should appear in the PR description for security updates, ensuring that all relevant information is clearly communicated.

<img width="682" alt="Screenshot 2024-08-07 at 9 56 18 AM" src="https://github.com/user-attachments/assets/23ec226e-e15c-4391-89f3-1d5e6fcc4a85">

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
