### PR TITLE
Remove python_new_version feature flag and irrelevant code

### DIFF
--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Dependabot::Maven::Version do
       let(:err_msg) { "Malformed version string - string is nil" }
 
       it "raises an exception" do
-        debugger
         expect { version }.to raise_error(Dependabot::BadRequirementError, err_msg)
       end
     end

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Dependabot::Maven::Version do
       let(:err_msg) { "Malformed version string - string is nil" }
 
       it "raises an exception" do
+        debugger
         expect { version }.to raise_error(Dependabot::BadRequirementError, err_msg)
       end
     end

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Dependabot::Python::Version do
   describe ".correct?" do
     subject { described_class.correct?(version_string) }
 
-    before do
-      Dependabot::Experiments.register(:python_new_version, true)
-    end
-
     context "with a valid version" do
       let(:version_string) { "1.0.0" }
 
@@ -148,7 +144,7 @@ RSpec.describe Dependabot::Python::Version do
       "1.0.0-rc.1",
       "1",
       "1.0.0+gc1",
-      # "1.0.0.post", TODO fails comparing to 1
+      "1.0.0.post", # TODO: fails comparing to 1
       "1.post2",
       "1.post2+gc1",
       "1.post2+gc1.2",
@@ -238,10 +234,6 @@ RSpec.describe Dependabot::Python::Version do
       end
 
       let(:versions) { version_strings.map { |v| described_class.new(v) } }
-
-      before do
-        Dependabot::Experiments.register(:python_new_version, true)
-      end
 
       it "returns list in the correct order" do
         expect(versions.shuffle.sort).to eq versions


### PR DESCRIPTION
### What are you trying to accomplish?
Remove a feature flag and code that is no longer needed.

<!-- Provide both a what and a _why_ for the change. -->
The feature flag was added in this [PR](https://github.com/dependabot/dependabot-core/pull/10613) to ensure the new python version changes could be turned off easily if necessary.
<!-- What issues does this affect or fix? -->

It also removes old code from the previous implementation that is no longer relevant e.g the old version regex.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
