### PR TITLE
Remove dedup_branch_names ff and existing_branches array

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -117,9 +117,6 @@ module Dependabot
     sig { returns(T.nilable(T.any(T::Array[String], Integer))) }
     attr_reader :milestone
 
-    sig { returns(T::Array[String]) }
-    attr_reader :existing_branches
-
     sig { returns(String) }
     attr_reader :branch_name_separator
 
@@ -164,7 +161,6 @@ module Dependabot
         reviewers: Reviewers,
         assignees: T.nilable(T.any(T::Array[String], T::Array[Integer])),
         milestone: T.nilable(T.any(T::Array[String], Integer)),
-        existing_branches: T::Array[String],
         branch_name_separator: String,
         branch_name_prefix: String,
         branch_name_max_length: T.nilable(Integer),
@@ -187,8 +183,7 @@ module Dependabot
                    pr_message_header: nil, pr_message_footer: nil,
                    custom_labels: nil, author_details: nil, signature_key: nil,
                    commit_message_options: {}, vulnerabilities_fixed: {},
-                   reviewers: nil, assignees: nil, milestone: nil,
-                   existing_branches: [], branch_name_separator: "/",
+                   reviewers: nil, assignees: nil, milestone: nil, branch_name_separator: "/",
                    branch_name_prefix: "dependabot", branch_name_max_length: nil,
                    label_language: false, automerge_candidate: false,
                    github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,
@@ -210,7 +205,6 @@ module Dependabot
       @assignees                  = assignees
       @milestone                  = milestone
       @vulnerabilities_fixed      = vulnerabilities_fixed
-      @existing_branches          = existing_branches
       @branch_name_separator      = branch_name_separator
       @branch_name_prefix         = branch_name_prefix
       @branch_name_max_length     = branch_name_max_length
@@ -404,7 +398,6 @@ module Dependabot
           files: files,
           target_branch: source.branch,
           dependency_group: dependency_group,
-          existing_branches: existing_branches,
           separator: branch_name_separator,
           prefix: branch_name_prefix,
           max_length: branch_name_max_length,

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -23,9 +23,6 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :target_branch
 
-      sig { returns(T::Array[String]) }
-      attr_reader :existing_branches
-
       sig { returns(String) }
       attr_reader :separator
 
@@ -47,7 +44,6 @@ module Dependabot
           files: T::Array[Dependabot::DependencyFile],
           target_branch: T.nilable(String),
           dependency_group: T.nilable(Dependabot::DependencyGroup),
-          existing_branches: T::Array[String],
           separator: String,
           prefix: String,
           max_length: T.nilable(Integer),
@@ -55,13 +51,12 @@ module Dependabot
         )
           .void
       end
-      def initialize(dependencies:, files:, target_branch:, dependency_group: nil, existing_branches: [],
-                     separator: "/", prefix: "dependabot", max_length: nil, includes_security_fixes: false)
+      def initialize(dependencies:, files:, target_branch:, dependency_group: nil, separator: "/", 
+                     prefix: "dependabot", max_length: nil, includes_security_fixes: false)
         @dependencies  = dependencies
         @files         = files
         @target_branch = target_branch
         @dependency_group = dependency_group
-        @existing_branches = existing_branches
         @separator     = separator
         @prefix        = prefix
         @max_length    = max_length
@@ -77,19 +72,12 @@ module Dependabot
 
       sig { returns(Dependabot::PullRequestCreator::BranchNamer::Base) }
       def strategy
-        if Dependabot::Experiments.enabled?(:dedup_branch_names) && existing_branches
-          Dependabot.logger.debug(
-            "Dependabot::PullRequestCreator::strategy : #{existing_branches}"
-          )
-        end
-
         @strategy ||= T.let(
           if dependency_group.nil?
             SoloStrategy.new(
               dependencies: dependencies,
               files: files,
               target_branch: target_branch,
-              existing_branches: existing_branches,
               separator: separator,
               prefix: prefix,
               max_length: max_length
@@ -101,7 +89,6 @@ module Dependabot
               target_branch: target_branch,
               dependency_group: T.must(dependency_group),
               includes_security_fixes: includes_security_fixes,
-              existing_branches: existing_branches,
               separator: separator,
               prefix: prefix,
               max_length: max_length

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -51,7 +51,7 @@ module Dependabot
         )
           .void
       end
-      def initialize(dependencies:, files:, target_branch:, dependency_group: nil, separator: "/", 
+      def initialize(dependencies:, files:, target_branch:, dependency_group: nil, separator: "/",
                      prefix: "dependabot", max_length: nil, includes_security_fixes: false)
         @dependencies  = dependencies
         @files         = files

--- a/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
@@ -38,7 +38,7 @@ module Dependabot
           )
             .void
         end
-        def initialize(dependencies:, files:, target_branch:, separator: "/", 
+        def initialize(dependencies:, files:, target_branch:, separator: "/",
                        prefix: "dependabot", max_length: nil)
           @dependencies      = dependencies
           @files             = files

--- a/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
@@ -18,9 +18,6 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         attr_reader :target_branch
 
-        sig { returns(T::Array[String]) }
-        attr_reader :existing_branches
-
         sig { returns(String) }
         attr_reader :separator
 
@@ -35,19 +32,17 @@ module Dependabot
             dependencies: T::Array[Dependency],
             files: T::Array[DependencyFile],
             target_branch: T.nilable(String),
-            existing_branches: T::Array[String],
             separator: String,
             prefix: String,
             max_length: T.nilable(Integer)
           )
             .void
         end
-        def initialize(dependencies:, files:, target_branch:, existing_branches: [],
-                       separator: "/", prefix: "dependabot", max_length: nil)
+        def initialize(dependencies:, files:, target_branch:, separator: "/", 
+                       prefix: "dependabot", max_length: nil)
           @dependencies      = dependencies
           @files             = files
           @target_branch     = target_branch
-          @existing_branches = existing_branches
           @separator         = separator
           @prefix            = prefix
           @max_length        = max_length

--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -17,7 +17,6 @@ module Dependabot
             target_branch: T.nilable(String),
             dependency_group: Dependabot::DependencyGroup,
             includes_security_fixes: T::Boolean,
-            existing_branches: T::Array[String],
             separator: String,
             prefix: String,
             max_length: T.nilable(Integer)
@@ -25,12 +24,11 @@ module Dependabot
             .void
         end
         def initialize(dependencies:, files:, target_branch:, dependency_group:, includes_security_fixes:,
-                       existing_branches: [], separator: "/", prefix: "dependabot", max_length: nil)
+                       separator: "/", prefix: "dependabot", max_length: nil)
           super(
             dependencies: dependencies,
             files: files,
             target_branch: target_branch,
-            existing_branches: existing_branches,
             separator: separator,
             prefix: prefix,
             max_length: max_length,

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -11,6 +11,7 @@ require "dependabot/pull_request_creator/commit_signer"
 
 module Dependabot
   class PullRequestCreator
+    # rubocop:disable Metrics/ClassLength
     class Github
       extend T::Sig
 
@@ -600,5 +601,6 @@ module Dependabot
         end
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -11,7 +11,6 @@ require "dependabot/pull_request_creator/commit_signer"
 
 module Dependabot
   class PullRequestCreator
-    # rubocop:disable Metrics/ClassLength
     class Github
       extend T::Sig
 
@@ -114,7 +113,7 @@ module Dependabot
           "Initiating Github pull request."
         )
 
-        if experiment_duplicate_branch? && branch_exists?(branch_name) && no_pull_request_exists?
+        if branch_exists?(branch_name) && no_pull_request_exists?
           Dependabot.logger.info(
             "Existing branch \"#{branch_name}\" found. Pull request not created."
           )
@@ -600,12 +599,6 @@ module Dependabot
           raise type, message
         end
       end
-
-      sig { returns(T::Boolean) }
-      def experiment_duplicate_branch?
-        Dependabot::Experiments.enabled?(:dedup_branch_names)
-      end
     end
-    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
   let(:previous_version) { "1.4.0" }
   let(:files) { [gemfile] }
   let(:target_branch) { nil }
-  let(:existing_branches) { [] }
 
   let(:gemfile) do
     Dependabot::DependencyFile.new(

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -615,14 +615,6 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
     context "when the branch already exists" do
       let(:service_pack_response) { fixture("git", "upload_packs", "existing-branch-with-no-pr") }
 
-      before do
-        Dependabot::Experiments.register(:dedup_branch_names, true)
-      end
-
-      after do
-        Dependabot::Experiments.register(:dedup_branch_names, false)
-      end
-
       context "when the branch already exists" do
         before do
           url = "#{repo_api_url}/pulls?head=gocardless:#{branch_name}" \

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -485,19 +485,10 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
           )
         end
 
-        it "creates a PR with the right details" do
-          creator.create
-
-          expect(WebMock)
-            .to have_requested(:post, "#{repo_api_url}/pulls")
-            .with(
-              body: {
-                base: "master",
-                head: "dependabot/bundler/business-1.5.0",
-                title: "PR name",
-                body: "PR msg"
-              }
-            )
+        it "raises a helpful error" do
+          expect { creator.create }
+            .to raise_error(Dependabot::PullRequestCreator::BranchAlreadyExists, /business-1.5.0 already exists/)
+          expect(WebMock).not_to have_requested(:post, "#{repo_api_url}/pulls")
         end
       end
 
@@ -537,9 +528,10 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
               )
           end
 
-          it "raises the error" do
+          it "raises a helpful error" do
             expect { creator.create }
-              .to raise_error(Octokit::UnprocessableEntity)
+              .to raise_error(Dependabot::PullRequestCreator::BranchAlreadyExists, /business-1.5.0 already exists/)
+            expect(WebMock).not_to have_requested(:post, "#{repo_api_url}/pulls")
           end
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the `dedup_branch_names` ff and existing_branches array
They are no longer being used

### Anything you want to highlight for special attention from reviewers?

n/a

### How will you know you've accomplished your goal?

No job logs about existing branches

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
