### PR TITLE
Add PR notices to refresh security update PR description

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -15,7 +15,6 @@ module Dependabot
     module Operations
       class RefreshSecurityUpdatePullRequest
         extend T::Sig
-        include SecurityUpdateHelpers
 
         sig { params(job: Job).returns(T::Boolean) }
         def self.applies_to?(job:)
@@ -142,7 +141,8 @@ module Dependabot
             job: job,
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
-            change_source: checker.dependency
+            change_source: checker.dependency,
+            notices: checker.generate_pr_notices
           )
 
           # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -1,0 +1,282 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/dummy_pkg_helpers"
+require "support/dependency_file_helpers"
+
+require "dependabot/dependency_change"
+require "dependabot/dependency_snapshot"
+require "dependabot/service"
+require "dependabot/updater/error_handler"
+require "dependabot/updater/operations/refresh_security_update_pull_request"
+require "dependabot/dependency_change_builder"
+
+require "dependabot/bundler"
+
+RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest do
+  include DependencyFileHelpers
+  include DummyPkgHelpers
+
+  subject(:perform) { refresh_security_update_pull_request.perform }
+
+  let(:refresh_security_update_pull_request) do
+    described_class.new(
+      service: mock_service,
+      job: job,
+      dependency_snapshot: dependency_snapshot,
+      error_handler: mock_error_handler
+    )
+  end
+
+  let(:mock_service) do
+    instance_double(Dependabot::Service, create_pull_request: nil, update_pull_request: nil, close_pull_request: nil)
+  end
+  let(:mock_error_handler) { instance_double(Dependabot::Updater::ErrorHandler) }
+
+  let(:job_definition) do
+    job_definition_fixture("bundler/version_updates/pull_request_simple")
+  end
+
+  let(:job) do
+    Dependabot::Job.new_update_job(
+      job_id: "1558782000",
+      job_definition: job_definition_with_fetched_files
+    )
+  end
+
+  let(:dependency_snapshot) do
+    Dependabot::DependencySnapshot.create_from_job_definition(
+      job: job,
+      job_definition: job_definition_with_fetched_files
+    )
+  end
+
+  let(:job_definition_with_fetched_files) do
+    job_definition.merge({
+      "base_commit_sha" => "mock-sha",
+      "base64_dependency_files" => encode_dependency_files(dependency_files)
+    })
+  end
+
+  let(:dependency_files) do
+    original_bundler_files(fixture: "bundler_simple")
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "dummy-pkg-a",
+      version: "4.0.0",
+      requirements: [{
+        file: "Gemfile",
+        requirement: "~> 4.0.0",
+        groups: ["default"],
+        source: nil
+      }],
+      package_manager: "bundler",
+      metadata: { all_versions: ["4.0.0"] }
+    )
+  end
+
+  let(:stub_update_checker) do
+    instance_double(
+      Dependabot::UpdateCheckers::Base,
+      vulnerable?: true,
+      latest_version: "2.3.0",
+      version_class: Gem::Version,
+      lowest_resolvable_security_fix_version: "2.3.0",
+      lowest_security_fix_version: "2.0.0",
+      conflicting_dependencies: [],
+      up_to_date?: false,
+      updated_dependencies: [dependency],
+      dependency: dependency,
+      requirements_unlocked_or_can_be?: true,
+      can_update?: true,
+      generate_pr_notices: []
+    )
+  end
+
+  let(:stub_update_checker_class) do
+    class_double(Dependabot::Bundler::UpdateChecker, new: stub_update_checker)
+  end
+
+  let(:stub_dependency_change) do
+    instance_double(
+      Dependabot::DependencyChange,
+      updated_dependencies: [dependency],
+      should_replace_existing_pr?: false,
+      grouped_update?: false,
+      matches_existing_pr?: false,
+      notices: []
+    )
+  end
+
+  before do
+    allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
+    allow(Dependabot::DependencyChangeBuilder)
+      .to receive(:create_from)
+      .and_return(stub_dependency_change)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
+
+  describe "#perform" do
+    before do
+      allow(dependency_snapshot).to receive(:job_dependencies).and_return([dependency])
+      allow(job).to receive(:package_manager).and_return("bundler")
+    end
+
+    context "when job allowed_update is false" do
+      before do
+        allow(job).to receive_messages(
+          allowed_update?: false, dependencies: ["dummy-pkg-a"]
+        )
+      end
+
+      it "does not check and create a pull request" do
+        expect(refresh_security_update_pull_request).to receive(
+          :close_pull_request
+        ).with(reason: :up_to_date)
+        perform
+      end
+    end
+
+    context "when job allowed_update is true" do
+      before do
+        allow(job).to receive_messages(
+          allowed_update?: true, dependencies: ["dummy-pkg-a"]
+        )
+      end
+
+      it "checks and creates a pull request" do
+        expect(refresh_security_update_pull_request).to receive(:check_and_update_pull_request).with([dependency])
+        perform
+      end
+    end
+  end
+
+  describe "#check_and_update_pull_request" do
+    before do
+      allow(dependency)
+        .to receive(:all_versions).and_return(["4.0.0", "4.1.0", "4.2.0"])
+      allow(job).to receive(:package_manager).and_return("bundler")
+    end
+
+    context "when the update is not allowed" do
+      before do
+        allow(stub_update_checker).to receive(:up_to_date?).and_return(true)
+        allow(job).to receive_messages(
+          allowed_update?: false, dependencies: ["dummy-pkg-a"]
+        )
+      end
+
+      it "does not create a pull request" do
+        expect(refresh_security_update_pull_request).not_to receive(
+          :create_pull_request
+        )
+        refresh_security_update_pull_request.send(
+          :check_and_update_pull_request, [dependency]
+        )
+      end
+    end
+
+    context "when the update is allowed" do
+      before do
+        allow(stub_update_checker)
+          .to receive_messages(
+            up_to_date?: false,
+            latest_version: Dependabot::Version.new("4.0.1"),
+            requirements_unlocked_or_can_be?: true
+          )
+        allow(job).to receive_messages(
+          allowed_update?: true,
+          dependencies: ["dummy-pkg-a"]
+        )
+      end
+
+      it "checks if a pull request already exists" do
+        allow(refresh_security_update_pull_request)
+          .to receive(:existing_pull_request).and_return(true)
+        expect(refresh_security_update_pull_request)
+          .to receive(:update_pull_request)
+        refresh_security_update_pull_request.send(
+          :check_and_update_pull_request, [dependency]
+        )
+      end
+
+      context "when pull request does not already exist" do
+        before do
+          allow(job)
+            .to receive(:existing_pull_requests).and_return([
+              [
+                {
+                  "dependency-name" => "dummy-pkg-a",
+                  "dependency-version" => "2.0.0"
+                }
+              ]
+            ])
+          allow(refresh_security_update_pull_request)
+            .to receive(:check_and_update_pull_request).and_call_original
+        end
+
+        it "creates a pull request without pr notices" do
+          expect(refresh_security_update_pull_request).to receive(
+            :create_pull_request
+          )
+          refresh_security_update_pull_request.send(
+            :check_and_update_pull_request, [dependency]
+          )
+        end
+
+        it "creates a pull request with pr notices" do
+          allow(stub_update_checker)
+            .to receive(:generate_pr_notices).and_return([{
+              mode: "WARN",
+              type: "bundler_deprecated_warn",
+              package_manager_name: "bundler",
+              details: {
+                message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                         "Please upgrade to one of the following versions: v2, v3.",
+                current_version: "v1",
+                markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n\n" \
+                          "> Please upgrade to one of the following versions: v2, v3."
+              }
+            }])
+          expect(refresh_security_update_pull_request).to receive(:create_pull_request)
+          refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])
+        end
+
+        it "creates a pull request with multiple pr notices" do
+          allow(stub_update_checker)
+            .to receive(:generate_pr_notices).and_return([
+              {
+                mode: "WARN",
+                type: "bundler_deprecated_warn",
+                package_manager_name: "bundler",
+                details: {
+                  message: "Dependabot will stop supporting `bundler` `v1`!\n" \
+                           "Please upgrade to one of the following versions: v2, v3.",
+                  current_version: "v1",
+                  markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler` `v1`!\n"
+                }
+              },
+              {
+                mode: "WARN",
+                type: "bundler_deprecated_warn",
+                package_manager_name: "bundler",
+                details: {
+                  message: "Another important notice.",
+                  current_version: "v1",
+                  markdown: "> [!WARNING]\n> Another important notice.\n"
+                }
+              }
+            ])
+          expect(refresh_security_update_pull_request).to receive(:create_pull_request)
+          refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Implementing a feature to attach generated PR notices into the created refresh security update pull requests. This includes using log levels to match messages shown on the UI, ensuring clear communication of deprecation and other important information.

### What issues does this affect or fix?

This enhancement generalizes the mechanism to attach various generated PR notices into the PR description for refresh security updates.

### Anything you want to highlight for special attention from reviewers?

- This PR introduces a **generic method to provide informational messages, warnings, and errors in the PR description**. Currently, it is used to show bundler v1 `deprecation` warning and other generated PR notices but can also be used to show other kinds of information, warnings, and errors.
- This includes using log levels to match messages shown on the UI, ensuring clear communication of deprecation and other important information.

### How will you know you've accomplished your goal?

- **Demonstration**: The generated PR notices should appear in the PR description as intended for refresh security updates.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
