### PR TITLE
Revert Smoke Test Branch to Dependabot-Core Main

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: feature-DependencySolver
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         id: changes
         with:
-          token: '' # use git commands to avoid excessive rate limit usage
+          token: "" # use git commands to avoid excessive rate limit usage
           filters: .github/smoke-filters.yml
 
       - name: Generate suites to run


### PR DESCRIPTION
### What are you trying to accomplish?

Revert the branch used for running smoke tests back to the one used in `dependabot-core` main. This is necessary to ensure consistency and compatibility with the main branch of `dependabot-core`.

### Anything you want to highlight for special attention from reviewers?

The previous change commit: https://github.com/dependabot/dependabot-core/commit/d09bc1efa1b95c321f7a58f5ce6b30b51bf6a0c4

This change reverts the smoke test branch to align with the `dependabot-core` main branch. It is important to review any potential impacts this might have on the existing tests and their outcomes.

### How will you know you've accomplished your goal?

- The smoke tests run successfully using the `dependabot-core` main branch.
- Any errors or issues specific to the previous branch setup are resolved.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.