### PR TITLE
[pub] Fix update fails when project contains dependency from Dart SDK

### DIFF
--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -229,6 +229,7 @@ module Dependabot
               "CI" => "true",
               "PUB_ENVIRONMENT" => "dependabot",
               "FLUTTER_ROOT" => "/tmp/flutter",
+              "DART_ROOT" => "/tmp/flutter/bin/cache/dart-sdk",
               "PUB_HOSTED_URL" => options[:pub_hosted_url],
               # This variable will make the solver run assuming that Dart SDK version.
               # TODO(sigurdm): Would be nice to have a better handle for fixing the dart sdk version.

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -839,6 +839,28 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     end
   end
 
+  context "when given a project with dependencies from dart sdk" do
+    let(:project) { "can_update_with_dart_sdk_deps" }
+    let(:dependency_name) { "lints" }
+    let(:requirements_to_unlock) { :all }
+
+    it "can update lints" do
+      expect(can_update).to be_truthy
+      expect(updated_dependencies).to eq [
+        { "name" => "lints",
+          "package_manager" => "pub",
+          "previous_requirements" => [{
+            file: "pubspec.yaml", groups: ["dev"], requirement: "^3.0.0", source: nil
+          }],
+          "previous_version" => "3.0.0",
+          "requirements" => [{
+            file: "pubspec.yaml", groups: ["dev"], requirement: "^4.0.0", source: nil
+          }],
+          "version" => "4.0.0" }
+      ]
+    end
+  end
+
   context "when loading a YAML file with alias" do
     fixture = "spec/fixtures/projects/yaml_alias/"
     alias_info_file = "pubspec_alias_true.yaml"

--- a/pub/spec/fixtures/projects/can_update_with_dart_sdk_deps/pubspec.yaml
+++ b/pub/spec/fixtures/projects/can_update_with_dart_sdk_deps/pubspec.yaml
@@ -1,0 +1,8 @@
+name: dependabot_testcase
+environment:
+  sdk: ^3.5.0
+dependencies:
+  _macros:
+    sdk: dart
+dev_dependencies:
+  lints: ^3.0.0


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

I have noticed that under certain conditions, Dependabot fails to create updates with the following logs:

```
updater | 2024/11/15 12:51:41 INFO <job_917330574> Checking if custom_lint 0.6.8 needs updating
updater | 2024/11/15 12:51:41 INFO <job_917330574> Latest version is 0.7.0
updater | 2024/11/15 12:51:41 INFO <job_917330574> Requirements to unlock update_not_possible
updater | 2024/11/15 12:51:41 INFO <job_917330574> Requirements update strategy 
2024/11/15 12:51:41 INFO <job_917330574> No update possible for custom_lint 0.6.8
```

Upon investigation, I found that the following error occurred in dependency_services internal, interrupting the update resolution. (different dependency, but same cause.)

```
Because every version of flutter from sdk depends on collection 1.18.0 and analyzer >=6.8.0 depends on collection ^1.19.0, flutter from sdk is incompatible with
  analyzer >=6.8.0.
And because analyzer >=6.6.0 <6.9.0 depends on macros >=0.1.2-main.3 <0.1.3, if flutter from sdk and analyzer >=6.6.0 then macros >=0.1.2-main.3 <0.1.3.
And because macros >=0.1.2-main.2 <0.1.2-main.4 depends on _macros 0.3.1 from sdk and macros >=0.1.2-main.4 <0.1.3-main.0 depends on _macros 0.3.2 from sdk, if flutter
  from sdk and analyzer >=6.6.0 then _macros 0.3.1 or 0.3.2 from sdk.
And because _macros from sdk doesn't exist (could not find package _macros in the Dart SDK) and riverpod_lint >=2.6.1 <3.0.0-dev.0 depends on analyzer ^6.7.0, flutter
  from sdk is incompatible with riverpod_lint >=2.6.1 <3.0.0-dev.0.
So, because my_project depends on both flutter from sdk and riverpod_lint ^2.6.1, version solving failed.
```

(Excerpt)

```
_macros from sdk doesn't exist (could not find package _macros in the Dart SDK) 
```

Packages such as `analyzer` depend on `macros` package, which depends on `_macros` which is included in the Dart SDK. When the project depends on such packages, Dependabot will no longer create any PRs because dependency_services cannot find `_macros` package. 

This PR passes the DART_ROOT environment variable to dependency_services so that it can find the Dart SDK.

<!-- What issues does this affect or fix? -->

#### Related Issue
* ~~#8903~~
  * I read the issue again but I can't determine if the cause is the same for now.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

#### pubspec.yaml
```YAML
name: foo
environment:
  sdk: '^3.5.0'

dev_dependencies:
  riverpod_lint: 2.6.1
```

(riverpod_lint depends on analyzer)

#### Command Line
```sh
$ dependabot update pub _ --local .
```

#### Result
(before)
```
...
updater | 2024/11/17 12:14:27 INFO Finished job processing
  proxy | 2024/11/17 12:14:29 Skipping sending metrics because api endpoint is empty
  proxy | 2024/11/17 12:14:29 34/239 calls cached (14%)
```

(after)
```
...
updater | 2024/11/17 12:08:16 INFO Finished job processing
updater | 2024/11/17 12:08:16 INFO Results:
updater | +-------------------------------------------------+
updater | |       Changes to Dependabot Pull Requests       |
updater | +---------+---------------------------------------+
updater | | created | riverpod_lint ( from 2.6.1 to 2.6.2 ) |
updater | +---------+---------------------------------------+
  proxy | 2024/11/17 12:08:18 Skipping sending metrics because api endpoint is empty
  proxy | 2024/11/17 12:08:18 159/376 calls cached (42%)
```

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
