### PR TITLE
Fix bug related to empty package manager name in npm_and_yarn package manager

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -278,8 +278,10 @@ module Dependabot
 
       private
 
-      sig { params(name: String).returns(Ecosystem::VersionManager) }
+      sig { params(name: T.nilable(String)).returns(Ecosystem::VersionManager) }
       def package_manager_by_name(name)
+        name = DEFAULT_PACKAGE_MANAGER if name.nil? || PACKAGE_MANAGER_CLASSES[name].nil?
+
         package_manager_class = PACKAGE_MANAGER_CLASSES[name]
 
         package_manager_class ||= PACKAGE_MANAGER_CLASSES[DEFAULT_PACKAGE_MANAGER]


### PR DESCRIPTION
### What are you trying to accomplish?
This PR fixes a bug in the `npm_and_yarn/package_manager.rb` file where an empty or undefined package manager name resulted in a `NoMethodError` (`undefined method 'to_sym' for an instance of Hash`). This error, as reported in [Sentry Issue DELTAFORCE-11XD](https://sentry.io/organizations/...), occurred when `package_manager_by_name` was called with an invalid package manager name.

The update ensures that the method handles cases of empty or invalid package manager names gracefully, preventing `to_sym` from being called on unintended data types.

### Anything you want to highlight for special attention from reviewers?
To resolve this issue, the code now checks the validity of the package manager name before calling `to_sym`. Reviewers should focus on the additional validation logic to confirm that it aligns with expected behavior for handling empty or missing package manager names.

### How will you know you've accomplished your goal?
- **Reproduction**: The bug has been reproduced, and the fix prevents the error when an empty package manager name is used.
- **Feature Validation**: Tests have been added for cases where the package manager name is empty or invalid to ensure consistent behavior.

### Checklist
- [x] Complete test suite executed, ensuring all tests and linters pass.
- [x] Additional tests added to cover scenarios with empty or invalid package manager names.
- [x] Commit messages are clear and descriptive.
- [x] Provided a detailed description, including the problem, solution, and relevant implementation details.
- [x] Ensured the code is well-documented and easy to understand.
