### PR TITLE
raise when an unsupported package manager version is present

### DIFF
--- a/silent/lib/dependabot/silent/file_parser.rb
+++ b/silent/lib/dependabot/silent/file_parser.rb
@@ -4,6 +4,8 @@
 require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
+require "dependabot/package_manager"
+require "dependabot/silent/package_manager"
 require "sorbet-runtime"
 
 module SilentPackageManager
@@ -24,6 +26,17 @@ module SilentPackageManager
       dependency_set.dependencies
     rescue JSON::ParserError
       raise Dependabot::DependencyFileNotParseable, T.must(dependency_files.first).path
+    end
+
+    sig { returns(Dependabot::PackageManagerBase) }
+    def package_manager
+      meta_data = JSON.parse(manifest_content)["silent"]
+      if meta_data.nil?
+        silent_version = "2"
+      else
+        silent_version = meta_data["version"]
+      end
+      Dependabot::Silent::PackageManager.new(silent_version)
     end
 
     private

--- a/silent/lib/dependabot/silent/file_parser.rb
+++ b/silent/lib/dependabot/silent/file_parser.rb
@@ -31,12 +31,14 @@ module SilentPackageManager
     sig { returns(Dependabot::PackageManagerBase) }
     def package_manager
       meta_data = JSON.parse(manifest_content)["silent"]
-      if meta_data.nil?
-        silent_version = "2"
-      else
-        silent_version = meta_data["version"]
-      end
+      silent_version = if meta_data.nil?
+                         "2"
+                       else
+                         meta_data["version"]
+                       end
       Dependabot::Silent::PackageManager.new(silent_version)
+    rescue JSON::ParserError
+      raise Dependabot::DependencyFileNotParseable, T.must(dependency_files.first).path
     end
 
     private

--- a/silent/lib/dependabot/silent/package_manager.rb
+++ b/silent/lib/dependabot/silent/package_manager.rb
@@ -1,0 +1,45 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/silent/version"
+require "dependabot/package_manager"
+
+module Dependabot
+  module Silent
+    PACKAGE_MANAGER = "silent"
+
+    SUPPORTED_SILENT_VERSIONS = T.let([Version.new("2")].freeze, T::Array[Dependabot::Version])
+    DEPRECATED_SILENT_VERSIONS = T.let([Version.new("1")].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < PackageManagerBase
+      extend T::Sig
+
+      sig { params(version: T.any(String, Dependabot::Version)).void }
+      def initialize(version)
+        @version = T.let(Version.new(version), Dependabot::Version)
+        @name = T.let(PACKAGE_MANAGER, String)
+        @deprecated_versions = T.let(DEPRECATED_SILENT_VERSIONS, T::Array[Dependabot::Version])
+        @supported_versions = T.let(SUPPORTED_SILENT_VERSIONS, T::Array[Dependabot::Version])
+      end
+
+      sig { override.returns(String) }
+      attr_reader :name
+
+      sig { override.returns(Dependabot::Version) }
+      attr_reader :version
+
+      sig { override.returns(T::Array[Dependabot::Version]) }
+      attr_reader :deprecated_versions
+
+      sig { override.returns(T::Array[Dependabot::Version]) }
+      attr_reader :supported_versions
+
+      sig { override.returns(T::Boolean) }
+      def unsupported?
+        # Check if the version is not supported
+        supported_versions.all? { |supported| supported > version }
+      end
+    end
+  end
+end

--- a/silent/tests/testdata/vu-unsupported.txt
+++ b/silent/tests/testdata/vu-unsupported.txt
@@ -1,0 +1,22 @@
+! dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
+! stderr 'created \| dependency-a \( from 1.2.3 to 1.2.5 \)'
+! pr-created expected.json
+stderr 'Currently, the following silent versions are supported in Dependabot: v2\.*\.'
+stdout {"data":{"error-type":"tool_version_not_supported","error-details":{"detected-version":"1","supported-versions":"v2.*","tool-name":"silent"}},"type":"record_update_job_error"}
+
+
+-- manifest.json --
+{
+  "silent": { "version": "1" },
+  "dependency-a": { "version": "1.2.3" }
+}
+
+-- input.yml --
+job:
+  package-manager: "silent"
+  source:
+    directory: "/"
+    provider: example
+    hostname: example.com
+    api-endpoint: https://example.com/api/v3
+    repo: dependabot/smoke-tests

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -241,8 +241,9 @@ module Dependabot
         reject_external_code: job.reject_external_code?,
         options: job.experiments
       )
-      # Add 'package_manager' to the depedency_snapshopt to use it in operations'
+      # Add 'package_manager' to the dependency_snapshot to use it in operations
       package_manager = parser.package_manager
+      package_manager&.raise_if_unsupported!
 
       @package_manager[@current_directory] = package_manager
 

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -243,6 +243,7 @@ module Dependabot
       )
       # Add 'package_manager' to the dependency_snapshot to use it in operations
       package_manager = parser.package_manager
+      # Raise an error if the package manager version is unsupported
       package_manager&.raise_if_unsupported!
 
       @package_manager[@current_directory] = package_manager

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -128,6 +128,6 @@ module Dependabot
         error_details: error_details[:"error-detail"]
       )
     end
-    # rubocop:enable Metrics/AbcSize, Layout/LineLength
+    # rubocop:enable Metrics/AbcSize, Layout/LineLength, Metrics/MethodLength
   end
 end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -67,7 +67,7 @@ module Dependabot
       Environment.job_definition["base_commit_sha"]
     end
 
-    # rubocop:disable Metrics/AbcSize, Layout/LineLength
+    # rubocop:disable Metrics/AbcSize, Layout/LineLength, Metrics/MethodLength
     def handle_parser_error(error)
       # This happens if the repo gets removed after a job gets kicked off.
       # The service will handle the removal without any prompt from the updater,

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -80,6 +80,16 @@ module Dependabot
         # Check if the error is a known "run halting" state we should handle
         if (error_type = Updater::ErrorHandler::RUN_HALTING_ERRORS[error.class])
           { "error-type": error_type }
+        elsif error.is_a?(ToolVersionNotSupported)
+          Dependabot.logger.error(error.message)
+          {
+            "error-type": "tool_version_not_supported",
+            "error-detail": {
+              "tool-name": error.tool_name,
+              "detected-version": error.detected_version,
+              "supported-versions": error.supported_versions
+            }
+          }
         else
           # If it isn't, then log all the details and let the application error
           # tracker know about it

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -241,9 +241,6 @@ module Dependabot
           return []
         end
 
-        # Raise an error if the package manager version is unsupported
-        dependency_snapshot.package_manager&.raise_if_unsupported!
-
         checker.updated_dependencies(
           requirements_to_unlock: requirements_to_unlock
         )

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -105,7 +105,6 @@ module Dependabot
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/MethodLength
-        # rubocop:disable Metrics/CyclomaticComplexity
         sig { params(dependency: Dependabot::Dependency).void }
         def check_and_create_pull_request(dependency)
           dependency = vulnerable_version(dependency) if dependency.metadata[:all_versions]
@@ -145,9 +144,6 @@ module Dependabot
           requirements_to_unlock = requirements_to_unlock(checker)
           log_requirements_for_update(requirements_to_unlock, checker)
           return record_security_update_not_possible_error(checker) if requirements_to_unlock == :update_not_possible
-
-          # Raise an error if the package manager version is unsupported
-          dependency_snapshot.package_manager&.raise_if_unsupported!
 
           updated_deps = checker.updated_dependencies(
             requirements_to_unlock: requirements_to_unlock
@@ -202,7 +198,6 @@ module Dependabot
         # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Metrics/CyclomaticComplexity
         sig { params(dependency: Dependabot::Dependency).returns(Dependabot::Dependency) }
         def vulnerable_version(dependency)
           return dependency if dependency.metadata[:all_versions].count == 1

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -54,9 +54,6 @@ module Dependabot
           Dependabot.logger.info("Starting update job for #{job.source.repo}")
           Dependabot.logger.info("Checking and updating security pull requests...")
 
-          # Raise an error if the package manager version is unsupported
-          dependency_snapshot.package_manager&.raise_if_unsupported!
-
           # Retrieve the list of initial notices from dependency snapshot
           @notices = dependency_snapshot.notices
           # More notices can be added during the update process

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -138,9 +138,6 @@ module Dependabot
             return close_pull_request(reason: :update_no_longer_possible)
           end
 
-          # Raise an error if the package manager version is unsupported
-          dependency_snapshot.package_manager&.raise_if_unsupported!
-
           updated_deps = checker.updated_dependencies(
             requirements_to_unlock: requirements_to_unlock
           )

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -172,9 +172,6 @@ module Dependabot
             notices: @notices
           )
 
-          # Raise an error if the package manager version is unsupported
-          dependency_snapshot.package_manager&.raise_if_unsupported!
-
           if dependency_change.updated_dependency_files.empty?
             raise "UpdateChecker found viable dependencies to be updated, but FileUpdater failed to update any files"
           end

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -68,6 +68,21 @@ RSpec.describe Dependabot::DependencySnapshot do
     ]
   end
 
+  let(:dependency_files_for_unsupported) do
+    [
+      Dependabot::DependencyFile.new(
+        name: "Gemfile",
+        content: fixture("bundler/unsupported/Gemfile"),
+        directory: directory
+      ),
+      Dependabot::DependencyFile.new(
+        name: "Gemfile.lock",
+        content: fixture("bundler/unsupported/Gemfile.lock"),
+        directory: directory
+      )
+    ]
+  end
+
   let(:dependency_groups) do
     [
       {
@@ -84,6 +99,21 @@ RSpec.describe Dependabot::DependencySnapshot do
     "mock-sha"
   end
 
+  let(:unsupported_error_enabled) { false }
+
+  before do
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:bundler_v1_unsupported_error)
+      .and_return(unsupported_error_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:add_deprecation_warn_to_pr_message)
+      .and_return(true)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
+
   describe "::add_handled_dependencies" do
     subject(:create_dependency_snapshot) do
       described_class.create_from_job_definition(
@@ -91,6 +121,8 @@ RSpec.describe Dependabot::DependencySnapshot do
         job_definition: job_definition
       )
     end
+
+    let(:unsupported_error_enabled) { false }
 
     let(:job_definition) do
       {
@@ -146,6 +178,23 @@ RSpec.describe Dependabot::DependencySnapshot do
         job: job,
         job_definition: job_definition
       )
+    end
+
+    context "when the package manager version is unsupported" do
+      let(:unsupported_error_enabled) { true }
+
+      let(:job_definition) do
+        {
+          "base_commit_sha" => base_commit_sha,
+          "base64_dependency_files" => encode_dependency_files(dependency_files_for_unsupported)
+        }
+      end
+
+      it "raises ToolVersionNotSupported error" do
+        expect do
+          create_dependency_snapshot
+        end.to raise_error(Dependabot::ToolVersionNotSupported)
+      end
     end
 
     context "when the job definition includes valid information prepared by the file fetcher step" do

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -305,29 +305,6 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
         perform
       end
     end
-
-    context "when package manager version is unsupported" do
-      let(:package_manager_version) { "1" }
-      let(:supported_versions) { %w(2 3) }
-
-      before do
-        # Enable the feature flag for unsupported version
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:bundler_v1_unsupported_error)
-          .and_return(true)
-
-        # Ensure unsupported? method returns true so the error is triggered
-        allow(package_manager).to receive(:unsupported?).and_return(true)
-      end
-
-      it "logs the ToolVersionNotSupported error to the error handler" do
-        # Ensure the error handler receives the expected error
-        expect(mock_error_handler).to receive(:handle_dependency_error)
-          .with(hash_including(error: instance_of(Dependabot::ToolVersionNotSupported)))
-
-        perform
-      end
-    end
   end
 
   describe "#check_and_create_pull_request" do

--- a/updater/spec/fixtures/bundler/unsupported/Gemfile
+++ b/updater/spec/fixtures/bundler/unsupported/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "bundler", "~> 1.15.0"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/updater/spec/fixtures/bundler/unsupported/Gemfile.lock
+++ b/updater/spec/fixtures/bundler/unsupported/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.15.0)
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.4


### PR DESCRIPTION
### What are you trying to accomplish?

When we parse the manifest files, if we come across an unsupported package manager version, we should immediately fail the job.

The idea is the customer will need to upgrade or remove the old manifest to get updates again. This keeps our code simple to maintain rather than trying to work around old outdated versions.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Most of this PR is implementing it in the "silent" ecosystem which is a dummy ecosystem used to test the updater.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

This change will cause bundler 1 jobs to start failing with a clear error message.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
