### PR TITLE
add explicit `clone` command for NuGet updater

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -41,7 +41,6 @@ public partial class EntryPointTests
                 ],
                 job: new Job()
                 {
-                    PackageManager = "nuget",
                     AllowedUpdates = [
                         new()
                         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
@@ -1,0 +1,40 @@
+using System.CommandLine;
+
+using NuGetUpdater.Core;
+using NuGetUpdater.Core.Clone;
+using NuGetUpdater.Core.Run;
+
+namespace NuGetUpdater.Cli.Commands;
+
+internal static class CloneCommand
+{
+    internal static readonly Option<FileInfo> JobPathOption = new("--job-path") { IsRequired = true };
+    internal static readonly Option<DirectoryInfo> RepoContentsPathOption = new("--repo-contents-path") { IsRequired = true };
+    internal static readonly Option<Uri> ApiUrlOption = new("--api-url") { IsRequired = true };
+    internal static readonly Option<string> JobIdOption = new("--job-id") { IsRequired = true };
+
+    internal static Command GetCommand(Action<int> setExitCode)
+    {
+        var command = new Command("clone", "Clones a repository in preparation for a dependabot job.")
+        {
+            JobPathOption,
+            RepoContentsPathOption,
+            ApiUrlOption,
+            JobIdOption,
+        };
+
+        command.TreatUnmatchedTokensAsErrors = true;
+
+        command.SetHandler(async (jobPath, repoContentsPath, apiUrl, jobId) =>
+        {
+            var apiHandler = new HttpApiHandler(apiUrl.ToString(), jobId);
+            var logger = new ConsoleLogger();
+            var gitCommandHandler = new ShellGitCommandHandler(logger);
+            var worker = new CloneWorker(apiHandler, gitCommandHandler, logger);
+            var exitCode = await worker.RunAsync(jobPath, repoContentsPath);
+            setExitCode(exitCode);
+        }, JobPathOption, RepoContentsPathOption, ApiUrlOption, JobIdOption);
+
+        return command;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Program.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Program.cs
@@ -13,6 +13,7 @@ internal sealed class Program
 
         var command = new RootCommand
         {
+            CloneCommand.GetCommand(setExitCode),
             FrameworkCheckCommand.GetCommand(setExitCode),
             DiscoverCommand.GetCommand(setExitCode),
             AnalyzeCommand.GetCommand(setExitCode),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -1,0 +1,183 @@
+using NuGetUpdater.Core.Clone;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test.Run;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Clone;
+
+public class CloneWorkerTests
+{
+    private const string TestRepoPath = "TEST/REPO/PATH";
+
+    [Fact]
+    public void CloneCommandsAreGenerated()
+    {
+        TestCommands(
+            provider: "github",
+            repoMoniker: "test/repo",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "https://github.com/test/repo", TestRepoPath], null)
+            ]
+        );
+    }
+
+    [Fact]
+    public void CloneCommandsAreGeneratedWhenBranchIsSpecified()
+    {
+        TestCommands(
+            provider: "github",
+            repoMoniker: "test/repo",
+            branch: "some-branch",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "--branch", "some-branch", "--single-branch", "https://github.com/test/repo", TestRepoPath], null)
+            ]
+        );
+    }
+
+    [Fact]
+    public void CloneCommandsAreGeneratedWhenCommitIsSpecified()
+    {
+        TestCommands(
+            provider: "github",
+            repoMoniker: "test/repo",
+            commit: "abc123",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "https://github.com/test/repo", TestRepoPath], null),
+                (["fetch", "--depth", "1", "--recurse-submodules=on-demand", "origin", "abc123"], TestRepoPath),
+                (["reset", "--hard", "--recurse-submodules", "abc123"], TestRepoPath)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SuccessfulCloneGeneratesNoApiMessages()
+    {
+        await TestCloneAsync(
+            provider: "github",
+            repoMoniker: "test/repo",
+            expectedApiMessages: []
+        );
+    }
+
+    [Fact]
+    public async Task UnauthorizedCloneGeneratesTheExpectedApiMessagesFromGenericOutput()
+    {
+        await TestCloneAsync(
+            provider: "github",
+            repoMoniker: "test/repo",
+            testGitCommandHandler: new TestGitCommandHandlerWithOutputs("Authentication failed for repo", ""),
+            expectedApiMessages:
+            [
+                new JobRepoNotFound("Authentication failed for repo"),
+                new MarkAsProcessed("unknown"),
+            ],
+            expectedExitCode: 1
+        );
+    }
+
+    [Fact]
+    public async Task UnauthorizedCloneGeneratesTheExpectedApiMessagesFromGitCommandOutput()
+    {
+        await TestCloneAsync(
+            provider: "github",
+            repoMoniker: "test/repo",
+            testGitCommandHandler: new TestGitCommandHandlerWithOutputs("", "fatal: could not read Username for 'https://github.com': No such device or address"),
+            expectedApiMessages:
+            [
+                new JobRepoNotFound("fatal: could not read Username for 'https://github.com': No such device or address"),
+                new MarkAsProcessed("unknown"),
+            ],
+            expectedExitCode: 1
+        );
+    }
+
+    private class TestGitCommandHandlerWithOutputs : TestGitCommandHandler
+    {
+        private readonly string _stdout;
+        private readonly string _stderr;
+
+        public TestGitCommandHandlerWithOutputs(string stdout, string stderr)
+        {
+            _stdout = stdout;
+            _stderr = stderr;
+        }
+
+        public override async Task RunGitCommandAsync(IReadOnlyCollection<string> args, string? workingDirectory = null)
+        {
+            await base.RunGitCommandAsync(args, workingDirectory);
+            ShellGitCommandHandler.HandleErrorsFromOutput(_stdout, _stderr);
+        }
+    }
+
+    private static void TestCommands(string provider, string repoMoniker, (string[] Args, string? WorkingDirectory)[] expectedCommands, string? branch = null, string? commit = null)
+    {
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = provider,
+                Repo = repoMoniker,
+                Branch = branch,
+                Commit = commit,
+            }
+        };
+        var actualCommands = CloneWorker.GetAllCommandArgs(job, TestRepoPath);
+        VerifyCommands(expectedCommands, actualCommands);
+    }
+
+    private static async Task TestCloneAsync(string provider, string repoMoniker, object[] expectedApiMessages, string? branch = null, string? commit = null, TestGitCommandHandler? testGitCommandHandler = null, int expectedExitCode = 0)
+    {
+        // arrange
+        var testApiHandler = new TestApiHandler();
+        testGitCommandHandler ??= new TestGitCommandHandler();
+        var testLogger = new TestLogger();
+        var worker = new CloneWorker(testApiHandler, testGitCommandHandler, testLogger);
+
+        // act
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = provider,
+                Repo = repoMoniker,
+                Branch = branch,
+                Commit = commit,
+            }
+        };
+        var exitCode = await worker.RunAsync(job, TestRepoPath);
+
+        // assert
+        Assert.Equal(expectedExitCode, exitCode);
+
+        var actualApiMessages = testApiHandler.ReceivedMessages.ToArray();
+        if (actualApiMessages.Length > expectedApiMessages.Length)
+        {
+            var extraApiMessages = actualApiMessages.Skip(expectedApiMessages.Length).Select(m => RunWorkerTests.SerializeObjectAndType(m.Object)).ToArray();
+            Assert.Fail($"Expected {expectedApiMessages.Length} API messages, but got {extraApiMessages.Length} extra:\n\t{string.Join("\n\t", extraApiMessages)}");
+        }
+        if (expectedApiMessages.Length > actualApiMessages.Length)
+        {
+            var missingApiMessages = expectedApiMessages.Skip(actualApiMessages.Length).Select(m => RunWorkerTests.SerializeObjectAndType(m)).ToArray();
+            Assert.Fail($"Expected {expectedApiMessages.Length} API messages, but only got {actualApiMessages.Length}; missing:\n\t{string.Join("\n\t", missingApiMessages)}");
+        }
+    }
+
+    private static void VerifyCommands((string[] Args, string? WorkingDirectory)[] expected, (string[] Args, string? WorkingDirectory)[] actual)
+    {
+        var expectedCommands = StringifyCommands(expected);
+        var actualCommands = StringifyCommands(actual);
+        Assert.True(expectedCommands.Length == actualCommands.Length, $"Expected {expectedCommands.Length} messages:\n\t{string.Join("\n\t", expectedCommands)}\ngot {actualCommands.Length}:\n\t{string.Join("\n\t", actualCommands)}");
+        foreach (var (expectedCommand, actualCommand) in expectedCommands.Zip(actualCommands))
+        {
+            Assert.Equal(expectedCommand, actualCommand);
+        }
+    }
+
+    private static string[] StringifyCommands((string[] Args, string? WorkingDirectory)[] commandArgs) => commandArgs.Select(a => StringifyCommand(a.Args, a.WorkingDirectory)).ToArray();
+    private static string StringifyCommand(string[] args, string? workingDirectory) => $"args=[{string.Join(", ", args)}], workingDirectory={ReplaceWorkingDirectory(workingDirectory)}";
+    private static string ReplaceWorkingDirectory(string? arg) => arg ?? "NULL";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/TestGitCommandHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/TestGitCommandHandler.cs
@@ -1,0 +1,16 @@
+using NuGetUpdater.Core.Clone;
+
+namespace NuGetUpdater.Core.Test.Clone;
+
+internal class TestGitCommandHandler : IGitCommandHandler
+{
+    private readonly List<(string[] Args, string? WorkingDirectory)> _seenCommands = new();
+
+    public IReadOnlyCollection<(string[] Args, string? WorkingDirectory)> SeenCommands => _seenCommands;
+
+    public virtual Task RunGitCommandAsync(IReadOnlyCollection<string> args, string? workingDirectory = null)
+    {
+        _seenCommands.Add((args.ToArray(), workingDirectory));
+        return Task.CompletedTask;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -26,7 +26,6 @@ public class RunWorkerTests
             ],
             job: new Job()
             {
-                PackageManager = "nuget",
                 Source = new()
                 {
                     Provider = "github",
@@ -161,10 +160,7 @@ public class RunWorkerTests
                     PrTitle = "TODO: title",
                     PrBody = "TODO: body",
                 },
-                new MarkAsProcessed()
-                {
-                    BaseCommitSha = "TEST-COMMIT-SHA",
-                }
+                new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
         );
     }
@@ -209,7 +205,6 @@ public class RunWorkerTests
             ],
             job: new Job()
             {
-                PackageManager = "nuget",
                 Source = new()
                 {
                     Provider = "github",
@@ -249,14 +244,8 @@ public class RunWorkerTests
             },
             expectedApiMessages:
             [
-                new PrivateSourceAuthenticationFailure()
-                {
-                    Details = $"({http.BaseUrl.TrimEnd('/')}/index.json)"
-                },
-                new MarkAsProcessed()
-                {
-                    BaseCommitSha = "TEST-COMMIT-SHA",
-                }
+                new PrivateSourceAuthenticationFailure([$"{http.BaseUrl.TrimEnd('/')}/index.json"]),
+                new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
         );
     }
@@ -308,7 +297,7 @@ public class RunWorkerTests
         }
     }
 
-    private static string SerializeObjectAndType(object obj)
+    internal static string SerializeObjectAndType(object obj)
     {
         return $"{obj.GetType().Name}:{JsonSerializer.Serialize(obj)}";
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -1,4 +1,5 @@
 using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
 
 using Xunit;
 
@@ -56,5 +57,14 @@ public class SerializationTests
         Assert.Equal("github", jobWrapper.Job.Source.Provider);
         Assert.Equal("some-org/some-repo", jobWrapper.Job.Source.Repo);
         Assert.Equal("specific-sdk", jobWrapper.Job.Source.Directory);
+    }
+
+    [Fact]
+    public void SerializeError()
+    {
+        var error = new JobRepoNotFound("some message");
+        var actual = HttpApiHandler.Serialize(error);
+        var expected = """{"data":{"error-type":"job_repo_not_found","error-details":{"message":"some message"}}}""";
+        Assert.Equal(expected, actual);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -1,0 +1,144 @@
+using System.Net;
+
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using CommandArguments = (string[] Args, string? WorkingDirectory);
+
+namespace NuGetUpdater.Core.Clone;
+
+public class CloneWorker
+{
+    private readonly IApiHandler _apiHandler;
+    private readonly IGitCommandHandler _gitCommandHandler;
+    private readonly ILogger _logger;
+
+    public CloneWorker(IApiHandler apiHandler, IGitCommandHandler gitCommandHandler, ILogger logger)
+    {
+        _apiHandler = apiHandler;
+        _gitCommandHandler = gitCommandHandler;
+        _logger = logger;
+    }
+
+    // entrypoint for cli
+    public async Task<int> RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath)
+    {
+        var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
+        var jobWrapper = RunWorker.Deserialize(jobFileContent);
+        var result = await RunAsync(jobWrapper.Job, repoContentsPath.FullName);
+        return result;
+    }
+
+    // object model entry point
+    public async Task<int> RunAsync(Job job, string repoContentsPath)
+    {
+        JobErrorBase? error = null;
+        try
+        {
+            var commandArgs = GetAllCommandArgs(job, repoContentsPath);
+            foreach (var (args, workingDirectory) in commandArgs)
+            {
+                await _gitCommandHandler.RunGitCommandAsync(args, workingDirectory);
+            }
+        }
+        catch (HttpRequestException ex)
+        when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            error = new JobRepoNotFound(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            error = new UnknownError(ex.ToString());
+        }
+
+        if (error is not null)
+        {
+            await _apiHandler.RecordUpdateJobError(error);
+            await _apiHandler.MarkAsProcessed(new("unknown"));
+            return 1;
+        }
+
+        return 0;
+    }
+
+    internal static CommandArguments[] GetAllCommandArgs(Job job, string repoContentsPath)
+    {
+        var commandArgs = new List<CommandArguments>()
+        {
+            GetCloneArgs(job, repoContentsPath)
+        };
+
+        if (job.Source.Commit is { } commit)
+        {
+            commandArgs.Add(GetFetchArgs(commit, repoContentsPath));
+            commandArgs.Add(GetResetArgs(commit, repoContentsPath));
+        }
+
+        return commandArgs.ToArray();
+    }
+
+    internal static CommandArguments GetCloneArgs(Job job, string repoContentsPath)
+    {
+        var url = GetRepoUrl(job);
+        var args = new List<string>()
+        {
+            "clone",
+            "--no-tags",
+            "--depth",
+            "1",
+            "--recurse-submodules",
+            "--shallow-submodules",
+        };
+
+        if (job.Source.Branch is { } branch)
+        {
+            args.Add("--branch");
+            args.Add(branch);
+            args.Add("--single-branch");
+        }
+
+        args.Add(url);
+        args.Add(repoContentsPath);
+        return (args.ToArray(), null);
+    }
+
+    internal static CommandArguments GetFetchArgs(string commit, string repoContentsPath)
+    {
+        return
+        (
+            [
+                "fetch",
+                "--depth",
+                "1",
+                "--recurse-submodules=on-demand",
+                "origin",
+                commit
+            ],
+            repoContentsPath
+        );
+    }
+
+    internal static CommandArguments GetResetArgs(string commit, string repoContentsPath)
+    {
+        return
+        (
+            [
+                "reset",
+                "--hard",
+                "--recurse-submodules",
+                commit
+            ],
+            repoContentsPath
+        );
+    }
+
+    private static string GetRepoUrl(Job job)
+    {
+        return job.Source.Provider switch
+        {
+            "azure" => $"https://dev.azure.com/{job.Source.Repo}",
+            "github" => $"https://github.com/{job.Source.Repo}",
+            _ => throw new ArgumentException($"Unknown provider: {job.Source.Provider}")
+        };
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/IGitCommandHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/IGitCommandHandler.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Clone;
+
+public interface IGitCommandHandler
+{
+    Task RunGitCommandAsync(IReadOnlyCollection<string> args, string? workingDirectory = null);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
@@ -1,0 +1,37 @@
+using System.Net;
+
+namespace NuGetUpdater.Core.Clone;
+
+public class ShellGitCommandHandler : IGitCommandHandler
+{
+    private readonly ILogger _logger;
+
+    public ShellGitCommandHandler(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task RunGitCommandAsync(IReadOnlyCollection<string> args, string? workingDirectory = null)
+    {
+        _logger.Log($"Running command: git {string.Join(" ", args)}{(workingDirectory is null ? "" : $" in directory {workingDirectory}")}");
+        var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("git", args, workingDirectory);
+        HandleErrorsFromOutput(stdout, stderr);
+    }
+
+    internal static void HandleErrorsFromOutput(string stdout, string stderr)
+    {
+        foreach (var output in new[] { stdout, stderr })
+        {
+            ThrowOnUnauthenticated(output);
+        }
+    }
+
+    private static void ThrowOnUnauthenticated(string output)
+    {
+        if (output.Contains("Authentication failed for") ||
+            output.Contains("could not read Username for"))
+        {
+            throw new HttpRequestException(output, inner: null, statusCode: HttpStatusCode.Unauthorized);
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
@@ -2,5 +2,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record DependencyFileNotFound : JobErrorBase
 {
-    public override string Type => "dependency_file_not_found";
+    public DependencyFileNotFound(string filePath)
+        : base("dependency_file_not_found")
+    {
+        Details = filePath;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -2,7 +2,7 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record Job
 {
-    public required string PackageManager { get; init; }
+    public string PackageManager { get; init; } = "nuget";
     public AllowedUpdate[]? AllowedUpdates { get; init; } = null;
     public bool Debug { get; init; } = false;
     public object[]? DependencyGroups { get; init; } = null;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -4,8 +4,15 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public abstract record JobErrorBase
 {
+    public JobErrorBase(string type)
+    {
+        Type = type;
+    }
+
     [JsonPropertyName("error-type")]
-    public abstract string Type { get; }
+    public string Type { get; }
+
     [JsonPropertyName("error-details")]
-    public required object Details { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? Details { get; init; } = null;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobRepoNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobRepoNotFound.cs
@@ -1,0 +1,13 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record JobRepoNotFound : JobErrorBase
+{
+    public JobRepoNotFound(string message)
+        : base("job_repo_not_found")
+    {
+        Details = new Dictionary<string, string>()
+        {
+            ["message"] = message
+        };
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobSource.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobSource.cs
@@ -4,6 +4,8 @@ public sealed class JobSource
 {
     public required string Provider { get; init; }
     public required string Repo { get; init; }
+    public string? Branch { get; init; } = null;
+    public string? Commit { get; init; } = null;
     public string? Directory { get; init; } = null;
     public string[]? Directories { get; init; } = null;
     public string? Hostname { get; init; } = null;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/MarkAsProcessed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/MarkAsProcessed.cs
@@ -4,6 +4,11 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record MarkAsProcessed
 {
+    public MarkAsProcessed(string baseCommitSha)
+    {
+        BaseCommitSha = baseCommitSha;
+    }
+
     [JsonPropertyName("base-commit-sha")]
-    public required string BaseCommitSha { get; init; }
+    public string BaseCommitSha { get; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
@@ -2,5 +2,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record PrivateSourceAuthenticationFailure : JobErrorBase
 {
-    public override string Type => "private_source_authentication_failure";
+    public PrivateSourceAuthenticationFailure(string[] urls)
+        : base("private_source_authentication_failure")
+    {
+        Details = $"({string.Join("|", urls)})";
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -2,5 +2,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record UnknownError : JobErrorBase
 {
-    public override string Type => "unknown_error";
+    public UnknownError(string details)
+        : base("unknown_error")
+    {
+        Details = details;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
@@ -2,5 +2,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record UpdateNotPossible : JobErrorBase
 {
-    public override string Type => "update_not_possible";
+    public UpdateNotPossible(string[] dependencies)
+        : base("update_not_possible")
+    {
+        Details = dependencies;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -50,13 +50,19 @@ public class HttpApiHandler : IApiHandler
         await PostAsJson("mark_as_processed", markAsProcessed);
     }
 
-    private async Task PostAsJson(string endpoint, object body)
+    internal static string Serialize(object body)
     {
         var wrappedBody = new
         {
-            Data = body,
+            Data = body
         };
         var payload = JsonSerializer.Serialize(wrappedBody, SerializerOptions);
+        return payload;
+    }
+
+    private async Task PostAsJson(string endpoint, object body)
+    {
+        var payload = Serialize(body);
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
         var response = await HttpClient.PostAsync($"{_apiUrl}/update_jobs/{_jobId}/{endpoint}", content);
         var _ = response.EnsureSuccessStatusCode();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -76,31 +76,19 @@ public class RunWorker
         catch (HttpRequestException ex)
         when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {
-            error = new PrivateSourceAuthenticationFailure()
-            {
-                Details = $"({string.Join("|", lastUsedPackageSourceUrls)})",
-            };
+            error = new PrivateSourceAuthenticationFailure(lastUsedPackageSourceUrls);
         }
         catch (MissingFileException ex)
         {
-            error = new DependencyFileNotFound()
-            {
-                Details = ex.FilePath,
-            };
+            error = new DependencyFileNotFound(ex.FilePath);
         }
         catch (UpdateNotPossibleException ex)
         {
-            error = new UpdateNotPossible()
-            {
-                Details = ex.Dependencies,
-            };
+            error = new UpdateNotPossible(ex.Dependencies);
         }
         catch (Exception ex)
         {
-            error = new UnknownError()
-            {
-                Details = ex.ToString(),
-            };
+            error = new UnknownError(ex.ToString());
         }
 
         if (error is not null)
@@ -108,7 +96,7 @@ public class RunWorker
             await _apiHandler.RecordUpdateJobError(error);
         }
 
-        await _apiHandler.MarkAsProcessed(new() { BaseCommitSha = baseCommitSha });
+        await _apiHandler.MarkAsProcessed(new(baseCommitSha));
 
         return runResult;
     }

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -1,37 +1,28 @@
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
+$updaterTool = "$env:DEPENDABOT_NATIVE_HELPERS_PATH/nuget/NuGetUpdater/NuGetUpdater.Cli"
 $jobString = Get-Content -Path $env:DEPENDABOT_JOB_PATH
 $job = (ConvertFrom-Json -InputObject $jobString).job
 
+# Function return values in PowerShell are wacky and contain all of the output produced during the function call.
+# Because of this, we need a reliable way to communicate _only_ the result of executing a single command, not its
+# output.  To accomplish this the value `$operationExitCode` is introduced and explicitly tracked.  The value
+# cannot be directly set, however, because it would be scoped locally to the function, so the `script:` prefix
+# is added when setting the value.
+$operationExitCode = 0
+
 function Get-Files {
     Write-Host "Job: $($job | ConvertTo-Json)"
-    $sourceRepo = $job.source.repo
-    # TODO: handle other values from $job.source.provider
-    $url = "https://github.com/$sourceRepo"
-    $path = $env:DEPENDABOT_REPO_CONTENTS_PATH
-    $cloneOptions = "--no-tags --depth 1 --recurse-submodules --shallow-submodules"
-    if ("branch" -in $job.source.PSobject.Properties.Name) {
-        $cloneOptions += " --branch $($job.source.branch) --single-branch"
-    }
-
-    Invoke-Expression "git clone $cloneOptions $url $path"
-
-    if ("commit" -in $job.source.PSobject.Properties.Name) {
-        # this is only called for testing; production will never pass a commit
-        Push-Location $path
-
-        $fetchOptions = "--depth 1 --recurse-submodules=on-demand"
-        Invoke-Expression "git fetch $fetchOptions origin $($job.source.commit)"
-
-        $resetOptions = "--hard --recurse-submodules"
-        Invoke-Expression "git reset $resetOptions $($job.source.commit)"
-
-        Pop-Location
-    }
+    & $updaterTool clone `
+        --job-path $env:DEPENDABOT_JOB_PATH `
+        --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `
+        --api-url $env:DEPENDABOT_API_URL `
+        --job-id $env:DEPENDABOT_JOB_ID
+    $script:operationExitCode = $LASTEXITCODE
 }
 
-function Install-Sdks([string] $directory) {
+function Install-Sdks {
     $installedSdks = dotnet --list-sdks | ForEach-Object { $_.Split(' ')[0] }
     if ($installedSdks.GetType().Name -eq "String") {
         # if only a single value was returned (expected in the container), then force it to an array
@@ -39,22 +30,36 @@ function Install-Sdks([string] $directory) {
     }
     Write-Host "Currently installed SDKs: $installedSdks"
     $rootDir = Convert-Path $env:DEPENDABOT_REPO_CONTENTS_PATH
-    $candidateDir = Convert-Path "$rootDir/$directory"
-    while ($true) {
-        $globalJsonPath = Join-Path $candidateDir "global.json"
-        if (Test-Path $globalJsonPath) {
-            $globalJson = Get-Content $globalJsonPath | ConvertFrom-Json
-            $sdkVersion = $globalJson.sdk.version
-            if (-Not ($sdkVersion -in $installedSdks)) {
-                $installedSdks += $sdkVersion
-                Write-Host "Installing SDK $sdkVersion as specified in $globalJsonPath"
-                & $env:DOTNET_INSTALL_SCRIPT_PATH --version $sdkVersion --install-dir $env:DOTNET_INSTALL_DIR
-            }
-        }
 
-        $candidateDir = Split-Path -Parent $candidateDir
-        if ($candidateDir -eq $rootDir) {
-            break
+    $candidateDirectories = @()
+    if ("directory" -in $job.source.PSobject.Properties.Name) {
+        $candidateDirectories += $job.source.directory
+    }
+    if ("directories" -in $job.source.PSobject.Properties.Name) {
+        $candidateDirectories += $job.source.directories
+    }
+
+    foreach ($candidateDirName in $candidateDirectories) {
+        $candidateFullPath = "$rootDir/$candidateDirName"
+        if (Test-Path $candidateFullPath) {
+            $candidateDir = Convert-Path $candidateFullPath
+            while ($true) {
+                $globalJsonPath = Join-Path $candidateDir "global.json"
+                if (Test-Path $globalJsonPath) {
+                    $globalJson = Get-Content $globalJsonPath | ConvertFrom-Json
+                    $sdkVersion = $globalJson.sdk.version
+                    if (-Not ($sdkVersion -in $installedSdks)) {
+                        $installedSdks += $sdkVersion
+                        Write-Host "Installing SDK $sdkVersion as specified in $globalJsonPath"
+                        & $env:DOTNET_INSTALL_SCRIPT_PATH --version $sdkVersion --install-dir $env:DOTNET_INSTALL_DIR
+                    }
+                }
+
+                $candidateDir = Split-Path -Parent $candidateDir
+                if ($candidateDir -eq $rootDir) {
+                    break
+                }
+            }
         }
     }
 
@@ -64,14 +69,13 @@ function Install-Sdks([string] $directory) {
 
 function Update-Files {
     # install relevant SDKs
-    Install-Sdks $job.source.directory
+    Install-Sdks
     # TODO: install workloads?
 
     Push-Location $env:DEPENDABOT_REPO_CONTENTS_PATH
     $baseCommitSha = git rev-parse HEAD
     Pop-Location
 
-    $updaterTool = "$env:DEPENDABOT_NATIVE_HELPERS_PATH/nuget/NuGetUpdater/NuGetUpdater.Cli"
     & $updaterTool run `
         --job-path $env:DEPENDABOT_JOB_PATH `
         --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `
@@ -79,13 +83,16 @@ function Update-Files {
         --job-id $env:DEPENDABOT_JOB_ID `
         --output-path $env:DEPENDABOT_OUTPUT_PATH `
         --base-commit-sha $baseCommitSha
+    $script:operationExitCode = $LASTEXITCODE
 }
 
 try {
     Switch ($args[0]) {
         "fetch_files" { Get-Files }
         "update_files" { Update-Files }
+        default { throw "unknown command: $args[0]" }
     }
+    exit $operationExitCode
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
## This code is not yet live

The changes in this PR are only relevant for the long-standing work item of rewriting the NuGet updater in C#.

This PR moves the calls to `git clone ...` from the PowerShell script into C#.  The reason is that we already have much of the architecture available there to process and report errors.

We can now unit test the result of the `git clone ...` commands without actually needing to invoke the tool.

The contents of the PowerShell script were also simplified to call the new tool.

There are still two separate calls into the `NuGetUpdater.Cli` tool because that's how an update job is invoked.  One call with `fetch_files` and another with `update_files`.  This also means that we can easily  test either half in isolation; no need to perform a meaningless clone just to test the updater, and no need to prepare a bunch of files just to test the clone behavior.

The shape of some of the error types was incorrect and has also been fixed.

I manually verified the following:

|    | Private repo - authenticated | Private repo - unauthenticated | Public repo |
|---|---|---|---|
| GitHub | works | appropriate error generated | works |
| AzureDevOps| works | appropriate error generated | untested, but no reason it shouldn't work |