### PR TITLE
Fix argument null exception when updating assembly references with no public key token

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1020,6 +1020,224 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task UpdateBindingRedirect_UnrelatedAssemblyReferenceWithMissingPublicKeyTokenAttribute()
+        {
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                ],
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package, Version=1.0.0.0, Culture=neutral">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFiles:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime>
+                            <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+                              </dependentAssembly>
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Unrelated.Package" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                              </dependentAssembly>
+                            </assemblyBinding>
+                          </runtime>
+                        </configuration>
+                        """)
+                ],
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package, Version=1.0.0.0, Culture=neutral">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFilesExpected:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime>
+                            <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+                              </dependentAssembly>
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Unrelated.Package" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                              </dependentAssembly>
+                            </assemblyBinding>
+                          </runtime>
+                        </configuration>
+                        """)
+                ]
+            );
+        }
+
+        [Fact]
+        public async Task UpdateBindingRedirect_UnrelatedAssemblyReferenceWithMissingCultureAttribute()
+        {
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                ],
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package, Version=1.0.0.0, PublicKeyToken=null">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFiles:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime>
+                            <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+                              </dependentAssembly>
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Unrelated.Package" publicKeyToken="null" />
+                                <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                              </dependentAssembly>
+                            </assemblyBinding>
+                          </runtime>
+                        </configuration>
+                        """)
+                ],
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Some.Unrelated.Package, Version=1.0.0.0, PublicKeyToken=null">
+                          <HintPath>packages\Some.Unrelated.Package.1.0.0\lib\net45\Some.Unrelated.Package.dll</HintPath>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFilesExpected:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime>
+                            <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+                              </dependentAssembly>
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Unrelated.Package" publicKeyToken="null" />
+                                <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                              </dependentAssembly>
+                            </assemblyBinding>
+                          </runtime>
+                        </configuration>
+                        """)
+                ]
+            );
+        }
+
+        [Fact]
         public async Task UpdateBindingRedirect_DuplicateRedirectsForTheSameAssemblyAreRemoved()
         {
             await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -304,12 +304,12 @@ internal static class BindingRedirectManager
     {
         public bool Equals(AssemblyIdentity? x, AssemblyIdentity? y) =>
             string.Equals(x?.Name, y?.Name, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(x?.PublicKeyToken, y?.PublicKeyToken, StringComparison.OrdinalIgnoreCase);
+            string.Equals(x?.PublicKeyToken ?? "null", y?.PublicKeyToken ?? "null", StringComparison.OrdinalIgnoreCase);
 
         public int GetHashCode(AssemblyIdentity obj) =>
             HashCode.Combine(
                 obj.Name?.ToLowerInvariant(),
-                obj.PublicKeyToken?.ToLowerInvariant()
+                obj.PublicKeyToken?.ToLowerInvariant() ?? "null"
             );
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
@@ -48,8 +48,8 @@ public static partial class BindingRedirectResolver
                 return false;
             }
 
-            dict.TryGetValue("PublicKeyToken", out var publicKeyToken);
-            dict.TryGetValue("Culture", out var culture);
+            var publicKeyToken = dict.GetValueOrDefault("PublicKeyToken", "null");
+            var culture = dict.GetValueOrDefault("Culture", "neutral");
 
             assemblyInfo = new AssemblyWrapper(name, version, publicKeyToken, culture);
             return true;
@@ -63,7 +63,7 @@ public static partial class BindingRedirectResolver
     /// </summary>
     private class AssemblyWrapper : Runtime_IAssembly
     {
-        public AssemblyWrapper(string name, Version version, string? publicKeyToken = null, string? culture = null)
+        public AssemblyWrapper(string name, Version version, string publicKeyToken, string culture)
         {
             Name = name;
             Version = version;
@@ -73,8 +73,8 @@ public static partial class BindingRedirectResolver
 
         public string Name { get; }
         public Version Version { get; }
-        public string? PublicKeyToken { get; }
-        public string? Culture { get; }
+        public string PublicKeyToken { get; }
+        public string Culture { get; }
         public IEnumerable<Runtime_IAssembly> ReferencedAssemblies { get; } = Enumerable.Empty<AssemblyWrapper>();
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix #10549.
See https://github.com/dependabot/dependabot-core/issues/10549#issuecomment-2333227090 for context.

When a .NET Framework project contains an assembly reference that does not have "PublicKeyToken" specified, e.g.
```csproj
<Reference Include="CSharpFunctionalExtensions, Version=2.40.3.0, Culture=neutral, processorArchitecture=MSIL">
  <HintPath>..\packages\CSharpFunctionalExtensions.2.40.3\lib\net461\CSharpFunctionalExtensions.dll</HintPath>
</Reference>
```

The update will fail when updating assembly binding redirects in `app.config`/`web.config`, e.g.
```log
Unhandled exception: System.ArgumentNullException: Value cannot be null. (Parameter 'value')
   at System.ArgumentNullException.Throw(String paramName)
   at System.Xml.Linq.XAttribute..ctor(XName name, Object value)
   at NuGet.Runtime.AssemblyBinding.ToXElement()
   at NuGetUpdater.Core.BindingRedirectManager.AddBindingRedirects(ConfigurationFile configFile, IEnumerable`1 bindingRedirects) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs:line 202
   at NuGetUpdater.Core.BindingRedirectManager.UpdateBindingRedirectsAsync(ProjectBuildFile projectBuildFile) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs:line 40
   at NuGetUpdater.Core.PackagesConfigUpdater.UpdateDependencyAsync(String repoRootPath, String projectPath, String dependencyName, String previousDependencyVersion, String newDependencyVersion, String packagesConfigPath, Logger logger) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs:line 89
   at NuGetUpdater.Core.UpdaterWorker.RunUpdaterAsync(String repoRootPath, String projectPath, String dependencyName, String previousDependencyVersion, String newDependencyVersion, Boolean isTransitive) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs:line 187
   at NuGetUpdater.Core.UpdaterWorker.RunForProjectAsync(String repoRootPath, String projectPath, String dependencyName, String previousDependencyVersion, String newDependencyVersion, Boolean isTransitive) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs:line 163
   at NuGetUpdater.Core.UpdaterWorker.RunAsync(String repoRootPath, String workspacePath, String dependencyName, String previousDependencyVersion, String newDependencyVersion, Boolean isTransitive, String resultOutputPath) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs:line 56
   at NuGetUpdater.Cli.Commands.UpdateCommand.<>c__DisplayClass8_0.<<GetCommand>b__0>d.MoveNext() in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/UpdateCommand.cs:line 37
```

From my [limited] understanding, the issue appears to be caused by a bug in the NuGet.Core v2 package.

The issue happens because when parsing assembly bindings, ["PublicKeyToken" is optional and can be null](https://github.com/NuGet/NuGet2/blob/875e7a4576d46785a8f2990b466e5add0229a726/src/Core/Runtime/AssemblyBinding.cs#L173C1-L173C103). However, when writing assembly bindings to config,  ["PublicKeyToken" is assumed to be non-null](https://github.com/NuGet/NuGet2/blob/875e7a4576d46785a8f2990b466e5add0229a726/src/Core/Runtime/AssemblyBinding.cs#L121C1-L121C83), which causes the `ArgumentNullException`.

This issue has been [fixed in NuGet.Client (v3+) by adding extra null checks](https://github.com/NuGet/NuGet.Client/blob/6970ffe10efff51d43862ea8f8a2ef0170250262/src/NuGet.Clients/NuGet.VisualStudio.Common/Runtime/AssemblyBinding.cs#L90C1-L93C14), but NuGetUpdater cannot update to this version without considerable rework.

The change proposed here makes "PublicKeyToken" required and treats `null` and the string literal `"null"` as the same thing during comparisons. When parsing assembly bindings, the token will default to `"null"` if not specified.

The same fix was also applied to the "Culture" property, which appears to also be affected by this issue (must be non-null). It defaults to "neutral" if not specified.

### Anything you want to highlight for special attention from reviewers?

If there is an easy way to remove NuGet.Core v2 and instead use NuGet.Client v6.x, that is probably the better way to fix this issue. I ran in to a lot of errors attempting to do this, but might not be doing it right.

### How will you know you've accomplished your goal?
Updates to NuGet projects containing assembly references with no public key token complete without errors.
This can be tested with:

```bash
bin/dry-run.rb nuget rhyskoedijk/dependabot-tests --dir="/WebApplication1-BindingRedirectNRE" --dep="System.Text.Json"
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
