### PR TITLE
Ensure Corepack Usage for npm, pnpm, and yarn Command Execution

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -253,11 +253,19 @@ module Dependabot
         end
 
         version ||= requested_version(name)
-        version ||= guessed_version(name).to_s
 
         if version
           raise_if_unsupported!(name, version)
+
           install(name, version)
+        else
+          version = guessed_version(name)
+
+          if version
+            raise_if_unsupported!(name, version.to_s)
+
+            install(name, version)
+          end
         end
         version
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -252,7 +252,6 @@ module Dependabot
           )
         end
 
-        version = nil
         if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
           version ||= requested_version(name) || guessed_version(name)
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -172,18 +172,15 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def name_from_lockfiles
-        PACKAGE_MANAGER_CLASSES.each_key do |manager_name| # iterates keys in order as defined in the hash
-          return manager_name.to_s if @lockfiles[manager_name.to_sym]
-        end
-        nil
+        PACKAGE_MANAGER_CLASSES.keys.map(&:to_s).find { |manager_name| @lockfiles[manager_name.to_sym] }
       end
 
       sig { returns(T.nilable(String)) }
       def name_from_package_manager_attr
         return unless @manifest_package_manager
 
-        PACKAGE_MANAGER_CLASSES.each_key do |manager_name| # iterates keys in order as defined in the hash
-          return manager_name.to_s if @manifest_package_manager.start_with?("#{manager_name}@")
+        PACKAGE_MANAGER_CLASSES.keys.map(&:to_s).find do |manager_name|
+          @manifest_package_manager.start_with?("#{manager_name}@")
         end
       end
 
@@ -256,21 +253,12 @@ module Dependabot
         end
 
         version ||= requested_version(name)
+        version ||= guessed_version(name).to_s
 
         if version
           raise_if_unsupported!(name, version)
-
           install(name, version)
-        else
-          version = guessed_version(name)
-
-          if version
-            raise_if_unsupported!(name, version.to_s)
-
-            install(name, version) if name == PNPMPackageManager::NAME
-          end
         end
-
         version
       end
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -299,6 +299,11 @@ module Dependabot
       end
 
       def install(name, version)
+        if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
+          Helpers.install(name, version.to_s)
+          return
+        end
+
         Dependabot.logger.info("Installing \"#{name}@#{version}\"")
 
         SharedHelpers.run_shell_command(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -300,8 +300,7 @@ module Dependabot
 
       def install(name, version)
         if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
-          Helpers.install(name, version.to_s)
-          return
+          return Helpers.install(name, version.to_s)
         end
 
         Dependabot.logger.info("Installing \"#{name}@#{version}\"")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -63,10 +63,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
   let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
+
   before do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -63,7 +63,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
 
   let(:repo_contents_path) { build_tmp_repo(project_name, path: "projects") }
 
-  before { FileUtils.mkdir_p(tmp_path) }
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
+
+  before do
+    FileUtils.mkdir_p(tmp_path)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
 
   describe "errors" do
     context "with a dependency version that can't be found" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -58,7 +58,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
 
   let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
-  before { FileUtils.mkdir_p(tmp_path) }
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
+
+  before do
+    FileUtils.mkdir_p(tmp_path)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
+  end
 
   describe "errors" do
     context "with a dependency version that can't be found" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -59,11 +59,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
   # Variable to control the npm fallback version feature flag
   let(:npm_fallback_version_above_v6_enabled) { true }
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
 
   before do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -33,9 +33,14 @@ RSpec.describe namespace::SubdependencyVersionResolver do
   # Variable to control the npm fallback version feature flag
   let(:npm_fallback_version_above_v6_enabled) { true }
 
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
+
   before do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -63,6 +63,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
   # Variable to control the npm fallback version feature flag
   let(:npm_fallback_version_above_v6_enabled) { true }
 
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
+
   before do
     stub_request(:get, react_dom_registry_listing_url)
       .to_return(status: 200, body: react_dom_registry_response)
@@ -79,7 +82,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   end
   let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
   let(:registry_base) { "https://registry.npmjs.org" }
+
+  # Variable to control the npm fallback version feature flag
+  let(:npm_fallback_version_above_v6_enabled) { false }
+
   # Variable to control the enabling feature flag for the corepack fix
   let(:enable_corepack_for_npm_and_yarn) { true }
 
@@ -65,6 +69,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .to_return(status: 200)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -55,12 +55,20 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   end
   let(:registry_listing_url) { "#{registry_base}/#{escaped_dependency_name}" }
   let(:registry_base) { "https://registry.npmjs.org" }
+  # Variable to control the enabling feature flag for the corepack fix
+  let(:enable_corepack_for_npm_and_yarn) { true }
 
   before do
     stub_request(:get, registry_listing_url)
       .to_return(status: 200, body: registry_response)
     stub_request(:head, "#{registry_base}/#{dependency_name}/-/#{unscoped_dependency_name}-#{target_version}.tgz")
       .to_return(status: 200)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+  end
+
+  after do
+    Dependabot::Experiments.reset!
   end
 
   it_behaves_like "an update checker"


### PR DESCRIPTION
### What are you trying to accomplish?

This PR ensures that `corepack` is explicitly invoked when running `npm`, `pnpm`, and `yarn` commands. By calling `corepack` directly, we can guarantee that the correct package manager versions (installed via Corepack) are used for each command. This change helps prevent version mismatches and enhances consistency across different environments.

<!-- What issues does this affect or fix? -->
This change resolves inconsistencies in package manager versions used in different environments and addresses potential issues caused by mismatched versions.

### Anything you want to highlight for special attention from reviewers?

The key change here is the addition of `corepack` to the `npm`, `pnpm`, and `yarn` command execution. This ensures that the commands run with the versions installed by Corepack. If there were multiple approaches to achieve this, I selected this one to make the execution explicit and straightforward.

### How will you know you've accomplished your goal?

- To confirm these changes, tests were run to verify that each package manager command executes correctly with Corepack and maintains version consistency.
- This PR includes updates to `run_npm_command`, `run_pnpm_command`, and `run_single_yarn_command` to prepend `corepack` to each command, ensuring the correct version usage.
- The implementation was verified by running the package manager commands and confirming the expected behavior.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
