### PR TITLE
Fix TOML parsing in Python ecosystem (fixes #10523)

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -14,9 +14,9 @@ from pip._internal.req.constructors import (
 )
 
 from packaging.requirements import InvalidRequirement, Requirement
-# TODO: Replace 3p package `toml` with 3.11's new stdlib `tomllib` once we drop
-# support for Python 3.10.
-import toml
+# TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we
+#       drop support for Python 3.10.
+import tomli
 
 # Inspired by pips internal check:
 # https://github.com/pypa/pip/blob/0bb3ac87f5bb149bd75cceac000844128b574385/src/pip/_internal/req/req_file.py#L35
@@ -24,7 +24,8 @@ COMMENT_RE = re.compile(r'(^|\s+)#.*$')
 
 
 def parse_pep621_dependencies(pyproject_path):
-    project_toml = toml.load(pyproject_path)
+    with open(pyproject_path, "rb") as file:
+        project_toml = tomli.load(file)
 
     def parse_toml_section_pep621_dependencies(pyproject_path, dependencies):
         requirement_packages = []

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -7,8 +7,8 @@ hashin==1.0.3; python_version >= '3.9'
 pipenv==2024.0.2
 plette==2.1.0
 poetry==1.8.5
-# TODO: Replace 3p package `toml` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
-toml==0.10.2
+# TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
+tomli==2.0.1
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.10

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -376,5 +376,44 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
 
       its(:length) { is_expected.to be > 0 }
     end
+
+    describe "parse standard python files" do
+      subject(:dependencies) { parser.dependency_set.dependencies }
+
+      let(:pyproject_fixture_name) { "pyproject_1_0_0.toml" }
+
+      # fixture has 1 build system requires and plus 1 dependencies exists
+
+      its(:length) { is_expected.to eq(1) }
+
+      context "with a string declaration" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("pydantic")
+          expect(dependency.version).to eq("2.7.0")
+        end
+      end
+
+      context "without dependencies" do
+        subject(:dependencies) { parser.dependency_set.dependencies }
+
+        let(:pyproject_fixture_name) { "pyproject_1_0_0_nodeps.toml" }
+
+        # fixture has 1 build system requires and no dependencies or
+        # optional dependencies exists
+
+        its(:length) { is_expected.to eq(0) }
+      end
+
+      context "with optional dependencies only" do
+        subject(:dependencies) { parser.dependency_set.dependencies }
+
+        let(:pyproject_fixture_name) { "pyproject_1_0_0_optional_deps.toml" }
+
+        its(:length) { is_expected.to be > 0 }
+      end
+    end
   end
 end

--- a/python/spec/fixtures/pyproject_files/pyproject_1_0_0.toml
+++ b/python/spec/fixtures/pyproject_files/pyproject_1_0_0.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dependabot-pyproject-toml-error"
+description = '''foo'''
+version = "0.0.1"
+requires-python = ">=3.12"
+license = { text = "GNU General Public License v3 or later (GPLv3+)" }
+classifiers = [
+    '''Development Status :: 4 - Beta''',
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    '''pydantic==2.7.0''',
+]
+
+[tool.coverage.report]
+exclude_also = [
+    '''if __name__ == ['"]__main__['"]:''',
+]

--- a/python/spec/fixtures/pyproject_files/pyproject_1_0_0_nodeps.toml
+++ b/python/spec/fixtures/pyproject_files/pyproject_1_0_0_nodeps.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dependabot-pyproject-toml-error"
+description = '''foo'''
+version = "0.0.1"
+requires-python = ">=3.12"
+license = { text = "GNU General Public License v3 or later (GPLv3+)" }
+classifiers = [
+    '''Development Status :: 4 - Beta''',
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[tool.coverage.report]
+exclude_also = [
+    '''if __name__ == ['"]__main__['"]:''',
+]

--- a/python/spec/fixtures/pyproject_files/pyproject_1_0_0_optional_deps.toml
+++ b/python/spec/fixtures/pyproject_files/pyproject_1_0_0_optional_deps.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dependabot-pyproject-toml-error"
+description = '''foo'''
+version = "0.0.1"
+requires-python = ">=3.12"
+license = { text = "GNU General Public License v3 or later (GPLv3+)" }
+classifiers = [
+    '''Development Status :: 4 - Beta''',
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    '''pydantic==2.7.0''',
+]
+
+[tool.coverage.report]
+exclude_also = [
+    '''if __name__ == ['"]__main__['"]:''',
+]
+[project.optional-dependencies]
+socks = [ 'PySocks >= 1.5.6, != 1.5.7, < 2' ]
+tests = [
+  'ddt >= 1.2.2, < 2',
+  'pytest < 6',
+  'mock >= 1.0.1, < 4; python_version < "3.4"',
+]


### PR DESCRIPTION
### What are you trying to accomplish?

This is a fix for issue #10523 (and possibly others). We use [`tomli`](https://github.com/hukkin/tomli) instead of the outdated [`toml`](https://github.com/uiri/toml) package because the former has full TOML `1.0.0` support.
The change is minimal and should not break anything, since the only thing that changes is the TOML parsing function.

https://github.com/dependabot/dependabot-core/blob/127a9586156843c68bfd2e1897365d288e0ffe07/python/helpers/lib/parser.py#L27

The above is replaced by this:

```python
with open(pyproject_path, "rb") as file:
    project_toml = tomli.load(file)
```

The requirements and comments are adjusted accordingly.

### Anything you want to highlight for special attention from reviewers?

I suppose it could be a topic of discussion, which third-party TOML parsing library is best to use, while support for older Python version is not dropped. But I am not aware of any better alternatives to `tomli`, which is the basis for the built-in [`tomllib`](https://docs.python.org/3/library/tomllib.html) in Python `>=3.11`. It is certainly superior to the currently used `toml`, which does not even advertise support for TOML `1.0.0`, but only for `0.5.0`.

### How will you know you've accomplished your goal?

When [this error](https://github.com/daniil-berg/dependabot-pyproject-toml-error/actions/runs/10632673662/job/29476101479) no longer occurs.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
