### PR TITLE
Add support for go ecosystem metrics collection

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -12,6 +12,8 @@ require "dependabot/errors"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/go_modules/version"
+require "dependabot/go_modules/language"
+require "dependabot/go_modules/package_manager"
 
 module Dependabot
   module GoModules
@@ -29,6 +31,33 @@ module Dependabot
         end
 
         dependency_set.dependencies
+      end
+
+      sig { returns(Ecosystem) }
+      def ecosystem
+        @ecosystem ||= T.let(
+          Ecosystem.new(
+            name: ECOSYSTEM,
+            package_manager: package_manager,
+            language: language
+          ),
+          T.nilable(Ecosystem)
+        )
+      end
+
+      sig { returns(Ecosystem::VersionManager) }
+      def package_manager
+        @package_manager ||= T.let(
+          PackageManager.new("NOT-AVAILABLE"),
+          T.nilable(Dependabot::GoModules::PackageManager)
+        )
+      end
+
+      sig { returns(T.nilable(Ecosystem::VersionManager)) }
+      def language
+        @language ||= T.let(begin
+          Language.new("NOT-AVAILABLE")
+        end, T.nilable(Dependabot::GoModules::Language))
       end
 
       private

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -45,10 +45,12 @@ module Dependabot
         )
       end
 
+      private
+
       sig { returns(Ecosystem::VersionManager) }
       def package_manager
         @package_manager ||= T.let(
-          PackageManager.new("NOT-AVAILABLE"),
+          PackageManager.new(go_version),
           T.nilable(Dependabot::GoModules::PackageManager)
         )
       end
@@ -56,11 +58,14 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def language
         @language ||= T.let(begin
-          Language.new("NOT-AVAILABLE")
+          Language.new(go_version)
         end, T.nilable(Dependabot::GoModules::Language))
       end
 
-      private
+      sig { returns(String) }
+      def go_version
+        @go_version ||= T.let(T.must(go_mod&.content&.match(/^go\s(\d+\.\d+)/)&.captures&.first), T.nilable(String))
+      end
 
       # set GOTOOLCHAIN=local+auto if go version >= 1.21
       sig { void }

--- a/go_modules/lib/dependabot/go_modules/language.rb
+++ b/go_modules/lib/dependabot/go_modules/language.rb
@@ -1,0 +1,25 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/go_modules/version"
+require "dependabot/go_modules/requirement"
+
+module Dependabot
+  module GoModules
+    LANGUAGE = "go"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          LANGUAGE,
+          Version.new(raw_version)
+        )
+      end
+    end
+  end
+end

--- a/go_modules/lib/dependabot/go_modules/package_manager.rb
+++ b/go_modules/lib/dependabot/go_modules/package_manager.rb
@@ -18,19 +18,13 @@ module Dependabot
     class PackageManager < Dependabot::Ecosystem::VersionManager
       extend T::Sig
 
-      sig do
-        params(
-          raw_version: String,
-          requirement: T.nilable(Requirement)
-        ).void
-      end
-      def initialize(raw_version, requirement = nil)
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
         super(
           PACKAGE_MANAGER,
           Version.new(raw_version),
           DEPRECATED_GO_VERSIONS,
-          SUPPORTED_GO_VERSIONS,
-          requirement,
+          SUPPORTED_GO_VERSIONS
         )
       end
 

--- a/go_modules/lib/dependabot/go_modules/package_manager.rb
+++ b/go_modules/lib/dependabot/go_modules/package_manager.rb
@@ -1,0 +1,48 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/go_modules/version"
+require "dependabot/go_modules/requirement"
+
+module Dependabot
+  module GoModules
+    ECOSYSTEM = "go"
+    PACKAGE_MANAGER = "go_modules"
+    SUPPORTED_GO_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_GO_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig do
+        params(
+          raw_version: String,
+          requirement: T.nilable(Requirement)
+        ).void
+      end
+      def initialize(raw_version, requirement = nil)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_GO_VERSIONS,
+          SUPPORTED_GO_VERSIONS,
+          requirement,
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -367,9 +367,9 @@ RSpec.describe Dependabot::GoModules::FileParser do
       subject(:package_manager) { ecosystem.package_manager }
 
       it "returns the correct package manager" do
-        expect(package_manager.name).to eq "go"
+        expect(package_manager.name).to eq "go_modules"
         expect(package_manager.requirement).to be_nil
-        expect(package_manager.version.to_s).to eq "NOT-AVAILABLE"
+        expect(package_manager.version.to_s).to eq "1.12"
       end
     end
 
@@ -377,9 +377,9 @@ RSpec.describe Dependabot::GoModules::FileParser do
       subject(:language) { ecosystem.language }
 
       it "returns the correct language" do
-        expect(language.name).to eq "java"
+        expect(language.name).to eq "go"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "NOT-AVAILABLE"
+        expect(language.version.to_s).to eq "1.12"
       end
     end
   end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -355,4 +355,32 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "go"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "go"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "NOT-AVAILABLE"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "java"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "NOT-AVAILABLE"
+      end
+    end
+  end
 end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -359,6 +359,10 @@ RSpec.describe Dependabot::GoModules::FileParser do
   describe "#ecosystem" do
     subject(:ecosystem) { parser.ecosystem }
 
+    before do
+      ENV["GO_LEGACY"] = "go1.20.10"
+    end
+
     it "has the correct name" do
       expect(ecosystem.name).to eq "go"
     end
@@ -369,7 +373,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
       it "returns the correct package manager" do
         expect(package_manager.name).to eq "go_modules"
         expect(package_manager.requirement).to be_nil
-        expect(package_manager.version.to_s).to eq "1.12"
+        expect(package_manager.version.to_s).to eq "1.20.10"
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/language_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/language_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/go_modules/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::GoModules::Language do
+  let(:language) { described_class.new(version) }
+  let(:version) { "3.0.0" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::GoModules::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::GoModules::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/package_manager_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/maven/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Maven::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "3.9.5" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version).to eq(Dependabot::Maven::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Maven::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Maven::DEPRECATED_MAVEN_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Maven::SUPPORTED_MAVEN_VERSIONS)
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/package_manager_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/package_manager_spec.rb
@@ -1,36 +1,36 @@
 # typed: false
 # frozen_string_literal: true
 
-require "dependabot/maven/package_manager"
+require "dependabot/go_modules/package_manager"
 require "dependabot/ecosystem"
 require "spec_helper"
 
-RSpec.describe Dependabot::Maven::PackageManager do
+RSpec.describe Dependabot::GoModules::PackageManager do
   subject(:package_manager) { described_class.new(version) }
 
-  let(:version) { "3.9.5" }
+  let(:version) { "1.12" }
 
   describe "#version" do
     it "returns the version" do
-      expect(package_manager.version).to eq(Dependabot::Maven::Version.new(version))
+      expect(package_manager.version).to eq(Dependabot::GoModules::Version.new(version))
     end
   end
 
   describe "#name" do
     it "returns the name" do
-      expect(package_manager.name).to eq(Dependabot::Maven::PACKAGE_MANAGER)
+      expect(package_manager.name).to eq(Dependabot::GoModules::PACKAGE_MANAGER)
     end
   end
 
   describe "#deprecated_versions" do
     it "returns deprecated versions" do
-      expect(package_manager.deprecated_versions).to eq(Dependabot::Maven::DEPRECATED_MAVEN_VERSIONS)
+      expect(package_manager.deprecated_versions).to eq(Dependabot::GoModules::DEPRECATED_GO_VERSIONS)
     end
   end
 
   describe "#supported_versions" do
     it "returns supported versions" do
-      expect(package_manager.supported_versions).to eq(Dependabot::Maven::SUPPORTED_MAVEN_VERSIONS)
+      expect(package_manager.supported_versions).to eq(Dependabot::GoModules::SUPPORTED_GO_VERSIONS)
     end
   end
 end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the go ecosystem to add support for gathering ecosystem metrics that need to be persisted in datadog via `POST /update_jobs/:id/record_ecosystem_meta`


#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog. See earlier PRs for [Bundler](https://github.com/dependabot/dependabot-core/pull/10826) and [NPM](https://github.com/dependabot/dependabot-core/pull/10862)

#### How will you know you've accomplished your goal?

- I'll be able to see Go ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.