### PR TITLE
fix(dotnet): Ensure that packages can be updated when referencing .NET workloads

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -3069,7 +3069,7 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
-        public async Task ProcessingProjectWithAspireDoesNotFailEvenThoughWorkloadIsNotInstalled()
+        public async Task ProcessingProjectWithWorkloadReferencesDoesNotFail()
         {
             // enumerating the build files will fail if the Aspire workload is not installed; this test ensures we can
             // still process the update
@@ -3082,7 +3082,7 @@ public partial class UpdateWorkerTests
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>net8.0</TargetFramework>
+                        <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;</TargetFrameworks>
                         <IsAspireHost>true</IsAspireHost>
                       </PropertyGroup>
                       <ItemGroup>
@@ -3093,7 +3093,7 @@ public partial class UpdateWorkerTests
                 expectedProjectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>net8.0</TargetFramework>
+                        <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;</TargetFrameworks>
                         <IsAspireHost>true</IsAspireHost>
                       </PropertyGroup>
                       <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -3104,6 +3104,42 @@ public partial class UpdateWorkerTests
             );
         }
 
+        [Fact]
+        public async Task ProcessingProjectWithAspireDoesNotFailEvenThoughWorkloadIsNotInstalled()
+        {
+            // enumerating the build files will fail if the Aspire workload is not installed; this test ensures we can
+            // still process the update
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "7.0.1", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
+                ],
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <IsAspireHost>true</IsAspireHost>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="7.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <IsAspireHost>true</IsAspireHost>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """
+            );
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -3122,7 +3158,7 @@ public partial class UpdateWorkerTests
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>net8.0</TargetFramework>
+                        <TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
                       </PropertyGroup>
                       <ItemGroup>
                         <PackageReference Include="Some.Other.Package" Version="$(SomeUnresolvableProperty)" />
@@ -3133,7 +3169,7 @@ public partial class UpdateWorkerTests
                 expectedProjectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
-                        <TargetFramework>net8.0</TargetFramework>
+                        <TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
                       </PropertyGroup>
                       <ItemGroup>
                         <PackageReference Include="Some.Other.Package" Version="$(SomeUnresolvableProperty)" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -525,7 +525,7 @@ public class MSBuildHelperTests : TestBase
         Assert.Equal("""
             <Project>
                 <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
+                    <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;</TargetFrameworks>
                 </PropertyGroup>
                 <ItemGroup>
                     <PackageReference Include="Some.Package" Version="1.1.1" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -497,6 +497,44 @@ public class MSBuildHelperTests : TestBase
         }
     }
 
+    [Fact]
+    public void UpdateWithWorkloadsTargetFrameworks()
+    {
+        // Arrange
+        var projectContents = """
+            <Project>
+                <PropertyGroup>
+                    <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;</TargetFrameworks>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="Some.Package" Version="$(PackageVersion1)" />
+                </ItemGroup>
+            </Project>
+            """;
+        var propertyInfo = new Dictionary<string, Property>
+        {
+            { "PackageVersion1", new("PackageVersion1", "1.1.1", "Packages.props") },
+        };
+
+        // Act
+        var (resultType, _, evaluatedValue, _, _) = MSBuildHelper.GetEvaluatedValue(projectContents, propertyInfo);
+
+        Assert.Equal(EvaluationResultType.Success, resultType);
+
+        // Assert
+        Assert.Equal("""
+            <Project>
+                <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="Some.Package" Version="1.1.1" />
+                </ItemGroup>
+            </Project>
+            """, evaluatedValue);
+    }
+
+
     #region
     // Updating root package
     // CS-Script Code to 2.0.0 requires its dependency Microsoft.CodeAnalysis.CSharp.Scripting to be 3.6.0 and its transitive dependency Microsoft.CodeAnalysis.Common to be 3.6.0

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -702,6 +702,7 @@ internal static partial class MSBuildHelper
                 <RunAnalyzers>false</RunAnalyzers>
                 <NuGetInteractive>false</NuGetInteractive>
                 <DesignTimeBuild>true</DesignTimeBuild>
+                <TargetPlatformVersion>1.0</TargetPlatformVersion>
               </PropertyGroup>
               <ItemGroup>
                 {packageReferences}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -702,7 +702,7 @@ internal static partial class MSBuildHelper
                 <RunAnalyzers>false</RunAnalyzers>
                 <NuGetInteractive>false</NuGetInteractive>
                 <DesignTimeBuild>true</DesignTimeBuild>
-                <TargetPlatformVersion Condition="$(TargetFramework.Contains("-"))">1.0</TargetPlatformVersion>
+                <TargetPlatformVersion Condition=" $(TargetFramework.Contains('-')) ">1.0</TargetPlatformVersion>
               </PropertyGroup>
               <ItemGroup>
                 {packageReferences}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -702,7 +702,7 @@ internal static partial class MSBuildHelper
                 <RunAnalyzers>false</RunAnalyzers>
                 <NuGetInteractive>false</NuGetInteractive>
                 <DesignTimeBuild>true</DesignTimeBuild>
-                <TargetPlatformVersion>1.0</TargetPlatformVersion>
+                <TargetPlatformVersion Condition="$(TargetFramework.Contains("-"))">1.0</TargetPlatformVersion>
               </PropertyGroup>
               <ItemGroup>
                 {packageReferences}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -701,6 +701,7 @@ internal static partial class MSBuildHelper
                 <GenerateDependencyFile>true</GenerateDependencyFile>
                 <RunAnalyzers>false</RunAnalyzers>
                 <NuGetInteractive>false</NuGetInteractive>
+                <DesignTimeBuild>true</DesignTimeBuild>
               </PropertyGroup>
               <ItemGroup>
                 {packageReferences}


### PR DESCRIPTION
### What are you trying to accomplish?

This PR is adding an MSBuild property that will prevent this [.NET SDK target](https://github.com/dotnet/sdk/blob/7ca2f7cf5dcb94cf852a964b2d003bbd4a684836/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.ImportWorkloads.targets#L36,) to execute in order to continue getting the dependency graph.

Fixes https://github.com/dependabot/dependabot-core/issues/10117

### Anything you want to highlight for special attention from reviewers?

There does not seem to be another way to avoid getting the `NETSDK1147` error.

This PR uses two specifics to get around workloads not being installed:
- It uses `DesignTimeBuild` to skip the workloads validation
- It defines a fake `TargetPlatformVersion` in order for nuget to still consider the platform-specific target frameworks.

### How will you know you've accomplished your goal?

Both tests that are added will succeed, as they reference target frameworks that require the use of .NET workloads.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
