### PR TITLE
report specific error when project cannot be restored

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
@@ -1,8 +1,10 @@
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
 
 using NuGetUpdater.Core;
 using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Test;
 using NuGetUpdater.Core.Test.Analyze;
 using NuGetUpdater.Core.Test.Update;
@@ -334,6 +336,11 @@ public partial class EntryPointTests
                     Console.SetOut(originalOut);
                     Console.SetError(originalErr);
                 }
+
+                var resultPath = Path.Join(path, AnalyzeWorker.AnalysisDirectoryName, $"{dependencyName}.json");
+                var resultJson = await File.ReadAllTextAsync(resultPath);
+                var resultObject = JsonSerializer.Deserialize<AnalysisResult>(resultJson, DiscoveryWorker.SerializerOptions);
+                return resultObject!;
             });
 
             ValidateAnalysisResult(expectedResult, actualResult);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 
 using NuGetUpdater.Core;
 using NuGetUpdater.Core.Discover;
@@ -390,6 +391,11 @@ public partial class EntryPointTests
                     Console.SetOut(originalOut);
                     Console.SetError(originalErr);
                 }
+
+                var resultPath = Path.Join(path, DiscoveryWorker.DiscoveryResultFileName);
+                var resultJson = await File.ReadAllTextAsync(resultPath);
+                var resultObject = JsonSerializer.Deserialize<WorkspaceDiscoveryResult>(resultJson, DiscoveryWorker.SerializerOptions);
+                return resultObject!;
             });
 
             ValidateWorkspaceResult(expectedResult, actualResult);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 using NuGetUpdater.Core.Updater;
 
 using Xunit;
@@ -137,10 +135,7 @@ public abstract class UpdateWorkerTestBase : TestBase
             // run update
             var worker = new UpdaterWorker(new Logger(verbose: true));
             var projectPath = placeFilesInSrc ? $"src/{projectFilePath}" : projectFilePath;
-            var updateResultFile = Path.Combine(temporaryDirectory, "update-result.json");
-            await worker.RunAsync(temporaryDirectory, projectPath, dependencyName, oldVersion, newVersion, isTransitive, updateResultFile);
-            var actualResultContents = await File.ReadAllTextAsync(updateResultFile);
-            var actualResult = JsonSerializer.Deserialize<UpdateOperationResult>(actualResultContents, UpdaterWorker.SerializerOptions);
+            var actualResult = await worker.RunWithErrorHandlingAsync(temporaryDirectory, projectPath, dependencyName, oldVersion, newVersion, isTransitive);
             if (expectedResult is { })
             {
                 ValidateUpdateOperationResult(expectedResult, actualResult!);
@@ -159,7 +154,7 @@ public abstract class UpdateWorkerTestBase : TestBase
     protected static void ValidateUpdateOperationResult(UpdateOperationResult expectedResult, UpdateOperationResult actualResult)
     {
         Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
-        Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
+        Assert.Equivalent(expectedResult.ErrorDetails, actualResult.ErrorDetails);
     }
 
     protected static Task TestNoChangeforSolution(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -31,6 +31,13 @@ public partial class AnalyzeWorker
 
     public async Task RunAsync(string repoRoot, string discoveryPath, string dependencyPath, string analysisDirectory)
     {
+        var analysisResult = await RunWithErrorHandlingAsync(repoRoot, discoveryPath, dependencyPath);
+        var dependencyInfo = await DeserializeJsonFileAsync<DependencyInfo>(dependencyPath, nameof(DependencyInfo));
+        await WriteResultsAsync(analysisDirectory, dependencyInfo.Name, analysisResult, _logger);
+    }
+
+    internal async Task<AnalysisResult> RunWithErrorHandlingAsync(string repoRoot, string discoveryPath, string dependencyPath)
+    {
         AnalysisResult analysisResult;
         var discovery = await DeserializeJsonFileAsync<WorkspaceDiscoveryResult>(discoveryPath, nameof(WorkspaceDiscoveryResult));
         var dependencyInfo = await DeserializeJsonFileAsync<DependencyInfo>(dependencyPath, nameof(DependencyInfo));
@@ -54,7 +61,7 @@ public partial class AnalyzeWorker
             };
         }
 
-        await WriteResultsAsync(analysisDirectory, dependencyInfo.Name, analysisResult, _logger);
+        return analysisResult;
     }
 
     public async Task<AnalysisResult> RunAsync(string repoRoot, WorkspaceDiscoveryResult discovery, DependencyInfo dependencyInfo)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -32,6 +32,12 @@ public partial class DiscoveryWorker
 
     public async Task RunAsync(string repoRootPath, string workspacePath, string outputPath)
     {
+        var result = await RunWithErrorHandlingAsync(repoRootPath, workspacePath);
+        await WriteResultsAsync(repoRootPath, outputPath, result);
+    }
+
+    internal async Task<WorkspaceDiscoveryResult> RunWithErrorHandlingAsync(string repoRootPath, string workspacePath)
+    {
         WorkspaceDiscoveryResult result;
         try
         {
@@ -49,7 +55,7 @@ public partial class DiscoveryWorker
             };
         }
 
-        await WriteResultsAsync(repoRootPath, outputPath, result);
+        return result;
     }
 
     internal async Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
@@ -6,4 +6,5 @@ public enum ErrorType
     None,
     AuthenticationFailure,
     MissingFile,
+    UpdateNotPossible,
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NativeResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NativeResult.cs
@@ -4,5 +4,5 @@ public record NativeResult
 {
     // TODO: nullable not required, `ErrorType.None` is the default anyway
     public ErrorType? ErrorType { get; init; }
-    public string? ErrorDetails { get; init; }
+    public object? ErrorDetails { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -7,5 +7,5 @@ public abstract record JobErrorBase
     [JsonPropertyName("error-type")]
     public abstract string Type { get; }
     [JsonPropertyName("error-details")]
-    public required string Details { get; init; }
+    public required object Details { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record UpdateNotPossible : JobErrorBase
+{
+    public override string Type => "update_not_possible";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -88,6 +88,13 @@ public class RunWorker
                 Details = ex.FilePath,
             };
         }
+        catch (UpdateNotPossibleException ex)
+        {
+            error = new UpdateNotPossible()
+            {
+                Details = ex.Dependencies,
+            };
+        }
         catch (Exception ex)
         {
             error = new UnknownError()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/UpdateNotPossibleException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/UpdateNotPossibleException.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core;
+
+internal class UpdateNotPossibleException : Exception
+{
+    public string[] Dependencies { get; }
+
+    public UpdateNotPossibleException(string[] dependencies)
+    {
+        Dependencies = dependencies;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -139,6 +139,7 @@ internal static class PackagesConfigUpdater
 
                     if (exitCodeAgain != 0)
                     {
+                        MSBuildHelper.ThrowOnMissingPackages(restoreOutput);
                         throw new Exception($"Unable to restore.\nOutput:\n${restoreOutput}\n");
                     }
 
@@ -147,6 +148,7 @@ internal static class PackagesConfigUpdater
 
                 MSBuildHelper.ThrowOnUnauthenticatedFeed(fullOutput);
                 MSBuildHelper.ThrowOnMissingFile(fullOutput);
+                MSBuildHelper.ThrowOnMissingPackages(fullOutput);
                 throw new Exception(fullOutput);
             }
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -833,6 +833,17 @@ internal static partial class MSBuildHelper
         }
     }
 
+    internal static void ThrowOnMissingPackages(string output)
+    {
+        var missingPackagesPattern = new Regex(@"Package '(?<PackageName>[^'].*)' is not found on source");
+        var matchCollection = missingPackagesPattern.Matches(output);
+        var missingPackages = matchCollection.Select(m => m.Groups["PackageName"].Value).Distinct().ToArray();
+        if (missingPackages.Length > 0)
+        {
+            throw new UpdateNotPossibleException(missingPackages);
+        }
+    }
+
     internal static bool TryGetGlobalJsonPath(string repoRootPath, string workspacePath, [NotNullWhen(returnValue: true)] out string? globalJsonPath)
     {
         globalJsonPath = PathHelper.GetFileInDirectoryOrParent(workspacePath, repoRootPath, "global.json", caseSensitive: false);

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -263,14 +263,16 @@ module Dependabot
       sig { params(json: T::Hash[String, T.untyped]).void }
       def self.ensure_no_errors(json)
         error_type = T.let(json.fetch("ErrorType", nil), T.nilable(String))
-        error_details = T.let(json.fetch("ErrorDetails", nil), T.nilable(String))
+        error_details = json.fetch("ErrorDetails", nil)
         case error_type
         when "None", nil
           # no issue
         when "AuthenticationFailure"
-          raise PrivateSourceAuthenticationFailure, error_details
+          raise PrivateSourceAuthenticationFailure, T.let(error_details, T.nilable(String))
         when "MissingFile"
-          raise DependencyFileNotFound, error_details
+          raise DependencyFileNotFound, T.let(error_details, T.nilable(String))
+        when "UpdateNotPossible"
+          raise UpdateNotPossible, T.let(error_details, T::Array[String])
         else
           raise "Unexpected error type from native tool: #{error_type}: #{error_details}"
         end


### PR DESCRIPTION
If a required package is missing from all sources in a `packages.config` scenario, report `UpdateNotPossible` instead of `unknown_error`.

An instance of this was seen where a `NuGet.Config` file was using an Azure DevOps feed with a restricted view that didn't have all packages listed.