### PR TITLE
Change default to Bundler v2 when unsupported feature flag is on and Gemfile.lock exists

### DIFF
--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 module Dependabot

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -4,26 +4,35 @@
 module Dependabot
   module Bundler
     module Helpers
+      extend T::Sig
+
       V1 = "1"
       V2 = "2"
       # If we are updating a project with no Gemfile.lock, we default to the
       # newest version we support
       DEFAULT = V2
-      # If we are updating a project with a Gemfile.lock that does not specify
-      # the version it was bundled with, we failover to V1 on the assumption
-      # it was created with an old version that didn't add this information
-      FAILOVER = V1
-
       BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m
 
+      sig { params(lockfile: T.untyped).returns(String) }
       def self.bundler_version(lockfile)
         return DEFAULT unless lockfile
 
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
           matches[:version].to_i >= 2 ? V2 : V1
+        elsif Dependabot::Experiments.enabled?(:bundler_v1_unsupported_error)
+          DEFAULT
         else
-          FAILOVER
+          failover_version
         end
+      end
+
+      # If we are updating a project with a Gemfile.lock that does not specify
+      # the version it was bundled with, we failover to V1 on the assumption
+      # it was created with an old version that didn't add this information
+      def self.failover_version
+        return V2 if Dependabot::Experiments.enabled?(:bundler_v1_unsupported_error)
+
+        V1
       end
 
       def self.detected_bundler_version(lockfile)


### PR DESCRIPTION
### What are you trying to accomplish?

This PR updates the default behavior to use Bundler v2 when the `bundler_v1_unsupported_error` feature flag is enabled and a Gemfile.lock exists. If the Gemfile.lock does not specify the Bundler version, we will now default to Bundler v2 instead of v1 when the flag is active.

### Anything you want to highlight for special attention from reviewers?

This change affects how dependencies are handled when there is no explicit Bundler version in the Gemfile.lock. With the feature flag enabled, the failover will be Bundler v2. This ensures compatibility with newer versions and prevents issues with unsupported Bundler v1.

### How will you know you've accomplished your goal?

- Bundler v2 is correctly used as the default when the `bundler_v1_unsupported_error` flag is enabled and the Gemfile.lock exists but lacks version information.
- Dependencies update as expected using Bundler v2 under these conditions.
- The feature flag controls the behavior as intended.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.