### PR TITLE
Add lowest_prerelease_suffix method

### DIFF
--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -52,7 +52,7 @@ module Dependabot
     def ignored_minor_versions
       parts = to_semver.split(".")
       version_parts = parts.fill("0", parts.length...2)
-      lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + ["a"]
+      lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
       upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1]
       lower_bound = ">= #{lower_parts.join('.')}"
       upper_bound = "< #{upper_parts.join('.')}"
@@ -63,10 +63,15 @@ module Dependabot
     sig { overridable.returns(T::Array[String]) }
     def ignored_major_versions
       version_parts = to_semver.split(".")
-      lower_parts = [version_parts[0].to_i + 1] + ["a"]
+      lower_parts = [version_parts[0].to_i + 1] + [lowest_prerelease_suffix]
       lower_bound = ">= #{lower_parts.join('.')}"
 
       [lower_bound]
+    end
+
+    sig { returns(String) }
+    def lowest_prerelease_suffix
+      "a"
     end
   end
 end

--- a/common/spec/dependabot/version_spec.rb
+++ b/common/spec/dependabot/version_spec.rb
@@ -7,6 +7,14 @@ require "dependabot/version"
 RSpec.describe Dependabot::Version do
   subject(:version) { described_class.new(version_string) }
 
+  describe "#lowest_prerelease_suffix" do
+    subject(:ignored_versions) { version.lowest_prerelease_suffix }
+
+    let(:version_string) { "1.2.3-alpha.1" }
+
+    it { is_expected.to eq "a" }
+  end
+
   describe "#ignored_major_versions" do
     subject(:ignored_versions) { version.ignored_major_versions }
 

--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -65,6 +65,11 @@ module Dependabot
         end
       end
 
+      sig { returns(String) }
+      def lowest_prerelease_suffix
+        "a0"
+      end
+
       sig { params(other: VersionParameter).returns(Integer) }
       def <=>(other)
         other = Dependabot::Maven::Version.new(other.to_s) unless other.is_a? Dependabot::Maven::Version
@@ -78,7 +83,7 @@ module Dependabot
 
         version_parts = parts.fill("0", parts.length...2)
         # the a0 is so we can get the next earliest prerelease patch version
-        upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + ["a0"]
+        upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
         lower_bound = "> #{to_semver}"
         upper_bound = "< #{upper_parts.join('.')}"
 
@@ -91,8 +96,8 @@ module Dependabot
         return [] if parts.empty? # for non-semver versions
 
         version_parts = parts.fill("0", parts.length...2)
-        lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + ["a0"]
-        upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1] + ["a0"]
+        lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
+        upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1] + [lowest_prerelease_suffix]
         lower_bound = ">= #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
 
@@ -104,7 +109,7 @@ module Dependabot
         version_parts = token_bucket.tokens # e.g [1,2,3] if version is 1.2.3-alpha3
         return [] if version_parts.empty? # for non-semver versions
 
-        lower_parts = [version_parts[0].to_i + 1] + ["a0"] # earliest next major version prerelease
+        lower_parts = [version_parts[0].to_i + 1] + [lowest_prerelease_suffix] # earliest next major version prerelease
         lower_bound = ">= #{lower_parts.join('.')}"
 
         [lower_bound]

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -559,6 +559,14 @@ RSpec.describe Dependabot::Maven::Version do
     it { is_expected.to eq(["> #{version_string}, < 1.3.a0"]) }
   end
 
+  describe "#lowest_prerelease_suffix" do
+    subject(:ignored_versions) { version.lowest_prerelease_suffix }
+
+    let(:version_string) { "1.2.3-alpha.1" }
+
+    it { is_expected.to eq "a0" }
+  end
+
   describe "compatibility with Gem::Requirement" do
     subject { requirement.satisfied_by?(version) }
 

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -254,6 +254,11 @@ module Dependabot
         T.must(dev)
       end
 
+      sig { returns(String) }
+      def lowest_prerelease_suffix
+        "dev0"
+      end
+
       private
 
       sig { params(other: Dependabot::Python::Version).returns(Integer) }

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -342,6 +342,14 @@ RSpec.describe Dependabot::Python::Version do
     end
   end
 
+  describe "#lowest_prerelease_suffix" do
+    subject { version.lowest_prerelease_suffix }
+
+    let(:version_string) { "1.2.3" }
+
+    it { is_expected.to eq "dev0" }
+  end
+
   describe "compatibility with Gem::Requirement" do
     subject { requirement.satisfied_by?(version) }
 


### PR DESCRIPTION
### What are you trying to accomplish?
I need to be able to get the correct lowest prerelease suffix for a version. I can then use this to build the correct version ignore ranges in dependabot core as well as dependabot API.

Currently, we have this suffix hardcoded in a few areas of the [core codebase](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/requirement.rb#L142) and [api codebase](https://github.com/github/dependabot-api/blob/main/app/actions/find_or_create_ignore_condition/ignore_condition_builder.rb#L29) . Unfortunately, this suffix is ecosystem-specific and that's why this PR adds a method to return the correct suffix in a specific ecosystem.

<!-- What issues does this affect or fix? -->
Once this PR get's merged I can then fix this [issue](https://github.com/dependabot/dependabot-core/issues/10798). There is already a draft PR for that [here](https://github.com/github/dependabot-api/pull/5838)

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
It is a bit cleaner rather than checking class names. For example:

`suffix = "a0" if version.is_a? Dependabot::Maven::Version`

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
