### PR TITLE
chore(python): Target latest Python 3.12 version to 3.12.7

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,6 +1,6 @@
 # This list must match the versions specified in
 # python/lib/dependabot/python/language_version_manager.rb: PRE_INSTALLED_PYTHON_VERSIONS
-ARG PY_3_12=3.12.5
+ARG PY_3_12=3.12.7
 ARG PY_3_11=3.11.9
 ARG PY_3_10=3.10.15
 ARG PY_3_9=3.9.18

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -9,7 +9,7 @@ module Dependabot
     class LanguageVersionManager
       # This list must match the versions specified at the top of `python/Dockerfile`
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.12.5
+        3.12.7
         3.11.9
         3.10.15
         3.9.18


### PR DESCRIPTION
### What are you trying to accomplish?

This PR bumps the latest Python version to 3.12.7 (the latest stable 3.12.* release - [link](https://www.python.org/doc/versions/)).

<!-- Provide both a what and a _why_ for the change. -->

Fix https://github.com/dependabot/dependabot-core/issues/10830
