### PR TITLE
Add `npm_and_yarn` package managers' requirements to ecosystem metrics

### DIFF
--- a/common/lib/dependabot/requirement.rb
+++ b/common/lib/dependabot/requirement.rb
@@ -62,9 +62,9 @@ module Dependabot
     sig { params(operator: String, version: Dependabot::Version).returns(T.nilable(Dependabot::Version)) }
     def handle_min_operator(operator, version)
       case operator
-      when ">=" then handle_gte_min(version)
-      when ">"  then handle_gt_min(version)
-      when "~>" then handle_tilde_pessimistic_min(version)
+      when ">=" then handle_greater_than_or_equal_for_min(version)
+      when ">"  then handle_greater_than_for_min(version)
+      when "~>" then handle_tilde_pessimistic_for_min(version)
       end
     end
 
@@ -72,36 +72,36 @@ module Dependabot
     sig { params(operator: String, version: Dependabot::Version).returns(T.nilable(Dependabot::Version)) }
     def handle_max_operator(operator, version)
       case operator
-      when "<=" then handle_lte_max(version)
-      when "<"  then handle_lt_max(version)
+      when "<=" then handle_less_than_or_equal_for_max(version)
+      when "<"  then handle_less_than_max(version)
       when "~>" then handle_tilde_pessimistic_max(version)
       end
     end
 
     # Methods for handling minimum constraints
     sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
-    def handle_gte_min(version)
+    def handle_greater_than_or_equal_for_min(version)
       version
     end
 
     sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
-    def handle_gt_min(version)
+    def handle_greater_than_for_min(version)
       version
     end
 
     sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
-    def handle_tilde_pessimistic_min(version)
+    def handle_tilde_pessimistic_for_min(version)
       version
     end
 
     # Methods for handling maximum constraints
     sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
-    def handle_lte_max(version)
+    def handle_less_than_or_equal_for_max(version)
       version
     end
 
     sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
-    def handle_lt_max(version)
+    def handle_less_than_max(version)
       version
     end
 

--- a/common/lib/dependabot/requirement.rb
+++ b/common/lib/dependabot/requirement.rb
@@ -34,11 +34,13 @@ module Dependabot
       # Select constraints with minimum operators
       min_constraints = requirements.select { |op, _| MINIMUM_OPERATORS.include?(op) }
 
-      # Choose the maximum version among the minimum constraints
-      max_min_constraint = min_constraints.max_by { |_, version| version }
+      # Process each minimum constraint using the respective handler
+      effective_min_versions = min_constraints.filter_map do |op, version|
+        handle_min_operator(op, version.is_a?(Dependabot::Version) ? version : Dependabot::Version.new(version))
+      end
 
-      # Return the version part of the max constraint, if it exists
-      Dependabot::Version.new(max_min_constraint&.last) if max_min_constraint&.last
+      # Return the maximum among the effective minimum constraints
+      Dependabot::Version.new(effective_min_versions.max) if effective_min_versions.any?
     end
 
     # Returns the lowest upper limit among all maximum constraints.
@@ -47,28 +49,89 @@ module Dependabot
       # Select constraints with maximum operators
       max_constraints = requirements.select { |op, _| MAXIMUM_OPERATORS.include?(op) }
 
-      # Process each maximum constraint, handling "~>" constraints based on length
-      effective_max_versions = max_constraints.map do |op, version|
-        if op == "~>"
-          # If "~>" constraint, bump based on the specificity of the version
-          case version.segments.length
-          when 1
-            # Bump major version (e.g., 2 -> 3.0.0)
-            Dependabot::Version.new((version.segments[0].to_i + 1).to_s + ".0.0")
-          when 2
-            # Bump minor version (e.g., 2.5 -> 2.6.0)
-            Dependabot::Version.new("#{version.segments[0]}.#{version.segments[1] + 1}.0")
-          else
-            # For three or more segments, use version.bump
-            version.bump # e.g., "~> 2.9.9" becomes upper bound 3.0.0
-          end
-        else
-          version
-        end
+      # Process each maximum constraint using the respective handler
+      effective_max_versions = max_constraints.filter_map do |op, version|
+        handle_max_operator(op, version.is_a?(Dependabot::Version) ? version : Dependabot::Version.new(version))
       end
 
-      # Return the smallest among the effective maximum constraints
-      Dependabot::Version.new(effective_max_versions.min) if effective_max_versions.min
+      # Return the minimum among the effective maximum constraints
+      Dependabot::Version.new(effective_max_versions.min) if effective_max_versions.any?
+    end
+
+    # Dynamically handles minimum operators
+    sig { params(operator: String, version: Dependabot::Version).returns(T.nilable(Dependabot::Version)) }
+    def handle_min_operator(operator, version)
+      case operator
+      when ">=" then handle_gte_min(version)
+      when ">"  then handle_gt_min(version)
+      when "~>" then handle_tilde_pessimistic_min(version)
+      end
+    end
+
+    # Dynamically handles maximum operators
+    sig { params(operator: String, version: Dependabot::Version).returns(T.nilable(Dependabot::Version)) }
+    def handle_max_operator(operator, version)
+      case operator
+      when "<=" then handle_lte_max(version)
+      when "<"  then handle_lt_max(version)
+      when "~>" then handle_tilde_pessimistic_max(version)
+      end
+    end
+
+    # Methods for handling minimum constraints
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_gte_min(version)
+      version
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_gt_min(version)
+      version
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_tilde_pessimistic_min(version)
+      version
+    end
+
+    # Methods for handling maximum constraints
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_lte_max(version)
+      version
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_lt_max(version)
+      version
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def handle_tilde_pessimistic_max(version)
+      case version.segments.length
+      when 1
+        bump_major_segment(version)
+      when 2
+        bump_minor_segment(version)
+      else
+        bump_version(version)
+      end
+    end
+
+    private
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def bump_major_segment(version)
+      Dependabot::Version.new("#{version.segments[0].to_i + 1}.0.0")
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def bump_minor_segment(version)
+      Dependabot::Version.new("#{version.segments[0]}.#{version.segments[1].to_i + 1}.0")
+    end
+
+    sig { params(version: Dependabot::Version).returns(Dependabot::Version) }
+    def bump_version(version)
+      Dependabot::Version.new(version.bump)
     end
   end
 end

--- a/common/spec/dependabot/requirement_spec.rb
+++ b/common/spec/dependabot/requirement_spec.rb
@@ -110,4 +110,70 @@ RSpec.describe Dependabot::Requirement do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#handle_min_operator" do
+    subject(:min_operator_result) { requirement.handle_min_operator(operator, version) }
+
+    let(:version) { Dependabot::Version.new("1.5.0") }
+
+    context "when operator is '>='" do
+      let(:operator) { ">=" }
+      let(:constraint_string) { ">= 1.5.0" }
+
+      it "returns the version itself" do
+        expect(min_operator_result).to eq(version)
+      end
+    end
+
+    context "when operator is '>'" do
+      let(:operator) { ">" }
+      let(:constraint_string) { "> 1.5.0" }
+
+      it "returns the version itself" do
+        expect(min_operator_result).to eq(version)
+      end
+    end
+
+    context "when operator is '~>'" do
+      let(:operator) { "~>" }
+      let(:constraint_string) { "~> 1.5.0" }
+
+      it "returns the version itself" do
+        expect(min_operator_result).to eq(version)
+      end
+    end
+  end
+
+  describe "#handle_max_operator" do
+    subject(:max_operator_result) { requirement.handle_max_operator(operator, version) }
+
+    let(:version) { Dependabot::Version.new("1.5.0") }
+
+    context "when operator is '<='" do
+      let(:operator) { "<=" }
+      let(:constraint_string) { "<= 1.5.0" }
+
+      it "returns the version itself" do
+        expect(max_operator_result).to eq(version)
+      end
+    end
+
+    context "when operator is '<'" do
+      let(:operator) { "<" }
+      let(:constraint_string) { "< 1.5.0" }
+
+      it "returns the version itself" do
+        expect(max_operator_result).to eq(version)
+      end
+    end
+
+    context "when operator is '~>'" do
+      let(:operator) { "~>" }
+      let(:constraint_string) { "~> 1.5.0" }
+
+      it "returns the effective upper bound of the '~>' constraint" do
+        expect(max_operator_result).to eq(Dependabot::Version.new("1.6.0"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds the ability to extract and report package manager version constraints for `npm`, `pnpm`, and `yarn` from the `engines` field in the `package.json` manifest file.

By including these constraints, the ecosystem metrics now provide better visibility into the range of supported package manager versions used in projects.

### What issues does this affect or fix?

This PR enhances ecosystem metrics tracking for the `npm_and_yarn` ecosystem by introducing package manager version requirement collection and normalization for `npm`, `pnpm`, and `yarn`.

### Anything you want to highlight for special attention from reviewers?

- Review the extraction logic for the `engines` field to ensure it handles constraints properly for `npm`, `pnpm`, and `yarn`.
- Validate that the conversion logic accurately transforms raw versions like `1.3.4` into `=1.3.4`.
- Consider edge cases where the `engines` field may contain incomplete or malformed version constraints.

### How will you know you've accomplished your goal?

- The extracted package manager constraints for `npm`, `pnpm`, and `yarn` are correctly represented in the ecosystem metrics.
- All tests pass, including new tests that cover the extraction and conversion logic.
- The system handles invalid or edge-case `engines` fields gracefully.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
