### PR TITLE
split artifacts on OS

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
@@ -12,6 +12,6 @@
     <CommonTargetFramework>net9.0</CommonTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts\$(OS)</ArtifactsPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The updaters build and run in a Linux container, but I, and likely other NuGet developers, use Windows.  When investigating issues that only repro in Linux, I'll commonly use a WSL instance and VS Code to do my work, but if I have to switch back and forth between Windows and WSL, it gets painful because I have to regularly clean/rebuild the `artifacts` directory.

By adding the well-known MSBuild value `$(OS)` this makes it easier to switch.  The value itself isn't interesting, but usually evaluates to either `Windows_NT` or `Unix`.  The end result is that there are separate `bin/` and `obj/` directories for each OS so it's possible to run unit tests in both instances in the same codebase at the same time.