### PR TITLE
handle all errors during an update job

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/ExpectedUpdateOperationResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/ExpectedUpdateOperationResult.cs
@@ -1,0 +1,8 @@
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Test.Updater;
+
+public record ExpectedUpdateOperationResult : UpdateOperationResult
+{
+    public string? ErrorDetailsRegex { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -1,3 +1,4 @@
+using NuGetUpdater.Core.Test.Updater;
 using NuGetUpdater.Core.Updater;
 
 using Xunit;
@@ -91,7 +92,7 @@ public abstract class UpdateWorkerTestBase : TestBase
         TestFile[]? additionalFilesExpected = null,
         MockNuGetPackage[]? packages = null,
         string projectFilePath = "test-project.csproj",
-        UpdateOperationResult? expectedResult = null)
+        ExpectedUpdateOperationResult? expectedResult = null)
         => TestUpdateForProject(
             dependencyName,
             oldVersion,
@@ -114,7 +115,7 @@ public abstract class UpdateWorkerTestBase : TestBase
         TestFile[]? additionalFiles = null,
         TestFile[]? additionalFilesExpected = null,
         MockNuGetPackage[]? packages = null,
-        UpdateOperationResult? expectedResult = null)
+        ExpectedUpdateOperationResult? expectedResult = null)
     {
         additionalFiles ??= [];
         additionalFilesExpected ??= [];
@@ -151,10 +152,17 @@ public abstract class UpdateWorkerTestBase : TestBase
         AssertContainsFiles(expectedResultFiles, actualResult);
     }
 
-    protected static void ValidateUpdateOperationResult(UpdateOperationResult expectedResult, UpdateOperationResult actualResult)
+    protected static void ValidateUpdateOperationResult(ExpectedUpdateOperationResult expectedResult, UpdateOperationResult actualResult)
     {
         Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
-        Assert.Equivalent(expectedResult.ErrorDetails, actualResult.ErrorDetails);
+        if (expectedResult.ErrorDetailsRegex is not null && actualResult.ErrorDetails is string errorDetails)
+        {
+            Assert.Matches(expectedResult.ErrorDetailsRegex, errorDetails);
+        }
+        else
+        {
+            Assert.Equivalent(expectedResult.ErrorDetails, actualResult.ErrorDetails);
+        }
     }
 
     protected static Task TestNoChangeforSolution(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 using NuGet;
 
+using NuGetUpdater.Core.Test.Updater;
 using NuGetUpdater.Core.Updater;
 
 using Xunit;
@@ -2195,6 +2196,137 @@ public partial class UpdateWorkerTests
         }
 
         [Fact]
+        public async Task ReportsUnexpectedResponseFromNuGetServer()
+        {
+            static (int, string) TestHttpHandler(string uriString)
+            {
+                var uri = new Uri(uriString, UriKind.Absolute);
+                var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+                return uri.PathAndQuery switch
+                {
+                    // initial and search query are good, update should be possible...
+                    "/index.json" => (200, $$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/query",
+                                "@type": "SearchQueryService"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """),
+                    "/registrations/some.package/index.json" => (200, $$"""
+                        {
+                            "count": 1,
+                            "items": [
+                                {
+                                    "lower": "1.0.0",
+                                    "upper": "1.1.0",
+                                    "items": [
+                                        {
+                                            "catalogEntry": {
+                                                "id": "Some.Package",
+                                                "listed": true,
+                                                "version": "1.0.0"
+                                            },
+                                            "packageContent": "{{baseUrl}}/download/some.package/1.0.0/some.package.1.0.0.nupkg",
+                                        },
+                                        {
+                                            "catalogEntry": {
+                                                "id": "Some.Package",
+                                                "listed": true,
+                                                "version": "1.1.0"
+                                            },
+                                            "packageContent": "{{baseUrl}}/download/some.package/1.1.0/some.package.1.1.0.nupkg",
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                        """),
+                    // ...but all other calls to the server fail
+                    _ => (500, "{}"),
+                };
+            }
+            using var http = TestHttpServer.CreateTestStringServer(TestHttpHandler);
+            await TestUpdateForProject("Some.Package", "1.0.0", "1.1.0",
+                // existing
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                          <HintPath>packages\Some.Package.1.0.0\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="Some.Package" version="1.0.0" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFiles:
+                [
+                    ("NuGet.Config", $"""
+                        <configuration>
+                          <packageSources>
+                            <clear />
+                            <add key="private_feed" value="{http.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                          </packageSources>
+                        </configuration>
+                        """)
+                ],
+                // expected
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                          <HintPath>packages\Some.Package.1.0.0\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <packages>
+                      <package id="Some.Package" version="1.0.0" targetFramework="net45" />
+                    </packages>
+                    """,
+                expectedResult: new()
+                {
+                    ErrorType = ErrorType.Unknown,
+                    ErrorDetailsRegex = "Response status code does not indicate success",
+                }
+            );
+        }
+
+        [Fact]
         public async Task MissingDependencyErrorIsReported()
         {
             // trying to update Some.Package from 1.0.1 to 1.0.2, but another package isn't available; update fails
@@ -2283,7 +2415,7 @@ public partial class UpdateWorkerTests
             (string Path, string Content)[]? additionalFiles = null,
             (string Path, string Content)[]? additionalFilesExpected = null,
             MockNuGetPackage[]? packages = null,
-            UpdateOperationResult? expectedResult = null)
+            ExpectedUpdateOperationResult? expectedResult = null)
         {
             var realizedAdditionalFiles = new List<(string Path, string Content)>
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
@@ -2,9 +2,9 @@ namespace NuGetUpdater.Core;
 
 public enum ErrorType
 {
-    // TODO: add `Unknown` option to track all other failure types
     None,
     AuthenticationFailure,
     MissingFile,
     UpdateNotPossible,
+    Unknown,
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -70,6 +70,14 @@ public class UpdaterWorker
                 ErrorDetails = ex.Dependencies,
             };
         }
+        catch (Exception ex)
+        {
+            result = new()
+            {
+                ErrorType = ErrorType.Unknown,
+                ErrorDetails = ex.ToString(),
+            };
+        }
 
         return result;
     }

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -273,6 +273,8 @@ module Dependabot
           raise DependencyFileNotFound, T.let(error_details, T.nilable(String))
         when "UpdateNotPossible"
           raise UpdateNotPossible, T.let(error_details, T::Array[String])
+        when "Unknown"
+          raise DependabotError, T.let(error_details, String)
         else
           raise "Unexpected error type from native tool: #{error_type}: #{error_details}"
         end

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -254,5 +254,16 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
 
       it { is_expected.to include("dependency 1, dependency 2") }
     end
+
+    context "when any other error is returned" do
+      let(:json) do
+        {
+          ErrorType: "Unknown",
+          ErrorDetails: "some error details"
+        }.to_json
+      end
+
+      it { is_expected.to include("some error details") }
+    end
   end
 end


### PR DESCRIPTION
While adding error handling last week I missed a spot to catch a generic `Exception` and report it up the chain; this fixes that.

Previously, the telemetry would classify a whole variety of failures under the category `Dependabot::SharedHelpers::HelperSubprocessFailed: No dotnet-tools.json file found.` due to the first line in the command's output.  Now we'll get properly grouped failures.

I found in the logs where a NuGet server returned a `500` and that made NuGet fail miserably but made for a great test case.