### PR TITLE
rearrange NuGet error handling to one location in full runner

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/.editorconfig
+++ b/nuget/helpers/lib/NuGetUpdater/.editorconfig
@@ -20,6 +20,7 @@ tab_width = 4
 
 # New line preferences
 insert_final_newline = true
+end_of_line = lf
 
 #### .NET Coding Conventions ####
 [*.{cs,vb}]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
@@ -9,27 +9,33 @@ internal class TestApiHandler : IApiHandler
 
     public IEnumerable<(Type Type, object Object)> ReceivedMessages => _receivedMessages;
 
+    public Task RecordUpdateJobError(JobErrorBase error)
+    {
+        _receivedMessages.Add((error.GetType(), error));
+        return Task.CompletedTask;
+    }
+
     public Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList)
     {
-        _receivedMessages.Add((typeof(UpdatedDependencyList), updatedDependencyList));
+        _receivedMessages.Add((updatedDependencyList.GetType(), updatedDependencyList));
         return Task.CompletedTask;
     }
 
     public Task IncrementMetric(IncrementMetric incrementMetric)
     {
-        _receivedMessages.Add((typeof(IncrementMetric), incrementMetric));
+        _receivedMessages.Add((incrementMetric.GetType(), incrementMetric));
         return Task.CompletedTask;
     }
 
     public Task CreatePullRequest(CreatePullRequest createPullRequest)
     {
-        _receivedMessages.Add((typeof(CreatePullRequest), createPullRequest));
+        _receivedMessages.Add((createPullRequest.GetType(), createPullRequest));
         return Task.CompletedTask;
     }
 
     public Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
     {
-        _receivedMessages.Add((typeof(MarkAsProcessed), markAsProcessed));
+        _receivedMessages.Add((markAsProcessed.GetType(), markAsProcessed));
         return Task.CompletedTask;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -257,14 +257,6 @@ public abstract class UpdateWorkerTestBase : TestBase
                 package.WriteToDirectory(localFeedPath);
             }
 
-            // override various nuget locations
-            foreach (var envName in new[] { "NUGET_PACKAGES", "NUGET_HTTP_CACHE_PATH", "NUGET_SCRATCH", "NUGET_PLUGINS_CACHE_PATH" })
-            {
-                string dir = Path.Join(temporaryDirectory, envName);
-                Directory.CreateDirectory(dir);
-                Environment.SetEnvironmentVariable(envName, dir);
-            }
-
             // ensure only the test feed is used
             string relativeLocalFeedPath = Path.GetRelativePath(temporaryDirectory, localFeedPath);
             await File.WriteAllTextAsync(Path.Join(temporaryDirectory, "NuGet.Config"), $"""
@@ -277,6 +269,14 @@ public abstract class UpdateWorkerTestBase : TestBase
                 </configuration>
                 """
             );
+        }
+
+        // override various nuget locations
+        foreach (var envName in new[] { "NUGET_PACKAGES", "NUGET_HTTP_CACHE_PATH", "NUGET_SCRATCH", "NUGET_PLUGINS_CACHE_PATH" })
+        {
+            string dir = Path.Join(temporaryDirectory, envName);
+            Directory.CreateDirectory(dir);
+            Environment.SetEnvironmentVariable(envName, dir);
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -30,7 +30,29 @@ public partial class DiscoveryWorker
         _logger = logger;
     }
 
-    public async Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)
+    public async Task RunAsync(string repoRootPath, string workspacePath, string outputPath)
+    {
+        WorkspaceDiscoveryResult result;
+        try
+        {
+            result = await RunAsync(repoRootPath, workspacePath);
+        }
+        catch (HttpRequestException ex)
+        when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            result = new WorkspaceDiscoveryResult
+            {
+                ErrorType = ErrorType.AuthenticationFailure,
+                ErrorDetails = "(" + string.Join("|", NuGetContext.GetPackageSourceUrls(PathHelper.JoinPath(repoRootPath, workspacePath))) + ")",
+                Path = workspacePath,
+                Projects = [],
+            };
+        }
+
+        await WriteResultsAsync(repoRootPath, outputPath, result);
+    }
+
+    internal async Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)
     {
         MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, repoRootPath);
 
@@ -51,67 +73,46 @@ public partial class DiscoveryWorker
         ImmutableArray<ProjectDiscoveryResult> projectResults = [];
         WorkspaceDiscoveryResult result;
 
-        try
+        if (Directory.Exists(workspacePath))
         {
-            if (Directory.Exists(workspacePath))
+            _logger.Log($"Discovering build files in workspace [{workspacePath}].");
+
+            dotNetToolsJsonDiscovery = DotNetToolsJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
+            globalJsonDiscovery = GlobalJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
+
+            if (globalJsonDiscovery is not null)
             {
-                _logger.Log($"Discovering build files in workspace [{workspacePath}].");
-
-                dotNetToolsJsonDiscovery = DotNetToolsJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
-                globalJsonDiscovery = GlobalJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
-
-                if (globalJsonDiscovery is not null)
-                {
-                    await TryRestoreMSBuildSdksAsync(repoRootPath, workspacePath, globalJsonDiscovery.Dependencies, _logger);
-                }
-
-                // this next line should throw or something
-                projectResults = await RunForDirectoryAsnyc(repoRootPath, workspacePath);
-
-                directoryPackagesPropsDiscovery = DirectoryPackagesPropsDiscovery.Discover(repoRootPath, workspacePath, projectResults, _logger);
-
-                if (directoryPackagesPropsDiscovery is not null)
-                {
-                    projectResults = projectResults.Remove(projectResults.First(p => p.FilePath.Equals(directoryPackagesPropsDiscovery.FilePath, StringComparison.OrdinalIgnoreCase)));
-                }
-            }
-            else
-            {
-                _logger.Log($"Workspace path [{workspacePath}] does not exist.");
+                await TryRestoreMSBuildSdksAsync(repoRootPath, workspacePath, globalJsonDiscovery.Dependencies, _logger);
             }
 
-            result = new WorkspaceDiscoveryResult
+            // this next line should throw or something
+            projectResults = await RunForDirectoryAsnyc(repoRootPath, workspacePath);
+
+            directoryPackagesPropsDiscovery = DirectoryPackagesPropsDiscovery.Discover(repoRootPath, workspacePath, projectResults, _logger);
+
+            if (directoryPackagesPropsDiscovery is not null)
             {
-                Path = initialWorkspacePath,
-                DotNetToolsJson = dotNetToolsJsonDiscovery,
-                GlobalJson = globalJsonDiscovery,
-                DirectoryPackagesProps = directoryPackagesPropsDiscovery,
-                Projects = projectResults.OrderBy(p => p.FilePath).ToImmutableArray(),
-            };
+                projectResults = projectResults.Remove(projectResults.First(p => p.FilePath.Equals(directoryPackagesPropsDiscovery.FilePath, StringComparison.OrdinalIgnoreCase)));
+            }
         }
-        catch (HttpRequestException ex)
-        when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
+        else
         {
-            // TODO: consolidate this error handling between AnalyzeWorker, DiscoveryWorker, and UpdateWorker
-            result = new WorkspaceDiscoveryResult
-            {
-                ErrorType = ErrorType.AuthenticationFailure,
-                ErrorDetails = "(" + string.Join("|", NuGetContext.GetPackageSourceUrls(workspacePath)) + ")",
-                Path = initialWorkspacePath,
-                Projects = [],
-            };
+            _logger.Log($"Workspace path [{workspacePath}] does not exist.");
         }
+
+        result = new WorkspaceDiscoveryResult
+        {
+            Path = initialWorkspacePath,
+            DotNetToolsJson = dotNetToolsJsonDiscovery,
+            GlobalJson = globalJsonDiscovery,
+            DirectoryPackagesProps = directoryPackagesPropsDiscovery,
+            Projects = projectResults.OrderBy(p => p.FilePath).ToImmutableArray(),
+        };
 
         _logger.Log("Discovery complete.");
         _processedProjectPaths.Clear();
 
         return result;
-    }
-
-    public async Task RunAsync(string repoRootPath, string workspacePath, string outputPath)
-    {
-        var result = await RunAsync(repoRootPath, workspacePath);
-        await WriteResultsAsync(repoRootPath, outputPath, result);
     }
 
     /// <summary>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record DependencyFileNotFound : JobErrorBase
+{
+    public override string Type => "dependency_file_not_found";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public abstract record JobErrorBase
+{
+    [JsonPropertyName("error-type")]
+    public abstract string Type { get; }
+    [JsonPropertyName("error-details")]
+    public required string Details { get; init; }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PrivateSourceAuthenticationFailure : JobErrorBase
+{
+    public override string Type => "private_source_authentication_failure";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record UnknownError : JobErrorBase
+{
+    public override string Type => "unknown_error";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -25,6 +25,11 @@ public class HttpApiHandler : IApiHandler
         _jobId = jobId;
     }
 
+    public async Task RecordUpdateJobError(JobErrorBase error)
+    {
+        await PostAsJson("record_update_job_error", error);
+    }
+
     public async Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList)
     {
         await PostAsJson("update_dependency_list", updatedDependencyList);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -4,6 +4,7 @@ namespace NuGetUpdater.Core.Run;
 
 public interface IApiHandler
 {
+    Task RecordUpdateJobError(JobErrorBase error);
     Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList);
     Task IncrementMetric(IncrementMetric incrementMetric);
     Task CreatePullRequest(CreatePullRequest createPullRequest);


### PR DESCRIPTION
# The changes in this PR will not be live, even when merged.  All of this behavior is behind an experiment which will not be enabled for some time.

This updates the full end-to-end update runner (not yet in production) for NuGet by rearranging the error handling.  The individual tools used by the current Ruby updater remain unchanged, but everything else has been refactored so that one single place of error handling could be added to `RunWorker.cs`.  This involved creating new types to represent `private_source_authentication_error`, `dependency_file_not_found`, and `unknown_error` as a catch-all.

The changes to `AnalyzeWorker.cs`, `DiscoveryWorker.cs`, and `UpdaterWorker.cs` are simply to move the `try`/`catch` blocks to a different function.

Future work will be to add support for more error types.