### PR TITLE
Add semver ignore-condition range code into python version

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -234,8 +234,8 @@ module Dependabot
                       .reject { |req_string| req_string.start_with?("<") }
                       .select { |req_string| req_string.match?(VERSION_REGEX) }
                       .map { |req_string| req_string.match(VERSION_REGEX) }
-                      .select { |version| Gem::Version.correct?(version) }
-                      .max_by { |version| Gem::Version.new(version) }
+                      .select { |version| Python::Version.correct?(version) }
+                      .max_by { |version| Python::Version.new(version) }
 
         ">=#{version_for_requirement || 0}"
       end

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -214,6 +214,38 @@ module Dependabot
         "dev0"
       end
 
+      sig { override.returns(T::Array[String]) }
+      def ignored_patch_versions
+        parts = release_segment # e.g [1,2,3] if version is 1.2.3-alpha3
+        version_parts = parts.fill(0, parts.length...2)
+        upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
+        lower_bound = "> #{self}"
+        upper_bound = "< #{upper_parts.join('.')}"
+
+        ["#{lower_bound}, #{upper_bound}"]
+      end
+
+      sig { override.returns(T::Array[String]) }
+      def ignored_minor_versions
+        parts = release_segment # e.g [1,2,3] if version is 1.2.3-alpha3
+        version_parts = parts.fill(0, parts.length...2)
+        lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
+        upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1] + [lowest_prerelease_suffix]
+        lower_bound = ">= #{lower_parts.join('.')}"
+        upper_bound = "< #{upper_parts.join('.')}"
+
+        ["#{lower_bound}, #{upper_bound}"]
+      end
+
+      sig { override.returns(T::Array[String]) }
+      def ignored_major_versions
+        version_parts = release_segment # e.g [1,2,3] if version is 1.2.3-alpha3
+        lower_parts = [version_parts[0].to_i + 1] + [lowest_prerelease_suffix] # earliest next major version prerelease
+        lower_bound = ">= #{lower_parts.join('.')}"
+
+        [lower_bound]
+      end
+
       private
 
       sig { params(other: Dependabot::Python::Version).returns(Integer) }

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -77,10 +77,6 @@ RSpec.describe Dependabot::Python::Version do
   describe ".new" do
     subject(:version) { described_class.new(version_string) }
 
-    before do
-      Dependabot::Experiments.register(:python_new_version, true)
-    end
-
     context "with an empty string" do
       let(:version_string) { "" }
       let(:error_msg) { "Malformed version string - string is empty" }
@@ -340,6 +336,30 @@ RSpec.describe Dependabot::Python::Version do
     let(:version_string) { "1.2.3" }
 
     it { is_expected.to eq "dev0" }
+  end
+
+  describe "#ignored_major_versions" do
+    subject(:ignored_versions) { version.ignored_major_versions }
+
+    let(:version_string) { "1.2.3-alpha.1" }
+
+    it { is_expected.to eq([">= 2.dev0"]) }
+  end
+
+  describe "#ignored_minor_versions" do
+    subject(:ignored_versions) { version.ignored_minor_versions }
+
+    let(:version_string) { "1.2.3-alpha.1" }
+
+    it { is_expected.to eq([">= 1.3.dev0, < 2.dev0"]) }
+  end
+
+  describe "#ignored_patch_versions" do
+    subject(:ignored_versions) { version.ignored_patch_versions }
+
+    let(:version_string) { "1.2.3-alpha.1" }
+
+    it { is_expected.to eq(["> #{version_string}, < 1.3.dev0"]) }
   end
 
   describe "compatibility with Gem::Requirement" do


### PR DESCRIPTION
Issue: https://github.com/dependabot/dependabot-core/issues/10845

### What are you trying to accomplish?
Backport [this fix from maven](https://github.com/dependabot/dependabot-core/pull/10664) into python. 

Though, currently, ignore conditions like ["version-update:semver-major", "version-update:semver-minor"] are working exactly like in the previous python version implementation, this is not strictly correct. Based on (the python version specification)[https://packaging.python.org/en/latest/specifications/version-specifiers], dev0 is the suffix with the lowest precedence so that's what we need to use in the ranges. Otherwise, we could end up in a situation where a dependency with version 2.9 and settings that say ignore majors could upgrade to 3.dev0 as 3.dev0 < 3.a.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
