### PR TITLE
Update Specs for NPM 8 as Default and Fallback Version

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           subject { dependencies.find { |d| d.name == "etag" } }
 
           let(:npm_fallback_version_above_v6_enabled) { false }
-          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/invalid_version_requirement") }
 
           it { is_expected.to be_nil }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
     )
   end
 
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { true }
+
+  before do
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
+
   it_behaves_like "a dependency file parser"
 
   describe "parse" do
@@ -40,6 +52,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       subject(:top_level_dependencies) { dependencies.select(&:top_level?) }
 
       context "with no lockfile" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
+
         let(:files) { project_dependency_files("npm6/exact_version_requirements_no_lockfile") }
 
         its(:length) { is_expected.to eq(3) }
@@ -66,6 +80,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       end
 
       context "with a package-lock.json" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
+
         let(:files) { project_dependency_files("npm6/simple") }
 
         its(:length) { is_expected.to eq(2) }
@@ -92,6 +108,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a blank requirement" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/blank_requirement") }
 
           describe "the first dependency" do
@@ -115,12 +133,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with an ignored hash requirement" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/hash_requirement") }
 
           its(:length) { is_expected.to eq(2) }
         end
 
         context "when containing an empty version string for a sub-dep" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/empty_version") }
 
           its(:length) { is_expected.to eq(2) }
@@ -129,12 +151,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         context "when containing a version requirement string" do
           subject { dependencies.find { |d| d.name == "etag" } }
 
+          let(:npm_fallback_version_above_v6_enabled) { false }
+          let(:npm_fallback_version_above_v6_enabled) { false }
           let(:files) { project_dependency_files("npm6/invalid_version_requirement") }
 
           it { is_expected.to be_nil }
         end
 
         context "when containing URL versions (i.e., is from a bad version of npm)" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/url_versions") }
 
           its(:length) { is_expected.to eq(1) }
@@ -160,6 +186,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with only dev dependencies" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/only_dev_dependencies") }
 
           describe "the first dependency" do
@@ -183,6 +211,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "when the dependency is specified as both dev and runtime" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/duplicate") }
 
           its(:length) { is_expected.to eq(1) }
@@ -213,6 +243,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a private-source dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/private_source") }
 
           its(:length) { is_expected.to eq(7) }
@@ -457,6 +489,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with an optional dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/optional_dependencies") }
 
           its(:length) { is_expected.to eq(2) }
@@ -482,6 +516,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a path-based dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) do
             project_dependency_files("npm6/path_dependency").tap do |files|
               file = files.find { |f| f.name == "deps/etag/package.json" }
@@ -496,6 +532,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a git-url dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/git_dependency") }
 
           its(:length) { is_expected.to eq(4) }
@@ -527,6 +565,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
             end
 
             context "when the lockfile has a branch for the version" do
+              let(:npm_fallback_version_above_v6_enabled) { false }
+
               let(:files) { project_dependency_files("npm6/git_dependency_branch_version") }
 
               it "is excluded" do
@@ -538,6 +578,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a github dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6/github_dependency") }
 
           its(:length) { is_expected.to eq(1) }
@@ -570,6 +612,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           context "when specifying a semver requirement" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6/github_dependency_semver") }
             let(:git_pack_fixture_name) { "is-number" }
 
@@ -638,6 +682,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           context "when not specifying a reference" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6/github_dependency_no_ref") }
 
             its(:length) { is_expected.to eq(1) }
@@ -671,6 +717,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           context "when specifying with its shortname" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6/github_shortname") }
 
             its(:length) { is_expected.to eq(1) }
@@ -705,6 +753,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with only a package.json" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:project_name) { "npm6/simple" }
           let(:files) { project_dependency_files(project_name).select { |f| f.name == "package.json" } }
 
@@ -730,6 +780,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           context "with a git dependency" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:project_name) { "npm6/git_dependency" }
 
             its(:length) { is_expected.to eq(4) }
@@ -759,6 +811,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
             end
 
             context "when the dependency also has a non-git source" do
+              let(:npm_fallback_version_above_v6_enabled) { false }
+
               let(:project_name) { "npm6/multiple_sources" }
 
               it "excludes the dependency" do
@@ -768,6 +822,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           context "when it does flat resolution" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:project_name) { "npm6/flat_resolution" }
 
             its(:length) { is_expected.to eq(0) }
@@ -794,7 +850,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^0.0.1",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: { type: "registry", url: "https://registry.npmjs.org" }
+                  source: nil
                 }]
               )
             end
@@ -1119,6 +1175,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with a git dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6_and_yarn/git_dependency") }
 
           its(:length) { is_expected.to eq(4) }
@@ -1242,6 +1300,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
             end
 
             context "when specified with https and a colon (supported by npm)" do
+              let(:npm_fallback_version_above_v6_enabled) { false }
+
               let(:files) { project_dependency_files("npm6/git_dependency_with_auth") }
 
               describe "the git dependency" do
@@ -1346,6 +1406,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         end
 
         context "with lerna.json" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6_and_yarn/lerna") }
 
           its(:length) { is_expected.to eq(5) }
@@ -1482,6 +1544,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       end
 
       context "with a package-lock.json" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
+
         let(:files) { project_dependency_files("npm6/blank_requirement") }
 
         its(:length) { is_expected.to eq(22) }
@@ -1491,6 +1555,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
     context "with duplicate dependencies" do
       subject(:parsed_file) { parser.parse }
 
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6_and_yarn/duplicate_dependency") }
 
       it "includes both registries" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -58,13 +58,25 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     files.find { |f| f.name == "package-lock.json" }
   end
 
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { true }
+
   let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
-  before { FileUtils.mkdir_p(tmp_path) }
+  before do
+    FileUtils.mkdir_p(tmp_path)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
 
   describe "npm 6 specific" do
     # NOTE: This is no longer failing in npm 8
     context "with a corrupted npm lockfile (version missing)" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6/version_missing") }
 
       it "raises a helpful error" do
@@ -80,6 +92,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
     # NOTE: This spec takes forever to run using npm 8
     context "when a git src dependency doesn't have a valid package.json" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6/git_missing_version") }
 
       let(:dependency_name) { "raven-js" }
@@ -121,6 +134,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
 
     context "when dealing with git sub-dependency with invalid from that is updating from an npm5 lockfile" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm5/git_sub_dep_invalid") }
 
       it "cleans up from field and successfully updates" do
@@ -133,6 +147,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
     # NOTE: This no longer raises in npm 8
     context "when there is a private git dep we don't have access to" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6/github_dependency_private") }
 
       let(:dependency_name) { "strict-uri-encode" }
@@ -153,6 +168,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
 
     context "when there is a dep hosted in github registry and no auth token is provided" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm/simple_with_github_with_no_auth_token") }
 
       let(:dependency_name) { "@Codertocat/hello-world-npm" }
@@ -172,6 +188,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
 
     context "when there is a dep hosted in github registry and invalid auth token is provided" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm/simple_with_github_with_invalid_auth_token") }
 
       let(:dependency_name) { "@Codertocat/hello-world-npm" }
@@ -366,6 +383,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
   %w(npm6 npm8).each do |npm_version|
     describe "#{npm_version} updates" do
+      let(:npm_fallback_version_above_v6_enabled) { false } if npm_version == "npm6"
       let(:files) { project_dependency_files("#{npm_version}/simple") }
 
       it "has details of the updated item" do
@@ -453,6 +471,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
 
     describe "#{npm_version} errors" do
+      let(:npm_fallback_version_above_v6_enabled) { false } if npm_version == "npm6"
       context "with a sub dependency name that can't be found" do
         let(:files) { project_dependency_files("#{npm_version}/github_sub_dependency_name_missing") }
 
@@ -688,6 +707,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
   context "when updating a git source dependency that is not pinned to a hash" do
     subject(:parsed_lock_file) { JSON.parse(updated_npm_lock_content) }
 
+    let(:npm_fallback_version_above_v6_enabled) { false }
     let(:files) { project_dependency_files("npm6/ghpr_no_hash_pinning") }
     let(:dependency_name) { "npm6-dependency" }
     let(:version) { "HEAD" }
@@ -1106,8 +1126,20 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
     let(:previous_requirements) { requirements }
 
-    it "raises a helpful error" do
-      expect { updated_npm_lock_content }.to raise_error(Dependabot::DependencyFileNotResolvable)
+    context "when npm version is 6" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
+
+      it "raises a helpful error" do
+        expect { updated_npm_lock_content }.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
+    context "when npm version is 8" do
+      let(:npm_fallback_version_above_v6_enabled) { true }
+
+      it "do not raises an error" do
+        expect(updated_npm_lock_content).not_to be_nil
+      end
     end
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -354,6 +354,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with a git dependency" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:dependency_name) { "is-number" }
       let(:requirements) do
         [{
@@ -622,6 +623,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         end
 
         context "when using git host URL: gitlab" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
           let(:dependency_name) { "babel-preset-php" }
           let(:version) { "5fbc24ccc37bd72052ce71ceae5b4934feb3ac19" }
           let(:previous_version) { "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced" }
@@ -670,6 +672,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         end
 
         context "when using git host URL: github" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
           let(:files) { project_dependency_files("npm6_and_yarn/githost_dependency") }
 
           it "correctly update the lockfiles" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -57,8 +57,17 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     )
   end
 
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { true }
+
   before do
     FileUtils.mkdir_p(tmp_path)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
   end
 
   it_behaves_like "a dependency file updater"
@@ -128,6 +137,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with both npm and yarn lockfiles" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
+
       let(:files) { project_dependency_files("npm6_and_yarn/simple") }
 
       it "updates the files" do
@@ -142,6 +153,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "without a lockfile" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
+
       let(:files) { project_dependency_files("npm6/simple_manifest") }
 
       its(:length) { is_expected.to eq(1) }
@@ -154,6 +167,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with multiple dependencies" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
+
       let(:files) { project_dependency_files("npm6_and_yarn/multiple_updates") }
 
       let(:dependencies) do
@@ -282,6 +297,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
     context "with diverged lockfiles" do
       context "when updating a sub-dependency" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
         let(:dependency_name) { "stringstream" }
         let(:requirements) { [] }
         let(:previous_requirements) { [] }
@@ -309,6 +325,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with a shrinkwrap" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm4/shrinkwrap") }
 
       let(:updated_shrinkwrap) do
@@ -397,6 +414,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         end
 
         context "when specified as a full URL" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
+
           let(:files) { project_dependency_files("npm6_and_yarn/git_dependency") }
 
           it "only updates the lockfile" do
@@ -414,6 +433,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           context "when the lockfile has an outdated source" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6_and_yarn/git_dependency_outdated_source") }
 
             it "updates the lockfile" do
@@ -439,6 +460,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           context "when the package lock is empty" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6_and_yarn/git_dependency_empty_npm_lockfile") }
 
             it "updates the lockfile" do
@@ -454,6 +477,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           context "when previously causing problems" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6_and_yarn/git_dependency_git_url") }
 
             let(:dependency_name) { "slick-carousel" }
@@ -495,6 +520,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           context "when using ssh" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6_and_yarn/git_dependency_ssh") }
 
             it "only updates the lockfile" do
@@ -551,6 +578,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             end
 
             context "with an npm6 lockfile" do
+              let(:npm_fallback_version_above_v6_enabled) { false }
+
               let(:files) { project_dependency_files("npm6/git_dependency") }
 
               it "doesn't update the 'from' entry" do
@@ -569,6 +598,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           context "when using a URL token" do
+            let(:npm_fallback_version_above_v6_enabled) { false }
+
             let(:files) { project_dependency_files("npm6_and_yarn/git_dependency_token") }
 
             it "only updates the lockfile" do
@@ -657,6 +688,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       end
 
       context "with a requirement" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
         let(:req) { "^4.0.0" }
         let(:git_pack_fixture_name) { "is-number" }
         let(:ref) { "master" }
@@ -741,6 +773,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       end
 
       context "with a reference" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
         let(:req) { nil }
         let(:ref) { "4.0.0" }
         let(:old_req) { nil }
@@ -980,6 +1013,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with a path-based dependency" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6_and_yarn/path_dependency") }
 
       let(:dependency_name) { "lodash" }
@@ -1017,6 +1051,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "with a lerna.json and both yarn and npm lockfiles" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6_and_yarn/lerna") }
 
       let(:dependency_name) { "etag" }
@@ -1081,6 +1116,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "when updating a sub dependency with both yarn and npm lockfiles" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6_and_yarn/nested_sub_dependency_update") }
 
       let(:dependency_name) { "extend" }
@@ -1136,6 +1172,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       end
 
       context "when one lockfile version is out of range" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
         let(:files) { project_dependency_files("npm6_and_yarn/nested_sub_dependency_update_npm_out_of_range") }
 
         it "updates out of range to latest resolvable version" do
@@ -1167,6 +1204,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
 
     context "when a wildcard is specified" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6_and_yarn/wildcard") }
 
       let(:version) { "0.2.0" }
@@ -1195,6 +1233,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     # npm specific tests #
     ######################
     describe "npm 6 specific" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:files) { project_dependency_files("npm6/simple") }
 
       context "when the package lock is empty" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe namespace::SubdependencyVersionResolver do
   end
   let(:ignored_versions) { [] }
 
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { true }
+
+  before do
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
+
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { resolver.latest_resolvable_version }
 
@@ -145,6 +157,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
     end
 
     context "with a npm5 package-lock.json" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:dependency_files) { project_dependency_files("npm5/subdependency_update") }
 
       let(:dependency) do
@@ -200,6 +213,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       it { is_expected.to eq(Gem::Version.new("5.7.4")) }
 
       context "when using npm5" do
+        let(:npm_fallback_version_above_v6_enabled) { false }
         let(:dependency_files) { project_dependency_files("npm5_and_yarn/npm_subdependency_update") }
 
         # NOTE: npm5 lockfiles have exact version requires so can't easily

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       dependency_group: group
     )
   end
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
   let(:dependency_files) { project_dependency_files(project_name) }
   let(:credentials) do
     [Dependabot::Credential.new({
@@ -59,6 +60,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
     fixture("npm_responses", "opentelemetry-context-async-hooks.json")
   end
 
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { true }
+
   before do
     stub_request(:get, react_dom_registry_listing_url)
       .to_return(status: 200, body: react_dom_registry_response)
@@ -72,6 +76,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       .to_return(status: 200, body: opentelemetry_api_registry_response)
     stub_request(:get, opentelemetry_context_async_hooks_registry_listing_url)
       .to_return(status: 200, body: opentelemetry_context_async_hooks_registry_response)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
   end
 
   describe "#latest_resolvable_version" do
@@ -479,6 +491,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
         end
 
         context "when it has (old) peer requirements that aren't included" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
           let(:project_name) { "npm6/peer_dependency_changed" }
           let(:latest_allowable_version) { Gem::Version.new("2.2.4") }
           let(:dependency) do
@@ -517,6 +530,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
         end
 
         context "when the peer dependency was previously a normal dependency" do
+          let(:npm_fallback_version_above_v6_enabled) { false }
           let(:project_name) { "npm6/peer_dependency_switch" }
           let(:latest_allowable_version) { Gem::Version.new("2.5.4") }
           let(:dependency) do
@@ -1537,6 +1551,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
     end
 
     context "when updating a dependency that is a peer requirement with npm 6" do
+      let(:npm_fallback_version_above_v6_enabled) { false }
       let(:project_name) { "npm6/peer_dependency" }
       let(:latest_allowable_version) { Gem::Version.new("16.3.1") }
       let(:dependency) do


### PR DESCRIPTION
### What are you trying to accomplish?

This PR updates test specs to align with the recent changes introduced in the merged PR [Update NPM Default and Fallback Versions to NPM 8](https://github.com/dependabot/dependabot-core/pull/10757). These changes ensure that all specs accurately reflect the new default and fallback npm version of 8.

<!-- What issues does this affect or fix? -->
These updates address test mismatches in registry URL and npm version handling following the update to npm 8 as the fallback version.

### Anything you want to highlight for special attention from reviewers?

This update ensures compatibility with npm 8 as the standard for dependency resolution, while maintaining legacy npm 6 behavior where necessary. The `npm_fallback_version_above_v6` feature flag is enabled or disabled in specs based on the specific scenario being tested.

### How will you know you've accomplished your goal?

- **Testing**: All tests should pass with npm 8 as the default and fallback version.
- **Validation**: Specs should reflect the correct npm version and registry URL under all test conditions.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including additional tests for flag-enabled functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.