### PR TITLE
Handle paths with multiple case-insenstive matches on disk.

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -280,7 +280,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                       EndGlobalSection
                     EndGlobal
                     """)
-                     
+
             },
             expectedResult: new()
             {
@@ -300,7 +300,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                     },
                     new()
                     {
-                        FilePath = "TEST/project2/project2.csproj", 
+                        FilePath = "TEST/project2/project2.csproj",
                         TargetFrameworks = ["net8.0"],
                         ReferencedProjectPaths = [],
                         Dependencies = [
@@ -314,7 +314,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
-    
+
     [Fact]
     public async Task TestDependenciesSeparatedBySemicolonWithWhitespace()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -307,7 +307,9 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFramework", "net8.0", "src/test/project1/project1.csproj"),
-                        ]
+                        ],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                     new()
                     {
@@ -319,7 +321,9 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFramework", "net8.0", "src/TEST/project2/project2.csproj"),
-                        ]
+                        ],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -227,8 +227,8 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         );
     }
 
-    [Fact]
-    public async Task TestDependenciesMultiplePaths_WithSameName()
+    [LinuxOnlyFact]
+    public async Task TestDependenciesCaseSensitiveProjectPaths()
     {
         await TestDiscoveryAsync(
             packages:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LinuxOnlyAttribute.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LinuxOnlyAttribute.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+public class LinuxOnlyFactAttribute : FactAttribute
+{
+    public LinuxOnlyFactAttribute()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            Skip = "This test runs only on Linux.";
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -41,11 +41,9 @@ public class PathHelperTests
         using var temp = new TemporaryDirectory();
         Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "src", "a"));
         Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "src", "A"));
-        Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "SRC", "a"));
 
         File.WriteAllText(Path.Combine(temp.DirectoryPath, "src", "a", "packages.config"), "");
         File.WriteAllText(Path.Combine(temp.DirectoryPath, "src", "A", "packages.config"), "");
-        File.WriteAllText(Path.Combine(temp.DirectoryPath, "SRC", "a", "packages.config"), "");
 
         var repoRootPath = Path.Combine(temp.DirectoryPath, "src");
 
@@ -55,7 +53,6 @@ public class PathHelperTests
         {
             Path.Combine(temp.DirectoryPath, "src", "a", "packages.config").NormalizePathToUnix(),
             Path.Combine(temp.DirectoryPath, "src", "A", "packages.config").NormalizePathToUnix(),
-            Path.Combine(temp.DirectoryPath, "SRC", "a", "packages.config").NormalizePathToUnix(),
         };
 
         Assert.Equal(expected, resolvedPaths!);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -35,7 +35,7 @@ public class PathHelperTests
         Assert.Equal(expected, resolvedPath!.First());
     }
 
-    [Fact]
+    [LinuxOnlyFact]
     public void VerifyMultipleMatchingPathsReturnsAllPaths()
     {
         using var temp = new TemporaryDirectory();
@@ -58,7 +58,7 @@ public class PathHelperTests
         Assert.Equal(expected, resolvedPaths!);
     }
 
-    [Fact]
+    [LinuxOnlyFact]
     public async void FilesWithDifferentlyCasedDirectoriesCanBeResolved()
     {
         // arrange

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -57,4 +57,26 @@ public class PathHelperTests
 
         Assert.Equal(expected, resolvedPaths!);
     }
+
+    [Fact]
+    public async void FilesWithDifferentlyCasedDirectoriesCanBeResolved()
+    {
+        // arrange
+        using var temp = new TemporaryDirectory();
+        var testFile1 = "src/project1/project1.csproj";
+        var testFile2 = "SRC/project2/project2.csproj";
+        var testFiles = new[] { testFile1, testFile2 };
+        foreach (var testFile in testFiles) 
+        {
+            var fullPath = Path.Join(temp.DirectoryPath, testFile); Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            await File.WriteAllTextAsync(fullPath, "");
+        }
+
+        // act        
+        var actualFile1 = PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(Path.Join(temp.DirectoryPath, testFile1), temp.DirectoryPath);
+        var actualFile2 = PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(Path.Join(temp.DirectoryPath, testFile2), temp.DirectoryPath);
+
+        // assert        
+        Assert.EndsWith(testFile1, actualFile1![0]); Assert.EndsWith(testFile2, actualFile2![0]);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -29,9 +29,35 @@ public class PathHelperTests
 
         var repoRootPath = Path.Combine(temp.DirectoryPath, "src");
 
-        var resolvedPath = PathHelper.ResolveCaseInsensitivePathInsideRepoRoot(Path.Combine(repoRootPath, "A", "PACKAGES.CONFIG"), repoRootPath);
+        var resolvedPath = PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(Path.Combine(repoRootPath, "A", "PACKAGES.CONFIG"), repoRootPath);
 
         var expected = Path.Combine(temp.DirectoryPath, "src", "a", "packages.config").NormalizePathToUnix();
-        Assert.Equal(expected, resolvedPath);
+        Assert.Equal(expected, resolvedPath!.First());
+    }
+
+    [Fact]
+    public void VerifyMultipleMatchingPathsReturnsAllPaths()
+    {
+        using var temp = new TemporaryDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "src", "a"));
+        Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "src", "A"));
+        Directory.CreateDirectory(Path.Combine(temp.DirectoryPath, "SRC", "a"));
+
+        File.WriteAllText(Path.Combine(temp.DirectoryPath, "src", "a", "packages.config"), "");
+        File.WriteAllText(Path.Combine(temp.DirectoryPath, "src", "A", "packages.config"), "");
+        File.WriteAllText(Path.Combine(temp.DirectoryPath, "SRC", "a", "packages.config"), "");
+
+        var repoRootPath = Path.Combine(temp.DirectoryPath, "src");
+
+        var resolvedPaths = PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(Path.Combine(repoRootPath, "A", "PACKAGES.CONFIG"), repoRootPath);
+
+        var expected = new[]
+        {
+            Path.Combine(temp.DirectoryPath, "src", "a", "packages.config").NormalizePathToUnix(),
+            Path.Combine(temp.DirectoryPath, "src", "A", "packages.config").NormalizePathToUnix(),
+            Path.Combine(temp.DirectoryPath, "SRC", "a", "packages.config").NormalizePathToUnix(),
+        };
+
+        Assert.Equal(expected, resolvedPaths!);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -66,7 +66,7 @@ public class PathHelperTests
         var testFile1 = "src/project1/project1.csproj";
         var testFile2 = "SRC/project2/project2.csproj";
         var testFiles = new[] { testFile1, testFile2 };
-        foreach (var testFile in testFiles) 
+        foreach (var testFile in testFiles)
         {
             var fullPath = Path.Join(temp.DirectoryPath, testFile); Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
             await File.WriteAllTextAsync(fullPath, "");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -18,7 +18,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
     private readonly ExperimentsManager _experimentsManager;
     private readonly ILogger _logger;
-    private readonly HashSet<string> _processedProjectPaths = new(StringComparer.OrdinalIgnoreCase); private readonly HashSet<string> _restoredMSBuildSdks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _processedProjectPaths = new(StringComparer.Ordinal); private readonly HashSet<string> _restoredMSBuildSdks = new(StringComparer.OrdinalIgnoreCase);
 
     internal static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -277,7 +277,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
     private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForProjectPathsAsync(string repoRootPath, string workspacePath, IEnumerable<string> projectPaths)
     {
-        var results = new Dictionary<string, ProjectDiscoveryResult>(StringComparer.OrdinalIgnoreCase);
+        var results = new Dictionary<string, ProjectDiscoveryResult>(StringComparer.Ordinal);
         foreach (var projectPath in projectPaths)
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project
@@ -295,6 +295,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 {
                     continue;
                 }
+                
                 _processedProjectPaths.Add(actualProjectPath);
 
                 var relativeProjectPath = Path.GetRelativePath(workspacePath, actualProjectPath).NormalizePathToUnix();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -295,7 +295,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 {
                     continue;
                 }
-                
+
                 _processedProjectPaths.Add(actualProjectPath);
 
                 var relativeProjectPath = Path.GetRelativePath(workspacePath, actualProjectPath).NormalizePathToUnix();


### PR DESCRIPTION
After a previous change we encountered issues when trying to resolve paths with different casing. The previous implementation assumed only one path would match after doing a case-insensitive search. We later encountered a case where there was more than one match. 

The revised version returns a list of a strings (paths) and then changes the discovery worker to be case-sensitive and loop over the found paths.