### PR TITLE
Fix git add command to handle paths with spaces

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -264,10 +264,14 @@ module Dependabot
 
     sig { params(env_cmd: T::Array[EnvCmdItem]).returns(T.nilable(String)) }
     def self.command_string_for_logging(env_cmd)
-      command = env_cmd.find { |item| item.is_a?(String) || item.is_a?(Array) }
-      return command.first if command.is_a?(Array)
+      command_parts = env_cmd.filter_map do |item|
+        case item
+        when Array then item.first
+        when String then item
+        end
+      end
 
-      T.cast(command, T.nilable(String))
+      command_parts.join(" ") unless command_parts.empty?
     end
     private_class_method :command_string_for_logging
 

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -26,6 +26,7 @@ module Dependabot
     EnvCmdItem = T.type_alias do
       T.any(
         String,
+        T::Array[String],
         T::Hash[T.any(String, Symbol), T.anything]
       )
     end
@@ -109,7 +110,7 @@ module Dependabot
                               else
                                 env_cmd
                               end
-          command_for_log = sanitized_env_cmd.join(" ")
+          command_for_log = sanitized_env_cmd.map { |item| item.is_a?(Array) ? item.first : item }.join(" ")
           Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{command_for_log}")
 
           # Write to stdin if input data is provided
@@ -263,7 +264,10 @@ module Dependabot
 
     sig { params(env_cmd: T::Array[EnvCmdItem]).returns(T.nilable(String)) }
     def self.command_string_for_logging(env_cmd)
-      T.cast(env_cmd.find { |item| item.is_a?(String) }, T.nilable(String))
+      command = env_cmd.find { |item| item.is_a?(String) || item.is_a?(Array) }
+      return command.first if command.is_a?(Array)
+
+      T.cast(command, T.nilable(String))
     end
     private_class_method :command_string_for_logging
 

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -483,7 +483,6 @@ module Dependabot
       safe_directories
     end
 
-    # rubocop:disable Metrics/PerceivedComplexity
     sig do
       params(
         command: Command,
@@ -549,7 +548,6 @@ module Dependabot
         error_context: error_context
       )
     end
-    # rubocop:enable Metrics/PerceivedComplexity
 
     sig { params(stderr: T.nilable(String), error_context: T::Hash[Symbol, String]).void }
     def self.check_out_of_disk_memory_error(stderr, error_context)

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -23,6 +23,8 @@ module Dependabot
   module SharedHelpers # rubocop:disable Metrics/ModuleLength
     extend T::Sig
 
+    Command = T.type_alias { T.any(String, T::Array[String]) }
+    CommandArguments = T.type_alias { T::Array[T.any(String, T::Array[String])] }
     USER_AGENT = T.let(
       "dependabot-core/#{Dependabot::VERSION} " \
       "#{Excon::USER_AGENT} ruby/#{RUBY_VERSION} " \
@@ -124,6 +126,26 @@ module Dependabot
     def self.escape_command(command)
       CommandHelpers.escape_command(command)
     end
+
+    sig do
+      params(command: Command, allow_unsafe_shell_command: T::Boolean)
+        .returns([CommandArguments, String])
+    end
+    def self.prepare_command(command, allow_unsafe_shell_command:)
+      unless command.is_a?(Array)
+        prepared_command = allow_unsafe_shell_command ? command : escape_command(command)
+        return [[prepared_command], prepared_command]
+      end
+
+      raise ArgumentError, "command must not be empty" if command.empty?
+      if allow_unsafe_shell_command
+        raise ArgumentError, "allow_unsafe_shell_command cannot be used with an argument vector"
+      end
+
+      executable = T.must(command.first)
+      [[[executable, executable], *command.drop(1)], Shellwords.join(command)]
+    end
+    private_class_method :prepare_command
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
@@ -464,7 +486,7 @@ module Dependabot
     # rubocop:disable Metrics/PerceivedComplexity
     sig do
       params(
-        command: String,
+        command: Command,
         allow_unsafe_shell_command: T::Boolean,
         cwd: T.nilable(String),
         env: T.nilable(T::Hash[String, String]),
@@ -485,14 +507,17 @@ module Dependabot
       output_observer: nil
     )
       start = Time.now
-      cmd = allow_unsafe_shell_command ? command : escape_command(command)
+      command_args, command_for_output = prepare_command(
+        command,
+        allow_unsafe_shell_command: allow_unsafe_shell_command
+      )
 
-      puts cmd if ENV["DEBUG_HELPERS"] == "true"
+      puts command_for_output if ENV["DEBUG_HELPERS"] == "true"
 
       opts = {}
       opts[:chdir] = cwd if cwd
 
-      env_cmd = [env || {}, cmd, opts].compact
+      env_cmd = [env || {}, *command_args, opts].compact
       kwargs = {
         stderr_to_stdout: stderr_to_stdout,
         timeout: timeout
@@ -511,7 +536,7 @@ module Dependabot
       return stdout || "" if process&.success?
 
       error_context = {
-        command: cmd,
+        command: command_for_output,
         fingerprint: fingerprint,
         time_taken: time_taken,
         process_exit_value: process.to_s

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -127,7 +127,7 @@ module Dependabot
 
       sig { params(memo: T.nilable(String)).returns(String) }
       def commit(memo = nil)
-        run_shell_command("git add #{path}")
+        run_shell_command(%(git add "#{path}"), allow_unsafe_shell_command: true)
 
         msg = memo || "workspace change"
         run_shell_command(

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -127,7 +127,7 @@ module Dependabot
 
       sig { params(memo: T.nilable(String)).returns(String) }
       def commit(memo = nil)
-        run_shell_command(%(git add "#{path}"), allow_unsafe_shell_command: true)
+        run_shell_command(["git", "add", "--", path.to_s])
 
         msg = memo || "workspace change"
         run_shell_command(
@@ -152,7 +152,7 @@ module Dependabot
         run_shell_command("git clean -fx .")
       end
 
-      sig { params(args: String, kwargs: T.any(T::Boolean, String)).returns(String) }
+      sig { params(args: SharedHelpers::Command, kwargs: T.any(T::Boolean, String)).returns(String) }
       def run_shell_command(*args, **kwargs)
         Dir.chdir(path) { T.unsafe(SharedHelpers).run_shell_command(*args, **kwargs) }
       end

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -170,6 +170,18 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(logger).to have_received(:debug).with(a_string_including("Total execution time"))
       end
 
+      it "logs direct-exec git config commands at debug level" do
+        stub_popen3_with_success
+
+        described_class.capture3_with_timeout(
+          [["git", "git"], "config", "--global", "--list"],
+          timeout: timeout
+        )
+
+        expect(logger).to have_received(:debug)
+          .with(a_string_including("command: git config --global --list"))
+      end
+
       it "logs non-git-config commands at info level" do
         described_class.capture3_with_timeout(
           [success_cmd],

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Dependabot::CommandHelpers do
         stub_popen3_with_success
 
         described_class.capture3_with_timeout(
-          [["git", "git"], "config", "--global", "--list"],
+          [%w(git git), "config", "--global", "--list"],
           timeout: timeout
         )
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -268,6 +268,102 @@ RSpec.describe Dependabot::SharedHelpers do
       end
     end
 
+    context "with an argument vector" do
+      let(:command) do
+        [
+          Gem.ruby,
+          "-e",
+          'require "json"; puts JSON.generate(ARGV)',
+          "argument with spaces",
+          '$(printf "injected")',
+          "`printf injected`"
+        ]
+      end
+
+      it "preserves argument boundaries without evaluating shell syntax" do
+        expect(JSON.parse(run_shell_command)).to eq(
+          ["argument with spaces", '$(printf "injected")', "`printf injected`"]
+        )
+      end
+
+      context "with only an executable" do
+        let(:command) { [File.join(spec_root, "helpers/test/run_bash")] }
+
+        it "executes it directly" do
+          expect(run_shell_command).to eq("\n")
+        end
+      end
+
+      context "when the executable contains shell syntax" do
+        let(:injected_path) { File.join(Dir.tmpdir, "dependabot-argv-injected-#{Process.pid}") }
+        let(:command) { ["missing-command; touch #{injected_path}"] }
+
+        before { FileUtils.rm_f(injected_path) }
+        after { FileUtils.rm_f(injected_path) }
+
+        it "does not evaluate the executable as a shell command" do
+          expect { run_shell_command }
+            .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, /No such file or directory/)
+          expect(File).not_to exist(injected_path)
+        end
+      end
+
+      context "with an environment variable" do
+        let(:command) { [File.join(spec_root, "helpers/test/run_bash"), "output"] }
+        let(:env) { { "TEST_ENV" => "prefix:" } }
+
+        it "is available to the command" do
+          expect(run_shell_command).to eq("prefix:output\n")
+        end
+      end
+
+      context "without redirecting stderr" do
+        subject(:run_shell_command) do
+          described_class.run_shell_command(command, stderr_to_stdout: false)
+        end
+
+        let(:command) { [File.join(spec_root, "helpers/test/run_bash"), "output"] }
+
+        it "returns stdout" do
+          expect(run_shell_command).to eq("output\n")
+        end
+      end
+
+      context "when the subprocess exits" do
+        let(:command) { [File.join(spec_root, "helpers/test/error_bash"), "disk"] }
+
+        it "raises a HelperSubprocessFailed error with a readable command" do
+          expect { run_shell_command }
+            .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+              expect(error.message).to include("No space left on device")
+              expect(error.error_context[:command]).to eq(Shellwords.join(command))
+            end
+        end
+      end
+
+      context "when the argument vector is empty" do
+        let(:command) { [] }
+
+        it "raises an argument error" do
+          expect { run_shell_command }.to raise_error(ArgumentError, "command must not be empty")
+        end
+      end
+
+      context "when allowing an unsafe shell command" do
+        subject(:run_shell_command) do
+          described_class.run_shell_command(command, allow_unsafe_shell_command: true)
+        end
+
+        it "raises an argument error" do
+          expect { run_shell_command }
+            .to raise_error(
+              ArgumentError,
+              "allow_unsafe_shell_command cannot be used with an argument vector"
+            )
+        end
+      end
+    end
+
     context "with an environment variable" do
       let(:env) { { "TEST_ENV" => "prefix:" } }
 

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -10,7 +10,7 @@ require "dependabot/workspace/git"
 RSpec.describe Dependabot::Workspace::Git do
   subject(:workspace) { described_class.new(repo_contents_path) }
 
-  let(:repo_contents_path) { build_tmp_repo("simple", tmp_dir_path: Dir.tmpdir) }
+  let(:repo_contents_path) { build_tmp_repo("simple", tmp_dir_path: File.join(Dir.tmpdir, "with space")) }
 
   around do |example|
     Dir.chdir(repo_contents_path) { example.run }

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -212,6 +212,41 @@ RSpec.describe Dependabot::Workspace::Git do
       end
     end
 
+    context "when the workspace path contains spaces and shell syntax" do
+      subject(:workspace) { described_class.new(workspace_path) }
+
+      let(:workspace_path) { Pathname.new(repo_contents_path).join("with space $(touch injected)") }
+
+      before do
+        FileUtils.mkdir_p(workspace_path)
+        File.write(workspace_path.join("tracked-file.txt"), "old content")
+        File.write(workspace_path.join("ignored-file.txt"), "old ignored content")
+        File.write(Pathname.new(repo_contents_path).join(".gitignore"), "ignored-file.txt\n")
+        `git add --all -- .`
+        `git commit -m workspace-setup`
+      end
+
+      it "stores additions and deletions without executing the path" do
+        workspace.change do |path|
+          FileUtils.rm(Pathname.new(path).join("tracked-file.txt"))
+          File.write(Pathname.new(path).join("new-file.txt"), "new content")
+          File.write(Pathname.new(path).join("ignored-file.txt"), "new ignored content")
+          File.write(Pathname.new(repo_contents_path).join("outside-file.txt"), "outside content")
+        end
+
+        workspace.store_change("Update files")
+
+        changed_files = `git show --format= --name-status HEAD`.lines.map(&:strip)
+        expect(changed_files).to contain_exactly(
+          "D\twith space $(touch injected)/tracked-file.txt",
+          "A\twith space $(touch injected)/new-file.txt"
+        )
+        expect(File).not_to exist(workspace_path.join("injected"))
+        expect(File.read(workspace_path.join("ignored-file.txt"))).to eq("new ignored content")
+        expect(`git status --short -- outside-file.txt`).to eq("?? outside-file.txt\n")
+      end
+    end
+
     context "when there are changes to ignored files" do
       # See: common/spec/fixtures/projects/simple/.gitignore
 


### PR DESCRIPTION
### What are you trying to accomplish?

- When committing to git the path is not escaped for whitespace so if there is a space in the path name it will fail with an error similar to:
```
updater | 2024/08/20 06:02:34 ERROR <job_871613656> fatal: pathspec '{{REMAINING PATH AFTER THE SPACE}}' did not match any files
```
- May help #10527
- Related to #8633

### Anything you want to highlight for special attention from reviewers?

- Nothing in particular

### How will you know you've accomplished your goal?

- Updated the tests to have a space in the path and verified the tests failed
- Implemented the fix and verified the tests now pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
  - [x] I ran `rspec spec` in the `bin/docker-dev-shell common` environment
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
