### PR TITLE
restrict when we add binding redirects

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
@@ -1,0 +1,122 @@
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Update;
+
+public class BindingRedirectsTests
+{
+    [Fact]
+    public async Task SimpleBindingRedirectIsPerformed()
+    {
+        await VerifyBindingRedirectsAsync(
+            projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="app.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Some.Package, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
+                      <HintPath>packages\Some.Package.2.0.0\lib\net45\Some.Package.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+            configContents: """
+                <configuration>
+                  <runtime>
+                    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <dependentAssembly>
+                        <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                      </dependentAssembly>
+                    </assemblyBinding>
+                  </runtime>
+                </configuration>
+                """,
+            expectedConfigContents: """
+                <configuration>
+                  <runtime>
+                    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <dependentAssembly>
+                        <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                      </dependentAssembly>
+                    </assemblyBinding>
+                  </runtime>
+                </configuration>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task ConfigFileIndentationIsPreserved()
+    {
+        await VerifyBindingRedirectsAsync(
+            projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="app.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Some.Package, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
+                      <HintPath>packages\Some.Package.2.0.0\lib\net45\Some.Package.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+            configContents: """
+                    <configuration>
+                   <runtime>
+                  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                 <dependentAssembly>
+                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                 </dependentAssembly>
+                  </assemblyBinding>
+                   </runtime>
+                    </configuration>
+                """,
+            expectedConfigContents: """
+                    <configuration>
+                   <runtime>
+                  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                 <dependentAssembly>
+                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                 </dependentAssembly>
+                  </assemblyBinding>
+                   </runtime>
+                    </configuration>
+                """
+        );
+    }
+
+    private static async Task VerifyBindingRedirectsAsync(string projectContents, string configContents, string expectedConfigContents, string configFileName = "app.config")
+    {
+        using var tempDir = new TemporaryDirectory();
+        var projectFileName = "project.csproj";
+        var projectFilePath = Path.Combine(tempDir.DirectoryPath, projectFileName);
+        var configFilePath = Path.Combine(tempDir.DirectoryPath, configFileName);
+
+        await File.WriteAllTextAsync(projectFilePath, projectContents);
+        await File.WriteAllTextAsync(configFilePath, configContents);
+
+        var projectBuildFile = ProjectBuildFile.Open(tempDir.DirectoryPath, projectFilePath);
+        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile);
+
+        var actualConfigContents = (await File.ReadAllTextAsync(configFilePath)).Replace("\r", "");
+        expectedConfigContents = expectedConfigContents.Replace("\r", "");
+        Assert.Equal(expectedConfigContents, actualConfigContents);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
@@ -38,6 +38,8 @@ public class BindingRedirectsTests
                   </runtime>
                 </configuration>
                 """,
+            updatedPackageName: "Some.Package",
+            updatedPackageVersion: "2.0.0",
             expectedConfigContents: """
                 <configuration>
                   <runtime>
@@ -87,6 +89,8 @@ public class BindingRedirectsTests
                    </runtime>
                     </configuration>
                 """,
+            updatedPackageName: "Some.Package",
+            updatedPackageVersion: "2.0.0",
             expectedConfigContents: """
                     <configuration>
                    <runtime>
@@ -102,7 +106,106 @@ public class BindingRedirectsTests
         );
     }
 
-    private static async Task VerifyBindingRedirectsAsync(string projectContents, string configContents, string expectedConfigContents, string configFileName = "app.config")
+    [Fact]
+    public async Task NoExtraBindingsAreAdded()
+    {
+        await VerifyBindingRedirectsAsync(
+            projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="app.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Some.Package, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
+                      <HintPath>packages\Some.Package.2.0.0\lib\net45\Some.Package.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                    <Reference Include="Some.Unrelated.Package, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null">
+                      <HintPath>packages\Some.Unrelated.Package.3.0.0\lib\net45\Some.Package.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+            configContents: """
+                <configuration>
+                  <runtime>
+                    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <dependentAssembly>
+                        <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                      </dependentAssembly>
+                    </assemblyBinding>
+                  </runtime>
+                </configuration>
+                """,
+            updatedPackageName: "Some.Package",
+            updatedPackageVersion: "2.0.0",
+            expectedConfigContents: """
+                <configuration>
+                  <runtime>
+                    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <dependentAssembly>
+                        <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                      </dependentAssembly>
+                    </assemblyBinding>
+                  </runtime>
+                </configuration>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task NewBindingIsAdded()
+    {
+        await VerifyBindingRedirectsAsync(
+            projectContents: """
+                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <None Include="app.config" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <Reference Include="Some.Package, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
+                      <HintPath>packages\Some.Package.2.0.0\lib\net45\Some.Package.dll</HintPath>
+                      <Private>True</Private>
+                    </Reference>
+                  </ItemGroup>
+                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                </Project>
+                """,
+            configContents: """
+                <configuration>
+                  <runtime />
+                </configuration>
+                """,
+            updatedPackageName: "Some.Package",
+            updatedPackageVersion: "2.0.0",
+            expectedConfigContents: """
+                <configuration>
+                  <runtime>
+                    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <dependentAssembly>
+                        <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                      </dependentAssembly>
+                    </assemblyBinding>
+                  </runtime>
+                </configuration>
+                """
+        );
+    }
+
+    private static async Task VerifyBindingRedirectsAsync(string projectContents, string configContents, string expectedConfigContents, string updatedPackageName, string updatedPackageVersion, string configFileName = "app.config")
     {
         using var tempDir = new TemporaryDirectory();
         var projectFileName = "project.csproj";
@@ -113,7 +216,7 @@ public class BindingRedirectsTests
         await File.WriteAllTextAsync(configFilePath, configContents);
 
         var projectBuildFile = ProjectBuildFile.Open(tempDir.DirectoryPath, projectFilePath);
-        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile);
+        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, updatedPackageName, updatedPackageVersion);
 
         var actualConfigContents = (await File.ReadAllTextAsync(configFilePath)).Replace("\r", "");
         expectedConfigContents = expectedConfigContents.Replace("\r", "");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -594,6 +594,7 @@ public partial class UpdateWorkerTests
                 [
                     MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
                     MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Unrelated.Package", "1.2.3", "net45","1.2.0.0"),
                 ],
                 projectContents: """
                     <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -610,6 +611,10 @@ public partial class UpdateWorkerTests
                       <ItemGroup>
                         <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
                           <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Unrelated.Package, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Unrelated.Package.1.2.3\lib\net45\Unrelated.Package.dll</HintPath>
                           <Private>True</Private>
                         </Reference>
                       </ItemGroup>
@@ -651,6 +656,107 @@ public partial class UpdateWorkerTests
                       <ItemGroup>
                         <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
                           <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Unrelated.Package, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Unrelated.Package.1.2.3\lib\net45\Unrelated.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedPackagesConfigContents: """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Some.Package" version="13.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFilesExpected:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime>
+                            <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                              <dependentAssembly>
+                                <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                                <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+                              </dependentAssembly>
+                            </assemblyBinding>
+                          </runtime>
+                        </configuration>
+                        """)
+                ]
+            );
+        }
+
+        [Fact]
+        public async Task BindingRedirectIsAddedForUpdatedPackage()
+        {
+            await TestUpdateForProject("Some.Package", "7.0.1", "13.0.1",
+                packages:
+                [
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "7.0.1", "net45", "7.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Some.Package", "13.0.1", "net45", "13.0.0.0"),
+                    MockNuGetPackage.CreatePackageWithAssembly("Unrelated.Package", "1.2.3", "net45","1.2.0.0"),
+                ],
+                projectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.7.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Unrelated.Package, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Unrelated.Package.1.2.3\lib\net45\Unrelated.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                packagesConfigContents: """
+                    <packages>
+                      <package id="Some.Package" version="7.0.1" targetFramework="net45" />
+                    </packages>
+                    """,
+                additionalFiles:
+                [
+                    ("app.config", """
+                        <configuration>
+                          <runtime />
+                        </configuration>
+                        """)
+                ],
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <None Include="app.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package, Version=13.0.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Some.Package.13.0.1\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                        <Reference Include="Unrelated.Package, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
+                          <HintPath>packages\Unrelated.Package.1.2.3\lib\net45\Unrelated.Package.dll</HintPath>
                           <Private>True</Private>
                         </Reference>
                       </ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -93,7 +93,7 @@ internal static class PackagesConfigUpdater
         projectBuildFile.NormalizeDirectorySeparatorsInProject();
 
         // Update binding redirects
-        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile);
+        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, dependencyName, newDependencyVersion);
 
         logger.Log("    Writing project file back to disk");
         await projectBuildFile.SaveAsync();
@@ -196,7 +196,7 @@ internal static class PackagesConfigUpdater
         return processes;
     }
 
-    internal static string? GetPathToPackagesDirectory(ProjectBuildFile projectBuildFile, string dependencyName, string dependencyVersion, string packagesConfigPath)
+    internal static string? GetPathToPackagesDirectory(ProjectBuildFile projectBuildFile, string dependencyName, string dependencyVersion, string? packagesConfigPath)
     {
         // the packages directory can be found from the hint path of the matching dependency, e.g., when given "Newtonsoft.Json", "7.0.1", and a project like this:
         // <Project>
@@ -242,7 +242,7 @@ internal static class PackagesConfigUpdater
             }
         }
 
-        if (partialPathMatch is null)
+        if (partialPathMatch is null && packagesConfigPath is not null)
         {
             // if we got this far, we couldn't find the packages directory for the specified dependency and there are 2 possibilities:
             // 1. the dependency doesn't actually exist in this project

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -27,6 +27,8 @@ internal static class PathHelper
 
     public static string EnsurePrefix(this string s, string prefix) => s.StartsWith(prefix) ? s : prefix + s;
 
+    public static string EnsureSuffix(this string s, string suffix) => s.EndsWith(suffix) ? s : s + suffix;
+
     public static string NormalizePathToUnix(this string path) => path.Replace("\\", "/");
 
     public static string NormalizeUnixPathParts(this string path)


### PR DESCRIPTION
Previously when updating a package in a `packages.config` scenario with an `app.config` file, we'd update or add binding redirects for all referenced assemblies.  This was too heavy-handed, particularly when a user's `app.config` file only had a few binding redirects.  We'd then add 20+ which wasn't really what they wanted.

Another approach would be to only update existing binding redirects, but ultimately the dependabot tool is meant to help address security vulnerabilities, which might mean updating a very specific transitive dependency and if a binding redirect wasn't added, this could lead to difficult to diagnose issues at runtime with an assembly mismatch.

So the approach taken here is twofold: (1) update any existing binding redirect, and (2) add new binding redirects, but _only_ for the updated package.

This can look complex, but it's not too bad.  A NuGet package can contain assemblies with any name, they don't have to match the name of the package, but thankfully all packages are extracted to a well-known location so to do the binding redirects, we simply look for all assemblies under that very specific path.