### PR TITLE
Fix nuget ecosystem arm build

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 ARG POWERSHELL_VERSION=7.4.5
 RUN ARCH=$([ $TARGETARCH = "arm64" ] && echo "arm64" || echo "x64") \
  && POWERSHELL_VERSION_MAJOR=$(echo $POWERSHELL_VERSION | cut -d. -f1) \
- && INSTALL_PATH=/opt/microsoft/powershell/${POWERSHELL_VERSION_MAJOR} \
+ && INSTALL_PATH=/usr/local/microsoft/powershell/${POWERSHELL_VERSION_MAJOR} \
  && curl --location --output /tmp/powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${ARCH}.tar.gz" \
  && mkdir -p $INSTALL_PATH \
  && tar zxf /tmp/powershell.tar.gz -C $INSTALL_PATH \

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -1,20 +1,29 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
+ARG TARGETARCH
+
 USER root
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
 # install dependencies
-RUN source /etc/os-release \
- && curl --location --output /tmp/packages-microsoft-prod.deb "https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb" \
- && dpkg -i /tmp/packages-microsoft-prod.deb \
- && rm /tmp/packages-microsoft-prod.deb
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     jq \
     libicu-dev=70.1-2 \
-    powershell \
  && rm -rf /var/lib/apt/lists/*
+
+ARG POWERSHELL_VERSION=7.4.5
+RUN ARCH=$([ $TARGETARCH = "arm64" ] && echo "arm64" || echo "x64") \
+ && POWERSHELL_VERSION_MAJOR=$(echo $POWERSHELL_VERSION | cut -d. -f1) \
+ && INSTALL_PATH=/opt/microsoft/powershell/${POWERSHELL_VERSION_MAJOR} \
+ && curl --location --output /tmp/powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${ARCH}.tar.gz" \
+ && mkdir -p $INSTALL_PATH \
+ && tar zxf /tmp/powershell.tar.gz -C $INSTALL_PATH \
+ && chmod +x $INSTALL_PATH/pwsh \
+ && ln -s $INSTALL_PATH/pwsh /usr/bin/pwsh \
+ && rm /tmp/powershell.tar.gz \
+ && pwsh --version
 
 # Install .NET SDK
 ARG DOTNET_LTS_SDK_VERSION=8.0.402


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes currently broken `nuget` ecosystem build for `arm64` architecture due to not having a prebuilt powershell `.deb` package. Changes installation method to use pre-built binaries instead of `.deb` package.

Fixes: https://github.com/dependabot/dependabot-core/issues/10689

### How will you know you've accomplished your goal?

Currently it's not possible to validate on CI due to not having `arm64` architecture builds. I have ran this locally though on my arm machine and image is building. If CI passes, it at least should show that regressions were not introduced.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
