### PR TITLE
update allowed files regex

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -20,6 +20,7 @@ module Dependabot
       def self.updated_files_regex
         [
           /.*\.([a-z]{2})?proj$/, # Matches files with any extension like .csproj, .vbproj, etc., in any directory
+          /packages\.lock\.json/,         # Matches packages.lock.json in any directory
           /packages\.config$/i,           # Matches packages.config in any directory
           /app\.config$/i,                # Matches app.config in any directory
           /web\.config$/i,                # Matches web.config in any directory

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           "project.csproj",
           "library.fsproj",
           "app.vbproj",
+          "packages.lock.json",
           "packages.config",
           "app.config",
           "web.config",


### PR DESCRIPTION
When lock file support was added, an allowed file regex was missed.  There is also an internal-only PR that has also been submitted with the same fix.

Fixes #10730.