### PR TITLE
Patch: Enforce npm 8 for Lockfile Version 2+

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -77,7 +77,9 @@ module Dependabot
 
         lockfile_version = lockfile_version_str.to_i
 
-        return NPM_V9 if lockfile_version == 3
+        # Using npm 8 as the default for lockfile_version > 2.
+        # Update needed to support npm 9+ based on lockfile version.
+        return NPM_V8 if lockfile_version >= 2
 
         NPM_DEFAULT_VERSION
       rescue JSON::ParserError

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -40,11 +40,11 @@ module Dependabot
       # Otherwise, we are going to use old versionining npm 6
       sig { params(lockfile: DependencyFile).returns(Integer) }
       def self.npm_version_numeric(lockfile)
-        fallback_version_npm8 = Dependabot::Experiments.enabled?(:npm_fallback_version_above_v6)
+        fallback_version_npm8 = true; # Dependabot::Experiments.enabled?(:npm_fallback_version_above_v6)
 
-        return npm_version_numeric_npm8_or_higher(lockfile) if fallback_version_npm8
+        npm_version_numeric_npm8_or_higher(lockfile) if fallback_version_npm8
 
-        npm_version_numeric_npm6_or_higher(lockfile)
+        # npm_version_numeric_npm6_or_higher(lockfile)
       end
 
       sig { params(lockfile: DependencyFile).returns(Integer) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -15,7 +15,6 @@ module Dependabot
         /^.*(?<error>The "yarn-path" option has been set \(in [^)]+\), but the specified location doesn't exist)/
 
       # NPM Version Constants
-      NPM_V9 = 9
       NPM_V8 = 8
       NPM_V6 = 6
       NPM_DEFAULT_VERSION = NPM_V8
@@ -40,11 +39,11 @@ module Dependabot
       # Otherwise, we are going to use old versionining npm 6
       sig { params(lockfile: DependencyFile).returns(Integer) }
       def self.npm_version_numeric(lockfile)
-        fallback_version_npm8 = true; # Dependabot::Experiments.enabled?(:npm_fallback_version_above_v6)
+        fallback_version_npm8 = Dependabot::Experiments.enabled?(:npm_fallback_version_above_v6)
 
-        npm_version_numeric_npm8_or_higher(lockfile) if fallback_version_npm8
+        return npm_version_numeric_npm8_or_higher(lockfile) if fallback_version_npm8
 
-        # npm_version_numeric_npm6_or_higher(lockfile)
+        npm_version_numeric_npm6_or_higher(lockfile)
       end
 
       sig { params(lockfile: DependencyFile).returns(Integer) }


### PR DESCRIPTION
### What are you trying to accomplish?

This patch builds on the prior update to set npm 8 as the default and fallback version for lockfile versions 2 and above. It addresses an issue where npm 9 was incorrectly altering the lockfile version to 1 for some projects, ensuring npm 8 consistency and lockfile stability for projects relying on version 3 lockfiles.

Just note that, this PR is continuation fix of following merged PR. 
- https://github.com/dependabot/dependabot-core/pull/10757

### What issues does this affect or fix?

- Resolves the issue of lockfile version inconsistency when npm 9 inadvertently changes lockfile version to 1.
- Ensures consistent use of npm 8 as the fallback, improving reliability for projects with lockfile versions above 2.

### Anything you want to highlight for special attention from reviewers?

- The patch limits npm handling by enforcing npm 8 as the fallback for lockfile versions 2+, maintaining expected behavior under the `npm_fallback_version_above_v6` flag.

### How will you know you've accomplished your goal?

- **Testing**: Confirmed npm 8 remains as the fallback without lockfile version downgrades when the feature flag `npm_fallback_version_above_v6` is active.
- **Validation**: Verified lockfile stability and consistent npm 8 use for projects that previously had lockfile version 3.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
