### PR TITLE
create interfaces for workers to make testing more direct

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestAnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestAnalyzeWorker.cs
@@ -1,0 +1,37 @@
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+
+namespace NuGetUpdater.Core.Test;
+
+internal class TestAnalyzeWorker : IAnalyzeWorker
+{
+    private readonly Func<(string, WorkspaceDiscoveryResult, DependencyInfo), Task<AnalysisResult>> _getResult;
+
+    public TestAnalyzeWorker(Func<(string, WorkspaceDiscoveryResult, DependencyInfo), Task<AnalysisResult>> getResult)
+    {
+        _getResult = getResult;
+    }
+
+    public Task<AnalysisResult> RunAsync(string repoRoot, WorkspaceDiscoveryResult discovery, DependencyInfo dependencyInfo)
+    {
+        return _getResult((repoRoot, discovery, dependencyInfo));
+    }
+
+    public static TestAnalyzeWorker FromResults(params (string RepoRoot, WorkspaceDiscoveryResult Discovery, DependencyInfo DependencyInfo, AnalysisResult Result)[] results)
+    {
+        return new TestAnalyzeWorker(((string RepoRoot, WorkspaceDiscoveryResult Discovery, DependencyInfo DependencyInfo) input) =>
+        {
+            foreach (var set in results)
+            {
+                if (set.RepoRoot == input.RepoRoot &&
+                    set.Discovery == input.Discovery &&
+                    set.DependencyInfo == input.DependencyInfo)
+                {
+                    return Task.FromResult(set.Result);
+                }
+            }
+
+            throw new NotImplementedException($"No saved response for {input}");
+        });
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestDiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestDiscoveryWorker.cs
@@ -1,0 +1,35 @@
+using NuGetUpdater.Core.Discover;
+
+namespace NuGetUpdater.Core.Test;
+
+internal class TestDiscoveryWorker : IDiscoveryWorker
+{
+    private readonly Func<(string, string), Task<WorkspaceDiscoveryResult>> _getResult;
+
+    public TestDiscoveryWorker(Func<(string, string), Task<WorkspaceDiscoveryResult>> getResult)
+    {
+        _getResult = getResult;
+    }
+
+    public Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)
+    {
+        return _getResult((repoRootPath, workspacePath));
+    }
+
+    public static TestDiscoveryWorker FromResults(params (string RepoRootPath, string WorkspacePath, WorkspaceDiscoveryResult Result)[] results)
+    {
+        return new TestDiscoveryWorker(((string RepoRootPath, string WorkspacePath) input) =>
+        {
+            foreach (var set in results)
+            {
+                if (set.RepoRootPath == input.RepoRootPath &&
+                    set.WorkspacePath == input.WorkspacePath)
+                {
+                    return Task.FromResult(set.Result);
+                }
+            }
+
+            throw new NotImplementedException($"No saved response for {input}");
+        });
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestUpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestUpdaterWorker.cs
@@ -1,0 +1,39 @@
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Test;
+
+internal class TestUpdaterWorker : IUpdaterWorker
+{
+    private readonly Func<(string, string, string, string, string, bool), Task<UpdateOperationResult>> _getResult;
+
+    public TestUpdaterWorker(Func<(string, string, string, string, string, bool), Task<UpdateOperationResult>> getResult)
+    {
+        _getResult = getResult;
+    }
+
+    public Task<UpdateOperationResult> RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
+    {
+        return _getResult((repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive));
+    }
+
+    public static TestUpdaterWorker FromResults(params (string RepoRootPath, string WorkspacePath, string DependencyName, string PreviousDependencyVersion, string NewDependencyVersion, bool IsTransitive, UpdateOperationResult Result)[] results)
+    {
+        return new TestUpdaterWorker(((string RepoRootPath, string WorkspacePath, string DependencyName, string PreviousDependencyVersion, string NewDependencyVersion, bool IsTransitive) input) =>
+        {
+            foreach (var set in results)
+            {
+                if (set.RepoRootPath == input.RepoRootPath &&
+                    set.WorkspacePath == input.WorkspacePath &&
+                    set.DependencyName == input.DependencyName &&
+                    set.PreviousDependencyVersion == input.PreviousDependencyVersion &&
+                    set.NewDependencyVersion == input.NewDependencyVersion &&
+                    set.IsTransitive == input.IsTransitive)
+                {
+                    return Task.FromResult(set.Result);
+                }
+            }
+
+            throw new NotImplementedException($"No saved response for {input}");
+        });
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -12,7 +12,7 @@ namespace NuGetUpdater.Core.Analyze;
 
 using MultiDependency = (string PropertyName, ImmutableArray<string> TargetFrameworks, ImmutableHashSet<string> DependencyNames);
 
-public partial class AnalyzeWorker
+public partial class AnalyzeWorker : IAnalyzeWorker
 {
     public const string AnalysisDirectoryName = "./.dependabot/analysis";
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -12,7 +12,7 @@ using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Discover;
 
-public partial class DiscoveryWorker
+public partial class DiscoveryWorker : IDiscoveryWorker
 {
     public const string DiscoveryResultFileName = "./.dependabot/discovery.json";
 
@@ -58,7 +58,7 @@ public partial class DiscoveryWorker
         return result;
     }
 
-    internal async Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)
+    public async Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath)
     {
         MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, repoRootPath);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -41,7 +41,7 @@ public record ExperimentsManager
 
         if (experiments.TryGetValue(experimentName, out var value))
         {
-            if ((value?.ToString()?? "").Equals("true", StringComparison.OrdinalIgnoreCase))
+            if ((value?.ToString() ?? "").Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IAnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IAnalyzeWorker.cs
@@ -1,0 +1,9 @@
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+
+namespace NuGetUpdater.Core;
+
+public interface IAnalyzeWorker
+{
+    Task<AnalysisResult> RunAsync(string repoRoot, WorkspaceDiscoveryResult discovery, DependencyInfo dependencyInfo);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IDiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IDiscoveryWorker.cs
@@ -1,0 +1,8 @@
+using NuGetUpdater.Core.Discover;
+
+namespace NuGetUpdater.Core;
+
+public interface IDiscoveryWorker
+{
+    Task<WorkspaceDiscoveryResult> RunAsync(string repoRootPath, string workspacePath);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IUpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IUpdaterWorker.cs
@@ -1,0 +1,9 @@
+
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core;
+
+public interface IUpdaterWorker
+{
+    Task<UpdateOperationResult> RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -7,7 +7,7 @@ using NuGetUpdater.Core.Updater;
 
 namespace NuGetUpdater.Core;
 
-public class UpdaterWorker
+public class UpdaterWorker : IUpdaterWorker
 {
     private readonly ExperimentsManager _experimentsManager;
     private readonly ILogger _logger;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -63,6 +63,8 @@ internal static class PathHelper
         return result;
     }
 
+    public static string FullyNormalizedRootedPath(this string path) => path.NormalizePathToUnix().NormalizeUnixPathParts().EnsurePrefix("/");
+
     public static string GetFullPathFromRelative(string rootPath, string relativePath)
         => Path.GetFullPath(JoinPath(rootPath, relativePath.NormalizePathToUnix()));
 

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -138,93 +138,93 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
     end
   end
 
-  # describe "#native_csharp_tests" do
-  #   subject(:dotnet_test) do
-  #     Dependabot::SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, cwd: cwd)
-  #   end
+  describe "#native_csharp_tests" do
+    subject(:dotnet_test) do
+      Dependabot::SharedHelpers.run_shell_command(command, allow_unsafe_shell_command: true, cwd: cwd)
+    end
 
-  #   let(:command) do
-  #     [
-  #       "dotnet",
-  #       "test",
-  #       "--configuration",
-  #       "Release",
-  #       "--tl:off",
-  #       "--logger",
-  #       "\"console;verbosity=normal\"",
-  #       project_path
-  #     ].join(" ")
-  #   end
+    let(:command) do
+      [
+        "dotnet",
+        "test",
+        "--configuration",
+        "Release",
+        "--tl:off",
+        "--logger",
+        "\"console;verbosity=normal\"",
+        project_path
+      ].join(" ")
+    end
 
-  #   let(:cwd) do
-  #     File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater")
-  #   end
+    let(:cwd) do
+      File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater")
+    end
 
-  #   context "when the output is from `dotnet test NuGetUpdater.Core.Test` output" do
-  #     let(:project_path) do
-  #       File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
-  #                 "NuGetUpdater.Core.Test", "NuGetUpdater.Core.Test.csproj")
-  #     end
+    context "when the output is from `dotnet test NuGetUpdater.Core.Test` output" do
+      let(:project_path) do
+        File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
+                  "NuGetUpdater.Core.Test", "NuGetUpdater.Core.Test.csproj")
+      end
 
-  #     it "contains the expected output" do
-  #       # In CI when the terminal logger is disabled by default in .NET 9 there is no
-  #       # output from the test runner: https://github.com/dotnet/msbuild/issues/10682.
-  #       # Instead we have to rely on the cmd invocation failing with a non-zero exit code
-  #       # if any tests fail. Locally when the terminal logger is enabled we can check
-  #       # there is an absence of any evidence of test failures in the output.
-  #       # expect(dotnet_test).to include("Passed!")
-  #       expect(dotnet_test).not_to include("Build failed")
-  #     end
-  #   end
+      it "contains the expected output" do
+        # In CI when the terminal logger is disabled by default in .NET 9 there is no
+        # output from the test runner: https://github.com/dotnet/msbuild/issues/10682.
+        # Instead we have to rely on the cmd invocation failing with a non-zero exit code
+        # if any tests fail. Locally when the terminal logger is enabled we can check
+        # there is an absence of any evidence of test failures in the output.
+        # expect(dotnet_test).to include("Passed!")
+        expect(dotnet_test).not_to include("Build failed")
+      end
+    end
 
-  #   context "when the output is from `dotnet test NuGetUpdater.Cli.Test`" do
-  #     let(:project_path) do
-  #       File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
-  #                 "NuGetUpdater.Cli.Test", "NuGetUpdater.Cli.Test.csproj")
-  #     end
+    context "when the output is from `dotnet test NuGetUpdater.Cli.Test`" do
+      let(:project_path) do
+        File.join(dependabot_home, "nuget", "helpers", "lib", "NuGetUpdater",
+                  "NuGetUpdater.Cli.Test", "NuGetUpdater.Cli.Test.csproj")
+      end
 
-  #     it "contains the expected output" do
-  #       # In CI when the terminal logger is disabled by default in .NET 9 there is no
-  #       # output from the test runner: https://github.com/dotnet/msbuild/issues/10682.
-  #       # Instead we have to rely on the cmd invocation failing with a non-zero exit code
-  #       # if any tests fail. Locally when the terminal logger is enabled we can check
-  #       # there is an absence of any evidence of test failures in the output.
-  #       # expect(dotnet_test).to include("Passed!")
-  #       expect(dotnet_test).not_to include("Build failed")
-  #     end
-  #   end
-  # end
+      it "contains the expected output" do
+        # In CI when the terminal logger is disabled by default in .NET 9 there is no
+        # output from the test runner: https://github.com/dotnet/msbuild/issues/10682.
+        # Instead we have to rely on the cmd invocation failing with a non-zero exit code
+        # if any tests fail. Locally when the terminal logger is enabled we can check
+        # there is an absence of any evidence of test failures in the output.
+        # expect(dotnet_test).to include("Passed!")
+        expect(dotnet_test).not_to include("Build failed")
+      end
+    end
+  end
 
-  # describe "#native_csharp_format" do
-  #   subject(:dotnet_test) do
-  #     Dependabot::SharedHelpers.run_shell_command(command)
-  #   end
+  describe "#native_csharp_format" do
+    subject(:dotnet_test) do
+      Dependabot::SharedHelpers.run_shell_command(command)
+    end
 
-  #   let(:command) do
-  #     [
-  #       "dotnet",
-  #       "format",
-  #       lib_path,
-  #       "--exclude",
-  #       except_path,
-  #       "--verify-no-changes",
-  #       "-v",
-  #       "diag"
-  #     ].join(" ")
-  #   end
+    let(:command) do
+      [
+        "dotnet",
+        "format",
+        lib_path,
+        "--exclude",
+        except_path,
+        "--verify-no-changes",
+        "-v",
+        "diag"
+      ].join(" ")
+    end
 
-  #   context "when output is from `dotnet format NuGetUpdater` output" do
-  #     let(:lib_path) do
-  #       File.absolute_path(File.join("helpers", "lib", "NuGetUpdater"))
-  #     end
+    context "when output is from `dotnet format NuGetUpdater` output" do
+      let(:lib_path) do
+        File.absolute_path(File.join("helpers", "lib", "NuGetUpdater"))
+      end
 
-  #     let(:except_path) { "helpers/lib/NuGet.Client" }
+      let(:except_path) { "helpers/lib/NuGet.Client" }
 
-  #     it "contains the expected output" do
-  #       expect(dotnet_test).to include("Format complete")
-  #     end
-  #   end
-  # end
+      it "contains the expected output" do
+        expect(dotnet_test).to include("Format complete")
+      end
+    end
+  end
 
   describe "#ensure_no_errors" do
     subject(:error_message) do


### PR DESCRIPTION
This makes testing `RunWorker.cs` much faster; approx 20s to 1s.

It also fixes some path handling on Windows machines; common for development, but not production or CI.