### PR TITLE
allow `null` when parsing `job.debug` field

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -60,6 +60,34 @@ public class SerializationTests
     }
 
     [Fact]
+    public void DeserializeJob_DebugIsNull()
+    {
+        // the `debug` field is defined as a `bool`, but can appear as `null` in the wild
+        var jobContent = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "allowed-updates": [
+                  {
+                    "update-type": "all"
+                  }
+                ],
+                "source": {
+                  "provider": "github",
+                  "repo": "some-org/some-repo",
+                  "directory": "specific-sdk",
+                  "hostname": null,
+                  "api-endpoint": null
+                },
+                "debug": null
+              }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jobContent);
+        Assert.False(jobWrapper.Job.Debug);
+    }
+
+    [Fact]
     public void DeserializeJob_FieldsNotYetSupported()
     {
         // the `source` field is required in the C# model; the remaining fields might exist in the JSON file, but are

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -1,9 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record Job
 {
     public string PackageManager { get; init; } = "nuget";
     public AllowedUpdate[]? AllowedUpdates { get; init; } = null;
+
+    [JsonConverter(typeof(NullAsBoolConverter))]
     public bool Debug { get; init; } = false;
     public object[]? DependencyGroups { get; init; } = null;
     public object[]? Dependencies { get; init; } = null;
@@ -45,5 +50,23 @@ public sealed record Job
         {
             yield return "/";
         }
+    }
+}
+
+public class NullAsBoolConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return false;
+        }
+
+        return reader.GetBoolean();
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
     }
 }


### PR DESCRIPTION
When parsing a `job.json` file, the field `$.job.debug` can appear as `null`.  This handles that.

Issue found during a manual audit of telemetry.