### PR TITLE
Revert "rework reporting of dependencies and requirements to better handle transitive dependencies"

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -348,57 +348,6 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
     }
 
     [Fact]
-    public async Task AnalyzeVulnerableTransitiveDependencies()
-    {
-        await TestAnalyzeAsync(
-            packages:
-            [
-                MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "1.0.0", "net8.0"),
-                MockNuGetPackage.CreateSimplePackage("Some.Transitive.Dependency", "1.0.1", "net8.0"),
-            ],
-            discovery: new()
-            {
-                Path = "/",
-                Projects = [
-                    new()
-                    {
-                        FilePath = "project.csproj",
-                        TargetFrameworks = ["net8.0"],
-                        Dependencies = [
-                            new("Some.Transitive.Dependency", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
-                        ]
-                    }
-                ]
-            },
-            dependencyInfo: new()
-            {
-                Name = "Some.Transitive.Dependency",
-                Version = "1.0.0",
-                IsVulnerable = true,
-                IgnoredVersions = [],
-                Vulnerabilities = [
-                    new()
-                    {
-                        DependencyName = "Some.Transitive.Dependency",
-                        PackageManager = "nuget",
-                        VulnerableVersions = [Requirement.Parse("<= 1.0.0")],
-                        SafeVersions = [Requirement.Parse("= 1.0.1")],
-                    }
-                ]
-            },
-            expectedResult: new()
-            {
-                UpdatedVersion = "1.0.1",
-                CanUpdate = true,
-                VersionComesFromMultiDependencyProperty = false,
-                UpdatedDependencies = [
-                    new("Some.Transitive.Dependency", "1.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
-                ],
-            }
-        );
-    }
-
-    [Fact]
     public async Task IgnoredVersionsCanHandleWildcardSpecification()
     {
         await TestAnalyzeAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -108,7 +108,6 @@ public partial class AnalyzeWorker
                         discovery,
                         dependenciesToUpdate,
                         updatedVersion,
-                        dependencyInfo,
                         nugetContext,
                         _logger,
                         CancellationToken.None);
@@ -360,7 +359,6 @@ public partial class AnalyzeWorker
         WorkspaceDiscoveryResult discovery,
         ImmutableHashSet<string> packageIds,
         NuGetVersion updatedVersion,
-        DependencyInfo dependencyInfo,
         NuGetContext nugetContext,
         Logger logger,
         CancellationToken cancellationToken)
@@ -381,23 +379,10 @@ public partial class AnalyzeWorker
             .Select(NuGetFramework.Parse)
             .ToImmutableArray();
 
-        // When updating dependencies, we only need to consider top-level dependencies _UNLESS_ it's specifically vulnerable
-        var relevantDependencies = projectsWithDependency.SelectMany(p => p.Dependencies)
-            .Where(d =>
-            {
-                if (string.Compare(d.Name, dependencyInfo.Name, StringComparison.OrdinalIgnoreCase) == 0 &&
-                    dependencyInfo.IsVulnerable)
-                {
-                    // if this dependency is one we're specifically updating _and_ if it's vulnerable, always update it
-                    return true;
-                }
-                else
-                {
-                    // otherwise only update if it's a top-level dependency
-                    return !d.IsTransitive;
-                }
-            });
-        var projectDependencyNames = relevantDependencies
+        // When updating peer dependencies, we only need to consider top-level dependencies.
+        var projectDependencyNames = projectsWithDependency
+            .SelectMany(p => p.Dependencies)
+            .Where(d => !d.IsTransitive)
             .Select(d => d.Name)
             .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 

--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -50,10 +50,7 @@ module Dependabot
           # cache discovery results
           NativeDiscoveryJsonReader.set_discovery_from_dependency_files(dependency_files: dependency_files,
                                                                         discovery: discovery_json_reader)
-          # we only return top-level dependencies and requirements here
-          dependency_set = discovery_json_reader.dependency_set(dependency_files: dependency_files,
-                                                                top_level_only: true)
-          dependency_set.dependencies
+          discovery_json_reader.dependency_set.dependencies
         end
 
         T.must(self.class.file_dependency_cache[key])

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -16,16 +16,6 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
-      DependencyDetails = T.type_alias do
-        {
-          file: String,
-          name: String,
-          version: String,
-          previous_version: String,
-          is_transitive: T::Boolean
-        }
-      end
-
       sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
         [
@@ -62,21 +52,9 @@ module Dependabot
       def updated_dependency_files
         base_dir = "/"
         SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
-          expanded_dependency_details.each do |dep_details|
-            file = T.let(dep_details.fetch(:file), String)
-            name = T.let(dep_details.fetch(:name), String)
-            version = T.let(dep_details.fetch(:version), String)
-            previous_version = T.let(dep_details.fetch(:previous_version), String)
-            is_transitive = T.let(dep_details.fetch(:is_transitive), T::Boolean)
-            NativeHelpers.run_nuget_updater_tool(repo_root: T.must(repo_contents_path),
-                                                 proj_path: file,
-                                                 dependency_name: name,
-                                                 version: version,
-                                                 previous_version: previous_version,
-                                                 is_transitive: is_transitive,
-                                                 credentials: credentials)
+          dependencies.each do |dependency|
+            try_update_projects(dependency) || try_update_json(dependency)
           end
-
           updated_files = dependency_files.filter_map do |f|
             updated_content = File.read(dependency_file_path(f))
             next if updated_content == f.content
@@ -96,69 +74,104 @@ module Dependabot
 
       private
 
-      # rubocop:disable Metrics/AbcSize
-      sig { returns(T::Array[DependencyDetails]) }
-      def expanded_dependency_details
+      sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
+      def try_update_projects(dependency)
+        update_ran = T.let(false, T::Boolean)
+        checked_files = Set.new
+
+        # run update for each project file
+        project_files.each do |project_file|
+          project_dependencies = project_dependencies(project_file)
+          proj_path = dependency_file_path(project_file)
+
+          next unless project_dependencies.any? { |dep| dep.name.casecmp?(dependency.name) }
+
+          next unless repo_contents_path
+
+          checked_key = "#{project_file.name}-#{dependency.name}#{dependency.version}"
+          call_nuget_updater_tool(dependency, proj_path) unless checked_files.include?(checked_key)
+
+          checked_files.add(checked_key)
+          # We need to check the downstream references even though we're already evaluated the file
+          downstream_files = referenced_project_paths(project_file)
+          downstream_files.each do |downstream_file|
+            checked_files.add("#{downstream_file}-#{dependency.name}#{dependency.version}")
+          end
+          update_ran = true
+        end
+        update_ran
+      end
+
+      sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
+      def try_update_json(dependency)
+        if dotnet_tools_json_dependencies.any? { |dep| dep.name.casecmp?(dependency.name) } ||
+           global_json_dependencies.any? { |dep| dep.name.casecmp?(dependency.name) }
+
+          # We just need to feed the updater a project file, grab the first
+          project_file = T.must(project_files.first)
+          proj_path = dependency_file_path(project_file)
+
+          return false unless repo_contents_path
+
+          call_nuget_updater_tool(dependency, proj_path)
+          return true
+        end
+
+        false
+      end
+
+      sig { params(dependency: Dependency, proj_path: String).void }
+      def call_nuget_updater_tool(dependency, proj_path)
+        NativeHelpers.run_nuget_updater_tool(repo_root: T.must(repo_contents_path), proj_path: proj_path,
+                                             dependency: dependency, is_transitive: !dependency.top_level?,
+                                             credentials: credentials)
+
+        # Tests need to track how many times we call the tooling updater to ensure we don't recurse needlessly
+        # Ideally we should find a way to not run this code in prod
+        # (or a better way to track calls made to NativeHelpers)
+        @update_tooling_calls ||= T.let({}, T.nilable(T::Hash[String, Integer]))
+        key = "#{proj_path.delete_prefix(T.must(repo_contents_path))}+#{dependency.name}"
+        @update_tooling_calls[key] =
+          if @update_tooling_calls[key]
+            T.must(@update_tooling_calls[key]) + 1
+          else
+            1
+          end
+      end
+
+      # Don't call this from outside tests, we're only checking that we aren't recursing needlessly
+      sig { returns(T.nilable(T::Hash[String, Integer])) }
+      def testonly_update_tooling_calls
+        @update_tooling_calls
+      end
+
+      sig { returns(T.nilable(NativeWorkspaceDiscovery)) }
+      def workspace
         discovery_json_reader = NativeDiscoveryJsonReader.get_discovery_from_dependency_files(dependency_files)
-        dependency_set = discovery_json_reader.dependency_set(dependency_files: dependency_files, top_level_only: false)
-        all_dependencies = dependency_set.dependencies
-        dependencies.map do |dep|
-          # if vulnerable metadata is set, re-fetch all requirements from discovery
-          is_vulnerable = T.let(dep.metadata.fetch(:is_vulnerable, false), T::Boolean)
-          relevant_dependencies = all_dependencies.filter { |d| d.name.casecmp?(dep.name) }
-          candidate_vulnerable_dependency = T.must(relevant_dependencies.first)
-          relevant_dependency = is_vulnerable ? candidate_vulnerable_dependency : dep
-          relevant_details = relevant_dependency.requirements.filter_map do |req|
-            dependency_details_from_requirement(dep.name, req, is_vulnerable: is_vulnerable)
-          end
-
-          next relevant_details if relevant_details.any?
-
-          # If we didn't find anything to update, we're in a very specific corner case: we were explicitly asked to
-          # (1) update a certain dependency, (2) it wasn't listed as a security update, but (3) it only exists as a
-          # transitive dependency.  In this case, we need to rebuild the dependency requirements as if this were a
-          # security update so that we can perform the appropriate update.
-          candidate_vulnerable_dependency.requirements.filter_map do |req|
-            rebuilt_req = {
-              file: req[:file], # simple copy
-              requirement: relevant_dependency.version, # the newly available version
-              metadata: {
-                is_transitive: T.let(req[:metadata], T::Hash[Symbol, T.untyped])[:is_transitive], # simple copy
-                previous_requirement: req[:requirement] # the old requirement's "current" version is now the "previous"
-              }
-            }
-            dependency_details_from_requirement(dep.name, rebuilt_req, is_vulnerable: true)
-          end
-        end.flatten
+        discovery_json_reader.workspace_discovery
       end
-      # rubocop:enable Metrics/AbcSize
 
-      sig do
-        params(
-          name: String,
-          requirement: T::Hash[Symbol, T.untyped],
-          is_vulnerable: T::Boolean
-        ).returns(T.nilable(DependencyDetails))
+      sig { params(project_file: Dependabot::DependencyFile).returns(T::Array[String]) }
+      def referenced_project_paths(project_file)
+        workspace&.projects&.find { |p| p.file_path == project_file.name }&.referenced_project_paths || []
       end
-      def dependency_details_from_requirement(name, requirement, is_vulnerable:)
-        metadata = T.let(requirement.fetch(:metadata), T::Hash[Symbol, T.untyped])
-        current_file = T.let(requirement.fetch(:file), String)
-        return nil unless current_file.match?(/\.(cs|vb|fs)proj$/)
 
-        is_transitive = T.let(metadata.fetch(:is_transitive), T::Boolean)
-        return nil if !is_vulnerable && is_transitive
+      sig { params(project_file: Dependabot::DependencyFile).returns(T::Array[NativeDependencyDetails]) }
+      def project_dependencies(project_file)
+        workspace&.projects&.find do |p|
+          full_project_file_path = File.join(project_file.directory, project_file.name)
+          p.file_path == full_project_file_path
+        end&.dependencies || []
+      end
 
-        version = T.let(requirement.fetch(:requirement), String)
-        previous_version = T.let(metadata[:previous_requirement], String)
-        return nil if version == previous_version
+      sig { returns(T::Array[NativeDependencyDetails]) }
+      def global_json_dependencies
+        workspace&.global_json&.dependencies || []
+      end
 
-        {
-          file: T.let(requirement.fetch(:file), String),
-          name: name,
-          version: version,
-          previous_version: previous_version,
-          is_transitive: is_transitive
-        }
+      sig { returns(T::Array[NativeDependencyDetails]) }
+      def dotnet_tools_json_dependencies
+        workspace&.dotnet_tools_json&.dependencies || []
       end
 
       # rubocop:disable Metrics/PerceivedComplexity

--- a/nuget/lib/dependabot/nuget/native_discovery/native_dependency_file_discovery.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_dependency_file_discovery.rb
@@ -106,20 +106,22 @@ module Dependabot
           .returns(T.nilable(T::Hash[Symbol, T.untyped]))
       end
       def build_requirement(file_name, dependency_details)
+        return if dependency_details.is_transitive
+
         version = dependency_details.version
         version = nil if version&.empty?
-        metadata = { is_transitive: dependency_details.is_transitive }
 
         requirement = {
           requirement: version,
           file: file_name,
           groups: [dependency_details.is_dev_dependency ? "devDependencies" : "dependencies"],
-          source: nil,
-          metadata: metadata
+          source: nil
         }
 
         property_name = dependency_details.evaluation&.root_property_name
-        metadata[:property_name] = property_name if property_name
+        return requirement unless property_name
+
+        requirement[:metadata] = { property_name: property_name }
         requirement
       end
     end

--- a/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
@@ -125,89 +125,15 @@ module Dependabot
       sig { returns(T.nilable(NativeWorkspaceDiscovery)) }
       attr_reader :workspace_discovery
 
+      sig { returns(Dependabot::FileParsers::Base::DependencySet) }
+      attr_reader :dependency_set
+
       sig { params(discovery_json: DependencyFile).void }
       def initialize(discovery_json:)
         @discovery_json = discovery_json
         @workspace_discovery = T.let(read_workspace_discovery, T.nilable(Dependabot::Nuget::NativeWorkspaceDiscovery))
+        @dependency_set = T.let(read_dependency_set, Dependabot::FileParsers::Base::DependencySet)
       end
-
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/PerceivedComplexity
-      sig do
-        params(
-          dependency_files: T::Array[Dependabot::DependencyFile],
-          top_level_only: T::Boolean
-        ).returns(Dependabot::FileParsers::Base::DependencySet)
-      end
-      def dependency_set(dependency_files:, top_level_only:)
-        # dependencies must be recalculated so that we:
-        #   1. only return dependencies that are in the file set we reported earlier
-        #      see https://github.com/dependabot/dependabot-core/issues/10303
-        #   2. the reported version is the minimum across all requirements; this ensures that we get the opportunity
-        #      to update everything later
-        dependency_file_set = T.let(Set.new(dependency_files.map do |df|
-          Pathname.new(File.join(df.directory, df.name)).cleanpath.to_path
-        end), T::Set[String])
-
-        rebuilt_dependencies = read_dependency_set.dependencies.filter_map do |dep|
-          # only report requirements in files we know about
-          matching_requirements = dep.requirements.filter do |req|
-            file = T.let(req.fetch(:file), String)
-            dependency_file_set.include?(file)
-          end
-
-          # find the minimum version across all requirements
-          min_version = matching_requirements.filter_map do |req|
-            v = T.let(req.fetch(:requirement), T.nilable(String))
-            next unless v
-
-            Dependabot::Nuget::Version.new(v)
-          end.min
-          next unless min_version
-
-          # only return dependency requirements that are top-level
-          if top_level_only
-            matching_requirements.reject! do |req|
-              metadata = T.let(req.fetch(:metadata), T::Hash[Symbol, T.untyped])
-              T.let(metadata.fetch(:is_transitive), T::Boolean)
-            end
-          end
-
-          # we might need to return a dependency like this
-          dep_without_reqs = Dependabot::Dependency.new(
-            name: dep.name,
-            version: min_version.to_s,
-            package_manager: "nuget",
-            requirements: []
-          )
-
-          dep_with_reqs = matching_requirements.filter_map do |req|
-            version = T.let(req.fetch(:requirement, nil), T.nilable(String))
-            next unless version
-
-            Dependabot::Dependency.new(
-              name: dep.name,
-              version: min_version.to_s,
-              package_manager: "nuget",
-              requirements: [req]
-            )
-          end
-
-          # if only returning top-level dependencies and we had no non-transitive requirements, return an empty
-          # dependency so it can be tracked for security updates
-          matching_requirements.empty? && top_level_only ? [dep_without_reqs] : dep_with_reqs
-        end.flatten
-
-        final_dependency_set = Dependabot::FileParsers::Base::DependencySet.new
-        rebuilt_dependencies.each do |dep|
-          final_dependency_set << dep
-        end
-        final_dependency_set
-      end
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/nuget/lib/dependabot/nuget/native_discovery/native_project_discovery.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_project_discovery.rb
@@ -1,7 +1,6 @@
 # typed: strong
 # frozen_string_literal: true
 
-require "dependabot/file_parsers/base/dependency_set"
 require "dependabot/nuget/native_discovery/native_dependency_details"
 require "dependabot/nuget/native_discovery/native_property_details"
 require "sorbet-runtime"

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -171,18 +171,10 @@ module Dependabot
 
       # rubocop:disable Metrics/MethodLength
       sig do
-        params(
-          repo_root: String,
-          proj_path: String,
-          dependency_name: String,
-          version: String,
-          previous_version: String,
-          is_transitive: T::Boolean,
-          result_output_path: String
-        ).returns([String, String])
+        params(repo_root: String, proj_path: String, dependency: Dependency,
+               is_transitive: T::Boolean, result_output_path: String).returns([String, String])
       end
-      def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency_name:, version:, previous_version:,
-                                              is_transitive:, result_output_path:)
+      def self.get_nuget_updater_tool_command(repo_root:, proj_path:, dependency:, is_transitive:, result_output_path:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command_parts = [
           exe_path,
@@ -192,11 +184,11 @@ module Dependabot
           "--solution-or-project",
           proj_path,
           "--dependency",
-          dependency_name,
+          dependency.name,
           "--new-version",
-          version,
+          dependency.version,
           "--previous-version",
-          previous_version,
+          dependency.previous_version,
           is_transitive ? "--transitive" : nil,
           "--result-output-path",
           result_output_path,
@@ -237,21 +229,14 @@ module Dependabot
         params(
           repo_root: String,
           proj_path: String,
-          dependency_name: String,
-          version: String,
-          previous_version: String,
+          dependency: Dependency,
           is_transitive: T::Boolean,
           credentials: T::Array[Dependabot::Credential]
         ).void
       end
-      def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency_name:, version:, previous_version:,
-                                      is_transitive:, credentials:)
-        (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root,
-                                                                proj_path: proj_path,
-                                                                dependency_name: dependency_name,
-                                                                version: version,
-                                                                previous_version: previous_version,
-                                                                is_transitive: is_transitive,
+      def self.run_nuget_updater_tool(repo_root:, proj_path:, dependency:, is_transitive:, credentials:)
+        (command, fingerprint) = get_nuget_updater_tool_command(repo_root: repo_root, proj_path: proj_path,
+                                                                dependency: dependency, is_transitive: is_transitive,
                                                                 result_output_path: update_result_file_path)
 
         puts "running NuGet updater:\n" + command

--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -166,8 +166,7 @@ module Dependabot
           requirements: updated_requirements,
           previous_version: dependency.version,
           previous_requirements: dependency.requirements,
-          package_manager: dependency.package_manager,
-          metadata: { is_vulnerable: vulnerable? }
+          package_manager: dependency.package_manager
         )
         updated_dependencies = [updated_dependency]
         updated_dependencies += DependencyFinder.new(

--- a/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
@@ -37,11 +37,10 @@ module Dependabot
         def updated_requirements
           return requirements unless latest_version
 
+          # NOTE: Order is important here. The FileUpdater needs the updated
+          # requirement at index `i` to correspond to the previous requirement
+          # at the same index.
           requirements.map do |req|
-            req[:metadata] ||= {}
-            req[:metadata][:is_transitive] = false
-            req[:metadata][:previous_requirement] = req[:requirement]
-
             next req if req.fetch(:requirement).nil?
             next req if req.fetch(:requirement).include?(",")
 
@@ -57,6 +56,7 @@ module Dependabot
                   latest_version.to_s
                 )
               end
+
             next req if new_req == req.fetch(:requirement)
 
             req.merge(requirement: new_req, source: updated_source)

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -45,12 +45,20 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
   let(:dependency_version) { "1.1.1" }
   let(:dependency_previous_version) { "1.0.0" }
   let(:requirements) do
-    [{ file: "dirs.proj", requirement: "1.1.1", groups: [], metadata: {}, source: nil }]
+    [{ file: "dirs.proj", requirement: "1.1.1", groups: [], source: nil }]
   end
   let(:previous_requirements) do
-    [{ file: "dirs.proj", requirement: "1.0.0", groups: [], metadata: {}, source: nil }]
+    [{ file: "dirs.proj", requirement: "1.0.0", groups: [], source: nil }]
   end
   let(:repo_contents_path) { nuget_build_tmp_repo(project_name) }
+
+  before do
+    stub_search_results_with_versions_v3("microsoft.extensions.dependencymodel", ["1.0.0", "1.1.1"])
+    stub_request(:get, "https://api.nuget.org/v3-flatcontainer/" \
+                       "microsoft.extensions.dependencymodel/1.0.0/" \
+                       "microsoft.extensions.dependencymodel.nuspec")
+      .to_return(status: 200, body: fixture("nuspecs", "Microsoft.Extensions.DependencyModel.1.0.0.nuspec"))
+  end
 
   it_behaves_like "a dependency file updater"
 
@@ -163,132 +171,139 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
     end
   end
 
-  describe "#expanded_dependency_details" do
-    context "when update operations are created" do
-      let(:dependency_files) do
-        [
-          Dependabot::DependencyFile.new(name: "project1/project1.csproj", content: "not-used"),
-          Dependabot::DependencyFile.new(name: "project2/project2.csproj", content: "not-used")
-        ]
-      end
-
-      let(:dependencies) do
-        [
-          Dependabot::Dependency.new(
-            name: "Dependency.A",
-            version: "1.0.3",
-            previous_version: "1.0.1",
-            package_manager: "nuget",
-            requirements: [
-              {
-                requirement: "1.0.3",
-                file: "/project1/project1.csproj",
-                groups: ["dependencies"],
-                source: nil,
-                metadata: {
-                  is_transitive: false,
-                  previous_requirement: "1.0.1"
-                }
-              }
-            ],
-            previous_requirements: []
-          ),
-          Dependabot::Dependency.new(
-            name: "Dependency.B",
-            version: "1.9.3",
-            previous_version: "1.9.1",
-            package_manager: "nuget",
-            requirements: [],
-            previous_requirements: []
-          )
-        ]
-      end
-
-      before do
-        intercept_native_tools(
-          discovery_content_hash: {
-            Path: "/",
-            IsSuccess: true,
-            Projects: [{
-              FilePath: "/project1/project1.csproj",
+  describe "#updated_dependency_files" do
+    before do
+      intercept_native_tools(
+        discovery_content_hash: {
+          Path: "",
+          IsSuccess: true,
+          Projects: [
+            {
+              FilePath: "Proj1/Proj1/Proj1.csproj",
               Dependencies: [{
-                Name: "Dependency.A",
-                Version: "1.0.1",
+                Name: "Microsoft.Extensions.DependencyModel",
+                Version: "1.0.0",
                 Type: "PackageReference",
                 EvaluationResult: nil,
-                TargetFrameworks: ["net8.0"],
+                TargetFrameworks: ["net461"],
                 IsDevDependency: false,
                 IsDirect: true,
                 IsTransitive: false,
                 IsOverride: false,
                 IsUpdate: false,
                 InfoUrl: nil
-              }, {
-                Name: "Dependency.B",
-                Version: "1.9.1",
+              }],
+              IsSuccess: true,
+              Properties: [{
+                Name: "TargetFramework",
+                Value: "net461",
+                SourceFilePath: "Proj1/Proj1/Proj1.csproj"
+              }],
+              TargetFrameworks: ["net461"],
+              ReferencedProjectPaths: []
+            }
+          ],
+          DirectoryPackagesProps: nil,
+          GlobalJson: nil,
+          DotNetToolsJson: nil
+        }
+      )
+    end
+
+    context "with a dirs.proj" do
+      it "does not repeatedly update the same project" do
+        run_update_test do |updater|
+          expect(updater.updated_dependency_files.map(&:name)).to contain_exactly("Proj1/Proj1/Proj1.csproj")
+
+          expect(updater.send(:testonly_update_tooling_calls)).to eq(
+            {
+              "/Proj1/Proj1/Proj1.csproj+Microsoft.Extensions.DependencyModel" => 1
+            }
+          )
+        end
+      end
+    end
+  end
+
+  describe "#updated_dependency_files_with_wildcard" do
+    let(:project_name) { "file_updater_dirsproj_wildcards" }
+    let(:dependency_files) { nuget_project_dependency_files(project_name, directory: directory).reverse }
+    let(:dependency_name) { "Microsoft.Extensions.DependencyModel" }
+    let(:dependency_version) { "1.1.1" }
+    let(:dependency_previous_version) { "1.0.0" }
+
+    before do
+      intercept_native_tools(
+        discovery_content_hash: {
+          Path: "",
+          IsSuccess: true,
+          Projects: [
+            {
+              FilePath: "Proj1/Proj1/Proj1.csproj",
+              Dependencies: [{
+                Name: "Microsoft.Extensions.DependencyModel",
+                Version: "1.0.0",
                 Type: "PackageReference",
                 EvaluationResult: nil,
-                TargetFrameworks: ["net8.0"],
+                TargetFrameworks: ["net461"],
                 IsDevDependency: false,
-                IsDirect: false,
-                IsTransitive: true,
+                IsDirect: true,
+                IsTransitive: false,
                 IsOverride: false,
                 IsUpdate: false,
                 InfoUrl: nil
               }],
               IsSuccess: true,
-              Properties: [],
-              TargetFrameworks: ["net8.0"],
+              Properties: [{
+                Name: "TargetFramework",
+                Value: "net461",
+                SourceFilePath: "Proj1/Proj1/Proj1.csproj"
+              }],
+              TargetFrameworks: ["net461"],
               ReferencedProjectPaths: []
             }, {
-              FilePath: "/project2/project2.csproj",
+              FilePath: "Proj2/Proj2.csproj",
               Dependencies: [{
-                Name: "Dependency.A",
-                Version: "1.0.2",
+                Name: "Microsoft.Extensions.DependencyModel",
+                Version: "1.0.0",
                 Type: "PackageReference",
                 EvaluationResult: nil,
-                TargetFrameworks: ["net8.0"],
+                TargetFrameworks: ["net461"],
                 IsDevDependency: false,
-                IsDirect: false,
-                IsTransitive: true,
+                IsDirect: true,
+                IsTransitive: false,
                 IsOverride: false,
                 IsUpdate: false,
                 InfoUrl: nil
               }],
               IsSuccess: true,
-              Properties: [],
-              TargetFrameworks: ["net8.0"],
+              Properties: [{
+                Name: "TargetFramework",
+                Value: "net461",
+                SourceFilePath: "Proj2/Proj2.csproj"
+              }],
+              TargetFrameworks: ["net461"],
               ReferencedProjectPaths: []
-            }],
-            DirectoryPackagesProps: nil,
-            GlobalJson: nil,
-            DotNetToolsJson: nil
+            }
+          ],
+          DirectoryPackagesProps: nil,
+          GlobalJson: nil,
+          DotNetToolsJson: nil
+        }
+      )
+    end
+
+    it "updates the wildcard project" do
+      run_update_test do |updater|
+        expect(updater.updated_dependency_files.map(&:name)).to contain_exactly("Proj1/Proj1/Proj1.csproj",
+                                                                                "Proj2/Proj2.csproj")
+
+        expect(updater.send(:testonly_update_tooling_calls)).to eq(
+          {
+            "/Proj1/Proj1/Proj1.csproj+Microsoft.Extensions.DependencyModel" => 1,
+            "/Proj2/Proj2.csproj+Microsoft.Extensions.DependencyModel" => 1
           }
         )
-      end
-
-      it "produces the correct update order" do
-        run_update_test do |updater|
-          to_process = updater.send(:expanded_dependency_details) # private method, need to invoke it like this
-          expect(to_process).to eq([
-            # this was a top-level dependency and will be updated
-            {
-              name: "Dependency.A",
-              file: "/project1/project1.csproj",
-              version: "1.0.3",
-              previous_version: "1.0.1",
-              is_transitive: false
-            },
-            # this was a transitive dependency, but explicitly requested to be updated
-            {
-              name: "Dependency.B",
-              file: "/project1/project1.csproj",
-              version: "1.9.3",
-              previous_version: "1.9.1",
-              is_transitive: true
-            }
-          ])
-        end
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
     subject(:command) do
       (command,) = described_class.get_nuget_updater_tool_command(repo_root: repo_root,
                                                                   proj_path: proj_path,
-                                                                  dependency_name: dependency.name,
-                                                                  version: dependency.version,
-                                                                  previous_version: dependency.previous_version,
+                                                                  dependency: dependency,
                                                                   is_transitive: is_transitive,
                                                                   result_output_path: result_output_path)
       command = command.gsub(/^.*NuGetUpdater.Cli/, "/path/to/NuGetUpdater.Cli") # normalize path for unit test
@@ -52,9 +50,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
         # This test will fail if the command line arguments weren't properly interpreted
         described_class.run_nuget_updater_tool(repo_root: repo_root,
                                                proj_path: proj_path,
-                                               dependency_name: dependency.name,
-                                               version: dependency.version,
-                                               previous_version: dependency.previous_version,
+                                               dependency: dependency,
                                                is_transitive: is_transitive,
                                                credentials: [])
         expect(Dependabot.logger).not_to have_received(:error)
@@ -79,9 +75,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
         expect do
           described_class.run_nuget_updater_tool(repo_root: repo_root,
                                                  proj_path: proj_path,
-                                                 dependency_name: dependency.name,
-                                                 version: dependency.version,
-                                                 previous_version: dependency.previous_version,
+                                                 dependency: dependency,
                                                  is_transitive: is_transitive,
                                                  credentials: [])
         end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
@@ -106,9 +100,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
         expect do
           described_class.run_nuget_updater_tool(repo_root: repo_root,
                                                  proj_path: proj_path,
-                                                 dependency_name: dependency.name,
-                                                 version: dependency.version,
-                                                 previous_version: dependency.previous_version,
+                                                 dependency: dependency,
                                                  is_transitive: is_transitive,
                                                  credentials: [])
         end.to raise_error(Dependabot::DependencyFileNotFound)
@@ -116,72 +108,72 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
     end
   end
 
-  # describe "#native_csharp_tests" do
-  #   subject(:dotnet_test) do
-  #     Dependabot::SharedHelpers.run_shell_command(command)
-  #   end
+  describe "#native_csharp_tests" do
+    subject(:dotnet_test) do
+      Dependabot::SharedHelpers.run_shell_command(command)
+    end
 
-  #   let(:command) do
-  #     [
-  #       "dotnet",
-  #       "test",
-  #       "--configuration",
-  #       "Release",
-  #       project_path
-  #     ].join(" ")
-  #   end
+    let(:command) do
+      [
+        "dotnet",
+        "test",
+        "--configuration",
+        "Release",
+        project_path
+      ].join(" ")
+    end
 
-  #   context "when the output is from `dotnet test NuGetUpdater.Core.Test` output" do
-  #     let(:project_path) do
-  #       File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
-  #                 "NuGetUpdater.Core.Test", "NuGetUpdater.Core.Test.csproj")
-  #     end
+    context "when the output is from `dotnet test NuGetUpdater.Core.Test` output" do
+      let(:project_path) do
+        File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
+                  "NuGetUpdater.Core.Test", "NuGetUpdater.Core.Test.csproj")
+      end
 
-  #     it "contains the expected output" do
-  #       expect(dotnet_test).to include("Passed!")
-  #     end
-  #   end
+      it "contains the expected output" do
+        expect(dotnet_test).to include("Passed!")
+      end
+    end
 
-  #   context "when the output is from `dotnet test NuGetUpdater.Cli.Test`" do
-  #     let(:project_path) do
-  #       File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
-  #                 "NuGetUpdater.Cli.Test", "NuGetUpdater.Cli.Test.csproj")
-  #     end
+    context "when the output is from `dotnet test NuGetUpdater.Cli.Test`" do
+      let(:project_path) do
+        File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
+                  "NuGetUpdater.Cli.Test", "NuGetUpdater.Cli.Test.csproj")
+      end
 
-  #     it "contains the expected output" do
-  #       expect(dotnet_test).to include("Passed!")
-  #     end
-  #   end
-  # end
+      it "contains the expected output" do
+        expect(dotnet_test).to include("Passed!")
+      end
+    end
+  end
 
-  # describe "#native_csharp_format" do
-  #   subject(:dotnet_test) do
-  #     Dependabot::SharedHelpers.run_shell_command(command)
-  #   end
+  describe "#native_csharp_format" do
+    subject(:dotnet_test) do
+      Dependabot::SharedHelpers.run_shell_command(command)
+    end
 
-  #   let(:command) do
-  #     [
-  #       "dotnet",
-  #       "format",
-  #       lib_path,
-  #       "--exclude",
-  #       except_path,
-  #       "--verify-no-changes",
-  #       "-v",
-  #       "diag"
-  #     ].join(" ")
-  #   end
+    let(:command) do
+      [
+        "dotnet",
+        "format",
+        lib_path,
+        "--exclude",
+        except_path,
+        "--verify-no-changes",
+        "-v",
+        "diag"
+      ].join(" ")
+    end
 
-  #   context "when output is from `dotnet format NuGetUpdater` output" do
-  #     let(:lib_path) do
-  #       File.absolute_path(File.join("helpers", "lib", "NuGetUpdater"))
-  #     end
+    context "when output is from `dotnet format NuGetUpdater` output" do
+      let(:lib_path) do
+        File.absolute_path(File.join("helpers", "lib", "NuGetUpdater"))
+      end
 
-  #     let(:except_path) { "helpers/lib/NuGet.Client" }
+      let(:except_path) { "helpers/lib/NuGet.Client" }
 
-  #     it "contains the expected output" do
-  #       expect(dotnet_test).to include("Format complete")
-  #     end
-  #   end
-  # end
+      it "contains the expected output" do
+        expect(dotnet_test).to include("Format complete")
+      end
+    end
+  end
 end

--- a/nuget/spec/dependabot/nuget/native_update_checker/native_requirements_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_update_checker/native_requirements_updater_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
   let(:updater) do
     described_class.new(
       requirements: requirements,
-      dependency_details: dependency_details,
-      vulnerable: vulnerable
+      dependency_details: dependency_details
     )
   end
 
@@ -19,9 +18,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
       file: "my.csproj",
       requirement: csproj_req_string,
       groups: ["dependencies"],
-      metadata: {
-        is_transitive: false
-      },
       source: nil
     }
   end
@@ -43,7 +39,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
       InfoUrl: info_url
     }.to_json))
   end
-  let(:vulnerable) { false }
 
   describe "#updated_requirements.version" do
     subject { updater.updated_requirements.first }
@@ -118,9 +113,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
             file: "another/my.csproj",
             requirement: other_requirement_string,
             groups: ["dependencies"],
-            metadata: {
-              is_transitive: false
-            },
             source: nil
           }
         end
@@ -132,10 +124,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
             file: "my.csproj",
             requirement: "23.6-jre",
             groups: ["dependencies"],
-            metadata: {
-              is_transitive: false,
-              previous_requirement: "23.3-jre"
-            },
             source: {
               type: "nuget_repo",
               source_url: "https://nuget.example.com/some.package"
@@ -144,10 +132,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
             file: "another/my.csproj",
             requirement: "[23.6-jre]",
             groups: ["dependencies"],
-            metadata: {
-              is_transitive: false,
-              previous_requirement: "[23.4-jre]"
-            },
             source: {
               type: "nuget_repo",
               source_url: "https://nuget.example.com/some.package"
@@ -163,10 +147,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
               file: "my.csproj",
               requirement: "23.6-jre",
               groups: ["dependencies"],
-              metadata: {
-                is_transitive: false,
-                previous_requirement: "23.3-jre"
-              },
               source: {
                 type: "nuget_repo",
                 source_url: "https://nuget.example.com/some.package"
@@ -175,10 +155,6 @@ RSpec.describe Dependabot::Nuget::NativeUpdateChecker::NativeRequirementsUpdater
               file: "another/my.csproj",
               requirement: "[23.0,)",
               groups: ["dependencies"],
-              metadata: {
-                is_transitive: false,
-                previous_requirement: "[23.0,)"
-              },
               source: nil
             })
           end

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -814,10 +814,6 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                 requirement: "6.3.0",
                 file: "/my.csproj",
                 groups: ["dependencies"],
-                metadata: {
-                  is_transitive: false,
-                  previous_requirement: "0.1.434"
-                },
                 source: {
                   type: "nuget_repo",
                   source_url: "https://nuget.example.com/nuke.codegeneration"
@@ -827,17 +823,9 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                 requirement: "0.1.434",
                 file: "/my.csproj",
                 groups: ["dependencies"],
-                metadata: {
-                  is_transitive: false,
-                  previous_requirement: "0.1.434"
-                },
                 source: nil
               }],
-              package_manager: "nuget",
-              metadata: {
-                information_only: true,
-                is_vulnerable: false
-              }
+              package_manager: "nuget"
             ),
             Dependabot::Dependency.new(
               name: "Nuke.Common",
@@ -847,10 +835,6 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                 requirement: "6.3.0",
                 file: "/my.csproj",
                 groups: ["dependencies"],
-                metadata: {
-                  is_transitive: false,
-                  previous_requirement: "0.1.434"
-                },
                 source: {
                   type: "nuget_repo",
                   source_url: "https://nuget.example.com/nuke.common"
@@ -860,16 +844,9 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                 requirement: "0.1.434",
                 file: "/my.csproj",
                 groups: ["dependencies"],
-                metadata: {
-                  is_transitive: false,
-                  previous_requirement: "0.1.434"
-                },
                 source: nil
               }],
-              package_manager: "nuget",
-              metadata: {
-                is_vulnerable: false
-              }
+              package_manager: "nuget"
             )
           ])
         end


### PR DESCRIPTION
~~## This PR contains a temporary commit to redirect the smoke tests.  That temporary commit needs to be removed before merging.~~

Corresponding smoke-tests PR that should go in at the same time: dependabot/smoke-tests#224

NuGet dependencies only exist via MSBuild and that allows arbitrary directory crawling.  Due to the complexities of that, the previous PR #10449 is being reverted.

Future NuGet work will require rewriting the updater to not use any of the common dependabot code and that means the NuGet updater will be in a "broken" state for the time being and the previous version of "broken" is better than the current.