### PR TITLE
report unix-friendly packages path

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
@@ -30,7 +30,7 @@ public class PackagesConfigUpdaterTests : TestBase
             """,
             "Newtonsoft.Json",
             "7.0.1",
-            @"..\packages"
+            "../packages"
         ];
 
         // project without namespace
@@ -48,7 +48,7 @@ public class PackagesConfigUpdaterTests : TestBase
             """,
             "Newtonsoft.Json",
             "7.0.1",
-            @"..\packages"
+            "../packages"
         ];
 
         // project with non-standard packages path
@@ -66,7 +66,7 @@ public class PackagesConfigUpdaterTests : TestBase
             """,
             "Newtonsoft.Json",
             "7.0.1",
-            @"..\not-a-path-you-would-expect"
+            "../not-a-path-you-would-expect"
         ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -133,10 +133,10 @@ internal static class PackagesConfigUpdater
                 //    and doesn't appear in the cache.  The message in this case will be "Could not install package
                 //    '<name> <version>'...the package does not contain any assembly references or content files that
                 //    are compatible with that framework.".
+                // 3. Yet another possibility is that the project explicitly imports a targets file without a condition
+                //    of `Exists(...)`.
                 // The solution in all cases is to run `restore` then try the update again.
-                if (!retryingAfterRestore &&
-                    (fullOutput.Contains("Existing packages must be restored before performing an install or update.") ||
-                    fullOutput.Contains("the package does not contain any assembly references or content files that are compatible with that framework.")))
+                if (!retryingAfterRestore && OutputIndicatesRestoreIsRequired(fullOutput))
                 {
                     retryingAfterRestore = true;
                     logger.Log($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
@@ -146,6 +146,8 @@ internal static class PackagesConfigUpdater
 
                     if (exitCodeAgain != 0)
                     {
+                        MSBuildHelper.ThrowOnMissingFile(fullOutput);
+                        MSBuildHelper.ThrowOnMissingFile(restoreOutput);
                         MSBuildHelper.ThrowOnMissingPackages(restoreOutput);
                         throw new Exception($"Unable to restore.\nOutput:\n${restoreOutput}\n");
                     }
@@ -181,6 +183,13 @@ internal static class PackagesConfigUpdater
         }
     }
 
+    private static bool OutputIndicatesRestoreIsRequired(string output)
+    {
+        return output.Contains("Existing packages must be restored before performing an install or update.")
+            || output.Contains("the package does not contain any assembly references or content files that are compatible with that framework.")
+            || MSBuildHelper.GetMissingFile(output) is not null;
+    }
+
     private static Process[] GetLikelyNuGetSpawnedProcesses()
     {
         var processes = Process.GetProcesses().Where(p => p.ProcessName.StartsWith("CredentialProvider", StringComparison.OrdinalIgnoreCase) == true).ToArray();
@@ -213,7 +222,7 @@ internal static class PackagesConfigUpdater
             {
                 // exact match was found, use it
                 var subpath = GetUpToIndexWithoutTrailingDirectorySeparator(hintPath, hintPathSubStringLocation);
-                return subpath;
+                return subpath.NormalizePathToUnix();
             }
 
             if (partialPathMatch is null)
@@ -251,7 +260,7 @@ internal static class PackagesConfigUpdater
             }
         }
 
-        return partialPathMatch;
+        return partialPathMatch?.NormalizePathToUnix();
     }
 
     private static bool IsHintPathNodeForDependency(this IXmlElementSyntax element, string dependencyName)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -812,13 +812,24 @@ internal static partial class MSBuildHelper
         }
     }
 
-    internal static void ThrowOnMissingFile(string output)
+    internal static string? GetMissingFile(string output)
     {
         var missingFilePattern = new Regex(@"The imported project \""(?<FilePath>.*)\"" was not found");
         var match = missingFilePattern.Match(output);
         if (match.Success)
         {
-            throw new MissingFileException(match.Groups["FilePath"].Value);
+            return match.Groups["FilePath"].Value;
+        }
+
+        return null;
+    }
+
+    internal static void ThrowOnMissingFile(string output)
+    {
+        var missingFile = GetMissingFile(output);
+        if (missingFile is not null)
+        {
+            throw new MissingFileException(missingFile);
         }
     }
 


### PR DESCRIPTION
When running an update in a `packages.config` scenario, the path to the packages directory is determined from existing `<HintPath>` elements.  If the path returned looks something like `..\packages` that causes problems on non-Windows machines because the backslash is retained and ultimately the packages are restored to a directory named `..?packages` which is incorrect.

The first fix was to simply normalize this path to the Unix standard which Windows can handle just fine.

The second fix was to expand the cases where we run `nuget.exe restore` _before_ we can update the package; this happens if a package's `.targets` file is directly imported without a guarding `Condition="Exists(path)"` attribute.

This fixes some bugs seen during an internal log audit.