### PR TITLE
Fix : RegistryError error handler correction to stop propagation to unknown_errors

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -245,6 +245,12 @@ module Dependabot
         "error-type": "illformed_requirement",
         "error-detail": { message: error.message }
       }
+    when RegistryError
+      {
+        "error-type": "registry_error",
+        "error-detail": { status: error.status,
+                          msg: error.message }
+      }
     when
       IncompatibleCPU,
       NetworkUnsafeHTTP
@@ -608,6 +614,19 @@ module Dependabot
     def initialize(source)
       @source = T.let(sanitize_source(source), String)
       msg = "Missing or invalid authentication token while accessing github package : #{@source}"
+      super(msg)
+    end
+  end
+
+  class RegistryError < DependabotError
+    extend T::Sig
+
+    sig { returns(Integer) }
+    attr_reader :status
+
+    sig { params(status: Integer, msg: String).void }
+    def initialize(status, msg)
+      @status = status
       super(msg)
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -17,15 +17,6 @@ module Dependabot
       class LatestVersionFinder
         extend T::Sig
 
-        class RegistryError < StandardError
-          attr_reader :status
-
-          def initialize(status, msg)
-            @status = status
-            super(msg)
-          end
-        end
-
         def initialize(dependency:, credentials:, dependency_files:,
                        ignored_versions:, security_advisories:,
                        raise_on_ignored: false)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -731,7 +731,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
 
       it "raises an error" do
         expect { version_finder.latest_version_from_registry }
-          .to raise_error(described_class::RegistryError)
+          .to raise_error(Dependabot::RegistryError)
       end
     end
 
@@ -777,7 +777,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       it "raises an error" do
         expect { version_finder.latest_version_from_registry }
           .to raise_error do |err|
-            expect(err.class).to eq(described_class::RegistryError)
+            expect(err.class).to eq(Dependabot::RegistryError)
             expect(err.status).to eq(404)
           end
       end
@@ -844,7 +844,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
 
           it "raises an error" do
             expect { version_finder.latest_version_from_registry }
-              .to raise_error(described_class::RegistryError)
+              .to raise_error(Dependabot::RegistryError)
           end
         end
       end
@@ -909,7 +909,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       it "raises an error" do
         expect { version_finder.latest_version_from_registry }
           .to raise_error do |err|
-            expect(err.class).to eq(described_class::RegistryError)
+            expect(err.class).to eq(Dependabot::RegistryError)
             expect(err.status).to eq(404)
           end
       end


### PR DESCRIPTION
### What are you trying to accomplish?

**Preface:** Issue related with `Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder::RegistryError`

**Issue:** Due to `RegistryError` exception placement, the error was incorrectly being thrown into `unknown_error` type

**Fix:** Fixes placement of `RegistryError` exception type so that it is raised under correct exception type instead of unknown_error type.
```

+-------------------------------+
| Dependencies failed to update |
+--------------+----------------+
| express      | registry_error |
+--------------+----------------+
```

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
