### PR TITLE
do case-insensitive comparison for `lead_security_dependency` experiment

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -132,7 +132,7 @@ module Dependabot
           # Dependabot::Experiments.register(:lead_security_dependency, true)
 
           if Dependabot::Experiments.enabled?(:lead_security_dependency)
-            lead_dep_name = security_advisory_dependency
+            lead_dep_name = security_advisory_dependency.downcase
 
             # telemetry data collection
             Dependabot.logger.info(


### PR DESCRIPTION
The `lead_security_dependency` experiment is downcasing only one half of the dependency name comparison resulting in closed PRs in an ecosystem where the current packages are reported with some upper case characters, e.g., NuGet reporting `System.Text.Json` and that string not matching `system.text.json`.  The result is that the comparison on line 155 is returning `false`: `dep.name.downcase == lead_dep_name` where `lead_dep_name` comes from `security_advisory_dependency`.  The NuGet example then expands to `"system.text.json" == "System.Text.Json" # => false`.

The fix is to restore the call to `.downcase` that is present when the experiment isn't enabled.