### PR TITLE
feat: Add Support for Bun Package Manager

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -484,6 +484,12 @@ module Dependabot
       env_keys = env ? env.compact.map { |k, v| "#{k}=#{v}" }.join(" ") + " " : ""
       "$ cd #{Dir.pwd} && echo \"#{escaped_stdin_data}\" | #{env_keys}#{command}"
     end
+
+    sig { params(additional_path: String).returns(String) }
+    def self.add_to_path_variable(additional_path:)
+      current_path = ENV['PATH']
+      ENV['PATH'] = "#{current_path}:#{additional_path}"
+    end
     private_class_method :helper_subprocess_bash_command
   end
 end


### PR DESCRIPTION
Install Bun Package Manager if specified in package.json file in npm_and_yarn workspace.

### What are you trying to accomplish?

Add Support for Bun as Package manager under the scope of `npm_and_yarn`.

Projects using Bun as Package manager and emitting a `yarn.lock` file as side effect should run `bun install` after parsing the lockfile and resolving the dependency updates. This will in return update `bun.lockb` and keep `yarn.lock` in sync.

### Anything you want to highlight for special attention from reviewers?

This is my first issue in this repository and I don't consider myself to be an expert in Ruby. Hence I would very much appreciate any guidance on the way.

### How will you know you've accomplished your goal?

This [PR](https://github.com/0xTheProDev/distributed-lock/pull/38) generated by dependabot could be used as to reference why this change is required. You can see I had to add one more fixup commit on top of original update to handle lockfile mismatch. I want this to be handled by dependabot itself.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
