### PR TITLE
Fix showing bundler v1 deprecation warnings in PR message and logs

### DIFF
--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -188,7 +188,7 @@ module Dependabot
       # Log each non-empty line of the deprecation notice description
       description.each_line do |line|
         line = line.strip
-        markdown += "> #{line}\n"
+        markdown += "> #{line}\n\n"
       end
       markdown
     end

--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -188,8 +188,9 @@ module Dependabot
       # Log each non-empty line of the deprecation notice description
       description.each_line do |line|
         line = line.strip
-        markdown += "> #{line}\n\n"
+        markdown += "> #{line}\n"
       end
+      markdown += ">\n\n"
       markdown
     end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -168,6 +168,14 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
     end
   end
 
+  before do
+    allow(Dependabot::Experiments).to receive(:enabled?).with(:add_deprecation_warn_to_pr_message).and_return(true)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
+
   describe "#pr_name" do
     subject(:pr_name) { builder.pr_name }
 

--- a/updater/lib/dependabot/notices_helpers.rb
+++ b/updater/lib/dependabot/notices_helpers.rb
@@ -37,6 +37,7 @@ module Dependabot
 
     sig { params(notice: Dependabot::Notice).void }
     def log_notice(notice)
+      logger = Dependabot.logger
       # Log each non-empty line of the deprecation notice description
       notice.description.each_line do |line|
         line = line.strip
@@ -44,13 +45,13 @@ module Dependabot
 
         case notice.mode
         when Dependabot::Notice::NoticeMode::INFO
-          return Dependabot.logger.info(line)
+          logger.info(line)
         when Dependabot::Notice::NoticeMode::WARN
-          Dependabot.logger.warn(line)
+          logger.warn(line)
         when Dependabot::Notice::NoticeMode::ERROR
-          Dependabot.logger.error(line)
+          logger.error(line)
         else
-          Dependabot.logger.info(line)
+          logger.info(line)
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR ensures that deprecation warnings for `bundler v1` are properly displayed in both the pull request message and the logs.

### Anything you want to highlight for special attention from reviewers?

There are two key fixes in this PR:
1. **PR Message Warning**: The `bundler v1` deprecation warning is now correctly displayed in the PR message without including the "Bumps rails..." message within the warning block.
   
   Example of the fixed warning:
   <img width="698" alt="Screenshot 2024-09-05 at 10 35 32 AM" src="https://github.com/user-attachments/assets/81cb2170-947c-4574-a1c3-011a0770db4f">
   
2. **Logging Warning Consistency**: In the log output, the second deprecation warning message ("Please upgrade to version `v2`.") should properly work under the updater thread. 
### Checklist

After fix: 
<img width="621" alt="Screenshot 2024-09-05 at 11 08 44 AM" src="https://github.com/user-attachments/assets/6de5c680-924f-48a2-94ad-3041b949b976">

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
