### PR TITLE
only report a package as existing if the actual `.nupkg` can be downloaded

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -50,7 +50,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
         {
             var localPath = PathHelper.JoinPath(repoRoot, discovery.Path);
-            var nugetContext = new NuGetContext(localPath);
+            using var nugetContext = new NuGetContext(localPath);
             analysisResult = new AnalysisResult
             {
                 ErrorType = ErrorType.AuthenticationFailure,


### PR DESCRIPTION
When checking if a newer package exists, we previously only checked the NuGet endpoint to see if the version is reported.  This doesn't necessarily work with an authenticated Azure DevOps feed because the version could be reported as existing, but actually attempting to download the `.nupkg` could fail because the current authentication isn't allowed to pull in the upstream package.

The fix is to try to actually download the package before we report it as a possible upgrade path.

This issue was found by manually scanning the logs from the `nuget_native_analysis` experiment.