### PR TITLE
update package to fix bug in XML reader

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="DiffPlex" Version="1.7.1" />
 
-    <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.60" />
+    <PackageVersion Include="GuiLabs.Language.Xml" Version="1.2.93" />
 
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.6.1" />
     <PackageVersion Include="Microsoft.Build" Version="17.5.0" ExcludeAssets="Runtime" PrivateAssets="All" />


### PR DESCRIPTION
There was a bug in an XML reader used by the NuGet updater that has been fixed in a recent release.  Simply bumping that package.

Specifically, the issue was round-tripping attributes with single quotes.  E.g., this:

``` xml
<Element Attribute='value' />
```

was incorrectly round-tripped as this:

``` xml
<Element Attribute='value" />
```

Notice the closing quote of the attribute was changed from a single to a double quote.