### PR TITLE
Logger can also be BroadcastLogger

### DIFF
--- a/common/lib/dependabot/logger.rb
+++ b/common/lib/dependabot/logger.rb
@@ -7,12 +7,17 @@ require "sorbet-runtime"
 module Dependabot
   extend T::Sig
 
-  sig { returns(::Logger) }
+  # Rails.logger in the latest versions is an ActiveSupport::BroadcastLogger
+  # which is not a subclass of Logger, but does implement the same interface and
+  # can be used interchangeably.
+  LoggerType = T.type_alias { T.any(::Logger, ActiveSupport::BroadcastLogger) }
+
+  sig { returns(LoggerType) }
   def self.logger
     @logger ||= T.let(::Logger.new(nil), T.nilable(::Logger))
   end
 
-  sig { params(logger: ::Logger).void }
+  sig { params(logger: LoggerType).void }
   def self.logger=(logger)
     @logger = logger
   end


### PR DESCRIPTION
### What are you trying to accomplish?

If we want to set the logger to a rails logger in recent versions of rails, the existing type definition no longer covers that.

### How will you know you've accomplished your goal?

It's a fairly straight-forward case, but I will verify this manually in a rails application on a recent version.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
