### PR TITLE
Rename  SdkPackageUpdater => PackageReferenceUpdater, for clarity

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -10,7 +10,7 @@ namespace NuGetUpdater.Core.Test.Update;
 
 public partial class UpdateWorkerTests
 {
-    public class Sdk : UpdateWorkerTestBase
+    public class PackageReference : UpdateWorkerTestBase
     {
         [Theory]
         [InlineData("net472")]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -18,6 +18,16 @@ internal static class BindingRedirectManager
     private static readonly XName DependentAssemblyName = AssemblyBinding.GetQualifiedName("dependentAssembly");
     private static readonly XName BindingRedirectName = AssemblyBinding.GetQualifiedName("bindingRedirect");
 
+    /// <summary>
+    /// Updates assembly binding redirects for a project build file.
+    /// </summary>
+    /// <remarks>
+    /// Assembly binding redirects are only applicable to projects targeting .NET Framework.
+    /// .NET Framework is restricted to non-SDK-style project files using either packages.config OR `<PackageReference>` MSBuild items.
+    /// See: https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/redirect-assembly-versions
+    ///      https://learn.microsoft.com/en-us/nuget/resources/check-project-format
+    /// </remarks>
+    /// <param name="projectBuildFile">The project build file (*.xproj) to be updated</param>
     public static async ValueTask UpdateBindingRedirectsAsync(ProjectBuildFile projectBuildFile)
     {
         var configFile = await TryGetRuntimeConfigurationFile(projectBuildFile);
@@ -33,7 +43,8 @@ internal static class BindingRedirectManager
         var bindings = BindingRedirectResolver.GetBindingRedirects(projectBuildFile.Path, references.Select(static x => x.Include));
         if (!bindings.Any())
         {
-            // no bindings to update
+            // no bindings are configured, nothing to update
+            // TODO: This assumption may not always be correct; A project could have no binding redirects prior to the update, but now requires them after the update.
             return;
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -23,7 +23,7 @@ internal static class BindingRedirectManager
     /// </summary>
     /// <remarks>
     /// Assembly binding redirects are only applicable to projects targeting .NET Framework.
-    /// .NET Framework is restricted to non-SDK-style project files using either packages.config OR `<PackageReference>` MSBuild items.
+    /// .NET Framework targets can appear in SDK-style OR non-SDK-style project files, using either packages.config OR `<PackageReference>` MSBuild items.
     /// See: https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/redirect-assembly-versions
     ///      https://learn.microsoft.com/en-us/nuget/resources/check-project-format
     /// </remarks>
@@ -43,8 +43,7 @@ internal static class BindingRedirectManager
         var bindings = BindingRedirectResolver.GetBindingRedirects(projectBuildFile.Path, references.Select(static x => x.Include));
         if (!bindings.Any())
         {
-            // no bindings are configured, nothing to update
-            // TODO: This assumption may not always be correct; A project could have no binding redirects prior to the update, but now requires them after the update.
+            // no bindings found in the project file, nothing to update
             return;
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -28,8 +28,8 @@ internal static class PackageReferenceUpdater
         bool isTransitive,
         ILogger logger)
     {
-        // SDK-style project, modify the XML directly
-        logger.Log("  Running for SDK-style project");
+        // PackageReference project; modify the XML directly
+        logger.Log("  Running 'PackageReference' project direct XML update");
 
         (ImmutableArray<ProjectBuildFile> buildFiles, string[] tfms) = await MSBuildHelper.LoadBuildFilesAndTargetFrameworksAsync(repoRootPath, projectPath);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -6,7 +6,18 @@ using NuGet.Versioning;
 
 namespace NuGetUpdater.Core;
 
-internal static class SdkPackageUpdater
+/// <summary>
+/// Handles package updates for projects containing `<PackageReference>` MSBuild items.
+/// </summary>
+/// <remarks>
+/// PackageReference items can appear in both SDK-style AND non-SDK-style project files.
+/// By default, PackageReference is used by [SDK-style] projects targeting .NET Core, .NET Standard, and UWP.
+/// By default, packages.config is used by [non-SDK-style] projects targeting .NET Framework; However, they can be migrated to PackageReference too.
+/// See: https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#project-type-support
+///      https://learn.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference
+///      https://learn.microsoft.com/en-us/nuget/resources/check-project-format
+/// </remarks>
+internal static class PackageReferenceUpdater
 {
     public static async Task UpdateDependencyAsync(
         string repoRootPath,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -13,6 +13,14 @@ using Console = System.Console;
 
 namespace NuGetUpdater.Core;
 
+/// <summary>
+/// Handles package updates for projects that use packages.config.
+/// </summary>
+/// <remarks>
+/// packages.config can only be used in non-SDK-style project files targeting .NET Framework.
+/// See: https://learn.microsoft.com/en-us/nuget/reference/packages-config
+///      https://learn.microsoft.com/en-us/nuget/resources/check-project-format
+/// <remarks>
 internal static class PackagesConfigUpdater
 {
     public static async Task UpdateDependencyAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -33,9 +33,8 @@ internal static class PackagesConfigUpdater
         ILogger logger
     )
     {
-        logger.Log($"  Found {NuGetHelper.PackagesConfigFileName}; running with NuGet.exe");
-
-        // use NuGet.exe to perform update
+        // packages.config project; use NuGet.exe to perform update
+        logger.Log($"  Found '{NuGetHelper.PackagesConfigFileName}' project; running NuGet.exe update");
 
         // ensure local packages directory exists
         var projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -17,7 +17,7 @@ namespace NuGetUpdater.Core;
 /// Handles package updates for projects that use packages.config.
 /// </summary>
 /// <remarks>
-/// packages.config can only be used in non-SDK-style project files targeting .NET Framework.
+/// packages.config can appear in non-SDK-style projects, but not in SDK-style projects.
 /// See: https://learn.microsoft.com/en-us/nuget/reference/packages-config
 ///      https://learn.microsoft.com/en-us/nuget/resources/check-project-format
 /// <remarks>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -221,7 +221,7 @@ public class UpdaterWorker
         }
 
         // Some repos use a mix of packages.config and PackageReference
-        await SdkPackageUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, _logger);
+        await PackageReferenceUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, _logger);
 
         // Update lock file if exists
         if (File.Exists(Path.Combine(Path.GetDirectoryName(projectPath), "packages.lock.json")))


### PR DESCRIPTION
### What are you trying to accomplish?

I'm looking at how https://github.com/dependabot/dependabot-core/issues/10260 can be fixed, but the current terminology is a little confusing; It would be good to clear this up.

The change adds documentation to clarify the scenarios where a "packages.config" update and "PackageReference" update could happen. The current terminology, "SdkPackageUpdater", gives the impression that "PackageReference" will only appear in SDK-style project files, which is not correct (see code comments).

### Anything you want to highlight for special attention from reviewers?

No changes to behaviour, purely documentation.
 
### How will you know you've accomplished your goal?

I can easily identify which updater class is applicable to each project file format.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
