### PR TITLE
Revert Changes to updated_files_regex method with latest regex from the API

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -14,24 +14,13 @@ module Dependabot
       require_relative "file_updater/gemspec_updater"
       require_relative "file_updater/lockfile_updater"
 
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            # Matches Gemfile, Gemfile.lock, gems.rb, gems.locked, .gemspec files, and anything in vendor directory
-            %r{^(Gemfile(\.lock)?|gems\.(rb|locked)|.*\.gemspec|vendor/.*)$},
-            # Matches the same files in any subdirectory
-            %r{^.*\/(Gemfile|Gemfile\.lock|gems\.rb|gems\.locked)$}
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            /^Gemfile$/,
-            /^Gemfile\.lock$/,
-            /^gems\.rb$/,
-            /^gems\.locked$/,
-            /^*\.gemspec$/
-          ]
-        end
+      def self.updated_files_regex
+        [
+          # Matches Gemfile, Gemfile.lock, gems.rb, gems.locked, .gemspec files, and anything in vendor directory
+          %r{^(Gemfile(\.lock)?|gems\.(rb|locked)|.*\.gemspec|vendor/.*)$},
+          # Matches the same files in any subdirectory
+          %r{^.*/(Gemfile|Gemfile\.lock|gems\.rb|gems\.locked)$}
+        ]
       end
 
       # rubocop:disable Metrics/PerceivedComplexity

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/cargo/lib/dependabot/cargo/file_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater.rb
@@ -13,10 +13,10 @@ module Dependabot
       require_relative "file_updater/manifest_updater"
       require_relative "file_updater/lockfile_updater"
 
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [
-          /^Cargo\.toml$/,
-          /^Cargo\.lock$/
+          /Cargo\.toml$/, # Matches Cargo.toml in the root directory or any subdirectory
+          /Cargo\.lock$/  # Matches Cargo.lock in the root directory or any subdirectory
         ]
       end
 

--- a/cargo/spec/dependabot/cargo/file_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater_spec.rb
@@ -56,9 +56,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/cargo/spec/dependabot/cargo/file_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater_spec.rb
@@ -68,7 +68,11 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
       it "returns true for files that should be updated" do
         matching_files = [
           "Cargo.toml",
-          "Cargo.lock"
+          "Cargo.lock",
+          "some_project/Cargo.toml",
+          "some_project/Cargo.lock",
+          "some_project/subdir/Cargo.toml",
+          "some_project/subdir/Cargo.lock"
         ]
 
         matching_files.each do |file_name|

--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -28,8 +28,8 @@ module Dependabot
       sig { returns(T::Hash[Symbol, T.untyped]) }
       attr_reader :options
 
-      sig { overridable.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
         raise NotImplementedError
       end
 

--- a/composer/lib/dependabot/composer/file_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater.rb
@@ -12,7 +12,7 @@ module Dependabot
       require_relative "file_updater/manifest_updater"
       require_relative "file_updater/lockfile_updater"
 
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [
           /^composer\.json$/,
           /^composer\.lock$/

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -12,7 +12,7 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           /^\.?devcontainer\.json$/,

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -12,8 +12,8 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { override.params(_: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(_ = false)
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
         [
           /^\.?devcontainer\.json$/,
           /^\.?devcontainer-lock\.json$/

--- a/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -17,8 +17,8 @@ module Dependabot
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
       DOCKER_REGEXP = /dockerfile/i
 
-      sig { override.params(_: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(_ = false)
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
         [
           DOCKER_REGEXP,
           YAML_REGEXP

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -17,7 +17,7 @@ module Dependabot
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
       DOCKER_REGEXP = /dockerfile/i
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           DOCKER_REGEXP,

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -142,9 +142,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/elm/lib/dependabot/elm/file_updater.rb
+++ b/elm/lib/dependabot/elm/file_updater.rb
@@ -9,7 +9,7 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       require_relative "file_updater/elm_json_updater"
 
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [
           /^elm\.json$/
         ]

--- a/elm/spec/dependabot/elm/file_updater_spec.rb
+++ b/elm/spec/dependabot/elm/file_updater_spec.rb
@@ -59,9 +59,7 @@ RSpec.describe Dependabot::Elm::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/git_submodules/lib/dependabot/git_submodules/file_updater.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_updater.rb
@@ -11,10 +11,11 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
-          /^.*/]
+          /^.*/
+        ]
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }

--- a/git_submodules/lib/dependabot/git_submodules/file_updater.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_updater.rb
@@ -11,18 +11,10 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            /^\.gitmodules$/,            # Matches the .gitmodules file in the root directory
-            %r{^.+/\.git$},              # Matches the .git file inside any submodule directory
-            %r{^\.git/modules/.+}        # Matches any files under .git/modules directory where submodule data is stored
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          []
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          /^.*/]
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }

--- a/git_submodules/spec/dependabot/git_submodules/file_updater_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/file_updater_spec.rb
@@ -67,9 +67,7 @@ RSpec.describe Dependabot::GitSubmodules::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/git_submodules/spec/dependabot/git_submodules/file_updater_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/file_updater_spec.rb
@@ -88,21 +88,6 @@ RSpec.describe Dependabot::GitSubmodules::FileUpdater do
           expect(updated_files_regex).to(be_any { |regex| file_name.match?(regex) })
         end
       end
-
-      it "returns false for files that should not be updated" do
-        non_matching_files = [
-          "README.md",
-          ".github/workflow/main.yml",
-          "some_random_file.rb",
-          "requirements.txt",
-          "package-lock.json",
-          "package.json"
-        ]
-
-        non_matching_files.each do |file_name|
-          expect(updated_files_regex).not_to(be_any { |regex| file_name.match?(regex) })
-        end
-      end
     end
   end
 

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -12,7 +12,7 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           # Matches .yml or .yaml files in the .github/workflows directories

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -12,14 +12,15 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [%r{\.github/workflows?/.+\.ya?ml$}]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [%r{\.github/workflows/.+\.ya?ml$}]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          # Matches .yml or .yaml files in the .github/workflows directories
+          %r{\.github/workflows/.+\.ya?ml$},
+
+          # Matches .yml or .yaml files in the root directory or any subdirectory
+          %r{(?:^|/).+\.ya?ml$}
+        ]
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -91,12 +91,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
       end
 
       it "returns false for files that should not be updated" do
-        non_matching_files = [
-          "README.md",
-          "some_random_file.rb",
-          "requirements.txt",
-          "package-lock.json",
-          "package.json"
+        matching_files = [
+          "action.yml",
+          "action.yaml",
+          "foo/bar/action.yml",
+          "foo/bar/action.yaml",
+          ".github/workflows/main.yml",
+          ".github/workflows/ci-test.yaml",
+          ".github/workflows/action.yml",
+          ".github/workflows/123-foo.yml",
+          "/.github/workflows/workflow.yml",
+          "/.github/workflows/123-foo-bar.yml"
         ]
 
         non_matching_files.each do |file_name|

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -69,9 +69,7 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty
@@ -79,18 +77,6 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
     context "when files match the regex patterns" do
       it "returns true for files that should be updated" do
-        matching_files = [
-          ".github/workflow/main.yml",
-          ".github/workflows/ci-test.yaml",
-          ".github/workflows/workflow.yml"
-        ]
-
-        matching_files.each do |file_name|
-          expect(updated_files_regex).to(be_any { |regex| file_name.match?(regex) })
-        end
-      end
-
-      it "returns false for files that should not be updated" do
         matching_files = [
           "action.yml",
           "action.yaml",
@@ -102,6 +88,20 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           ".github/workflows/123-foo.yml",
           "/.github/workflows/workflow.yml",
           "/.github/workflows/123-foo-bar.yml"
+        ]
+
+        matching_files.each do |file_name|
+          expect(updated_files_regex).to(be_any { |regex| file_name.match?(regex) })
+        end
+      end
+
+      it "returns false for files that should not be updated" do
+        non_matching_files = [
+          "README.md",
+          "some_random_file.rb",
+          "requirements.txt",
+          "package-lock.json",
+          "package.json"
         ]
 
         non_matching_files.each do |file_name|

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -33,7 +33,7 @@ module Dependabot
         use_repo_contents_stub if repo_contents_path.nil?
       end
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           /^go\.mod$/,

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -33,21 +33,13 @@ module Dependabot
         use_repo_contents_stub if repo_contents_path.nil?
       end
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            /^go\.mod$/,
-            /^go\.sum$/,
-            %r{^vendor/.*}
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            /^go\.mod$/,
-            /^go\.sum$/
-          ]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          /^go\.mod$/,
+          /^go\.sum$/,
+          %r{^vendor/.*}
+        ]
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -68,9 +68,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -17,18 +17,17 @@ module Dependabot
 
       SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts).freeze
 
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            # Matches build.gradle or build.gradle.kts in root directory
-            %r{(^|.*/)build\.gradle(\.kts)?$},
-            # Matches gradle/libs.versions.toml in root or any subdirectory
-            %r{(^|.*/)?gradle/libs\.versions\.toml$}
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [/^build\.gradle(\.kts)?$/, %r{/build\.gradle(\.kts)?$}, %r{/gradle/libs\.versions\.toml$}]
-        end
+      def self.updated_files_regex
+        [
+          # Matches build.gradle or build.gradle.kts in root directory
+          %r{(^|.*/)build\.gradle(\.kts)?$},
+          # Matches gradle/libs.versions.toml in root or any subdirectory
+          %r{(^|.*/)?gradle/libs\.versions\.toml$},
+          # Matches settings.gradle or settings.gradle.kts in root or any subdirectory
+          %r{(^|.*/)settings\.gradle(\.kts)?$},
+          # Matches dependencies.gradle in root or any subdirectory
+          %r{(^|.*/)dependencies\.gradle$}
+        ]
       end
 
       def updated_dependency_files

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -54,9 +54,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -67,10 +67,16 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
         matching_files = [
           "build.gradle",
           "build.gradle.kts",
+          "settings.gradle",
+          "settings.gradle.kts",
           "subproject/build.gradle",
           "subproject/build.gradle.kts",
+          "subproject/settings.gradle",
+          "subproject/settings.gradle.kts",
           "gradle/libs.versions.toml",
-          "subproject/gradle/libs.versions.toml"
+          "subproject/gradle/libs.versions.toml",
+          "dependencies.gradle",
+          "subproject/dependencies.gradle"
         ]
 
         matching_files.each do |file_name|

--- a/hex/lib/dependabot/hex/file_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater.rb
@@ -14,11 +14,11 @@ module Dependabot
       require_relative "file_updater/mixfile_updater"
       require_relative "file_updater/lockfile_updater"
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           /^.*mix\.exs$/,
-          /^.*mix\.lock$/,
+          /^.*mix\.lock$/
         ]
       end
 

--- a/hex/lib/dependabot/hex/file_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater.rb
@@ -14,20 +14,12 @@ module Dependabot
       require_relative "file_updater/mixfile_updater"
       require_relative "file_updater/lockfile_updater"
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            /^.*mix\.exs$/,
-            /^.*mix\.lock$/
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            /^mix\.exs$/,
-            /^mix\.lock$/
-          ]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          /^.*mix\.exs$/,
+          /^.*mix\.lock$/,
+        ]
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -57,9 +57,7 @@ RSpec.describe Dependabot::Hex::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -11,7 +11,7 @@ module Dependabot
       require_relative "file_updater/declaration_finder"
       require_relative "file_updater/property_value_updater"
 
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [
           /^pom\.xml$/, %r{/pom\.xml$},
           /.*\.xml$/, %r{/.*\.xml$},

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -30,7 +30,7 @@ module Dependabot
         end
       end
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           %r{^(?:.*/)?package\.json$},
@@ -39,7 +39,7 @@ module Dependabot
           %r{^(?:.*/)?yarn\.lock$},
           %r{^(?:.*/)?pnpm-lock\.yaml$},
           %r{^(?:.*/)?\.yarn/.*}, # Matches any file within the .yarn/ directory
-          %r{^(?:.*/)?\.pnp\.(?:js|cjs)$}, # Matches .pnp.js or .pnp.cjs files
+          %r{^(?:.*/)?\.pnp\.(?:js|cjs)$} # Matches .pnp.js or .pnp.cjs files
         ]
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -30,26 +30,17 @@ module Dependabot
         end
       end
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            %r{^(?:.*\/)?package\.json$},
-            %r{^(?:.*\/)?package-lock\.json$},
-            %r{^(?:.*\/)?npm-shrinkwrap\.json$},
-            %r{^(?:.*\/)?yarn\.lock$},
-            %r{^(?:.*\/)?pnpm-lock\.yaml$}
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            /^package\.json$/,
-            /^package-lock\.json$/,
-            /^npm-shrinkwrap\.json$/,
-            /^yarn\.lock$/,
-            /^pnpm-lock\.yaml$/
-          ]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          %r{^(?:.*/)?package\.json$},
+          %r{^(?:.*/)?package-lock\.json$},
+          %r{^(?:.*/)?npm-shrinkwrap\.json$},
+          %r{^(?:.*/)?yarn\.lock$},
+          %r{^(?:.*/)?pnpm-lock\.yaml$},
+          %r{^(?:.*/)?\.yarn/.*}, # Matches any file within the .yarn/ directory
+          %r{^(?:.*/)?\.pnp\.(?:js|cjs)$}, # Matches .pnp.js or .pnp.cjs files
+        ]
       end
 
       sig { override.returns(T::Array[DependencyFile]) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -64,9 +64,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -87,7 +87,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           "subdirectory/pnpm-lock.yaml",
           "apps/dependabot_business/package.json",
           "packages/package1/package.json",
-          "packages/package2/yarn.lock"
+          "packages/package2/yarn.lock",
+          ".yarn/install-state.gz",
+          ".yarn/cache/@es-test-npm-0.46.0-d544b36047-96010ece49.zip",
+          ".pnp.js",
+          ".pnp.cjs"
         ]
 
         matching_files.each do |file_name|

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -16,7 +16,7 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           /.*\.([a-z]{2})?proj$/, # Matches files with any extension like .csproj, .vbproj, etc., in any directory
@@ -30,7 +30,7 @@ module Dependabot
           /Directory\.targets$/i,         # Matches Directory.targets in any directory or root directory
           /Packages\.props$/i, # Matches Packages.props in any directory
           /.*\.nuspec$/, # Matches any .nuspec files in any directory
-          %r{^\.config/dotnet-tools\.json$}, # Matches .config/dotnet-tools.json in only root directory
+          %r{^\.config/dotnet-tools\.json$} # Matches .config/dotnet-tools.json in only root directory
         ]
       end
 

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -16,35 +16,22 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            /^.*\.([a-z]{2})?proj$/,
-            /^packages\.config$/i,
-            /^app\.config$/i,
-            /^web\.config$/i,
-            /^global\.json$/i,
-            /^dotnet-tools\.json$/i,
-            /^Directory\.Build\.props$/i,
-            /^Directory\.Build\.targets$/i,
-            /^Packages\.props$/i
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            %r{^[^/]*\.([a-z]{2})?proj$},
-            /^.*\.([a-z]{2})?proj$/,
-            /^packages\.config$/i,
-            /^app\.config$/i,
-            /^web\.config$/i,
-            /^global\.json$/i,
-            /^dotnet-tools\.json$/i,
-            /^Directory\.Build\.props$/i,
-            /^Directory\.Build\.targets$/i,
-            /^Packages\.props$/i
-          ]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          /.*\.([a-z]{2})?proj$/, # Matches files with any extension like .csproj, .vbproj, etc., in any directory
+          /packages\.config$/i,           # Matches packages.config in any directory
+          /app\.config$/i,                # Matches app.config in any directory
+          /web\.config$/i,                # Matches web.config in any directory
+          /global\.json$/i,               # Matches global.json in any directory
+          /dotnet-tools\.json$/i,         # Matches dotnet-tools.json in any directory
+          /Directory\.Build\.props$/i,    # Matches Directory.Build.props in any directory
+          /Directory\.Build\.targets$/i,  # Matches Directory.Build.targets in any directory
+          /Directory\.targets$/i,         # Matches Directory.targets in any directory or root directory
+          /Packages\.props$/i, # Matches Packages.props in any directory
+          /.*\.nuspec$/, # Matches any .nuspec files in any directory
+          %r{^\.config/dotnet-tools\.json$}, # Matches .config/dotnet-tools.json in only root directory
+        ]
       end
 
       sig { params(original_content: T.nilable(String), updated_content: String).returns(T::Boolean) }

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -25,7 +25,7 @@ module Dependabot
           is_transitive: T::Boolean
         }
       end
-      
+
       sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -131,9 +131,18 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           "global.json",
           "dotnet-tools.json",
           "Directory.Build.props",
+          "Source/Directory.Build.props",
+          "Directory.targets",
+          "src/Directory.targets",
           "Directory.Build.targets",
+          "Directory.Packages.props",
+          "Source/Directory.Packages.props",
           "Packages.props",
-          "Proj1/Proj1/Proj1.csproj"
+          "Proj1/Proj1/Proj1.csproj",
+          ".config/dotnet-tools.json",
+          ".nuspec",
+          "subdirectory/.nuspec",
+          "Service/Contract/packages.config"
         ]
 
         matching_files.each do |file_name|

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -111,9 +111,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
   end
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/pub/lib/dependabot/pub/file_updater.rb
+++ b/pub/lib/dependabot/pub/file_updater.rb
@@ -13,11 +13,11 @@ module Dependabot
 
       include Dependabot::Pub::Helpers
 
-      sig { override.params(_: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(_ = false)
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
         [
-          /^pubspec\.yaml$/,
-          /^pubspec\.lock$/
+          %r{^(.*/)?pubspec\.yaml$},
+          %r{^(.*/)?pubspec\.lock$}
         ]
       end
 

--- a/pub/lib/dependabot/pub/file_updater.rb
+++ b/pub/lib/dependabot/pub/file_updater.rb
@@ -13,7 +13,7 @@ module Dependabot
 
       include Dependabot::Pub::Helpers
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           %r{^(.*/)?pubspec\.yaml$},

--- a/pub/spec/dependabot/pub/file_updater_spec.rb
+++ b/pub/spec/dependabot/pub/file_updater_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe Dependabot::Pub::FileUpdater do
       it "returns true for files that should be updated" do
         matching_files = [
           "pubspec.yaml",
-          "pubspec.lock"
+          "pubspec.lock",
+          "packages/foo_bar/pubspec.yaml",
+          "packages/foo_bar/pubspec.lock"
         ]
 
         matching_files.each do |file_name|

--- a/pub/spec/dependabot/pub/file_updater_spec.rb
+++ b/pub/spec/dependabot/pub/file_updater_spec.rb
@@ -73,8 +73,7 @@ RSpec.describe Dependabot::Pub::FileUpdater do
   end
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/python/lib/dependabot/python/file_updater.rb
+++ b/python/lib/dependabot/python/file_updater.rb
@@ -17,33 +17,19 @@ module Dependabot
       require_relative "file_updater/poetry_file_updater"
       require_relative "file_updater/requirement_file_updater"
 
-      sig { override.params(allowlist_enabled: T::Boolean).returns(T::Array[Regexp]) }
-      def self.updated_files_regex(allowlist_enabled = false)
-        if allowlist_enabled
-          [
-            /^.*Pipfile$/,             # Match Pipfile at any level
-            /^.*Pipfile\.lock$/,       # Match Pipfile.lock at any level
-            /^.*\.txt$/,               # Match any .txt files (e.g., requirements.txt) at any level
-            /^.*\.in$/,                # Match any .in files at any level
-            /^.*setup\.py$/,           # Match setup.py at any level
-            /^.*setup\.cfg$/,          # Match setup.cfg at any level
-            /^.*pyproject\.toml$/,     # Match pyproject.toml at any level
-            /^.*pyproject\.lock$/,     # Match pyproject.lock at any level
-            /^.*poetry\.lock$/         # Match poetry.lock at any level
-          ]
-        else
-          # Old regex. After 100% rollout of the allowlist, this will be removed.
-          [
-            /^Pipfile$/,
-            /^Pipfile\.lock$/,
-            /.*\.txt$/,
-            /.*\.in$/,
-            /^setup\.py$/,
-            /^setup\.cfg$/,
-            /^pyproject\.toml$/,
-            /^pyproject\.lock$/
-          ]
-        end
+      sig { overridable.returns(T::Array[Regexp]) }
+      def self.updated_files_regex
+        [
+          /^.*Pipfile$/,             # Match Pipfile at any level
+          /^.*Pipfile\.lock$/,       # Match Pipfile.lock at any level
+          /^.*\.txt$/,               # Match any .txt files (e.g., requirements.txt) at any level
+          /^.*\.in$/,                # Match any .in files at any level
+          /^.*setup\.py$/,           # Match setup.py at any level
+          /^.*setup\.cfg$/,          # Match setup.cfg at any level
+          /^.*pyproject\.toml$/,     # Match pyproject.toml at any level
+          /^.*pyproject\.lock$/,     # Match pyproject.lock at any level
+          /^.*poetry\.lock$/, # Match poetry.lock at any level
+        ]
       end
 
       sig { override.returns(T::Array[DependencyFile]) }

--- a/python/lib/dependabot/python/file_updater.rb
+++ b/python/lib/dependabot/python/file_updater.rb
@@ -17,7 +17,7 @@ module Dependabot
       require_relative "file_updater/poetry_file_updater"
       require_relative "file_updater/requirement_file_updater"
 
-      sig { overridable.returns(T::Array[Regexp]) }
+      sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
           /^.*Pipfile$/,             # Match Pipfile at any level
@@ -28,7 +28,7 @@ module Dependabot
           /^.*setup\.cfg$/,          # Match setup.cfg at any level
           /^.*pyproject\.toml$/,     # Match pyproject.toml at any level
           /^.*pyproject\.lock$/,     # Match pyproject.lock at any level
-          /^.*poetry\.lock$/, # Match poetry.lock at any level
+          /^.*poetry\.lock$/ # Match poetry.lock at any level
         ]
       end
 

--- a/python/spec/dependabot/python/file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater_spec.rb
@@ -58,9 +58,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-
-    let(:allowlist_enabled) { true }
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/swift/lib/dependabot/swift/file_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater.rb
@@ -9,7 +9,7 @@ require "dependabot/swift/file_updater/manifest_updater"
 module Dependabot
   module Swift
     class FileUpdater < Dependabot::FileUpdaters::Base
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [
           /Package(@swift-\d(\.\d){0,2})?\.swift/,
           /^Package\.resolved$/

--- a/swift/spec/dependabot/swift/file_updater_spec.rb
+++ b/swift/spec/dependabot/swift/file_updater_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Dependabot::Swift::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -20,7 +20,7 @@ module Dependabot
       MODULE_NOT_INSTALLED_ERROR =  /Module not installed.*module\s*\"(?<mod>\S+)\"/m
       GIT_HTTPS_PREFIX = %r{^git::https://}
 
-      def self.updated_files_regex(_ = false)
+      def self.updated_files_regex
         [/\.tf$/, /\.hcl$/]
       end
 

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   describe "#updated_files_regex" do
-    subject(:updated_files_regex) { described_class.updated_files_regex(allowlist_enabled) }
-    let(:allowlist_enabled) { false } # default value
+    subject(:updated_files_regex) { described_class.updated_files_regex }
 
     it "is not empty" do
       expect(updated_files_regex).not_to be_empty


### PR DESCRIPTION
### What are you trying to accomplish?

- Revert changes to `updated_files_regex` method from the [PR](https://github.com/dependabot/dependabot-core/pull/10389). From the PR only regex with allowlist_enabled is added which is in match with the latest regex from the API. The old regex is removed. The `updated_files_regex` does not get used anywhere in the Core except in the API so its functionality is now implemented in API. 

- All the test cases are also updated.


<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Context: https://github.com/dependabot/dependabot-core/pull/10389

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
