### PR TITLE
allow for various xml formatting when finding runtime config file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -603,8 +603,12 @@ public partial class UpdateWorkerTests
             );
         }
 
-        [Fact]
-        public async Task UpdateBindingRedirectInWebConfig()
+        // the xml can take various shapes and they're all formatted, so we need very specific values here
+        [Theory]
+        [InlineData("<Content Include=\"web.config\" />")]
+        [InlineData("<Content Include=\"web.config\">\n    </Content>")]
+        [InlineData("<Content Include=\"web.config\">\n      <SubType>Designer</SubType>\n    </Content>")]
+        public async Task UpdateBindingRedirectInWebConfig(string webConfigXml)
         {
             await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
                 packages:
@@ -612,7 +616,7 @@ public partial class UpdateWorkerTests
                     MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
                     MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
                 ],
-                projectContents: """
+                projectContents: $$"""
                     <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                       <PropertyGroup>
                         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -669,7 +673,7 @@ public partial class UpdateWorkerTests
                       </ItemGroup>
                       <ItemGroup>
                         <None Include="packages.config" />
-                        <Content Include="web.config" />
+                        {{webConfigXml}}
                         <Content Include="web.Debug.config">
                           <DependentUpon>web.config</DependentUpon>
                         </Content>
@@ -711,7 +715,7 @@ public partial class UpdateWorkerTests
                         </configuration>
                         """)
                 ],
-                expectedProjectContents: """
+                expectedProjectContents: $$"""
                     <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                       <PropertyGroup>
                         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -768,7 +772,7 @@ public partial class UpdateWorkerTests
                       </ItemGroup>
                       <ItemGroup>
                         <None Include="packages.config" />
-                        <Content Include="web.config" />
+                        {{webConfigXml}}
                         <Content Include="web.Debug.config">
                           <DependentUpon>web.config</DependentUpon>
                         </Content>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -116,19 +116,19 @@ internal static class BindingRedirectManager
             return null;
         }
 
-        var configFilePath = Path.GetFullPath(Path.Combine(directoryPath, GetContent(configFile)));
+        var configFilePath = Path.GetFullPath(Path.Combine(directoryPath, GetValue(configFile)));
         var configFileContents = await File.ReadAllTextAsync(configFilePath);
         return new ConfigurationFile(configFilePath, configFileContents, false);
 
-        static string GetContent(IXmlElementSyntax element)
+        static string GetValue(IXmlElementSyntax element)
         {
-            var content = element.GetContentValue();
+            var content = element.GetAttributeValue("Include");
             if (!string.IsNullOrEmpty(content))
             {
                 return content;
             }
 
-            content = element.GetAttributeValue("Include");
+            content = element.GetContentValue();
             if (!string.IsNullOrEmpty(content))
             {
                 return content;
@@ -139,7 +139,7 @@ internal static class BindingRedirectManager
 
         static bool IsConfigFile(IXmlElementSyntax element)
         {
-            var content = GetContent(element);
+            var content = GetValue(element);
             if (content is null)
             {
                 return false;


### PR DESCRIPTION
When looking in a `.csproj` for a `web.config` file, the XML can take various forms.  Previously only the exact form of `<Content Include="web.config" />` was allowed.

This PR fixes that.  The bug was that we were first considering the `<Content>` element's raw content before considering the `Include` attribute, but we need to look at the attribute first and only if that fails consider the raw content.

Now the tested formats include (values seen in the wild):

``` xml
<Content Include="web.config" />
```

``` xml
<Content Include="web.config">
</Content>
```

``` xml
<Content Include="web.config">
  <SubType>Designer</SubType>
</Content>
```