### PR TITLE
Update pnpm Specs with Public Git Dependency for Private Testing

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(error.dependency_urls)
             .to eq(
               [
-                "https://github.com/Zelcord/electron-context-menu"
+                "https://github.com/dsp-testing/pnpm_github_dependency_private"
               ]
             )
         end
@@ -419,7 +419,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(error.dependency_urls)
             .to eq(
               [
-                "https://github.com/Zelcord/electron-context-menu"
+                "https://github.com/dsp-testing/pnpm_github_dependency_private"
               ]
             )
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(error.dependency_urls)
             .to eq(
               [
-                "https://github.com/dsp-testing/pnpm_github_dependency_private"
+                "https://github.com/dependabot-fixtures/pnpm_github_dependency_private"
               ]
             )
         end
@@ -419,7 +419,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(error.dependency_urls)
             .to eq(
               [
-                "https://github.com/dsp-testing/pnpm_github_dependency_private"
+                "https://github.com/dependabot-fixtures/pnpm_github_dependency_private"
               ]
             )
         end

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/package.json
@@ -18,6 +18,6 @@
     "homepage": "https://github.com/Zelcord/Zelcord#readme",
     "dependencies": {
         "cross-fetch": "^3.1.5",
-        "electron-context-menu": "github:Zelcord/electron-context-menu"
+        "pnpm_github_dependency_private": "github:dsp-testing/pnpm_github_dependency_private"
     }
 }

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/package.json
@@ -18,6 +18,6 @@
     "homepage": "https://github.com/Zelcord/Zelcord#readme",
     "dependencies": {
         "cross-fetch": "^3.1.5",
-        "pnpm_github_dependency_private": "github:dsp-testing/pnpm_github_dependency_private"
+        "pnpm_github_dependency_private": "github:dependabot-fixtures/pnpm_github_dependency_private"
     }
 }

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
@@ -11,18 +11,18 @@ importers:
       cross-fetch:
         specifier: ^3.1.5
         version: 3.1.5
-      electron-context-menu:
-        specifier: github:Zelcord/electron-context-menu
-        version: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32
+      pnpm_github_dependency_private:
+        specifier: github:dsp-testing/pnpm_github_dependency_private
+        version: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32
 
 packages:
 
   cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
 
-  electron-context-menu@https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32:
-    resolution: {tarball: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
-    name: electron-context-menu
+  pnpm_github_dependency_private@https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+    name: pnpm_github_dependency_private
     version: 3.5.0
 
   node-fetch@2.6.7:
@@ -51,7 +51,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  electron-context-menu@https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32: {}
+  pnpm_github_dependency_private@https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32: {}
 
   node-fetch@2.6.7:
     dependencies:

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private/pnpm-lock.yaml
@@ -12,16 +12,16 @@ importers:
         specifier: ^3.1.5
         version: 3.1.5
       pnpm_github_dependency_private:
-        specifier: github:dsp-testing/pnpm_github_dependency_private
-        version: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32
+        specifier: github:dependabot-fixtures/pnpm_github_dependency_private
+        version: https://codeload.github.com/dependabot-fixtures/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32
 
 packages:
 
   cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
 
-  pnpm_github_dependency_private@https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32:
-    resolution: {tarball: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+  pnpm_github_dependency_private@https://codeload.github.com/dependabot-fixtures/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/dependabot-fixtures/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
     name: pnpm_github_dependency_private
     version: 3.5.0
 
@@ -51,7 +51,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  pnpm_github_dependency_private@https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32: {}
+  pnpm_github_dependency_private@https://codeload.github.com/dependabot-fixtures/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32: {}
 
   node-fetch@2.6.7:
     dependencies:

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
@@ -18,7 +18,7 @@
     "homepage": "https://github.com/Zelcord/Zelcord#readme",
     "dependencies": {
         "cross-fetch": "^3.1.5",
-        "electron-context-menu": "github:Zelcord/electron-context-menu"
+        "pnpm_github_dependency_private": "github:dsp-testing/pnpm_github_dependency_private"
     },
     "packageManager": "pnpm@8.15.6"
 }

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/package.json
@@ -18,7 +18,7 @@
     "homepage": "https://github.com/Zelcord/Zelcord#readme",
     "dependencies": {
         "cross-fetch": "^3.1.5",
-        "pnpm_github_dependency_private": "github:dsp-testing/pnpm_github_dependency_private"
+        "pnpm_github_dependency_private": "github:dependabot-fixtures/pnpm_github_dependency_private"
     },
     "packageManager": "pnpm@8.15.6"
 }

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.1.5
     version: 3.1.5
   pnpm_github_dependency_private:
-    specifier: github:dsp-testing/pnpm_github_dependency_private
-    version: github.com/dsp-testing/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32
+    specifier: github:dependabot-fixtures/pnpm_github_dependency_private
+    version: github.com/dependabot-fixtures/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32
 
 packages:
 
@@ -49,8 +49,8 @@ packages:
       webidl-conversions: 3.0.1
     dev: false
 
-  github.com/dsp-testing/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32:
-    resolution: {tarball: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+  github.com/dependabot-fixtures/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/dependabot-fixtures/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
     name: pnpm_github_dependency_private
     version: 3.5.0
     dev: false

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/github_dependency_private_v8/pnpm-lock.yaml
@@ -8,9 +8,9 @@ dependencies:
   cross-fetch:
     specifier: ^3.1.5
     version: 3.1.5
-  electron-context-menu:
-    specifier: github:Zelcord/electron-context-menu
-    version: github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32
+  pnpm_github_dependency_private:
+    specifier: github:dsp-testing/pnpm_github_dependency_private
+    version: github.com/dsp-testing/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32
 
 packages:
 
@@ -49,8 +49,8 @@ packages:
       webidl-conversions: 3.0.1
     dev: false
 
-  github.com/Zelcord/electron-context-menu/280c81398c02a063f46e3285a9708d8db1a7ce32:
-    resolution: {tarball: https://codeload.github.com/Zelcord/electron-context-menu/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
-    name: electron-context-menu
+  github.com/dsp-testing/pnpm_github_dependency_private/280c81398c02a063f46e3285a9708d8db1a7ce32:
+    resolution: {tarball: https://codeload.github.com/dsp-testing/pnpm_github_dependency_private/tar.gz/280c81398c02a063f46e3285a9708d8db1a7ce32}
+    name: pnpm_github_dependency_private
     version: 3.5.0
     dev: false


### PR DESCRIPTION
**PR Description**:

This PR addresses an issue in the `pnpm` specs where we were using the `https://github.com/Zelcord/electron-context-menu` dependency as a git dependency, which was previously private. This setup led to errors in tests involving private dependencies. To resolve this, I've created an equivalent dependency in our `dependabot-fixtures` account, named `pnpm_github_dependency_private`, at `https://github.com/dependabot-fixtures/pnpm_github_dependency_private`.

### What are you trying to accomplish?

The goal is to replace the private `electron-context-menu` dependency in `pnpm` specs with an equivalent dependency in our `dsp-testing` repository. This change ensures that tests for private dependencies can run without errors.

### Anything you want to highlight for special attention from reviewers?

I opted for creating an equivalent dependency in our controlled `dependabot-fixtures` account to maintain stability in testing private dependencies.

### How will you know you've accomplished your goal?

- By verifying that tests involving private dependencies in `pnpm` specs pass without errors.
- By demonstrating that the new dependency functions equivalently to the original `electron-context-menu` in tests.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.