### PR TITLE
remove duplicate TFMs when considering updates

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -391,8 +391,8 @@ public partial class AnalyzeWorker : IAnalyzeWorker
 
         var projectFrameworks = projectsWithDependency
             .SelectMany(p => p.TargetFrameworks)
-            .Distinct()
             .Select(NuGetFramework.Parse)
+            .Distinct()
             .ToImmutableArray();
 
         // When updating peer dependencies, we only need to consider top-level dependencies.


### PR DESCRIPTION
When considering package updates, we call `.Distinct()` on the `string` version of the target frameworks.  These can differ by case, e.g., `net8.0` vs `NET8.0` which will result in duplicates further on in the analysis process.  These can also differ in form, but not function, e.g., `net48` vs `.NETFramework,Version=v4.8`.  Because of this the call to `.Distinct()` was moved to be after the conversion to a proper framework value.