### PR TITLE
Add updater job flag to update the dependency list without updating the dependency files

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -44,6 +44,7 @@ module Dependabot
       security_advisories
       security_updates_only
       source
+      update_dependency_list_only
       update_subdependencies
       updating_a_pull_request
       vendor_dependencies
@@ -164,6 +165,7 @@ module Dependabot
       @source                         = T.let(build_source(attributes.fetch(:source)), Dependabot::Source)
       @token                          = T.let(attributes.fetch(:token, nil), T.nilable(String))
       @update_subdependencies         = T.let(attributes.fetch(:update_subdependencies), T::Boolean)
+      @update_dependency_list_only    = T.let(attributes.fetch(:update_dependency_list_only, false), T::Boolean)
       @updating_a_pull_request        = T.let(attributes.fetch(:updating_a_pull_request), T::Boolean)
       @vendor_dependencies            = T.let(attributes.fetch(:vendor_dependencies, false), T::Boolean)
       # TODO: Make this hash required
@@ -214,6 +216,11 @@ module Dependabot
     sig { returns(T::Boolean) }
     def update_subdependencies?
       @update_subdependencies
+    end
+
+    sig { returns(T::Boolean) }
+    def update_dependency_list_only?
+      @update_dependency_list_only
     end
 
     sig { returns(T::Boolean) }

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -32,6 +32,11 @@ module Dependabot
 
         # Update the service's metadata about this project
         service.update_dependency_list(dependency_snapshot: dependency_snapshot)
+        if job.update_dependency_list_only?
+          # If the job is to only discover dependencies, there's nothing more to do,
+          # skip the updater, mark the job as processed and stop.
+          return service.mark_job_as_processed(dependency_snapshot.base_commit_sha)
+        end
 
         # TODO: Pull fatal error handling handling up into this class
         #

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Dependabot::Job do
       lockfile_only: lockfile_only,
       requirements_update_strategy: nil,
       update_subdependencies: false,
+      update_dependency_list_only: update_dependency_list_only,
       updating_a_pull_request: false,
       vendor_dependencies: vendor_dependencies,
       experiments: experiments,
@@ -56,6 +57,7 @@ RSpec.describe Dependabot::Job do
   let(:package_manager) { "bundler" }
   let(:lockfile_only) { false }
   let(:security_updates_only) { false }
+  let(:update_dependency_list_only) { false }
   let(:allowed_updates) do
     [
       {
@@ -406,6 +408,18 @@ RSpec.describe Dependabot::Job do
 
     context "with security only allowed updates" do
       let(:security_updates_only) { true }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
+  describe "#update_dependency_list_only?" do
+    subject { job.update_dependency_list_only? }
+
+    it { is_expected.to be(false) }
+
+    context "with update dependency list only allowed" do
+      let(:update_dependency_list_only) { true }
 
       it { is_expected.to be(true) }
     end

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -92,6 +92,37 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         perform_job
       end
     end
+
+    context "with update_dependency_list_only" do
+      let(:snapshot) do
+        instance_double(Dependabot::DependencySnapshot,
+                        base_commit_sha: "1c6331732c41e4557a16dacb82534f1d1c831848")
+      end
+      let(:repo_contents_path) { "repo/path" }
+
+      let(:job_definition) do
+        JSON.parse(fixture("file_fetcher_output/update_dependency_list_only_output.json"))
+      end
+
+      before do
+        allow(Dependabot::Environment).to receive(:repo_contents_path).and_return(repo_contents_path)
+        allow(Dependabot::DependencySnapshot).to receive(:create_from_job_definition).and_return(snapshot)
+      end
+
+      it "sends dependency metadata to the service" do
+        expect(service).to receive(:update_dependency_list)
+          .with(dependency_snapshot: an_instance_of(Dependabot::DependencySnapshot))
+
+        perform_job
+      end
+
+      it "does not delegate to Dependabot::Updater" do
+        expect(Dependabot::Updater)
+          .not_to receive(:new)
+
+        perform_job
+      end
+    end
   end
 
   describe "#perform_job when there is an error parsing the dependency files" do

--- a/updater/spec/fixtures/file_fetcher_output/list_dependencies_only_output.json
+++ b/updater/spec/fixtures/file_fetcher_output/list_dependencies_only_output.json
@@ -1,0 +1,71 @@
+{
+  "job": {
+    "allowed-updates": [
+      {
+        "dependency-type": "direct",
+        "update-type": "all"
+      },
+      {
+        "dependency-type": "indirect",
+        "update-type": "security"
+      }
+    ],
+    "credentials": [
+      {
+        "type": "git_source",
+        "host": "github.com",
+        "username": "x-access-token",
+        "password": "v1.exampletokenfromgithubinityesitisforsure"
+      },
+      {
+        "type": "rubygems_index",
+        "host": "my.rubygems-host.org",
+        "token": "secret"
+      }
+    ],
+    "credentials-metadata": [
+      {
+        "type": "git_source",
+        "host": "github.com"
+      },
+      {
+        "type": "rubygems_index",
+        "host": "my.rubygems-host.org"
+      }
+    ],
+    "dependencies": null,
+    "directory": "/",
+    "existing-pull-requests": [],
+    "ignore-conditions": [],
+    "security-advisories": [],
+    "package_manager": "bundler",
+    "repo-name": "dependabot-fixtures/dependabot-test-ruby-package",
+    "source": {
+      "provider": "github",
+      "repo": "dependabot-fixtures/dependabot-test-ruby-package",
+      "directory": "/",
+      "branch": null,
+      "hostname": "github.com",
+      "api-endpoint": "https://api.github.com/"
+    },
+    "lockfile-only": false,
+    "requirements-update-strategy": null,
+    "update-subdependencies": false,
+    "update_dependency_list_only": true,
+    "updating-a-pull-request": false,
+    "vendor-dependencies": true,
+    "security-updates-only": false
+  },
+  "base64_dependency_files":[
+     {
+        "name":"dependabot-test-ruby-package.gemspec",
+        "content":"IyBmcm96ZW5fc3RyaW5nX2xpdGVyYWw6IHRydWUKCkdlbTo6U3BlY2lmaWNh\ndGlvbi5uZXcgZG8gfHNwZWN8CiAgc3BlYy5uYW1lICAgICA9ICdkZXBlbmRh\nYm90LXRlc3QtcnVieS1wYWNrYWdlJwogIHNwZWMudmVyc2lvbiAgPSAnMS4w\nLjEnCiAgc3BlYy5zdW1tYXJ5ICA9ICdBIGR1bW15IHBhY2thZ2UgZm9yIHRl\nc3RpbmcgRGVwZW5kYWJvdCcKICBzcGVjLmF1dGhvciAgID0gJ0RlcGVuZGFi\nb3QnCiAgc3BlYy5saWNlbnNlICA9ICdNSVQnCiAgc3BlYy5lbWFpbCAgICA9\nICdub3JlcGx5QGdpdGh1Yi5jb20nCiAgc3BlYy5ob21lcGFnZSA9ICdodHRw\nOi8vZ2l0aHViLmNvbS9kZXBlbmRhYm90LWZpeHR1cmVzL2RlcGVuZGFib3Qt\ndGVzdC1ydWJ5LXBhY2thZ2UnCmVuZAo=\n",
+        "directory":"/",
+        "type":"file",
+        "support_file":false,
+        "content_encoding":"utf-8",
+        "deleted":false
+     }
+  ],
+  "base_commit_sha":"1c6331732c41e4557a16dacb82534f1d1c831848"
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Resolve https://github.com/dependabot/cli/issues/360 and further progress @jakecoffman's `dependabot ls` CLI suggestion from https://github.com/dependabot/cli/pull/325.

This change adds a new `update_dependency_list_only` attribute to `Dependabot::Job`.
When true, `Dependabot::UpdateFilesCommand` will exit immediately after publishing the `update_dependency_list` API, skipping the call to `Dependabot::Updater.run()`. The default value is `false`.

The change allows community users a way to use Dependabot purely for discovering dependencies, without actually updating them.

As mentioned in https://github.com/dependabot/cli/issues/360, there is currently no obvious way _(that I could find)_ for the community _(outside GitHub)_ to use Dependabot [CLI] for security-only updates since a prerequisite of security-only updates is that the job definition contains the names of the vulnerable dependencies to be updated. The dependency names are not known until the update has started and discovery has completed, but the update cannot be started without first knowing the dependency names; catch-22.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I understand that in the GitHub hosted environment, this is likely not a problem. Dependencies for security-only updates are probably discovered through other (private) processes. I hope that you consider accepting this _(or some variation of it)_ to benefit community Dependabot implementations and users of Dependabot CLI.
 
### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
