### PR TITLE
Make sure process parameters are correctly quoted

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
@@ -352,8 +352,7 @@ public partial class EntryPointTests
                 </Project>
                 """);
             var executableName = Path.Join(Path.GetDirectoryName(GetType().Assembly.Location), "NuGetUpdater.Cli.dll");
-            var executableArgs = string.Join(" ",
-            [
+            IEnumerable<string> executableArgs = [
                 executableName,
                 "update",
                 "--repo-root",
@@ -367,7 +366,7 @@ public partial class EntryPointTests
                 "--previous-version",
                 "7.0.1",
                 "--verbose"
-            ]);
+            ];
 
             // verify base run
             var workingDirectory = tempDir.DirectoryPath;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -315,7 +315,7 @@ namespace NuGetUpdater.Core.Test
                     </Project>
                     """
                 );
-                var (exitCode, stdout, stderr) = ProcessEx.RunAsync("dotnet", $"msbuild {projectPath} /t:_ReportCurrentSdkVersion").Result;
+                var (exitCode, stdout, stderr) = ProcessEx.RunAsync("dotnet", ["msbuild", projectPath, "/t:_ReportCurrentSdkVersion"]).Result;
                 if (exitCode != 0)
                 {
                     throw new Exception($"Failed to report the current SDK version:\n{stdout}\n{stderr}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
@@ -18,7 +18,7 @@ internal static class LockFileUpdater
 
         await MSBuildHelper.SidelineGlobalJsonAsync(projectDirectory, repoRootPath, async () =>
         {
-            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"restore --force-evaluate {projectPath}", workingDirectory: projectDirectory);
+            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", ["restore", "--force-evaluate", projectPath], workingDirectory: projectDirectory);
             if (exitCode != 0)
             {
                 logger.Log($"      Lock file update failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SdkPackageUpdater.cs
@@ -231,7 +231,7 @@ internal static class SdkPackageUpdater
             logger.Log($"    Adding [{dependencyName}/{newDependencyVersion}] as a top-level package reference.");
 
             // see https://learn.microsoft.com/nuget/consume-packages/install-use-packages-dotnet-cli
-            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"add {projectPath} package {dependencyName} --version {newDependencyVersion}", workingDirectory: projectDirectory);
+            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", ["add", projectPath, "package", dependencyName, "--version", newDependencyVersion], workingDirectory: projectDirectory);
             MSBuildHelper.ThrowOnUnauthenticatedFeed(stdout);
             if (exitCode != 0)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -322,7 +322,7 @@ internal static partial class MSBuildHelper
         try
         {
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"", workingDirectory: tempDirectory.FullName);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["restore", tempProjectPath], workingDirectory: tempDirectory.FullName);
 
             // NU1608: Detected package version outside of dependency constraint
 
@@ -359,7 +359,7 @@ internal static partial class MSBuildHelper
         try
         {
             string tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"", workingDirectory: tempDirectory.FullName);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["restore", tempProjectPath], workingDirectory: tempDirectory.FullName);
 
             // Add Dependency[] packages to List<PackageToUpdate> existingPackages
             List<PackageToUpdate> existingPackages = packages
@@ -515,7 +515,7 @@ internal static partial class MSBuildHelper
         try
         {
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"", workingDirectory: tempDirectory.FullName);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["restore", tempProjectPath], workingDirectory: tempDirectory.FullName);
             ThrowOnUnauthenticatedFeed(stdOut);
 
             // simple cases first
@@ -540,7 +540,7 @@ internal static partial class MSBuildHelper
             foreach ((string PackageName, NuGetVersion packageVersion) in badPackagesAndVersions)
             {
                 // this command dumps a JSON object with all versions of the specified package from all package sources
-                (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"package search {PackageName} --exact-match --format json", workingDirectory: tempDirectory.FullName);
+                (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["package", "search", PackageName, "--exact-match", "--format", "json"], workingDirectory: tempDirectory.FullName);
                 if (exitCode != 0)
                 {
                     continue;
@@ -770,7 +770,7 @@ internal static partial class MSBuildHelper
             var topLevelPackagesNames = packages.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages);
 
-            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", $"build \"{tempProjectPath}\" /t:_ReportDependencies", workingDirectory: tempDirectory.FullName);
+            var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", ["build", tempProjectPath, "/t:_ReportDependencies"], workingDirectory: tempDirectory.FullName);
             ThrowOnUnauthenticatedFeed(stdout);
 
             if (exitCode == 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
@@ -26,7 +26,7 @@ internal static class NuGetHelper
         try
         {
             var tempProjectPath = await MSBuildHelper.CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, "netstandard2.0", packages, usePackageDownload: true);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", $"restore \"{tempProjectPath}\"");
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["restore", tempProjectPath]);
 
             return exitCode == 0;
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -12,7 +12,7 @@ public static class ProcessEx
         var redirectInitiated = new ManualResetEventSlim();
         var process = new Process
         {
-            StartInfo = new ProcessStartInfo(fileName, arguments ?? Array.Empty<string>())
+            StartInfo = new ProcessStartInfo(fileName, arguments ?? [])
             {
                 UseShellExecute = false, // required to redirect output
                 RedirectStandardOutput = true,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -5,17 +5,15 @@ namespace NuGetUpdater.Core;
 
 public static class ProcessEx
 {
-    public static Task<(int ExitCode, string Output, string Error)> RunAsync(string fileName, string arguments = "", string? workingDirectory = null)
+    public static Task<(int ExitCode, string Output, string Error)> RunAsync(string fileName, IEnumerable<string>? arguments = null, string? workingDirectory = null)
     {
         var tcs = new TaskCompletionSource<(int, string, string)>();
 
         var redirectInitiated = new ManualResetEventSlim();
         var process = new Process
         {
-            StartInfo =
+            StartInfo = new ProcessStartInfo(fileName, arguments ?? Array.Empty<string>())
             {
-                FileName = fileName,
-                Arguments = arguments,
                 UseShellExecute = false, // required to redirect output
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,


### PR DESCRIPTION
### What are you trying to accomplish?

With #9678, the nuget updated gained support for package lock files.
However, it fails when the csproj path contains spaces (see https://github.com/dependabot/dependabot-core/pull/9678#issuecomment-2376037446).

This now changes the `ProcessEx` helper to accept a list of args (instead of just a string). This should fix this issue for the lock file update as well as several other places.

### Anything you want to highlight for special attention from reviewers?

My initial thought was to simply escape the strings myself, but `ProcessStartInfo` has a constructor that also takes an argument list, so I opted to use that one and leave the escaping to the system.
Also, I didn't just want to fix the lock file updater, because I found other places where paths (which can possibly contains spaces) weren't correctly escaped. With that API change, it should no longer be an issue, also for new usages of the `ProcessEx` helper.

### How will you know you've accomplished your goal?

I've updated all the call sites of the old extension by passing the args as array. One was even creating an array and joining it with a string.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Unfortunately, I was unable to run the tests. Starting the development shell fails with the following error:
```
E: Unable to locate package powershell
```
