### PR TITLE
`source_url` in `Maven::UpdaterChecker::RequirementsUpdater` can be `nil`

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -27,7 +27,7 @@ module Dependabot
           params(
             requirements: T::Array[T::Hash[Symbol, T.untyped]],
             latest_version: T.nilable(T.any(Version, String)),
-            source_url: String,
+            source_url: T.nilable(String),
             properties_to_update: T::Array[String]
           ).void
         end
@@ -68,7 +68,7 @@ module Dependabot
         sig { returns(T.nilable(Version)) }
         attr_reader :latest_version
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_reader :source_url
 
         sig { returns(T::Array[String]) }


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

We're seeing the following Sorbet errors:

```
Parameter 'source_url': Expected type String, got type NilClass
Caller: /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11577/lib/types/private/methods/call_validation.rb:133
Definition: /home/dependabot/maven/lib/dependabot/maven/update_checker/requirements_updater.rb:34 (Dependabot::Maven::UpdateChecker::RequirementsUpdater#initialize)
```

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
