### PR TITLE
Add support for centralized package manager & language abstraction fo…

### DIFF
--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -8,6 +8,8 @@ require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/maven/version"
+require "dependabot/maven/language"
+require "dependabot/maven/package_manager"
 require "dependabot/errors"
 
 # The best Maven documentation is at:
@@ -44,7 +46,46 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      sig { returns(Ecosystem) }
+      def ecosystem
+        @ecosystem ||= T.let(
+          Ecosystem.new(
+            name: ECOSYSTEM,
+            package_manager: package_manager,
+            language: language
+          ),
+          T.nilable(Ecosystem)
+        )
+      end
+
       private
+
+      sig { returns(Ecosystem::VersionManager) }
+      def package_manager
+        @package_manager ||= T.let(
+          PackageManager.new(maven_version),
+          T.nilable(Dependabot::Maven::PackageManager)
+        )
+      end
+
+      sig { returns(T.nilable(Ecosystem::VersionManager)) }
+      def language
+        @language ||= T.let(begin
+          return if package_manager.unsupported?
+
+          Language.new(ruby_version)
+        end, T.nilable(Dependabot::Maven::Language))
+      end
+
+      sig { returns(String) }
+      def ruby_version
+        @ruby_version ||= T.let(RUBY_VERSION, T.nilable(String))
+      end
+
+      sig { returns(String) }
+      def maven_version
+        ""
+      end
 
       sig { params(pom: Dependabot::DependencyFile).returns(DependencySet) }
       def pomfile_dependencies(pom)

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -63,7 +63,7 @@ module Dependabot
       sig { returns(Ecosystem::VersionManager) }
       def package_manager
         @package_manager ||= T.let(
-          PackageManager.new(maven_version),
+          PackageManager.new("NOT-AVAILABLE"),
           T.nilable(Dependabot::Maven::PackageManager)
         )
       end
@@ -71,20 +71,8 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def language
         @language ||= T.let(begin
-          return if package_manager.unsupported?
-
-          Language.new(ruby_version)
+          Language.new("NOT-AVAILABLE")
         end, T.nilable(Dependabot::Maven::Language))
-      end
-
-      sig { returns(String) }
-      def ruby_version
-        @ruby_version ||= T.let(RUBY_VERSION, T.nilable(String))
-      end
-
-      sig { returns(String) }
-      def maven_version
-        ""
       end
 
       sig { params(pom: Dependabot::DependencyFile).returns(DependencySet) }

--- a/maven/lib/dependabot/maven/language.rb
+++ b/maven/lib/dependabot/maven/language.rb
@@ -1,0 +1,25 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/maven/version"
+require "dependabot/maven/requirement"
+
+module Dependabot
+  module Maven
+    LANGUAGE = "java"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          LANGUAGE,
+          Version.new(raw_version)
+        )
+      end
+    end
+  end
+end

--- a/maven/lib/dependabot/maven/package_manager.rb
+++ b/maven/lib/dependabot/maven/package_manager.rb
@@ -12,7 +12,7 @@ module Dependabot
     PACKAGE_MANAGER = "maven"
 
     # Supported versions specified here: https://maven.apache.org/docs/history.html
-    SUPPORTED_MAVEN_VERSIONS = T.let([Version.new("3.6.3")].freeze, T::Array[Dependabot::Version])
+    SUPPORTED_MAVEN_VERSIONS = T.let([Version.new("3")].freeze, T::Array[Dependabot::Version])
 
     # When a version is going to be unsupported, it will be added here
     DEPRECATED_MAVEN_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
@@ -34,6 +34,16 @@ module Dependabot
           SUPPORTED_MAVEN_VERSIONS,
           requirement,
         )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
       end
     end
   end

--- a/maven/lib/dependabot/maven/package_manager.rb
+++ b/maven/lib/dependabot/maven/package_manager.rb
@@ -1,0 +1,40 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/maven/version"
+require "dependabot/maven/requirement"
+
+module Dependabot
+  module Maven
+    ECOSYSTEM = "maven"
+    PACKAGE_MANAGER = "maven"
+
+    # Supported versions specified here: https://maven.apache.org/docs/history.html
+    SUPPORTED_MAVEN_VERSIONS = T.let([Version.new("3.6.3")].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_MAVEN_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig do
+        params(
+          raw_version: String,
+          requirement: T.nilable(Requirement)
+        ).void
+      end
+      def initialize(raw_version, requirement = nil)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_MAVEN_VERSIONS,
+          SUPPORTED_MAVEN_VERSIONS,
+          requirement,
+        )
+      end
+    end
+  end
+end

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -1065,35 +1065,30 @@ RSpec.describe Dependabot::Maven::FileParser do
       end
     end
 
-    describe "#package_manager" do
-      context "when there are no constraints" do
-        it "returns the correct package manager with no requirement" do
-          expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
-          expect(parser.ecosystem.package_manager.requirement).to be_nil
+    describe "#ecosystem" do
+      subject(:ecosystem) { parser.ecosystem }
+
+      it "has the correct name" do
+        expect(ecosystem.name).to eq "maven"
+      end
+
+      describe "#package_manager" do
+        subject(:package_manager) { ecosystem.package_manager }
+
+        it "returns the correct package manager" do
+          expect(package_manager.name).to eq "maven"
+          expect(package_manager.requirement).to be_nil
+          expect(package_manager.version.to_s).to eq "NOT-AVAILABLE"
         end
       end
 
-      context "when there are constraints" do
-        context "when bundler requirement specified in the Gemfile" do
-          let(:dependency_files) { bundler_project_dependency_files("bundler_specified") }
+      describe "#language" do
+        subject(:language) { ecosystem.language }
 
-          it "returns the correct package manager with requirement" do
-            expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
-            expect(parser.ecosystem.package_manager.requirement).to be_a(Dependabot::Bundler::Requirement)
-            expect(parser.ecosystem.package_manager.requirement.min_version).to eq(Dependabot::Version.new("2.3.0"))
-            expect(parser.ecosystem.package_manager.requirement.max_version).to eq(Dependabot::Version.new("2.4.0"))
-          end
-        end
-
-        context "when bundler requirement specified in .gemspec" do
-          let(:dependency_files) { bundler_project_dependency_files("gemfile_example") }
-
-          it "returns the correct package manager with requirement" do
-            expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
-            expect(parser.ecosystem.package_manager.requirement).to be_a(Dependabot::Bundler::Requirement)
-            expect(parser.ecosystem.package_manager.requirement.min_version).to eq(Dependabot::Version.new("1.12.0"))
-            expect(parser.ecosystem.package_manager.requirement.max_version).to be_nil
-          end
+        it "returns the correct language" do
+          expect(language.name).to eq "java"
+          expect(language.requirement).to be_nil
+          expect(language.version.to_s).to eq "NOT-AVAILABLE"
         end
       end
     end

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -1064,5 +1064,38 @@ RSpec.describe Dependabot::Maven::FileParser do
         end
       end
     end
+
+    describe "#package_manager" do
+      context "when there are no constraints" do
+        it "returns the correct package manager with no requirement" do
+          expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
+          expect(parser.ecosystem.package_manager.requirement).to be_nil
+        end
+      end
+
+      context "when there are constraints" do
+        context "when bundler requirement specified in the Gemfile" do
+          let(:dependency_files) { bundler_project_dependency_files("bundler_specified") }
+
+          it "returns the correct package manager with requirement" do
+            expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
+            expect(parser.ecosystem.package_manager.requirement).to be_a(Dependabot::Bundler::Requirement)
+            expect(parser.ecosystem.package_manager.requirement.min_version).to eq(Dependabot::Version.new("2.3.0"))
+            expect(parser.ecosystem.package_manager.requirement.max_version).to eq(Dependabot::Version.new("2.4.0"))
+          end
+        end
+
+        context "when bundler requirement specified in .gemspec" do
+          let(:dependency_files) { bundler_project_dependency_files("gemfile_example") }
+
+          it "returns the correct package manager with requirement" do
+            expect(parser.ecosystem.package_manager).to be_a(Dependabot::Bundler::PackageManager)
+            expect(parser.ecosystem.package_manager.requirement).to be_a(Dependabot::Bundler::Requirement)
+            expect(parser.ecosystem.package_manager.requirement.min_version).to eq(Dependabot::Version.new("1.12.0"))
+            expect(parser.ecosystem.package_manager.requirement.max_version).to be_nil
+          end
+        end
+      end
+    end
   end
 end

--- a/maven/spec/dependabot/maven/language_spec.rb
+++ b/maven/spec/dependabot/maven/language_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/maven/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Maven::Language do
+  let(:language) { described_class.new(version) }
+  let(:version) { "3.0.0" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::Maven::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Maven::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/maven/spec/dependabot/maven/package_manager_spec.rb
+++ b/maven/spec/dependabot/maven/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/maven/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Maven::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "3.9.5" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version).to eq(Dependabot::Maven::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Maven::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Maven::DEPRECATED_MAVEN_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Maven::SUPPORTED_MAVEN_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
…r maven

#### What are you trying to accomplish?

Update the maven ecosystem to add support for gathering ecosystem metrics that need to be persisted in datadog via `POST /update_jobs/:id/record_ecosystem_meta`


#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog. See earlier PRs for [Bundler](https://github.com/dependabot/dependabot-core/pull/10826) and [NPM](https://github.com/dependabot/dependabot-core/pull/10862)

In this PR, I'm returning `NOT-AVAILABLE` for the maven version and java version. From my investigations thus far, there is no consistent way to gather this data as we don't actually run maven when generating dependabot updates. All the processing seems to be done in Ruby. As discussed with @kbukum1 and @abdulapopoola I've created [Issue-7534](https://github.com/github/dependabot-updates/issues/7534) to track this issue.

#### How will you know you've accomplished your goal?

- I'll be able to see maven ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
