### PR TITLE
clean up warnings from NuGet.Client submodule

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);IS_CORECLR</DefineConstants>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <NoWarn>$(NoWarn);CA1305</NoWarn><!-- behavior of StringBuilder could vary based on user's locale -->
+    <NoWarn>$(NoWarn);CA2022</NoWarn><!-- avoid inexact Stream.Read() -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn><!-- package target framework may not be compatible -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn><!-- package has a known high severity vulnerability -->
+    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn><!-- obsolete -->
     <NuGetSourceLocation>$(MSBuildThisFileDirectory)..\..\NuGet.Client</NuGetSourceLocation>
     <SharedDirectory>$(NuGetSourceLocation)\build\Shared</SharedDirectory>
     <Version>6.8.0</Version>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0018</NoWarn><!-- ReflectionOnly loading is not supported -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Configuration/NuGet.Configuration.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;RS0041</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;RS0041</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/NuGet.Packaging.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>$(NoWarn);CS0414;CS1591;CS1574;CS1573;CS1572;RS0041</NoWarn>
+    <NoWarn>$(NoWarn);CA1305;CS0414;CS1591;CS1574;CS1573;CS1572;RS0041</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We don't control the code in the `NuGet.Client` submodule, but we can turn off the warnings so they don't clutter the build.

There are still build warnings in the code that we _do_ control, but that's for another day.