### PR TITLE
allow empty version after comma in a requirement

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/RequirementTests.cs
@@ -46,11 +46,14 @@ public class RequirementTests
     }
 
     [Theory]
+    [InlineData("> *", "> 0")] // standard wildcard, no digits
     [InlineData("> 1.*", "> 1.0")] // standard wildcard, single digit
     [InlineData("> 1.2.*", "> 1.2.0")] // standard wildcard, multiple digit
+    [InlineData("> a", "> 0")] // alternate wildcard, no digits
     [InlineData("> 1.a", "> 1.0")] // alternate wildcard, single digit
     [InlineData("> 1.2.a", "> 1.2.0")] // alternate wildcard, multiple digit
-    public void Parse_ConvertsWildcardInVersion(string givenRequirementString, string expectedRequirementString)
+    [InlineData(">= 1.40.0, ", ">= 1.40.0")] // empty string following comma
+    public void Parse_Requirement(string givenRequirementString, string expectedRequirementString)
     {
         var parsedRequirement = Requirement.Parse(givenRequirementString);
         var actualRequirementString = parsedRequirement.ToString();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Requirement.cs
@@ -52,10 +52,10 @@ public abstract class Requirement
 
     public static Requirement Parse(string requirement)
     {
-        var specificParts = requirement.Split(',');
+        var specificParts = requirement.Split(',').Where(p => !string.IsNullOrWhiteSpace(p)).ToArray();
         if (specificParts.Length == 1)
         {
-            return IndividualRequirement.ParseIndividual(requirement);
+            return IndividualRequirement.ParseIndividual(specificParts[0]);
         }
 
         var specificRequirements = specificParts.Select(IndividualRequirement.ParseIndividual).ToArray();

--- a/nuget/lib/dependabot/nuget/requirement.rb
+++ b/nuget/lib/dependabot/nuget/requirement.rb
@@ -42,6 +42,8 @@ module Dependabot
           convert_dotnet_constraint_to_ruby_constraint(req_string)
         end
 
+        requirements = requirements.compact.reject(&:empty?)
+
         super(requirements)
       end
 

--- a/nuget/spec/dependabot/nuget/requirement_spec.rb
+++ b/nuget/spec/dependabot/nuget/requirement_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Dependabot::Nuget::Requirement do
         it { is_expected.to eq(Gem::Requirement.new(">= 1.0.0", "< 2.0.0")) }
       end
 
+      context "when an empty string follows a comma" do
+        let(:requirement_string) { ">= 1.40.0, " }
+
+        it { is_expected.to eq(Gem::Requirement.new(">= 1.40.0")) }
+      end
+
       context "when including a * in the lower bound" do
         let(:requirement_string) { "[2.1.*,3.0.0)" }
 


### PR DESCRIPTION
Requirement strings were found in the wild with a trailing comma, e.g., `>= 1.40.0, `

A quick check of two other requirement handlers, NPM and Python, both allow for an empty value so the NuGet version is being updated as well.