### PR TITLE
Add package_manager for Composer v1 deprecation warning and unsupported error

### DIFF
--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -33,6 +33,11 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      sig { returns(PackageManagerBase) }
+      def package_manager
+        PackageManager.new(composer_version)
+      end
+
       private
 
       def manifest_dependencies
@@ -207,6 +212,10 @@ module Dependabot
 
       def lockfile
         @lockfile ||= get_original_file("composer.lock")
+      end
+
+      def composer_version
+        @composer_version ||= Helpers.composer_version(parsed_composer_json, parsed_lockfile)
       end
     end
   end

--- a/composer/lib/dependabot/composer/package_manager.rb
+++ b/composer/lib/dependabot/composer/package_manager.rb
@@ -1,0 +1,60 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/package_manager"
+
+module Dependabot
+  module Composer
+    PACKAGE_MANAGER = "composer"
+
+    # Keep versions in ascending order
+    SUPPORTED_COMPOSER_VERSIONS = T.let([Version.new("2")].freeze, T::Array[Dependabot::Version])
+
+    DEPRECATED_COMPOSER_VERSIONS = T.let([
+      Version.new("1")
+    ].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < PackageManagerBase
+      extend T::Sig
+
+      sig { params(version: T.any(String, Dependabot::Version)).void }
+      def initialize(version)
+        @version = T.let(Version.new(version), Dependabot::Version)
+        @name = T.let(PACKAGE_MANAGER, String)
+        @deprecated_versions = T.let(DEPRECATED_COMPOSER_VERSIONS, T::Array[Dependabot::Version])
+        @supported_versions = T.let(SUPPORTED_COMPOSER_VERSIONS, T::Array[Dependabot::Version])
+      end
+
+      sig { override.returns(String) }
+      attr_reader :name
+
+      sig { override.returns(Dependabot::Version) }
+      attr_reader :version
+
+      sig { override.returns(T::Array[Dependabot::Version]) }
+      attr_reader :deprecated_versions
+
+      sig { override.returns(T::Array[Dependabot::Version]) }
+      attr_reader :supported_versions
+
+      sig { override.returns(T::Boolean) }
+      def deprecated?
+        return false if unsupported?
+
+        # Check if the feature flag for Composer v1 unsupported error is enabled.
+        return false unless Dependabot::Experiments.enabled?(:composer_v1_deprecation_warning)
+
+        deprecated_versions.include?(version)
+      end
+
+      sig { override.returns(T::Boolean) }
+      def unsupported?
+        # Check if the feature flag for Composer v1 unsupported error is enabled.
+        return false unless Dependabot::Experiments.enabled?(:composer_v1_unsupported_error)
+
+        supported_versions.all? { |supported| supported > version }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces a `package_manager` subclass for Composer and sets Composer v1 as deprecated and unsupported. The deprecation warning and unsupported error are controlled by the following feature flags:
- `composer_v1_deprecation_warning`
- `composer_v1_unsupported_error`

This mirrors the approach used for Bundler v1, allowing us to guide users towards migrating to Composer v2 while providing a controlled rollout.

### Anything you want to highlight for special attention from reviewers?

The deprecation and unsupported checks for Composer v1 are controlled by feature flags, similar to how it was implemented for Bundler v1. Please focus on verifying that the logic tied to the feature flags works as expected.

### How will you know you've accomplished your goal?

We will monitor logs and metrics to ensure:
- Composer v1 users see the deprecation warning when the feature flag is enabled.
- Actions using Composer v1 are blocked when the unsupported error flag is enabled.
- Tests have been added to validate the behavior of both feature flags.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.