### PR TITLE
only discover dependencies from known project types

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -376,6 +376,89 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task NonSupportedProjectExtensionsAreSkipped()
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+            ],
+            workspacePath: "/",
+            files: new[]
+            {
+                ("solution.sln", """
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio Version 17
+                    VisualStudioVersion = 17.10.35027.167
+                    MinimumVisualStudioVersion = 10.0.40219.1
+                    Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "supported", "src\supported.csproj", "{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}"
+                    EndProject
+                    Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "unsupported", "src\unsupported.vdproj", "{271E533C-8A44-4572-8C18-CD65A79F8658}"
+                    EndProject
+                    Global
+                    	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                    		Debug|Any CPU = Debug|Any CPU
+                    		Release|Any CPU = Release|Any CPU
+                    	EndGlobalSection
+                    	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                    		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                    		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                    		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                    		{4A3B8D8A-A585-4593-8AF3-DED05AE3C40F}.Release|Any CPU.Build.0 = Release|Any CPU
+                    		{271E533C-8A44-4572-8C18-CD65A79F8658}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                    		{271E533C-8A44-4572-8C18-CD65A79F8658}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                    		{271E533C-8A44-4572-8C18-CD65A79F8658}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                    		{271E533C-8A44-4572-8C18-CD65A79F8658}.Release|Any CPU.Build.0 = Release|Any CPU
+                    	EndGlobalSection
+                    	GlobalSection(SolutionProperties) = preSolution
+                    		HideSolutionNode = FALSE
+                    	EndGlobalSection
+                    	GlobalSection(ExtensibilityGlobals) = postSolution
+                    		SolutionGuid = {EE5BDEF7-1D4D-4773-9659-FC4A3846CD6D}
+                    	EndGlobalSection
+                    EndGlobal
+                    """),
+                ("src/supported.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/unsupported.vdproj", """
+                    "DeployProject"
+                    {
+                    "SomeKey" = "SomeValue"
+                    }
+                    """),
+            },
+            expectedResult: new()
+            {
+                Path = "",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "src/supported.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        ReferencedProjectPaths = [],
+                        ExpectedDependencyCount = 2,
+                        Dependencies = [
+                            new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
+                        ],
+                        Properties = [
+                            new("TargetFramework", "net8.0", @"src/supported.csproj"),
+                        ]
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
     public async Task ResultFileHasCorrectShapeForAuthenticationFailure()
     {
         using var temporaryDirectory = await TemporaryDirectory.CreateWithContentsAsync([]);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -199,13 +199,21 @@ public partial class DiscoveryWorker
                 }
                 else
                 {
-                    // .csproj, .fsproj, .vbproj
-                    // keep this project and check for references
-                    expandedProjects.Add(candidateEntryPoint);
-                    IEnumerable<string> referencedProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectReference");
-                    foreach (string referencedProject in referencedProjects)
+                    switch (extension)
                     {
-                        filesToExpand.Push(referencedProject);
+                        case ".csproj":
+                        case ".fsproj":
+                        case ".vbproj":
+                            // keep this project and check for references
+                            expandedProjects.Add(candidateEntryPoint);
+                            IEnumerable<string> referencedProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectReference");
+                            foreach (string referencedProject in referencedProjects)
+                            {
+                                filesToExpand.Push(referencedProject);
+                            }
+                            break;
+                        default:
+                            continue;
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -169,7 +169,7 @@ internal static partial class MSBuildHelper
                                                         string.Equals(property.Condition, $"'$({property.Name})' == ''", StringComparison.OrdinalIgnoreCase);
                 if (hasEmptyCondition || conditionIsCheckingForEmptyString)
                 {
-                    properties[property.Name] = new(property.Name, property.Value, buildFile.RelativePath);
+                    properties[property.Name] = new(property.Name, property.Value, PathHelper.NormalizePathToUnix(buildFile.RelativePath));
                 }
             }
         }


### PR DESCRIPTION
When running NuGet dependency discovery, we should only process project types that are explicitly supported, namely `.csproj`, `.vbproj`, and `.fsproj`.  This is consistent with how it's done elsewhere in this repo, we just missed a spot.

Fixes #10372