### PR TITLE
Remove replacement of plus with dot in python latest version

### DIFF
--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -159,10 +159,7 @@ module Dependabot
         end
 
         def wants_prerelease?
-          if dependency.version
-            version = version_class.new(dependency.version.tr("+", "."))
-            return version.prerelease?
-          end
+          return version_class.new(dependency.version).prerelease? if dependency.version
 
           dependency.requirements.any? do |req|
             reqs = (req.fetch(:requirement) || "").split(",").map(&:strip)

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -204,6 +204,16 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       end
 
       it { is_expected.to eq(Gem::Version.new("2.7.0b1")) }
+
+      context "with a local version" do
+        before do
+          Dependabot::Experiments.register(:python_new_version, true)
+        end
+
+        let(:dependency_version) { "2.6.0a1+local.1" }
+
+        it { is_expected.to eq(Gem::Version.new("2.7.0b1")) }
+      end
     end
 
     context "when raise_on_ignored is enabled and later versions are allowed" do

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -206,10 +206,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       it { is_expected.to eq(Gem::Version.new("2.7.0b1")) }
 
       context "with a local version" do
-        before do
-          Dependabot::Experiments.register(:python_new_version, true)
-        end
-
         let(:dependency_version) { "2.6.0a1+local.1" }
 
         it { is_expected.to eq(Gem::Version.new("2.7.0b1")) }


### PR DESCRIPTION
### What are you trying to accomplish?
Fix [issue 10813](https://github.com/dependabot/dependabot-core/issues/10813) where a local python version like `20241015.20437.714166+master.fe8974a` is getting the plus sign replaced with a dot and, as a result, failing validation. With the [updated version regex](https://github.com/dependabot/dependabot-core/pull/10613), the plus gets parsed correctly therefore this hack is no longer necessary.

### How will you know you've accomplished your goal?
The added test will pass.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
