### PR TITLE
Make DiscoveryWorker project path check case insensitive

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -476,6 +476,147 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task TestRepo_SolutionFileCasingIsDifferent()
+    {
+        var solutionPath = "solution.sln";
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
+            ],
+            workspacePath: "",
+            files: new[]
+            {
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                        <SomePackageVersion>9.0.1</SomePackageVersion>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                (solutionPath, """
+                    Microsoft Visual Studio Solution File, Format Version 12.00
+                    # Visual Studio 14
+                    VisualStudioVersion = 14.0.22705.0
+                    MinimumVisualStudioVersion = 10.0.40219.1
+                    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProJect", ".\src\ProJect.csproj", "{782E0C0A-10D3-444D-9640-263D03D2B20C}"
+                    EndProject
+                    Global
+                      GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                      EndGlobalSection
+                      GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {782E0C0A-10D3-444D-9640-263D03D2B20C}.Release|Any CPU.Build.0 = Release|Any CPU
+                      EndGlobalSection
+                      GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                      EndGlobalSection
+                    EndGlobal
+                    """),
+                ("global.json", """
+                    {
+                      "sdk": {
+                        "version": "6.0.405",
+                        "rollForward": "latestPatch"
+                      },
+                      "msbuild-sdks": {
+                        "My.Custom.Sdk": "5.0.0",
+                        "My.Other.Sdk": "1.0.0-beta"
+                      }
+                    }
+                    """),
+                (".config/dotnet-tools.json", """
+                    {
+                      "version": 1,
+                      "isRoot": true,
+                      "tools": {
+                        "microsoft.botsay": {
+                          "version": "1.0.0",
+                          "commands": [
+                            "botsay"
+                          ]
+                        },
+                        "dotnetsay": {
+                          "version": "2.1.3",
+                          "commands": [
+                            "dotnetsay"
+                          ]
+                        }
+                      }
+                    }
+                    """),
+            },
+            expectedResult: new()
+            {
+                Path = "",
+                ExpectedProjectCount = 2,
+                Projects = [
+                    new()
+                    {
+                        FilePath = "src/project.csproj",
+                        TargetFrameworks = ["net7.0", "net8.0"],
+                        ExpectedDependencyCount = 2,
+                        Dependencies = [
+                            new("Microsoft.NET.Sdk", null, DependencyType.MSBuildSdk),
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true)
+                        ],
+                        Properties = [
+                            new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
+                            new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
+                            new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
+                        ]
+                    }
+                ],
+                DirectoryPackagesProps = new()
+                {
+                    FilePath = "Directory.Packages.props",
+                    Dependencies = [
+                        new("Some.Package", "9.0.1", DependencyType.PackageVersion, IsDirect: true)
+                    ],
+                },
+                GlobalJson = new()
+                {
+                    FilePath = "global.json",
+                    Dependencies = [
+                        new("Microsoft.NET.Sdk", "6.0.405", DependencyType.MSBuildSdk),
+                        new("My.Custom.Sdk", "5.0.0", DependencyType.MSBuildSdk),
+                        new("My.Other.Sdk", "1.0.0-beta", DependencyType.MSBuildSdk),
+                    ]
+                },
+                DotNetToolsJson = new()
+                {
+                    FilePath = ".config/dotnet-tools.json",
+                    Dependencies = [
+                        new("microsoft.botsay", "1.0.0", DependencyType.DotNetTool),
+                        new("dotnetsay", "2.1.3", DependencyType.DotNetTool),
+                    ]
+                }
+            }
+        );
+    }
+
+    [Fact]
     public async Task NonSupportedProjectExtensionsAreSkipped()
     {
         await TestDiscoveryAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -19,4 +19,18 @@ public class PathHelperTests
         var actual = input.NormalizeUnixPathParts();
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void VerifyResolveCaseInsensitivePath()
+    {
+        var temp = new TemporaryDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "src", "a"));
+        File.WriteAllText(Path.Combine(temp.DirectoryPath, "src", "a", "packages.config"), "");
+
+        var repoRootPath = Path.Combine(temp.DirectoryPath, "src");
+
+        var resolvedPath = PathHelper.ResolveCaseInsensitivePathInsideRepoRoot(Path.Combine(repoRootPath, "A", "PACKAGES.CONFIG"), repoRootPath);
+
+        Assert.Equal(Path.Combine(temp.DirectoryPath, "src", "a", "packages.config"), resolvedPath);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -276,7 +276,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project
             // Ensure file existence is checked case-insensitively
-            var actualProjectPath = ResolveCaseInsensitivePath(projectPath);
+            var actualProjectPath = PathHelper.ResolveCaseInsensitivePathInsideRepoRoot(projectPath, repoRootPath);
             if (actualProjectPath == null)
             {
                 continue;
@@ -333,31 +333,6 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
         return [.. results.Values];
     }
-
-    private static string? ResolveCaseInsensitivePath(string filePath)
-    {
-        // Get directory and file name
-        var directory = Path.GetDirectoryName(filePath);
-        var fileName = Path.GetFileName(filePath);
-
-        if (directory == null || fileName == null || !Directory.Exists(directory))
-        {
-            return null; // Invalid path or directory does not exist
-        }
-
-        try
-        {
-            // Enumerate files in the directory and find a case-insensitive match
-            return Directory
-                .EnumerateFiles(directory)
-                .FirstOrDefault(f => string.Equals(Path.GetFileName(f), fileName, StringComparison.OrdinalIgnoreCase));
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
 
     internal static async Task WriteResultsAsync(string repoRootPath, string outputPath, WorkspaceDiscoveryResult result)
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -104,7 +104,7 @@ internal static class PathHelper
         var normalizedRepoRoot = repoRootPath.FullyNormalizedRootedPath();
 
         // Ensure the file path starts with the repo root path
-        if (!normalizedFilePath.StartsWith(normalizedRepoRoot, StringComparison.OrdinalIgnoreCase))
+        if (!normalizedFilePath.StartsWith(normalizedRepoRoot + "/", StringComparison.OrdinalIgnoreCase))
         {
             return null; // filePath is outside of repoRootPath
         }


### PR DESCRIPTION
### What are you trying to accomplish?
Make file check in DiscoveryWorker case insensitive. This allows projects referenced from solution files to be found even if the case of the file path is different.
<!-- Provide both a what and a _why_ for the change. -->
Currently we have issues where a `.sln` file references a project found on disk but we fail to discover it because the casing is different.

<!-- What issues does this affect or fix? -->
Fixes #10957 

### Anything you want to highlight for special attention from reviewers?
The approach taken was to crawl our way through the directories while and looking for matching names on each section while ignoring casing differences.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
