### PR TITLE
Refactor: Update File Parser to Return DependabotContext with Dependencies and Package Manager Info

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -16,11 +16,13 @@ require "dependabot/errors"
 module Dependabot
   module Bundler
     class FileParser < Dependabot::FileParsers::Base
+      extend T::Sig
       require "dependabot/file_parsers/base/dependency_set"
       require "dependabot/bundler/file_parser/file_preparer"
       require "dependabot/bundler/file_parser/gemfile_declaration_finder"
       require "dependabot/bundler/file_parser/gemspec_declaration_finder"
 
+      sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
         dependency_set = DependencySet.new
         dependency_set += gemfile_dependencies
@@ -28,6 +30,11 @@ module Dependabot
         dependency_set += lockfile_dependencies
         check_external_code(dependency_set.dependencies)
         dependency_set.dependencies
+      end
+
+      sig { returns(PackageManagerBase) }
+      def package_manager
+        PackageManager.new(bundler_version)
       end
 
       private

--- a/bundler/lib/dependabot/bundler/package_manager.rb
+++ b/bundler/lib/dependabot/bundler/package_manager.rb
@@ -1,0 +1,48 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module Bundler
+    PACKAGE_MANAGER = "bundler"
+    SUPPORTED_BUNDLER_VERSIONS = T.let(["2"].freeze, T::Array[String])
+    DEPRECATED_BUNDLER_VERSIONS = T.let(["1"].freeze, T::Array[String])
+
+    class PackageManager < PackageManagerBase
+      extend T::Sig
+      include Helpers
+
+      sig { params(version: String).void }
+      def initialize(version)
+        @version = T.let(version, String)
+        @name = T.let(PACKAGE_MANAGER, String)
+        @deprecated_versions = T.let(DEPRECATED_BUNDLER_VERSIONS, T::Array[String])
+
+        @supported_versions = T.let(SUPPORTED_BUNDLER_VERSIONS, T::Array[String])
+      end
+
+      sig { override.returns(String) }
+      attr_reader :name
+
+      sig { override.returns(String) }
+      attr_reader :version
+
+      sig { override.returns(T.nilable(T::Array[String])) }
+      attr_reader :deprecated_versions
+
+      sig { override.returns(T::Array[String]) }
+      attr_reader :supported_versions
+
+      sig { override.returns(T::Boolean) }
+      def deprecated
+        deprecated_versions&.include?(version) || false
+      end
+
+      sig { override.returns(T::Boolean) }
+      def unsupported
+        Gem::Version.new(version) < Gem::Version.new("2.0.0")
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/file_parsers/base.rb
+++ b/common/lib/dependabot/file_parsers/base.rb
@@ -53,6 +53,11 @@ module Dependabot
       sig { abstract.returns(T::Array[Dependabot::Dependency]) }
       def parse; end
 
+      sig { returns(T.nilable(PackageManagerBase)) }
+      def package_manager
+        nil
+      end
+
       private
 
       sig { abstract.void }

--- a/common/lib/dependabot/package_manager.rb
+++ b/common/lib/dependabot/package_manager.rb
@@ -1,0 +1,52 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class PackageManagerBase
+    extend T::Sig
+    extend T::Helpers
+
+    abstract!
+
+    # The name of the package manager (e.g., "bundler")
+    sig { abstract.returns(String) }
+    def name; end
+
+    # The version of the package manager (e.g., "2.1.4")
+    sig { abstract.returns(T.nilable(String)) }
+    def version; end
+
+    # The major version of the package manager (e.g., "2")
+    sig { returns(T.nilable(String)) }
+    def major_version
+      version&.split(".")&.first
+    end
+
+    sig { returns(T.nilable(T::Array[String])) }
+    def deprecated_versions
+      nil
+    end
+
+    sig { returns(T.nilable(T::Array[String])) }
+    def unsupported_versions
+      nil
+    end
+
+    sig { returns(T.nilable(T::Array[String])) }
+    def supported_versions
+      nil
+    end
+
+    sig { returns(T::Boolean) }
+    def deprecated
+      deprecated_versions&.include?(version) || false
+    end
+
+    sig { returns(T::Boolean) }
+    def unsupported
+      unsupported_versions&.include?(version) || false
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

The goal of this PR is to enhance the file parser to return a `DependabotContext` that includes both dependencies and package manager information. Previously, the file parser only returned dependencies. This change has been applied to all ecosystems (package managers) so that package manager information can be utilized when needed.

### What issues does this affect or fix?

This change sets the groundwork for better handling and utilization of package manager information across all ecosystems. It is an improvement and a step towards more robust dependency management.

### Anything you want to highlight for special attention from reviewers?

- I have created an abstract package manager class.
- For the Bundler package manager, the package manager information has already been implemented.
- For other package managers, the `package_manager` field is currently set to `nil` and can be filled in the future as needed.
- Ensure to review the abstract package manager class implementation and the changes in the file parser.

### How will you know you've accomplished your goal?

- The file parser will now return a `DependabotContext` containing both dependencies and package manager information.
- Tests should cover the new functionality and ensure that the parser works correctly for all ecosystems.
- Future updates to include package manager info for other ecosystems will be simplified due to the abstract package manager structure.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.