### PR TITLE
raise specific error when no update was possible

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -240,6 +240,13 @@ module Dependabot
           "go-mod": error.go_mod
         }
       }
+    when Dependabot::UpdateNotPossible
+      {
+        "error-type": "update_not_possible",
+        "error-detail": {
+          dependencies: error.dependencies
+        }
+      }
     when BadRequirementError
       {
         "error-type": "illformed_requirement",
@@ -638,6 +645,21 @@ module Dependabot
   ###########################
   # Dependency level errors #
   ###########################
+
+  class UpdateNotPossible < DependabotError
+    extend T::Sig
+
+    sig { returns(T::Array[String]) }
+    attr_reader :dependencies
+
+    sig { params(dependencies: T::Array[String]).void }
+    def initialize(dependencies)
+      @dependencies = dependencies
+
+      msg = "The following dependencies could not be updated: #{@dependencies.join(', ')}"
+      super(msg)
+    end
+  end
 
   class GitDependenciesNotReachable < DependabotError
     extend T::Sig

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -51,7 +51,7 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
         base_dir = "/"
-        SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+        all_updated_files = SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
           dependencies.each do |dependency|
             try_update_projects(dependency) || try_update_json(dependency)
           end
@@ -70,6 +70,10 @@ module Dependabot
           end
           updated_files
         end
+
+        raise UpdateNotPossible, dependencies.map(&:name) if all_updated_files.empty?
+
+        all_updated_files
       end
 
       private

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -223,6 +223,27 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
         end
       end
     end
+
+    context "when no update is performed" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "This.Dependency.Does.Not.Exist",
+          version: "4.5.6",
+          previous_version: "1.2.3",
+          requirements: [{ file: "Proj1/Proj1/Proj1.csproj", requirement: "4.5.6", groups: [], source: nil }],
+          previous_requirements: [{ file: "Proj1/Proj1/Proj1.csproj", requirement: "1.2.3", groups: [], source: nil }],
+          package_manager: "nuget"
+        )
+      end
+
+      it "raises the expected error" do
+        run_update_test do |updater|
+          expect do
+            updater.updated_dependency_files
+          end.to raise_error(Dependabot::UpdateNotPossible)
+        end
+      end
+    end
   end
 
   describe "#updated_dependency_files_with_wildcard" do


### PR DESCRIPTION
When the NuGet updater cannot perform any update, jobs currently fail with `unknown_error` which comes from here: https://github.com/dependabot/dependabot-core/blob/dddd7b2f60e72bd93e3490f1ab88d413419f3a27/updater/lib/dependabot/dependency_change_builder.rb#L73

This isn't very descriptive and makes it difficult to investigate the `unknown_error` bucket, especially since in this case we know exactly what went wrong.

The fix is to add a new error type that represents this scenario and raise it directly in the NuGet updater.  This has the benefit of making the call stack more usable.

The error type string `update_not_possible` is already well-known.