### PR TITLE
Support retrieving workspace of path dependencies in cargo

### DIFF
--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
 
       stub_request(:get, url + "excluded/Cargo.toml?ref=sha")
         .with(headers: { "Authorization" => "token token" })
-        .to_return(status: 200, body: member_fixture, headers: json_header)
+        .to_return(status: 200, body: excluded_fixture, headers: json_header)
     end
 
     let(:parent_fixture) do

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -742,4 +742,162 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         .to raise_error(Dependabot::DependencyFileNotFound)
     end
   end
+
+  context "with a path dependency to a workspace member" do
+    let(:url) do
+      "https://api.github.com/repos/gocardless/bump/contents/"
+    end
+
+    before do
+      # Contents of these dirs aren't important
+      stub_request(:get, /#{Regexp.escape(url)}detached_crate_(success|fail_1|fail_2)\?ref=sha/)
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member", "contents_dir_detached_crate_success.json"),
+          headers: json_header
+        )
+
+      # Ignoring any .cargo requests
+      stub_request(:get, %r{#{Regexp.escape(url)}\w+/\.cargo\?ref=sha})
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404, headers: json_header)
+
+      # All the manifest requests
+      stub_request(:get, url + "detached_crate_fail_1/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_detached_crate_fail_1.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "detached_crate_fail_2/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_detached_crate_fail_2.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "detached_crate_success/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_detached_crate_success.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "detached_workspace_member/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_detached_workspace_member.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "incorrect_detached_workspace_member/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_incorrect_detached_workspace_member.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "incorrect_workspace/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_incorrect_workspace.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "workspace/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member", "contents_cargo_manifest_workspace.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "workspace/nested_one/nested_two/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "path_dependency_workspace_member",
+                        "contents_cargo_manifest_workspace_nested_one_nested_two.json"),
+          headers: json_header
+        )
+
+      # nested_one dir has nothing of interest
+      stub_request(:get, url + "workspace/nested_one?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: "[]", headers: json_header)
+      stub_request(:get, url + "workspace/nested_one/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404, headers: json_header)
+    end
+
+    context "with a resolvable workspace root" do
+      let(:source) do
+        Dependabot::Source.new(
+          provider: "github",
+          repo: "gocardless/bump",
+          directory: "detached_crate_success/"
+        )
+      end
+
+      it "fetches the dependency successfully" do
+        expect(file_fetcher_instance.files.map(&:name))
+          .to match_array(%w(
+            Cargo.toml
+            ../detached_workspace_member/Cargo.toml
+            ../workspace/Cargo.toml
+            ../workspace/nested_one/nested_two/Cargo.toml
+          ))
+        expect(file_fetcher_instance.files.map(&:path))
+          .to match_array(%w(
+            /detached_crate_success/Cargo.toml
+            /detached_workspace_member/Cargo.toml
+            /workspace/Cargo.toml
+            /workspace/nested_one/nested_two/Cargo.toml
+          ))
+      end
+    end
+
+    context "with no workspace root via parent directory search" do
+      let(:source) do
+        Dependabot::Source.new(
+          provider: "github",
+          repo: "gocardless/bump",
+          directory: "detached_crate_fail_1/"
+        )
+      end
+
+      it "raises a DependencyFileNotEvaluatable error" do
+        expect { file_fetcher_instance.files }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+          expect(error.message)
+            .to eq("Could not resolve workspace root for path dependency " \
+                   "/incorrect_workspace/Cargo.toml of /detached_crate_fail_1/Cargo.toml")
+        end
+      end
+    end
+
+    context "with no workspace root via package.workspace key" do
+      let(:source) do
+        Dependabot::Source.new(
+          provider: "github",
+          repo: "gocardless/bump",
+          directory: "detached_crate_fail_2/"
+        )
+      end
+
+      it "raises a DependencyFileNotEvaluatable error" do
+        expect { file_fetcher_instance.files }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+          expect(error.message)
+            .to eq("Could not resolve workspace root for path dependency " \
+                   "/incorrect_detached_workspace_member/Cargo.toml of /detached_crate_fail_2/Cargo.toml")
+        end
+      end
+    end
+  end
 end

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_fail_1.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_fail_1.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "detached_crate_fail_1/Cargo.toml",
+  "sha": "478610ce460c32a710e00cc0d1528cf1f03002e8",
+  "size": 150,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_fail_1/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_fail_1/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/478610ce460c32a710e00cc0d1528cf1f03002e8",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/detached_crate_fail_1/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiZGV0YWNoZWRfY3JhdGVfZmFpbF8xIgp2ZXJz\naW9uID0gIjAuMS4wIgplZGl0aW9uID0gIjIwMjEiCgpbZGVwZW5kZW5jaWVz\nXQppbmNvcnJlY3Rfd29ya3NwYWNlID0geyBwYXRoID0gIi4uL2luY29ycmVj\ndF93b3Jrc3BhY2UiIH0K\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_fail_1/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/478610ce460c32a710e00cc0d1528cf1f03002e8",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_fail_1/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_fail_2.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_fail_2.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "detached_crate_fail_2/Cargo.toml",
+  "sha": "64b36bdb1f27623f91db2fce80c442dbfdc1e3de",
+  "size": 182,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_fail_2/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_fail_2/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/64b36bdb1f27623f91db2fce80c442dbfdc1e3de",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/detached_crate_fail_2/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiZGV0YWNoZWRfY3JhdGVfZmFpbF8yIgp2ZXJz\naW9uID0gIjAuMS4wIgplZGl0aW9uID0gIjIwMjEiCgpbZGVwZW5kZW5jaWVz\nXQppbmNvcnJlY3RfZGV0YWNoZWRfd29ya3NwYWNlX21lbWJlciA9IHsgcGF0\naCA9ICIuLi9pbmNvcnJlY3RfZGV0YWNoZWRfd29ya3NwYWNlX21lbWJlciIg\nfQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_fail_2/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/64b36bdb1f27623f91db2fce80c442dbfdc1e3de",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_fail_2/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_success.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_crate_success.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "detached_crate_success/Cargo.toml",
+  "sha": "ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+  "size": 224,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_success/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/detached_crate_success/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiZGV0YWNoZWRfY3JhdGVfc3VjY2VzcyIKdmVy\nc2lvbiA9ICIwLjEuMCIKZWRpdGlvbiA9ICIyMDIxIgoKW2RlcGVuZGVuY2ll\nc10KbmVzdGVkX3R3byA9IHsgcGF0aCA9ICIuLi93b3Jrc3BhY2UvbmVzdGVk\nX29uZS9uZXN0ZWRfdHdvIiB9CmRldGFjaGVkX3dvcmtzcGFjZV9tZW1iZXIg\nPSB7IHBhdGggPSAiLi4vZGV0YWNoZWRfd29ya3NwYWNlX21lbWJlciIgfQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_success/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_workspace_member.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_detached_workspace_member.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "detached_workspace_member/Cargo.toml",
+  "sha": "722adc04921df580cef0ac8dc7a6f255ba2d785a",
+  "size": 134,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_workspace_member/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_workspace_member/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/722adc04921df580cef0ac8dc7a6f255ba2d785a",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/detached_workspace_member/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiZGV0YWNoZWRfd29ya3NwYWNlX21lbWJlciIK\ndmVyc2lvbiA9IHsgd29ya3NwYWNlID0gdHJ1ZSB9CmVkaXRpb24gPSB7IHdv\ncmtzcGFjZSA9IHRydWUgfQp3b3Jrc3BhY2UgPSAiLi4vd29ya3NwYWNlIgo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_workspace_member/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/722adc04921df580cef0ac8dc7a6f255ba2d785a",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_workspace_member/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_incorrect_detached_workspace_member.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_incorrect_detached_workspace_member.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "incorrect_detached_workspace_member/Cargo.toml",
+  "sha": "5e66c8d8fefaa5597fcc8e42f3825fd5345da41d",
+  "size": 156,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/incorrect_detached_workspace_member/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/incorrect_detached_workspace_member/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/5e66c8d8fefaa5597fcc8e42f3825fd5345da41d",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/incorrect_detached_workspace_member/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiaW5jb3JyZWN0X2RldGFjaGVkX3dvcmtzcGFj\nZV9tZW1iZXIiCnZlcnNpb24gPSB7IHdvcmtzcGFjZSA9IHRydWUgfQplZGl0\naW9uID0geyB3b3Jrc3BhY2UgPSB0cnVlIH0Kd29ya3NwYWNlID0gIi4uL2Rl\ndGFjaGVkX2NyYXRlX2ZhaWxfMSIK\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/incorrect_detached_workspace_member/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/5e66c8d8fefaa5597fcc8e42f3825fd5345da41d",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/incorrect_detached_workspace_member/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_incorrect_workspace.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_incorrect_workspace.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "incorrect_workspace/Cargo.toml",
+  "sha": "06d462e30161e08716938ad0a3eec47d4287795d",
+  "size": 101,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/incorrect_workspace/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/incorrect_workspace/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/06d462e30161e08716938ad0a3eec47d4287795d",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/incorrect_workspace/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiaW5jb3JyZWN0X3dvcmtzcGFjZSIKdmVyc2lv\nbiA9IHsgd29ya3NwYWNlID0gdHJ1ZSB9CmVkaXRpb24gPSB7IHdvcmtzcGFj\nZSA9IHRydWUgfQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/incorrect_workspace/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/06d462e30161e08716938ad0a3eec47d4287795d",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/incorrect_workspace/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_workspace.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_workspace.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "workspace/Cargo.toml",
+  "sha": "18480978e4ccef6558c226de82efb70bb0afd3e8",
+  "size": 143,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/workspace/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/workspace/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/18480978e4ccef6558c226de82efb70bb0afd3e8",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/workspace/Cargo.toml",
+  "type": "file",
+  "content": "W3dvcmtzcGFjZS5wYWNrYWdlXQp2ZXJzaW9uID0gIjAuMS4wIgplZGl0aW9u\nID0gIjIwMjEiCgpbd29ya3NwYWNlXQptZW1iZXJzID0gWwogICJuZXN0ZWRf\nb25lL25lc3RlZF90d28iLAogICIuLi9kZXRhY2hlZF93b3Jrc3BhY2VfbWVt\nYmVyIgpdCgo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/workspace/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/18480978e4ccef6558c226de82efb70bb0afd3e8",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/workspace/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_workspace_nested_one_nested_two.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_cargo_manifest_workspace_nested_one_nested_two.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "workspace/nested_one/nested_two/Cargo.toml",
+  "sha": "f74aff39c4387e28f0ccf42e270b2da5eea15927",
+  "size": 93,
+  "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/workspace/nested_one/nested_two/Cargo.toml?ref=master",
+  "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/workspace/nested_one/nested_two/Cargo.toml",
+  "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/f74aff39c4387e28f0ccf42e270b2da5eea15927",
+  "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/workspace/nested_one/nested_two/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAibmVzdGVkX3R3byIKdmVyc2lvbiA9IHsgd29y\na3NwYWNlID0gdHJ1ZSB9CmVkaXRpb24gPSB7IHdvcmtzcGFjZSA9IHRydWUg\nfQoK\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/workspace/nested_one/nested_two/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/f74aff39c4387e28f0ccf42e270b2da5eea15927",
+    "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/workspace/nested_one/nested_two/Cargo.toml"
+  }
+}

--- a/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_dir_detached_crate_success.json
+++ b/cargo/spec/fixtures/github/path_dependency_workspace_member/contents_dir_detached_crate_success.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "Cargo.toml",
+    "path": "detached_crate_success/Cargo.toml",
+    "sha": "ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+    "size": 224,
+    "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/Cargo.toml?ref=master",
+    "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_success/Cargo.toml",
+    "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+    "download_url": "https://raw.githubusercontent.com/Jefffrey/dependabot-cargo-test/master/detached_crate_success/Cargo.toml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/Cargo.toml?ref=master",
+      "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/blobs/ac8001fcf77093cd9d06e07dcb6150a5b94f80cc",
+      "html": "https://github.com/Jefffrey/dependabot-cargo-test/blob/master/detached_crate_success/Cargo.toml"
+    }
+  },
+  {
+    "name": "src",
+    "path": "detached_crate_success/src",
+    "sha": "475cc15852634f09f9d0e0c6a20ff81cfb1e5439",
+    "size": 0,
+    "url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/src?ref=master",
+    "html_url": "https://github.com/Jefffrey/dependabot-cargo-test/tree/master/detached_crate_success/src",
+    "git_url": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/trees/475cc15852634f09f9d0e0c6a20ff81cfb1e5439",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/contents/detached_crate_success/src?ref=master",
+      "git": "https://api.github.com/repos/Jefffrey/dependabot-cargo-test/git/trees/475cc15852634f09f9d0e0c6a20ff81cfb1e5439",
+      "html": "https://github.com/Jefffrey/dependabot-cargo-test/tree/master/detached_crate_success/src"
+    }
+  }
+]


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Given a repository like so:

```
.
├── cli_crate
│   ├── Cargo.toml
└── workspace
    ├── Cargo.toml
    └── nested
        └── Cargo.toml
```

Where `workspace` represents a workspace containing only `nested`, and `cli_crate` has a path dependency to `nested`, and `nested` inherits any property from the root (e.g. `edition =  { workspace = true }`).

If we point dependabot to only `cli_crate`, it will error out when running `cargo update` as though it can fetch the path dependency `nested`, it cannot resolve this as it also needs the `workspace` due to this inheritance. Fix Cargo file_fetcher to support this logic of locating the root of a workspace member who is a path dependency, and fetching it.

For negative cases, where the root cannot be located or is incorrect, emit an error message (instead of when running `cargo update` which can be confusing to understand).

<!-- What issues does this affect or fix? -->

Closes #9533

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Unit tests added (see reference repository: https://github.com/Jefffrey/dependabot-cargo-test/tree/master)

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
