### PR TITLE
Sending Bundler v1 Deprecation Warning Alert

### DIFF
--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -29,6 +29,7 @@ module Dependabot
     # @param markdown [String] The markdown formatted description.
     # @param show_in_pr [Boolean] Whether the notice should be shown in a pull request.
     # @param show_in_log [Boolean] Whether the notice should be shown in the log.
+    # @param show_in_alert [Boolean] Whether the notice should be shown in alerts.
     sig do
       params(
         mode: String,
@@ -38,13 +39,14 @@ module Dependabot
         description: String,
         markdown: String,
         show_in_pr: T::Boolean,
-        show_in_log: T::Boolean
+        show_in_log: T::Boolean,
+        show_in_alert: T::Boolean
       ).void
     end
     def initialize(
       mode:, type:, package_manager_name:,
       title: "", description: "", markdown: "",
-      show_in_pr: false, show_in_log: true
+      show_in_pr: false, show_in_log: true, show_in_alert: false
     )
       @mode = mode
       @type = type
@@ -54,6 +56,7 @@ module Dependabot
       @markdown = markdown
       @show_in_pr = show_in_pr
       @show_in_log = show_in_log
+      @show_in_alert = show_in_alert
     end
 
     # Converts the Notice object to a hash.
@@ -68,7 +71,8 @@ module Dependabot
         description: @description,
         markdown: @markdown,
         show_in_pr: @show_in_pr,
-        show_in_log: @show_in_log
+        show_in_log: @show_in_log,
+        show_in_alert: @show_in_alert
       }
     end
 
@@ -152,7 +156,8 @@ module Dependabot
         description: description,
         markdown: markdown,
         show_in_pr: true,
-        show_in_log: true
+        show_in_log: true,
+        show_in_alert: true
       )
     end
 
@@ -194,7 +199,8 @@ module Dependabot
         description: description,
         markdown: markdown,
         show_in_pr: true,
-        show_in_log: true
+        show_in_log: true,
+        show_in_alert: true
       )
     end
   end

--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -6,32 +6,54 @@ require "dependabot/package_manager"
 
 module Dependabot
   class Notice
+    module NoticeMode
+      INFO = "INFO"
+      WARN = "WARN"
+      ERROR = "ERROR"
+    end
+
     extend T::Sig
 
     sig { returns(String) }
-    attr_reader :mode, :type, :package_manager_name, :message, :markdown
+    attr_reader :mode, :type, :package_manager_name, :title, :description, :markdown
+
+    sig { returns(T::Boolean) }
+    attr_reader :show_in_pr, :show_in_log
 
     # Initializes a new Notice object.
     # @param mode [String] The mode of the notice (e.g., "WARN", "ERROR").
     # @param type [String] The type of the notice (e.g., "bundler_deprecated_warn").
     # @param package_manager_name [String] The name of the package manager (e.g., "bundler").
-    # @param message [String] The main message of the notice.
-    # @param markdown [String] The markdown formatted message.
+    # @param title [String] The title of the notice.
+    # @param description [String] The main description of the notice.
+    # @param markdown [String] The markdown formatted description.
+    # @param show_in_pr [Boolean] Whether the notice should be shown in a pull request.
+    # @param show_in_log [Boolean] Whether the notice should be shown in the log.
     sig do
       params(
         mode: String,
         type: String,
         package_manager_name: String,
-        message: String,
-        markdown: String
+        title: String,
+        description: String,
+        markdown: String,
+        show_in_pr: T::Boolean,
+        show_in_log: T::Boolean
       ).void
     end
-    def initialize(mode:, type:, package_manager_name:, message: "", markdown: "")
+    def initialize(
+      mode:, type:, package_manager_name:,
+      title: "", description: "", markdown: "",
+      show_in_pr: false, show_in_log: true
+    )
       @mode = mode
       @type = type
       @package_manager_name = package_manager_name
-      @message = message
+      @title = title
+      @description = description
       @markdown = markdown
+      @show_in_pr = show_in_pr
+      @show_in_log = show_in_log
     end
 
     # Converts the Notice object to a hash.
@@ -42,22 +64,25 @@ module Dependabot
         mode: @mode,
         type: @type,
         package_manager_name: @package_manager_name,
-        message: @message,
-        markdown: @markdown
+        title: @title,
+        description: @description,
+        markdown: @markdown,
+        show_in_pr: @show_in_pr,
+        show_in_log: @show_in_log
       }
     end
 
-    # Generates a message for supported versions.
+    # Generates a description for supported versions.
     # @param supported_versions [Array<Dependabot::Version>, nil] The supported versions of the package manager.
     # @param support_later_versions [Boolean] Whether later versions are supported.
-    # @return [String, nil] The generated message or nil if no supported versions are provided.
+    # @return [String, nil] The generated description or nil if no supported versions are provided.
     sig do
       params(
         supported_versions: T.nilable(T::Array[Dependabot::Version]),
         support_later_versions: T::Boolean
       ).returns(String)
     end
-    def self.generate_supported_versions_message(supported_versions, support_later_versions)
+    def self.generate_supported_versions_description(supported_versions, support_later_versions)
       return "" unless supported_versions&.any?
 
       versions_string = supported_versions.map { |version| "`v#{version}`" }
@@ -66,11 +91,11 @@ module Dependabot
 
       versions_string = versions_string.join(", ")
 
-      later_message = support_later_versions ? ", or later" : ""
+      later_description = support_later_versions ? ", or later" : ""
 
-      return "Please upgrade to version #{versions_string}#{later_message}." if supported_versions.count == 1
+      return "Please upgrade to version #{versions_string}#{later_description}." if supported_versions.count == 1
 
-      "Please upgrade to one of the following versions: #{versions_string}#{later_message}."
+      "Please upgrade to one of the following versions: #{versions_string}#{later_description}."
     end
 
     # Generates a support notice for the given package manager.
@@ -100,30 +125,34 @@ module Dependabot
     def self.generate_pm_deprecation_notice(package_manager)
       return nil unless package_manager.deprecated?
 
-      mode = "WARN"
-      supported_versions_message = generate_supported_versions_message(
+      mode = NoticeMode::WARN
+      supported_versions_description = generate_supported_versions_description(
         package_manager.supported_versions,
         package_manager.support_later_versions?
       )
-      notice_type = "#{package_manager.name}_deprecated_#{mode.downcase}"
-      message = "Dependabot will stop supporting `#{package_manager.name} v#{package_manager.version}`!"
-      ## Create a warning markdown message
+      notice_type = "#{package_manager.name}_deprecated_warn"
+      title = "Package manager deprecation notice"
+      description = "Dependabot will stop supporting `#{package_manager.name} v#{package_manager.version}`!"
+      ## Create a warning markdown description
       markdown = "> [!WARNING]\n"
-      ## Add the deprecation warning to the message
-      markdown += "> #{message}\n>\n"
+      ## Add the deprecation warning to the description
+      markdown += "> #{description}\n>\n"
 
-      ## Add the supported versions to the message
-      unless supported_versions_message.empty?
-        message += "\n#{supported_versions_message}\n"
-        markdown += "> #{supported_versions_message}\n>\n"
+      ## Add the supported versions to the description
+      unless supported_versions_description.empty?
+        description += "\n#{supported_versions_description}\n"
+        markdown += "> #{supported_versions_description}\n>\n"
       end
 
       Notice.new(
         mode: mode,
         type: notice_type,
         package_manager_name: package_manager.name,
-        message: message,
-        markdown: markdown
+        title: title,
+        description: description,
+        markdown: markdown,
+        show_in_pr: true,
+        show_in_log: true
       )
     end
 
@@ -138,30 +167,34 @@ module Dependabot
     def self.generate_pm_unsupported_notice(package_manager)
       return nil unless package_manager.unsupported?
 
-      mode = "ERROR"
-      supported_versions_message = generate_supported_versions_message(
+      mode = NoticeMode::ERROR
+      supported_versions_description = generate_supported_versions_description(
         package_manager.supported_versions,
         package_manager.support_later_versions?
       )
-      notice_type = "#{package_manager.name}_unsupported_#{mode.downcase}"
-      message = "Dependabot no longer supports `#{package_manager.name} v#{package_manager.version}`!"
-      ## Create an error markdown message
+      notice_type = "#{package_manager.name}_unsupported_error"
+      title = "Package manager unsupported notice"
+      description = "Dependabot no longer supports `#{package_manager.name} v#{package_manager.version}`!"
+      ## Create an error markdown description
       markdown = "> [!IMPORTANT]\n"
-      ## Add the error message to the message
-      markdown += "> #{message}\n>\n"
+      ## Add the error description to the description
+      markdown += "> #{description}\n>\n"
 
-      ## Add the supported versions to the message
-      unless supported_versions_message.empty?
-        message += "\n#{supported_versions_message}\n"
-        markdown += "> #{supported_versions_message}\n>\n"
+      ## Add the supported versions to the description
+      unless supported_versions_description.empty?
+        description += "\n#{supported_versions_description}\n"
+        markdown += "> #{supported_versions_description}\n>\n"
       end
 
       Notice.new(
         mode: mode,
         type: notice_type,
         package_manager_name: package_manager.name,
-        message: message,
-        markdown: markdown
+        title: title,
+        description: description,
+        markdown: markdown,
+        show_in_pr: true,
+        show_in_log: true
       )
     end
   end

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -143,8 +143,8 @@ module Dependabot
       def pr_notices
         notices = @notices || []
         unique_messages = notices.filter_map do |notice|
-          markdown = notice.markdown if notice
-          markdown unless markdown.empty?
+          markdown = notice.markdown if notice.show_in_pr
+          markdown if markdown && !markdown.empty?
         end.uniq
 
         message = unique_messages.join("\n\n")

--- a/common/spec/dependabot/notices_spec.rb
+++ b/common/spec/dependabot/notices_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe Dependabot::Notice do
             markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                       "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
             show_in_pr: true,
-            show_in_log: true
+            show_in_log: true,
+            show_in_alert: true
           })
       end
     end
@@ -151,7 +152,8 @@ RSpec.describe Dependabot::Notice do
             markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
                       "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
             show_in_pr: true,
-            show_in_log: true
+            show_in_log: true,
+            show_in_alert: true
           })
       end
     end
@@ -206,7 +208,8 @@ RSpec.describe Dependabot::Notice do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         })
     end
   end
@@ -237,7 +240,8 @@ RSpec.describe Dependabot::Notice do
           markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         })
     end
   end

--- a/common/spec/dependabot/notices_spec.rb
+++ b/common/spec/dependabot/notices_spec.rb
@@ -26,17 +26,17 @@ class StubPackageManager < Dependabot::PackageManagerBase
 end
 
 RSpec.describe Dependabot::Notice do
-  describe ".generate_supported_versions_message" do
-    subject(:generate_supported_versions_message) do
-      described_class.generate_supported_versions_message(supported_versions, support_later_versions)
+  describe ".generate_supported_versions_description" do
+    subject(:generate_supported_versions_description) do
+      described_class.generate_supported_versions_description(supported_versions, support_later_versions)
     end
 
     context "when supported_versions has one version" do
       let(:supported_versions) { [Dependabot::Version.new("2")] }
       let(:support_later_versions) { false }
 
-      it "returns the correct message" do
-        expect(generate_supported_versions_message)
+      it "returns the correct description" do
+        expect(generate_supported_versions_description)
           .to eq("Please upgrade to version `v2`.")
       end
     end
@@ -45,8 +45,8 @@ RSpec.describe Dependabot::Notice do
       let(:supported_versions) { [Dependabot::Version.new("2")] }
       let(:support_later_versions) { true }
 
-      it "returns the correct message" do
-        expect(generate_supported_versions_message)
+      it "returns the correct description" do
+        expect(generate_supported_versions_description)
           .to eq("Please upgrade to version `v2`, or later.")
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe Dependabot::Notice do
       end
       let(:support_later_versions) { false }
 
-      it "returns the correct message" do
-        expect(generate_supported_versions_message)
+      it "returns the correct description" do
+        expect(generate_supported_versions_description)
           .to eq("Please upgrade to one of the following versions: `v2`, `v3`, or `v4`.")
       end
     end
@@ -71,8 +71,8 @@ RSpec.describe Dependabot::Notice do
       end
       let(:support_later_versions) { true }
 
-      it "returns the correct message" do
-        expect(generate_supported_versions_message)
+      it "returns the correct description" do
+        expect(generate_supported_versions_description)
           .to eq("Please upgrade to one of the following versions: `v2`, `v3`, `v4`, or later.")
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe Dependabot::Notice do
       let(:support_later_versions) { false }
 
       it "returns empty string" do
-        expect(generate_supported_versions_message).to eq("")
+        expect(generate_supported_versions_description).to eq("")
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Dependabot::Notice do
       let(:support_later_versions) { false }
 
       it "returns nil" do
-        expect(generate_supported_versions_message).to eq("")
+        expect(generate_supported_versions_description).to eq("")
       end
     end
   end
@@ -124,10 +124,13 @@ RSpec.describe Dependabot::Notice do
             mode: "WARN",
             type: "bundler_deprecated_warn",
             package_manager_name: "bundler",
-            message: "Dependabot will stop supporting `bundler v1`!\n" \
-                     "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+            title: "Package manager deprecation notice",
+            description: "Dependabot will stop supporting `bundler v1`!\n" \
+                         "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
             markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                      "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                      "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+            show_in_pr: true,
+            show_in_log: true
           })
       end
     end
@@ -142,10 +145,13 @@ RSpec.describe Dependabot::Notice do
             mode: "ERROR",
             type: "bundler_unsupported_error",
             package_manager_name: "bundler",
-            message: "Dependabot no longer supports `bundler v1`!\n" \
-                     "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+            title: "Package manager unsupported notice",
+            description: "Dependabot no longer supports `bundler v1`!\n" \
+                         "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
             markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
-                      "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                      "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+            show_in_pr: true,
+            show_in_log: true
           })
       end
     end
@@ -194,10 +200,13 @@ RSpec.describe Dependabot::Notice do
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         })
     end
   end
@@ -222,10 +231,13 @@ RSpec.describe Dependabot::Notice do
           mode: "ERROR",
           type: "bundler_unsupported_error",
           package_manager_name: "bundler",
-          message: "Dependabot no longer supports `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager unsupported notice",
+          description: "Dependabot no longer supports `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         })
     end
   end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -3330,7 +3330,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         )]
       end
 
@@ -3351,7 +3352,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         ), Dependabot::Notice.new(
           mode: "ERROR",
           type: "bundler_unsupported_error",
@@ -3362,7 +3364,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         )]
       end
 
@@ -3385,7 +3388,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         ), Dependabot::Notice.new(
           mode: "WARN",
           type: "bundler_deprecated_warn",
@@ -3396,7 +3400,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         )]
       end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -3324,10 +3324,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         )]
       end
 
@@ -3342,18 +3345,24 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         ), Dependabot::Notice.new(
           mode: "ERROR",
           type: "bundler_unsupported_error",
           package_manager_name: "bundler",
-          message: "Dependabot no longer supports `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot no longer supports `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!IMPORTANT]\n> Dependabot no longer supports `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         )]
       end
 
@@ -3370,18 +3379,24 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         ), Dependabot::Notice.new(
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         )]
       end
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -102,13 +102,54 @@ module Dependabot
     sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }
     def record_update_job_error(error_type:, error_details:)
       ::Dependabot::OpenTelemetry.tracer.in_span("record_update_job_error", kind: :internal) do |_span|
-        ::Dependabot::OpenTelemetry.record_update_job_error(job_id: job_id, error_type: error_type,
-                                                            error_details: error_details)
+        ::Dependabot::OpenTelemetry.record_update_job_error(
+          job_id: job_id,
+          error_type: error_type,
+          error_details: error_details
+        )
         api_url = "#{base_url}/update_jobs/#{job_id}/record_update_job_error"
         body = {
           data: {
             "error-type": error_type,
             "error-details": error_details
+          }
+        }
+        response = http_client.post(api_url, json: body)
+        raise ApiError, response.body if response.code >= 400
+      rescue HTTP::ConnectionError, OpenSSL::SSL::SSLError
+        retry_count ||= 0
+        retry_count += 1
+        raise if retry_count > 3
+
+        sleep(rand(3.0..10.0))
+        retry
+      end
+    end
+
+    sig do
+      params(
+        package_manager: String,
+        warn_type: T.any(String, Symbol),
+        warn_title: String,
+        warn_description: String
+      ).void
+    end
+    def record_update_job_warn(package_manager:, warn_type:, warn_title:, warn_description:)
+      ::Dependabot::OpenTelemetry.tracer.in_span("record_update_job_message", kind: :internal) do |_span|
+        ::Dependabot::OpenTelemetry.record_update_job_warn(
+          job_id: job_id,
+          package_manager: package_manager,
+          warn_type: warn_type,
+          warn_title: warn_title,
+          warn_description: warn_description
+        )
+        api_url = "#{base_url}/update_jobs/#{job_id}/record_update_job_warn"
+        body = {
+          data: {
+            "package-manager": package_manager,
+            "warn-type": warn_type,
+            "warn-title": warn_title,
+            "warn-description": warn_description
           }
         }
         response = http_client.post(api_url, json: body)

--- a/updater/lib/dependabot/opentelemetry.rb
+++ b/updater/lib/dependabot/opentelemetry.rb
@@ -10,6 +10,11 @@ module Dependabot
 
     module Attributes
       JOB_ID = "dependabot.job.id"
+      PACKAGE_MANAGER = "dependabot.job.package_manager"
+      WARN_TYPE = "dependabot.job.warn_type"
+      WARN_TITLE = "dependabot.job.warn_title"
+      WARN_DESCRIPTION = "dependabot.job.warn_description"
+      WARN_DETAILS = "dependabot.job.warn_details"
       ERROR_TYPE = "dependabot.job.error_type"
       ERROR_DETAILS = "dependabot.job.error_details"
       METRIC = "dependabot.metric"
@@ -87,6 +92,28 @@ module Dependabot
       end
 
       current_span.add_event(error_type, attributes: attributes)
+    end
+
+    sig do
+      params(
+        job_id: T.any(String, Integer),
+        package_manager: String,
+        warn_type: T.any(String, Symbol),
+        warn_title: String,
+        warn_description: String
+      ).void
+    end
+    def self.record_update_job_warn(job_id:, package_manager:, warn_type:, warn_title:, warn_description:)
+      current_span = ::OpenTelemetry::Trace.current_span
+
+      attributes = {
+        Attributes::JOB_ID => job_id,
+        Attributes::PACKAGE_MANAGER => package_manager,
+        Attributes::WARN_TYPE => warn_type,
+        Attributes::WARN_TITLE => warn_title,
+        Attributes::WARN_DESCRIPTION => warn_description
+      }
+      current_span.add_event(warn_type, attributes: attributes)
     end
 
     sig do

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -27,11 +27,15 @@ module Dependabot
     sig { returns(T::Array[T::Array[T.untyped]]) }
     attr_reader :errors
 
+    sig { returns(T::Array[T::Array[T.untyped]]) }
+    attr_reader :warnings
+
     sig { params(client: Dependabot::ApiClient).void }
     def initialize(client:)
       @client = client
       @pull_requests = T.let([], T::Array[T.untyped])
       @errors = T.let([], T::Array[T.untyped])
+      @warnings = T.let([], T::Array[T.untyped])
       @threads = T.let([], T::Array[T.untyped])
     end
 
@@ -79,6 +83,24 @@ module Dependabot
     def record_update_job_error(error_type:, error_details:, dependency: nil)
       errors << [error_type.to_s, dependency]
       client.record_update_job_error(error_type: error_type, error_details: error_details)
+    end
+
+    sig do
+      params(
+        package_manager: String,
+        warn_type: T.any(String, Symbol),
+        warn_title: String,
+        warn_description: String
+      ).void
+    end
+    def record_update_job_warn(package_manager:, warn_type:, warn_title:, warn_description:)
+      warnings << [warn_type.to_s, warn_description]
+      client.record_update_job_warn(
+        package_manager: package_manager,
+        warn_type: warn_type,
+        warn_title: warn_title,
+        warn_description: warn_description
+      )
     end
 
     sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -123,6 +123,9 @@ module Dependabot
           notices: notices
         )
 
+        # Record any warning notices that were generated during the update process if show_in_log is true
+        record_warning_notices(notices)
+
         if Experiments.enabled?("dependency_change_validation") && !dependency_change.all_have_previous_version?
           log_missing_previous_version(dependency_change)
           return nil

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -46,7 +46,7 @@ module Dependabot
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = T.let([], T::Array[PullRequest])
 
-          @pr_notices = T.let([], T::Array[Dependabot::Notice])
+          @notices = T.let([], T::Array[Dependabot::Notice])
         end
 
         # TODO: We currently tolerate multiple dependencies for this operation
@@ -61,7 +61,7 @@ module Dependabot
 
           # Add a deprecation notice if the package manager is deprecated
           add_deprecation_notice(
-            notices: @pr_notices,
+            notices: @notices,
             package_manager: dependency_snapshot.package_manager
           )
 
@@ -180,8 +180,11 @@ module Dependabot
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
             change_source: checker.dependency,
-            notices: @pr_notices
+            notices: @notices
           )
+
+          # Record any warning notices that were generated during the update process if conditions are met
+          record_warning_notices(@notices)
 
           create_pull_request(dependency_change)
         rescue Dependabot::AllVersionsIgnored

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -46,7 +46,7 @@ module Dependabot
           @dependency_snapshot = dependency_snapshot
           @error_handler = error_handler
 
-          @pr_notices = T.let([], T::Array[Dependabot::Notice])
+          @notices = T.let([], T::Array[Dependabot::Notice])
         end
 
         sig { void }
@@ -56,7 +56,7 @@ module Dependabot
 
           # Add a deprecation notice if the package manager is deprecated
           add_deprecation_notice(
-            notices: @pr_notices,
+            notices: @notices,
             package_manager: dependency_snapshot.package_manager
           )
 
@@ -158,8 +158,11 @@ module Dependabot
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
             change_source: checker.dependency,
-            notices: @pr_notices
+            notices: @notices
           )
+
+          # Record any warning notices that were generated during the update process if conditions are met
+          record_warning_notices(@notices)
 
           # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
           # and the dependency name in the security advisory often doesn't match

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -47,7 +47,7 @@ module Dependabot
           @dependency_snapshot = dependency_snapshot
           @error_handler = error_handler
 
-          @pr_notices = T.let([], T::Array[Dependabot::Notice])
+          @notices = T.let([], T::Array[Dependabot::Notice])
 
           return unless job.source.directory.nil? && job.source.directories&.count == 1
 
@@ -62,7 +62,7 @@ module Dependabot
 
           # Add a deprecation notice if the package manager is deprecated
           add_deprecation_notice(
-            notices: @pr_notices,
+            notices: @notices,
             package_manager: dependency_snapshot.package_manager
           )
 
@@ -146,8 +146,11 @@ module Dependabot
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
             change_source: checker.dependency,
-            notices: @pr_notices
+            notices: @notices
           )
+
+          # Record any warning notices that were generated during the update process if conditions are met
+          record_warning_notices(@notices)
 
           # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
           # and the dependency name in the security advisory often doesn't match

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -40,7 +40,7 @@ module Dependabot
           # TODO: Collect @created_pull_requests on the Job object?
           @created_pull_requests = T.let([], T::Array[PullRequest])
 
-          @pr_notices = T.let([], T::Array[Dependabot::Notice])
+          @notices = T.let([], T::Array[Dependabot::Notice])
 
           return unless job.source.directory.nil? && job.source.directories&.count == 1
 
@@ -54,7 +54,7 @@ module Dependabot
 
           # Add a deprecation notice if the package manager is deprecated
           add_deprecation_notice(
-            notices: @pr_notices,
+            notices: @notices,
             package_manager: dependency_snapshot.package_manager
           )
 
@@ -167,12 +167,15 @@ module Dependabot
             dependency_files: dependency_snapshot.dependency_files,
             updated_dependencies: updated_deps,
             change_source: checker.dependency,
-            notices: @pr_notices
+            notices: @notices
           )
 
           if dependency_change.updated_dependency_files.empty?
             raise "UpdateChecker found viable dependencies to be updated, but FileUpdater failed to update any files"
           end
+
+          # Record any warning notices that were generated during the update process if conditions are met
+          record_warning_notices(@notices)
 
           create_pull_request(dependency_change)
         end

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                     "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
           show_in_pr: true,
-          show_in_log: true
+          show_in_log: true,
+          show_in_alert: true
         ).to_hash
       ]
     )
@@ -172,7 +173,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
               markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                         "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
               show_in_pr: true,
-              show_in_log: true
+              show_in_log: true,
+              show_in_alert: true
             }
           )
           create_group_update_pull_request.perform

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -122,21 +122,25 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
           mode: "WARN",
           type: "bundler_deprecated_warn",
           package_manager_name: "bundler",
-          message: "Dependabot will stop supporting `bundler v1`!\n" \
-                   "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+          title: "Package manager deprecation notice",
+          description: "Dependabot will stop supporting `bundler v1`!\n" \
+                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
           markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                    "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+          show_in_pr: true,
+          show_in_log: true
         ).to_hash
       ]
     )
   end
 
   before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+
     allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
     allow(Dependabot::DependencyChangeBuilder)
       .to receive(:create_from)
       .and_return(stub_dependency_change)
-    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
   end
 
   after do
@@ -162,10 +166,13 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
               mode: "WARN",
               type: "bundler_deprecated_warn",
               package_manager_name: "bundler",
-              message: "Dependabot will stop supporting `bundler v1`!\n" \
-                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+              title: "Package manager deprecation notice",
+              description: "Dependabot will stop supporting `bundler v1`!\n" \
+                           "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
               markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                        "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                        "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+              show_in_pr: true,
+              show_in_log: true
             }
           )
           create_group_update_pull_request.perform

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -203,6 +203,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
   let(:mock_package_manager_instance) { concrete_package_manager_class.new }
 
   before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+
     # Allow for_package_manager to return the stub_update_checker_class
     allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
 
@@ -219,8 +221,6 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
     allow(dependency_snapshot)
       .to receive(:package_manager)
       .and_return(mock_package_manager_instance)
-
-    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
   end
 
   after do
@@ -369,10 +369,13 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
                 mode: "WARN",
                 type: "bundler_deprecated_warn",
                 package_manager_name: "bundler",
-                message: "Dependabot will stop supporting `bundler v1`!\n" \
-                         "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+                title: "Package manager deprecation notice",
+                description: "Dependabot will stop supporting `bundler v1`!\n" \
+                             "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
                 markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                          "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
+                          "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+                show_in_pr: true,
+                show_in_log: true
               )
             )
 

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -375,7 +375,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
                 markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                           "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
                 show_in_pr: true,
-                show_in_log: true
+                show_in_log: true,
+                show_in_alert: true
               )
             )
 

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -213,7 +213,8 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
             markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
                       "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
             show_in_pr: true,
-            show_in_log: true
+            show_in_log: true,
+            show_in_alert: true
           }])
           expect(refresh_security_update_pull_request).to receive(:create_pull_request)
           refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -112,11 +112,12 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
   end
 
   before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+
     allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
     allow(Dependabot::DependencyChangeBuilder)
       .to receive(:create_from)
       .and_return(stub_dependency_change)
-    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
   end
 
   after do
@@ -206,13 +207,13 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
             mode: "WARN",
             type: "bundler_deprecated_warn",
             package_manager_name: "bundler",
-            details: {
-              message: "Dependabot will stop supporting `bundler v1`!\n" \
-                       "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
-              current_version: "v1",
-              markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
-                        "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n"
-            }
+            title: "Package manager deprecation notice",
+            description: "Dependabot will stop supporting `bundler v1`!\n" \
+                         "Please upgrade to one of the following versions: `v2`, or `v3`.\n",
+            markdown: "> [!WARNING]\n> Dependabot will stop supporting `bundler v1`!\n>\n" \
+                      "> Please upgrade to one of the following versions: `v2`, or `v3`.\n>\n",
+            show_in_pr: true,
+            show_in_log: true
           }])
           expect(refresh_security_update_pull_request).to receive(:create_pull_request)
           refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -143,14 +143,13 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
   end
 
   before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+
     allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
     allow(Dependabot::DependencyChangeBuilder)
       .to receive(:create_from)
       .and_return(stub_dependency_change)
     allow(dependency_snapshot).to receive(:package_manager).and_return(package_manager)
-    allow(Dependabot::Experiments).to receive(:enabled?).with(
-      :add_deprecation_warn_to_pr_message
-    ).and_return(true)
   end
 
   after do

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -152,6 +152,8 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
   end
 
   before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+
     allow(Dependabot::UpdateCheckers).to receive(
       :for_package_manager
     ).and_return(stub_update_checker_class)
@@ -161,9 +163,6 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
     allow(dependency_snapshot).to receive(
       :package_manager
     ).and_return(package_manager)
-    allow(Dependabot::Experiments).to receive(:enabled?).with(
-      :add_deprecation_warn_to_pr_message
-    ).and_return(true)
   end
 
   after do
@@ -210,7 +209,7 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
       end
     end
 
-    context "when package manager version is 1" do
+    context "when package manager version is deprecated" do
       let(:package_manager_version) { "1" }
 
       it "creates a pull request" do
@@ -225,7 +224,7 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
       end
     end
 
-    context "when package manager version is 2" do
+    context "when package manager version is not deprecated" do
       let(:package_manager_version) { "2" }
 
       it "creates a pull request" do


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces a deprecation warning alert for `bundler v1`.

**Why:**
- To provide information regarding deprecation if used ecosystem versions in the alert with users. 

<!-- What issues does this affect or fix? -->
This change ensures the bundler v1 deprecation is sent to api that can be used to displayed on github ui. 

### Anything you want to highlight for special attention from reviewers?

The changes are focused on sending bundler v1 deprecation notice to api. 

Note: The sent notice is going to be delegate github UI through api and from there is going to be shown to the user on dependabot insight page. 

### How will you know you've accomplished your goal?

- Successfully sending deprecation warnings for Bundler v1 to dependabot-api.
- Verification through tests that the correct deprecation warning shown in alerts on github ui for bundler v1
- Similar to the following deprecation warnings should appear in the log when job runs on bundler v1. 

The following 
### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.