### PR TITLE
project discovery reports its own imported and additional files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
@@ -94,7 +94,9 @@ public partial class EntryPointTests
                               "TargetFrameworks": [
                                 "net8.0"
                               ],
-                              "ReferencedProjectPaths": []
+                              "ReferencedProjectPaths": [],
+                              "ImportedFiles": [],
+                              "AdditionalFiles": []
                             }
                           ],
                           "DirectoryPackagesProps": null,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
@@ -66,6 +66,9 @@ public partial class EntryPointTests
                             Properties = [
                                 new("TargetFramework", "net8.0", "path/to/some directory with spaces/project.csproj"),
                             ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -156,6 +159,11 @@ public partial class EntryPointTests
                                 new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
                             ],
                             Properties = [],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.config"
+                            ],
                         }
                     ]
                 }
@@ -223,6 +231,11 @@ public partial class EntryPointTests
                                 new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
                             ],
                             Properties = [],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.config"
+                            ],
                         }
                     ]
                 }
@@ -291,6 +304,11 @@ public partial class EntryPointTests
                                 new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"])
                             ],
                             Properties = [],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.config"
+                            ],
                         }
                     ]
                 }
@@ -359,11 +377,13 @@ public partial class EntryPointTests
                                 new("ManagePackageVersionsCentrally", "false", "path/to/my.csproj"),
                                 new("TargetFramework", "net8.0", "path/to/my.csproj"),
                             ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "../Directory.Build.props"
+                            ],
+                            AdditionalFiles = [],
                         }
                     ],
-                    ImportedFiles = [
-                        "Directory.Build.props"
-                    ]
                 }
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -32,6 +32,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -80,6 +83,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                             new("Some.Package", "4.0.1", DependencyType.PackageReference),
                             new("Some.Transitive.Dependency", "4.0.1", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -129,6 +135,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Transitive.Dependency", "4.0.1", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                     new()
                     {
@@ -137,6 +146,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "4.0.1", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -187,6 +199,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Package.A", "4.5.0", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                     new()
                     {
@@ -195,6 +210,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Package.B", "4.5.0", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -241,6 +259,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Transitive.Dependency", "$(MissingPackageVersion)", DependencyType.PackageReference, EvaluationResult: new EvaluationResult(EvaluationResultType.PropertyNotFound, "$(MissingPackageVersion)", "$(MissingPackageVersion)", "$(MissingPackageVersion)", ErrorMessage: null)),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -281,6 +302,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference), // this was found in the source, but doesn't exist in any feed
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -326,6 +350,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Transitive.Dependency", "4.0.1", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -366,7 +393,10 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                     new()
                     {
@@ -374,7 +404,10 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         TargetFrameworks = ["NET8.0"],
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },
@@ -418,6 +451,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     },
                 ],
             },
@@ -585,7 +621,10 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies =
                         [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },
@@ -754,7 +793,10 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies =
                         [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },
@@ -939,7 +981,10 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies =
                         [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },
@@ -1049,6 +1094,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.2.3", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },
@@ -1167,6 +1215,9 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference),
                         ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -43,7 +43,6 @@ public class DiscoveryWorkerTestBase : TestBase
         ValidateResultWithDependencies(expectedResult.GlobalJson, actualResult.GlobalJson);
         ValidateResultWithDependencies(expectedResult.DotNetToolsJson, actualResult.DotNetToolsJson);
         ValidateProjectResults(expectedResult.Projects, actualResult.Projects, experimentsManager);
-        AssertEx.Equal(expectedResult.ImportedFiles, actualResult.ImportedFiles, PathComparer.Instance);
         Assert.Equal(expectedResult.ExpectedProjectCount ?? expectedResult.Projects.Length, actualResult.Projects.Length);
         Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
         Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
@@ -92,10 +91,8 @@ public class DiscoveryWorkerTestBase : TestBase
             AssertEx.Equal(expectedProject.Properties, actualProperties, PropertyComparer.Instance);
             AssertEx.Equal(expectedProject.TargetFrameworks, actualProject.TargetFrameworks);
             AssertEx.Equal(expectedProject.ReferencedProjectPaths, actualProject.ReferencedProjectPaths);
-            if (expectedProject.ImportedFiles is not null)
-            {
-                AssertEx.Equal(expectedProject.ImportedFiles.Value.Select(PathHelper.NormalizePathToUnix), actualProject.ImportedFiles.Select(PathHelper.NormalizePathToUnix));
-            }
+            AssertEx.Equal(expectedProject.ImportedFiles, actualProject.ImportedFiles);
+            AssertEx.Equal(expectedProject.AdditionalFiles, actualProject.AdditionalFiles);
 
             // some dependencies are byproducts of the older temporary project discovery process and shouldn't be returned
             var actualDependencies = actualProject.Dependencies;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -30,6 +30,9 @@ public partial class DiscoveryWorkerTests
                           <PropertyGroup>
                             <TargetFramework>net46</TargetFramework>
                           </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
                         </Project>
                         """)
                 ],
@@ -47,6 +50,11 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
                                 new("Package.B", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.config"
                             ],
                         }
                     ],
@@ -78,6 +86,9 @@ public partial class DiscoveryWorkerTests
                           <PropertyGroup>
                             <TargetFramework>net46</TargetFramework>
                           </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
                         </Project>
                         """)
                 ],
@@ -93,6 +104,11 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
                                 new("Package.B", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.config"
                             ],
                         }
                     ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Proj.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Proj.cs
@@ -73,6 +73,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "src/project1/project1.csproj")
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         },
                         new()
                         {
@@ -86,6 +89,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "src/project2/project2.csproj")
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -57,11 +57,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0"], // net8.0 has no packages and is not reported
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props",
+                                "Directory.Packages.props",
+                            ],
+                            AdditionalFiles = [],
                         },
-                    ],
-                    ImportedFiles = [
-                        "Directory.Build.props",
-                        "Directory.Packages.props",
                     ],
                 }
             );
@@ -119,11 +121,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0", "net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props",
+                                "Directory.Packages.props",
+                            ],
+                            AdditionalFiles = [],
                         },
-                    ],
-                    ImportedFiles = [
-                        "Directory.Build.props",
-                        "Directory.Packages.props",
                     ],
                 }
             );
@@ -187,11 +191,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props",
+                                "Directory.Build.targets",
+                            ],
+                            AdditionalFiles = [],
                         }
-                    ],
-                    ImportedFiles = [
-                        "Directory.Build.props",
-                        "Directory.Build.targets"
                     ],
                 }
             );
@@ -255,11 +261,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props",
+                                "Directory.Build.targets"
+                            ],
+                            AdditionalFiles = [],
                         }
-                    ],
-                    ImportedFiles = [
-                        "Directory.Build.props",
-                        "Directory.Build.targets"
                     ],
                 }
             );
@@ -308,11 +316,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Packages.props"
+                            ],
+                            AdditionalFiles = [],
                         },
                     ],
-                    ImportedFiles = [
-                        "Directory.Packages.props",
-                    ]
                 }
             );
         }
@@ -360,11 +370,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Packages.props"
+                            ],
+                            AdditionalFiles = [],
                         },
                     ],
-                    ImportedFiles = [
-                        "Directory.Packages.props",
-                    ]
                 }
             );
         }
@@ -426,14 +438,16 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net7.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.targets",
+                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
+                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
+                                "Packages.props",
+                            ],
+                            AdditionalFiles = [],
                         },
                     ],
-                    ImportedFiles = [
-                        "Directory.Build.targets",
-                        "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
-                        "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
-                        "Packages.props",
-                    ]
                 }
             );
         }
@@ -496,14 +510,16 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net7.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.targets",
+                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
+                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
+                                "Packages.props",
+                            ],
+                            AdditionalFiles = [],
                         },
                     ],
-                    ImportedFiles = [
-                        "Directory.Build.targets",
-                        "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
-                        "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
-                        "Packages.props",
-                    ]
                 }
             );
         }
@@ -547,6 +563,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ],
                 }
@@ -592,6 +611,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ],
                 }
@@ -641,9 +663,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props"
+                            ],
+                            AdditionalFiles = [],
                         }
                     ],
-                    ImportedFiles = ["Directory.Build.props"],
                 }
             );
         }
@@ -692,9 +718,13 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "$(SomeTfm)", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props"
+                            ],
+                            AdditionalFiles = [],
                         }
                     ],
-                    ImportedFiles = ["Directory.Build.props"],
                 }
             );
         }
@@ -765,6 +795,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -812,6 +845,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0", "net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ],
                 }
@@ -857,6 +893,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0", "net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ],
                 }
@@ -918,6 +957,8 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", @"test/unit-tests.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         },
                         new()
                         {
@@ -929,6 +970,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", @"src/helpers.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -989,6 +1033,8 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", @"test/unit-tests.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         },
                         new()
                         {
@@ -1000,6 +1046,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", @"src/helpers.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -1062,6 +1111,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFramework", "net8.0", @"projects/library.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -1108,6 +1160,9 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst", @"src/project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 }
@@ -1151,6 +1206,62 @@ public partial class DiscoveryWorkerTests
                                 new("TargetFrameworks", "net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst", @"src/project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ]
+                }
+            );
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task PackageLockJsonFileIsReported(bool useDirectDiscovery)
+        {
+            await TestDiscoveryAsync(
+                experimentsManager: new ExperimentsManager() { UseDirectDiscovery = useDirectDiscovery },
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3", "net8.0"),
+                ],
+                workspacePath: "src",
+                files:
+                [
+                    ("src/project.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net8.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="1.2.3" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("src/packages.lock.json", """
+                        {}
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
+                            ],
+                            Properties = [
+                                new("TargetFramework", "net8.0", "src/project.csproj"),
+                            ],
+                            TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "packages.lock.json"
+                            ],
                         }
                     ]
                 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -65,7 +65,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Properties = [
                             new("SomePackageVersion", "9.0.1", projectPath),
                             new("TargetFramework", "net8.0", projectPath),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }
@@ -111,7 +114,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFramework", "net472", "src/project.csproj"),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }
@@ -160,7 +166,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Properties = [
                             new("SomePackageVersion", "9.0.1", "src/project.csproj"),
                             new("TargetFramework", "net8.0", "src/project.csproj"),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }
@@ -209,7 +218,9 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Properties = [
                             new("SomePackageVersion", "9.0.1", "src/project.csproj"),
                             new("TargetFramework", "net8.0", "src/project.csproj"),
-                        ]
+                        ],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }
@@ -258,7 +269,9 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Properties = [
                             new("SomePackageVersion", "9.0.1", "src/project.csproj"),
                             new("TargetFramework", "net8.0", "src/project.csproj"),
-                        ]
+                        ],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }
@@ -315,7 +328,12 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
                         ],
-                        Properties = []
+                        Properties = [],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [
+                            "packages.config",
+                        ],
                     }
                 ]
             }
@@ -372,13 +390,15 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFramework", "net8.0", "src/project.csproj")
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
                     }
                 ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props",
-                ]
             }
         );
     }
@@ -435,13 +455,15 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                             new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
                             new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
                             new("TargetFramework", "net8.0", "src/project.csproj")
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
                     }
                 ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props",
-                ]
             }
         );
     }
@@ -553,12 +575,14 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj")
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
                     }
-                ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props",
                 ],
                 GlobalJson = new()
                 {
@@ -656,13 +680,15 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                             new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
                             new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
                             new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
                     }
                 ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props"
-                ]
             }
         );
     }
@@ -717,23 +743,25 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 Path = "",
                 Projects = [
                     new()
-                {
-                    FilePath = "src/project.csproj",
-                    TargetFrameworks = ["net7.0", "net8.0"],
-                    Dependencies = [
-                        new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true)
-                    ],
-                    Properties = [
-                        new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
-                        new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
-                        new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
-                    ]
-                }
+                    {
+                        FilePath = "src/project.csproj",
+                        TargetFrameworks = ["net7.0", "net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true)
+                        ],
+                        Properties = [
+                            new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
+                            new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
+                            new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
+                    }
                 ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props"
-                ]
             }
         );
     }
@@ -846,12 +874,14 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                             new("ManagePackageVersionsCentrally", "true", "Directory.Packages.props"),
                             new("SomePackageVersion", "9.0.1", "Directory.Packages.props"),
                             new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj")
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
                     }
-                ],
-                ImportedFiles = [
-                    "Directory.Build.props",
-                    "Directory.Packages.props",
                 ],
                 GlobalJson = new()
                 {
@@ -951,7 +981,10 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ],
                         Properties = [
                             new("TargetFramework", "net8.0", @"src/supported.csproj"),
-                        ]
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
                     }
                 ]
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -9,7 +9,6 @@ public record ExpectedWorkspaceDiscoveryResult : NativeResult
     public required string Path { get; init; }
     public bool IsSuccess { get; init; } = true;
     public ImmutableArray<ExpectedSdkProjectDiscoveryResult> Projects { get; init; }
-    public ImmutableArray<string> ImportedFiles { get; init; } = [];
     public int? ExpectedProjectCount { get; init; }
     public ExpectedDependencyDiscoveryResult? GlobalJson { get; init; }
     public ExpectedDependencyDiscoveryResult? DotNetToolsJson { get; init; }
@@ -17,10 +16,11 @@ public record ExpectedWorkspaceDiscoveryResult : NativeResult
 
 public record ExpectedSdkProjectDiscoveryResult : ExpectedDependencyDiscoveryResult
 {
-    public ImmutableArray<Property> Properties { get; init; } = [];
-    public ImmutableArray<string> TargetFrameworks { get; init; } = [];
-    public ImmutableArray<string> ReferencedProjectPaths { get; init; } = [];
-    public ImmutableArray<string>? ImportedFiles { get; init; } = null;
+    public required ImmutableArray<Property> Properties { get; init; }
+    public required ImmutableArray<string> TargetFrameworks { get; init; }
+    public required ImmutableArray<string> ReferencedProjectPaths { get; init; }
+    public required ImmutableArray<string> ImportedFiles { get; init; }
+    public required ImmutableArray<string> AdditionalFiles { get; init; }
 }
 
 public record ExpectedDependencyDiscoveryResult : IDiscoveryResultWithDependencies

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
@@ -50,7 +50,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 }
             ]
         );
@@ -99,7 +101,12 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [
+                        "../Directory.Build.targets"
+                    ],
+                    AdditionalFiles = [],
                 }
             ]
         );
@@ -160,7 +167,8 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library1/library1.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    AdditionalFiles = [],
                 },
                 new()
                 {
@@ -173,7 +181,10 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library2/library2.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
                 }
             ]
         );
@@ -232,7 +243,8 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library1/library1.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    AdditionalFiles = [],
                 },
                 new()
                 {
@@ -247,7 +259,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "net8.0", "src/library2/library2.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 }
             ]
         );
@@ -291,7 +305,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFrameworks", "net7.0;net8.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["net7.0", "net8.0"]
+                    TargetFrameworks = ["net7.0", "net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 },
             ]
         );
@@ -334,7 +350,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     [
                         new("TargetFramework", "netstandard2.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["netstandard2.0"]
+                    TargetFrameworks = ["netstandard2.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 },
             ]
         );
@@ -386,7 +404,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("ManagePackageVersionsCentrally", "true", "src/library.csproj"),
                         new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 },
             ]
         );
@@ -451,7 +471,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("ManagePackageVersionsCentrally", "true", "src/library.csproj"),
                         new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
-                    TargetFrameworks = ["net8.0"]
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
                 },
             ]
         );

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -63,7 +63,10 @@ public class RunWorkerTests
                             Dependencies =
                             [
                                 new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
-                            ]
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 });
@@ -268,7 +271,10 @@ public class RunWorkerTests
                             [
                                 new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
                                 new("Some.Package2", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
-                            ]
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 });
@@ -584,7 +590,10 @@ public class RunWorkerTests
                             [
                                 new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
                                 new("Some.Package2", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net8.0"]),
-                            ]
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 });
@@ -936,7 +945,10 @@ public class RunWorkerTests
                             [
                                 new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
                                 new("Some.Package2", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net8.0"]),
-                            ]
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         },
                         new()
                         {
@@ -946,7 +958,10 @@ public class RunWorkerTests
                             [
                                 new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
                                 new("Some.Package2", "2.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net8.0"]),
-                            ]
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
                         }
                     ]
                 });

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -686,6 +686,17 @@ public class RunWorkerTests
                     new DependencyFile()
                     {
                         Directory = "/some-dir",
+                        Name = "packages.config",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <?xml version="1.0" encoding="utf-8"?>
+                            <packages>
+                              <package id="Some.Package2" version="2.0.0" targetFramework="net8.0" />
+                            </packages>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/some-dir",
                         Name = "project.csproj",
                         Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
                             <Project Sdk="Microsoft.NET.Sdk">
@@ -698,17 +709,6 @@ public class RunWorkerTests
                             </Project>
                             """))
                     },
-                    new DependencyFile()
-                    {
-                        Directory = "/some-dir",
-                        Name = "packages.config",
-                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
-                            <?xml version="1.0" encoding="utf-8"?>
-                            <packages>
-                              <package id="Some.Package2" version="2.0.0" targetFramework="net8.0" />
-                            </packages>
-                            """))
-                    }
                 ],
                 BaseCommitSha = "TEST-COMMIT-SHA",
             },
@@ -747,7 +747,7 @@ public class RunWorkerTests
                             ]
                         }
                     ],
-                    DependencyFiles = ["/some-dir/project.csproj", "/some-dir/packages.config"],
+                    DependencyFiles = ["/some-dir/packages.config", "/some-dir/project.csproj"],
                 },
                 new IncrementMetric()
                 {
@@ -824,6 +824,17 @@ public class RunWorkerTests
                     [
                         new DependencyFile()
                         {
+                            Name = "packages.config",
+                            Directory = "/some-dir",
+                            Content = """
+                                <?xml version="1.0" encoding="utf-8"?>
+                                <packages>
+                                  <package id="Some.Package2" version="2.0.1" targetFramework="net8.0" />
+                                </packages>
+                                """,
+                        },
+                        new DependencyFile()
+                        {
                             Name = "project.csproj",
                             Directory = "/some-dir",
                             Content = """
@@ -841,17 +852,6 @@ public class RunWorkerTests
                                     </Reference>
                                   </ItemGroup>
                                 </Project>
-                                """,
-                        },
-                        new DependencyFile()
-                        {
-                            Name = "packages.config",
-                            Directory = "/some-dir",
-                            Content = """
-                                <?xml version="1.0" encoding="utf-8"?>
-                                <packages>
-                                  <package id="Some.Package2" version="2.0.1" targetFramework="net8.0" />
-                                </packages>
                                 """,
                         },
                     ],
@@ -1096,22 +1096,7 @@ public class RunWorkerTests
                 [
                     new DependencyFile()
                     {
-                        Directory = "/some-dir/ProjectB",
-                        Name = "ProjectB.csproj",
-                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
-                            <Project Sdk="Microsoft.NET.Sdk">
-                              <PropertyGroup>
-                                <TargetFramework>net8.0</TargetFramework>
-                              </PropertyGroup>
-                              <ItemGroup>
-                                <PackageReference Include="Some.Package" Version="1.0.0" />
-                              </ItemGroup>
-                            </Project>
-                            """))
-                    },
-                    new DependencyFile()
-                    {
-                        Directory = "/some-dir/ProjectB",
+                        Directory = "/some-dir/ProjectA",
                         Name = "packages.config",
                         Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
                             <?xml version="1.0" encoding="utf-8"?>
@@ -1140,13 +1125,28 @@ public class RunWorkerTests
                     },
                     new DependencyFile()
                     {
-                        Directory = "/some-dir/ProjectA",
+                        Directory = "/some-dir/ProjectB",
                         Name = "packages.config",
                         Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
                             <?xml version="1.0" encoding="utf-8"?>
                             <packages>
                               <package id="Some.Package2" version="2.0.0" targetFramework="net8.0" />
                             </packages>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/some-dir/ProjectB",
+                        Name = "ProjectB.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Some.Package" Version="1.0.0" />
+                              </ItemGroup>
+                            </Project>
                             """))
                     },
                 ],
@@ -1215,7 +1215,7 @@ public class RunWorkerTests
                             ]
                         },
                     ],
-                    DependencyFiles = ["/some-dir/ProjectB/ProjectB.csproj", "/some-dir/ProjectA/ProjectA.csproj", "/some-dir/ProjectB/packages.config", "/some-dir/ProjectA/packages.config"],
+                    DependencyFiles = ["/some-dir/ProjectA/packages.config", "/some-dir/ProjectA/ProjectA.csproj", "/some-dir/ProjectB/packages.config", "/some-dir/ProjectB/ProjectB.csproj"],
                 },
                 new IncrementMetric()
                 {
@@ -1350,29 +1350,8 @@ public class RunWorkerTests
                     [
                         new DependencyFile()
                         {
-                            Name = "ProjectB.csproj",
-                            Directory = "/some-dir/ProjectB",
-                            Content = """
-                                <Project Sdk="Microsoft.NET.Sdk">
-                                  <PropertyGroup>
-                                    <TargetFramework>net8.0</TargetFramework>
-                                  </PropertyGroup>
-                                  <ItemGroup>
-                                    <PackageReference Include="Some.Package" Version="1.0.1" />
-                                  </ItemGroup>
-                                  <ItemGroup>
-                                    <Reference Include="Some.Package2">
-                                      <HintPath>..\packages\Some.Package2.2.0.1\lib\net8.0\Some.Package2.dll</HintPath>
-                                      <Private>True</Private>
-                                    </Reference>
-                                  </ItemGroup>
-                                </Project>
-                                """,
-                        },
-                        new DependencyFile()
-                        {
                             Name = "packages.config",
-                            Directory = "/some-dir/ProjectB",
+                            Directory = "/some-dir/ProjectA",
                             Content = """
                                 <?xml version="1.0" encoding="utf-8"?>
                                 <packages>
@@ -1407,7 +1386,7 @@ public class RunWorkerTests
                         new DependencyFile()
                         {
                             Name = "packages.config",
-                            Directory = "/some-dir/ProjectA",
+                            Directory = "/some-dir/ProjectB",
                             Content = """
                                 <?xml version="1.0" encoding="utf-8"?>
                                 <packages>
@@ -1415,6 +1394,336 @@ public class RunWorkerTests
                                 </packages>
                                 """,
                         },
+                        new DependencyFile()
+                        {
+                            Name = "ProjectB.csproj",
+                            Directory = "/some-dir/ProjectB",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net8.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Some.Package" Version="1.0.1" />
+                                  </ItemGroup>
+                                  <ItemGroup>
+                                    <Reference Include="Some.Package2">
+                                      <HintPath>..\packages\Some.Package2.2.0.1\lib\net8.0\Some.Package2.dll</HintPath>
+                                      <Private>True</Private>
+                                    </Reference>
+                                  </ItemGroup>
+                                </Project>
+                                """,
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = "TODO: message",
+                    PrTitle = "TODO: title",
+                    PrBody = "TODO: body",
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA")
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task UpdatedFilesAreOnlyReportedOnce()
+    {
+        await RunAsync(
+            job: new()
+            {
+                PackageManager = "nuget",
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                    Directory = "/",
+                },
+                AllowedUpdates =
+                [
+                    new() { UpdateType = "all" }
+                ]
+            },
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0"),
+            ],
+            files:
+            [
+                ("dirs.proj", """
+                    <Project>
+                      <ItemGroup>
+                        <ProjectFile Include="project1/project1.csproj" />
+                        <ProjectFile Include="project2/project2.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <SomePackageVersion>1.0.0</SomePackageVersion>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                ("project1/project1.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("project2/project2.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            discoveryWorker: new TestDiscoveryWorker(_input =>
+            {
+                return Task.FromResult(new WorkspaceDiscoveryResult()
+                {
+                    Path = "",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project1/project1.csproj",
+                            TargetFrameworks = ["net8.0"],
+                            Dependencies = [
+                                new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "../Directory.Build.props",
+                            ],
+                            AdditionalFiles = [],
+                        },
+                        new()
+                        {
+                            FilePath = "project2/project2.csproj",
+                            TargetFrameworks = ["net8.0"],
+                            Dependencies = [
+                                new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "../Directory.Build.props",
+                            ],
+                            AdditionalFiles = [],
+                        },
+                    ]
+                });
+            }),
+            analyzeWorker: new TestAnalyzeWorker(_input =>
+            {
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "1.1.0",
+                    UpdatedDependencies =
+                        [
+                            new("Some.Package", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                        ]
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRootPath = input.Item1;
+                var filePath = input.Item2;
+                var packageName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var _isTransitive = input.Item6;
+
+                var directoryBuildPropsPath = Path.Join(repoRootPath, "Directory.Build.props");
+                await File.WriteAllTextAsync(directoryBuildPropsPath, """
+                    <Project>
+                      <PropertyGroup>
+                        <SomePackageVersion>1.1.0</SomePackageVersion>
+                      </PropertyGroup>
+                    </Project>
+                    """);
+                return new UpdateOperationResult();
+            }),
+            expectedResult: new RunResult()
+            {
+                Base64DependencyFiles =
+                [
+                    new DependencyFile()
+                    {
+                        Directory = "/",
+                        Name = "Directory.Build.props",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project>
+                              <PropertyGroup>
+                                <SomePackageVersion>1.0.0</SomePackageVersion>
+                              </PropertyGroup>
+                            </Project>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/project1",
+                        Name = "project1.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                              </ItemGroup>
+                            </Project>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/project2",
+                        Name = "project2.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                              </ItemGroup>
+                            </Project>
+                            """))
+                    },
+                ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+            },
+            expectedApiMessages:
+            [
+                new UpdatedDependencyList()
+                {
+                    Dependencies =
+                    [
+                        new ReportedDependency()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project1/project1.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new ReportedDependency()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project2/project2.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        }
+                    ],
+                    DependencyFiles = ["/Directory.Build.props", "/project1/project1.csproj", "/project2/project2.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions"
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies =
+                    [
+                        new ReportedDependency()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.1.0",
+                            Requirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.1.0",
+                                    File = "/project1/project1.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project1/project1.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                        new ReportedDependency()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.1.0",
+                            Requirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.1.0",
+                                    File = "/project2/project2.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project2/project2.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles =
+                    [
+                        new DependencyFile()
+                        {
+                            Name = "Directory.Build.props",
+                            Directory = "/",
+                            Content = """
+                                <Project>
+                                  <PropertyGroup>
+                                    <SomePackageVersion>1.1.0</SomePackageVersion>
+                                  </PropertyGroup>
+                                </Project>
+                                """,
+                        }
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
                     CommitMessage = "TODO: message",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -593,7 +593,7 @@ public class RunWorkerTests
                             ],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
-                            AdditionalFiles = [],
+                            AdditionalFiles = ["packages.config"],
                         }
                     ]
                 });
@@ -616,9 +616,9 @@ public class RunWorkerTests
                         CanUpdate = true,
                         UpdatedVersion = "2.0.1",
                         UpdatedDependencies =
-                                [
-                                    new("Some.Package2", "2.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package2"),
-                                ]
+                            [
+                                new("Some.Package2", "2.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package2"),
+                            ]
                     },
                     _ => throw new NotSupportedException(),
                 };
@@ -741,7 +741,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/packages.config",
+                                    File = "/some-dir/project.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -799,7 +799,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.1",
-                                    File = "/some-dir/packages.config",
+                                    File = "/some-dir/project.csproj",
                                     Groups = ["dependencies"],
                                     Source = new()
                                     {
@@ -814,7 +814,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/packages.config",
+                                    File = "/some-dir/project.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],
@@ -948,7 +948,7 @@ public class RunWorkerTests
                             ],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
-                            AdditionalFiles = [],
+                            AdditionalFiles = ["packages.config"],
                         },
                         new()
                         {
@@ -961,7 +961,7 @@ public class RunWorkerTests
                             ],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
-                            AdditionalFiles = [],
+                            AdditionalFiles = ["packages.config"],
                         }
                     ]
                 });
@@ -984,9 +984,9 @@ public class RunWorkerTests
                         CanUpdate = true,
                         UpdatedVersion = "2.0.1",
                         UpdatedDependencies =
-                                [
-                                    new("Some.Package2", "2.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package2"),
-                                ]
+                            [
+                                new("Some.Package2", "2.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package2"),
+                            ]
                     },
                     _ => throw new NotSupportedException(),
                 };
@@ -1181,7 +1181,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectB/packages.config",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1209,7 +1209,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectA/packages.config",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1267,7 +1267,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.1",
-                                    File = "/some-dir/ProjectB/packages.config",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                     Source = new()
                                     {
@@ -1282,7 +1282,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectB/packages.config",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],
@@ -1325,7 +1325,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.1",
-                                    File = "/some-dir/ProjectA/packages.config",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                     Source = new()
                                     {
@@ -1340,7 +1340,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectA/packages.config",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -40,6 +40,8 @@ public class UpdatedDependencyListTests
                     Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
                 },
                 new()
                 {
@@ -50,6 +52,8 @@ public class UpdatedDependencyListTests
                     Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
                 },
                 new()
                 {
@@ -62,6 +66,8 @@ public class UpdatedDependencyListTests
                     Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
                 }
             ]
         };

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -41,7 +41,7 @@ public class UpdatedDependencyListTests
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],
-                    AdditionalFiles = [],
+                    AdditionalFiles = ["packages.config"],
                 },
                 new()
                 {
@@ -53,7 +53,7 @@ public class UpdatedDependencyListTests
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],
-                    AdditionalFiles = [],
+                    AdditionalFiles = ["packages.config"],
                 },
                 new()
                 {
@@ -67,7 +67,7 @@ public class UpdatedDependencyListTests
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],
-                    AdditionalFiles = [],
+                    AdditionalFiles = ["packages.config"],
                 }
             ]
         };
@@ -105,7 +105,7 @@ public class UpdatedDependencyListTests
                         new ReportedRequirement()
                         {
                             Requirement = "13.0.1",
-                            File = "/src/c/packages.config",
+                            File = "/src/c/project.csproj",
                             Groups = ["dependencies"],
                         },
                     ]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
@@ -2,7 +2,7 @@ using Xunit;
 
 namespace NuGetUpdater.Core.Test.Update;
 
-public class BindingRedirectsTests
+public class BindingRedirectsTests : TestBase
 {
     [Fact]
     public async Task SimpleBindingRedirectIsPerformed()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscoveryResult.cs
@@ -8,4 +8,5 @@ public sealed record PackagesConfigDiscoveryResult : IDiscoveryResultWithDepende
     public bool IsSuccess { get; init; } = true;
     public required ImmutableArray<Dependency> Dependencies { get; init; }
     public required ImmutableArray<string> TargetFrameworks { get; init; }
+    public required ImmutableArray<string> AdditionalFiles { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -11,8 +11,6 @@ public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
     public ImmutableArray<Property> Properties { get; init; } = [];
     public ImmutableArray<string> TargetFrameworks { get; init; } = [];
     public ImmutableArray<string> ReferencedProjectPaths { get; init; } = [];
-
-    // this is purely for internal record keeping and should not be serialized
-    [JsonIgnore]
-    public ImmutableArray<string> ImportedFiles { get; init; } = [];
+    public required ImmutableArray<string> ImportedFiles { get; init; }
+    public required ImmutableArray<string> AdditionalFiles { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
@@ -7,7 +7,6 @@ public sealed record WorkspaceDiscoveryResult : NativeResult
     public required string Path { get; init; }
     public bool IsSuccess { get; init; } = true;
     public ImmutableArray<ProjectDiscoveryResult> Projects { get; init; }
-    public ImmutableArray<string> ImportedFiles { get; init; } = [];
     public GlobalJsonDiscoveryResult? GlobalJson { get; init; }
     public DotNetToolsJsonDiscoveryResult? DotNetToolsJson { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -8,6 +8,8 @@ using Microsoft.Language.Xml;
 
 using NuGet.ProjectManagement;
 
+using NuGetUpdater.Core.Utilities;
+
 using Runtime_AssemblyBinding = CoreV2::NuGet.Runtime.AssemblyBinding;
 
 namespace NuGetUpdater.Core;
@@ -32,7 +34,7 @@ internal static class BindingRedirectManager
     /// <param name="updatedPackageVersion">The version of the package that was updated</param>
     public static async ValueTask UpdateBindingRedirectsAsync(ProjectBuildFile projectBuildFile, string updatedPackageName, string updatedPackageVersion)
     {
-        var configFile = await TryGetRuntimeConfigurationFile(projectBuildFile);
+        var configFile = await TryGetRuntimeConfigurationFile(projectBuildFile.Path);
         if (configFile is null)
         {
             // no runtime config file so no need to add binding redirects
@@ -124,56 +126,24 @@ internal static class BindingRedirectManager
         }
     }
 
-    private static async ValueTask<ConfigurationFile?> TryGetRuntimeConfigurationFile(ProjectBuildFile projectBuildFile)
+    private static async ValueTask<ConfigurationFile?> TryGetRuntimeConfigurationFile(string fullProjectPath)
     {
-        var directoryPath = Path.GetDirectoryName(projectBuildFile.Path);
-        if (directoryPath is null)
+        var additionalFiles = ProjectHelper.GetAdditionalFilesFromProjectContent(fullProjectPath, ProjectHelper.PathFormat.Full);
+        var configFilePath = additionalFiles
+            .FirstOrDefault(p =>
+            {
+                var fileName = Path.GetFileName(p);
+                return fileName.Equals(ProjectHelper.AppConfigFileName, StringComparison.OrdinalIgnoreCase)
+                    || fileName.Equals(ProjectHelper.WebConfigFileName, StringComparison.OrdinalIgnoreCase);
+            });
+
+        if (configFilePath is null)
         {
             return null;
         }
 
-        var configFile = projectBuildFile.ItemNodes
-            .Where(IsConfigFile)
-            .FirstOrDefault();
-
-        if (configFile is null)
-        {
-            return null;
-        }
-
-        var configFilePath = Path.GetFullPath(Path.Combine(directoryPath, GetValue(configFile)));
         var configFileContents = await File.ReadAllTextAsync(configFilePath);
         return new ConfigurationFile(configFilePath, configFileContents, false);
-
-        static string GetValue(IXmlElementSyntax element)
-        {
-            var content = element.GetAttributeValue("Include");
-            if (!string.IsNullOrEmpty(content))
-            {
-                return content;
-            }
-
-            content = element.GetContentValue();
-            if (!string.IsNullOrEmpty(content))
-            {
-                return content;
-            }
-
-            return string.Empty;
-        }
-
-        static bool IsConfigFile(IXmlElementSyntax element)
-        {
-            var content = GetValue(element);
-            if (content is null)
-            {
-                return false;
-            }
-
-            var path = Path.GetFileName(content);
-            return (element.Name == "None" && string.Equals(path, "app.config", StringComparison.OrdinalIgnoreCase))
-                   || (element.Name == "Content" && string.Equals(path, "web.config", StringComparison.OrdinalIgnoreCase));
-        }
     }
 
     private static string AddBindingRedirects(ConfigurationFile configFile, IEnumerable<(Runtime_AssemblyBinding Binding, string AssemblyPath)> bindingRedirectsAndAssemblyPaths, string assemblyPathPrefix)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
@@ -7,15 +7,7 @@ internal static class LockFileUpdater
         string projectPath,
         ILogger logger)
     {
-        var projectDirectory = Path.GetDirectoryName(projectPath);
-        var lockPath = Path.Combine(projectDirectory, "packages.lock.json");
-        logger.Log($"    Updating lock file");
-        if (!File.Exists(lockPath))
-        {
-            logger.Log($"      File [{Path.GetRelativePath(repoRootPath, lockPath)}] does not exist.");
-            return;
-        }
-
+        var projectDirectory = Path.GetDirectoryName(projectPath)!;
         await MSBuildHelper.SidelineGlobalJsonAsync(projectDirectory, repoRootPath, async () =>
         {
             var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", ["restore", "--force-evaluate", projectPath], workingDirectory: projectDirectory);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -9,6 +9,7 @@ using Microsoft.Language.Xml;
 using NuGet.CommandLine;
 
 using NuGetUpdater.Core.Updater;
+using NuGetUpdater.Core.Utilities;
 
 using Console = System.Console;
 
@@ -35,7 +36,7 @@ internal static class PackagesConfigUpdater
     )
     {
         // packages.config project; use NuGet.exe to perform update
-        logger.Log($"  Found '{NuGetHelper.PackagesConfigFileName}' project; running NuGet.exe update");
+        logger.Log($"  Found '{ProjectHelper.PackagesConfigFileName}' project; running NuGet.exe update");
 
         // ensure local packages directory exists
         var projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
@@ -4,22 +4,6 @@ namespace NuGetUpdater.Core;
 
 internal static class NuGetHelper
 {
-    internal const string PackagesConfigFileName = "packages.config";
-
-    public static bool TryGetPackagesConfigFile(string projectPath, [NotNullWhen(returnValue: true)] out string? packagesConfigPath)
-    {
-        var projectDirectory = Path.GetDirectoryName(projectPath);
-
-        packagesConfigPath = PathHelper.JoinPath(projectDirectory, PackagesConfigFileName);
-        if (File.Exists(packagesConfigPath))
-        {
-            return true;
-        }
-
-        packagesConfigPath = null;
-        return false;
-    }
-
     internal static async Task<bool> DownloadNuGetPackagesAsync(string repoRoot, string projectPath, IReadOnlyCollection<Dependency> packages, ILogger logger)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("msbuild_sdk_restore_");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
@@ -1,0 +1,96 @@
+using System.Collections.Immutable;
+
+using Microsoft.Build.Construction;
+
+namespace NuGetUpdater.Core.Utilities;
+
+internal static class ProjectHelper
+{
+    public const string PackagesConfigFileName = "packages.config";
+    public const string AppConfigFileName = "app.config";
+    public const string WebConfigFileName = "web.config";
+    public const string PackagesLockJsonFileName = "packages.lock.json";
+
+    public enum PathFormat
+    {
+        Relative,
+        Full,
+    }
+
+    public static ImmutableArray<string> GetAllAdditionalFilesFromProject(string fullProjectPath, PathFormat pathFormat)
+    {
+        return GetAdditionalFilesFromProjectContent(fullProjectPath, pathFormat)
+            .AddRange(GetAdditionalFilesFromProjectLocation(fullProjectPath, pathFormat));
+    }
+
+    public static ImmutableArray<string> GetAdditionalFilesFromProjectContent(string fullProjectPath, PathFormat pathFormat)
+    {
+        var projectRootElement = ProjectRootElement.Open(fullProjectPath);
+        var additionalFilesWithFullPaths = new[]
+        {
+            projectRootElement.GetItemPathWithFileName(PackagesConfigFileName),
+            projectRootElement.GetItemPathWithFileName(AppConfigFileName),
+            projectRootElement.GetItemPathWithFileName(WebConfigFileName),
+        }.Where(p => p is not null).Cast<string>().ToImmutableArray();
+
+        var additionalFiles = additionalFilesWithFullPaths
+            .Select(p => MakePathAppropriateFormat(fullProjectPath, p, pathFormat))
+            .ToImmutableArray();
+        return additionalFiles;
+    }
+
+    public static ImmutableArray<string> GetAdditionalFilesFromProjectLocation(string fullProjectPath, PathFormat pathFormat)
+    {
+        var additionalFilesWithFullPaths = new[]
+        {
+            GetPathWithRegardsToProjectFile(fullProjectPath, PackagesLockJsonFileName),
+        }.Where(p => p is not null).Cast<string>().ToImmutableArray();
+
+        var additionalFiles = additionalFilesWithFullPaths
+            .Select(p => MakePathAppropriateFormat(fullProjectPath, p, pathFormat))
+            .ToImmutableArray();
+        return additionalFiles;
+    }
+
+    public static string? GetPackagesConfigPathFromProject(string fullProjectPath, PathFormat pathFormat)
+    {
+        var additionalFiles = GetAdditionalFilesFromProjectContent(fullProjectPath, pathFormat);
+        var packagesConfigFile = additionalFiles.FirstOrDefault(p => Path.GetFileName(p).Equals(PackagesConfigFileName, StringComparison.Ordinal));
+        return packagesConfigFile;
+    }
+
+    private static string MakePathAppropriateFormat(string fullProjectPath, string fullFilePath, PathFormat pathFormat)
+    {
+        var projectDirectory = Path.GetDirectoryName(fullProjectPath)!;
+        var updatedPath = pathFormat switch
+        {
+            PathFormat.Full => fullFilePath,
+            PathFormat.Relative => Path.GetRelativePath(projectDirectory, fullFilePath),
+            _ => throw new NotSupportedException(),
+        };
+        return updatedPath.NormalizePathToUnix();
+    }
+
+    private static string? GetItemPathWithFileName(this ProjectRootElement projectRootElement, string itemFileName)
+    {
+        var projectDirectory = Path.GetDirectoryName(projectRootElement.FullPath)!;
+        var packagesConfigPath = projectRootElement.Items
+            .Where(i => i.ElementName.Equals("None", StringComparison.OrdinalIgnoreCase) ||
+                        i.ElementName.Equals("Content", StringComparison.OrdinalIgnoreCase))
+            .Where(i => Path.GetFileName(i.Include).Equals(itemFileName, StringComparison.OrdinalIgnoreCase))
+            .Select(i => Path.GetFullPath(Path.Combine(projectDirectory, i.Include)))
+            .Where(File.Exists)
+            .FirstOrDefault()
+            ?.NormalizePathToUnix();
+        return packagesConfigPath;
+    }
+
+    private static string? GetPathWithRegardsToProjectFile(string fullProjectPath, string fileName)
+    {
+        var projectDirectory = Path.GetDirectoryName(fullProjectPath)!;
+        var filePath = Directory.EnumerateFiles(projectDirectory)
+            .Where(p => Path.GetFileName(p).Equals(fileName, StringComparison.Ordinal))
+            .FirstOrDefault();
+        return filePath;
+    }
+}

--- a/nuget/lib/dependabot/nuget/native_discovery/native_project_discovery.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_project_discovery.rb
@@ -10,6 +10,7 @@ module Dependabot
     class NativeProjectDiscovery < NativeDependencyFileDiscovery
       extend T::Sig
 
+      # rubocop:disable Metrics/AbcSize
       sig do
         override.params(json: T.nilable(T::Hash[String, T.untyped]),
                         directory: String).returns(T.nilable(NativeProjectDiscovery))
@@ -36,26 +37,41 @@ module Dependabot
 
           details
         end
+        imported_files = T.let(json.fetch("ImportedFiles"), T::Array[String])
+        additional_files = T.let(json.fetch("AdditionalFiles"), T::Array[String])
 
         NativeProjectDiscovery.new(file_path: file_path,
                                    properties: properties,
                                    target_frameworks: target_frameworks,
                                    referenced_project_paths: referenced_project_paths,
-                                   dependencies: dependencies)
+                                   dependencies: dependencies,
+                                   imported_files: imported_files,
+                                   additional_files: additional_files)
       end
+      # rubocop:enable Metrics/AbcSize
 
       sig do
         params(file_path: String,
                properties: T::Array[NativePropertyDetails],
                target_frameworks: T::Array[String],
                referenced_project_paths: T::Array[String],
-               dependencies: T::Array[NativeDependencyDetails]).void
+               dependencies: T::Array[NativeDependencyDetails],
+               imported_files: T::Array[String],
+               additional_files: T::Array[String]).void
       end
-      def initialize(file_path:, properties:, target_frameworks:, referenced_project_paths:, dependencies:)
+      def initialize(file_path:,
+                     properties:,
+                     target_frameworks:,
+                     referenced_project_paths:,
+                     dependencies:,
+                     imported_files:,
+                     additional_files:)
         super(file_path: file_path, dependencies: dependencies)
         @properties = properties
         @target_frameworks = target_frameworks
         @referenced_project_paths = referenced_project_paths
+        @imported_files = imported_files
+        @additional_files = additional_files
       end
 
       sig { returns(T::Array[NativePropertyDetails]) }
@@ -66,6 +82,12 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       attr_reader :referenced_project_paths
+
+      sig { returns(T::Array[String]) }
+      attr_reader :imported_files
+
+      sig { returns(T::Array[String]) }
+      attr_reader :additional_files
 
       sig { override.returns(Dependabot::FileParsers::Base::DependencySet) }
       def dependency_set

--- a/nuget/lib/dependabot/nuget/native_discovery/native_workspace_discovery.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_workspace_discovery.rb
@@ -20,7 +20,6 @@ module Dependabot
         projects = T.let(json.fetch("Projects"), T::Array[T::Hash[String, T.untyped]]).filter_map do |project|
           NativeProjectDiscovery.from_json(project, path)
         end
-        imported_files = T.let(json.fetch("ImportedFiles"), T::Array[String])
         global_json = NativeDependencyFileDiscovery
                       .from_json(T.let(json.fetch("GlobalJson"), T.nilable(T::Hash[String, T.untyped])), path)
         dotnet_tools_json = NativeDependencyFileDiscovery
@@ -29,7 +28,6 @@ module Dependabot
 
         NativeWorkspaceDiscovery.new(path: path,
                                      projects: projects,
-                                     imported_files: imported_files,
                                      global_json: global_json,
                                      dotnet_tools_json: dotnet_tools_json)
       end
@@ -37,14 +35,12 @@ module Dependabot
       sig do
         params(path: String,
                projects: T::Array[NativeProjectDiscovery],
-               imported_files: T::Array[String],
                global_json: T.nilable(NativeDependencyFileDiscovery),
                dotnet_tools_json: T.nilable(NativeDependencyFileDiscovery)).void
       end
-      def initialize(path:, projects:, imported_files:, global_json:, dotnet_tools_json:)
+      def initialize(path:, projects:, global_json:, dotnet_tools_json:)
         @path = path
         @projects = projects
-        @imported_files = imported_files
         @global_json = global_json
         @dotnet_tools_json = dotnet_tools_json
       end
@@ -54,9 +50,6 @@ module Dependabot
 
       sig { returns(T::Array[NativeProjectDiscovery]) }
       attr_reader :projects
-
-      sig { returns(T::Array[String]) }
-      attr_reader :imported_files
 
       sig { returns(T.nilable(NativeDependencyFileDiscovery)) }
       attr_reader :global_json

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -148,9 +148,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["net462"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -211,7 +212,9 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["net462"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }, {
               FilePath: "my.vbproj",
               Dependencies: [{
@@ -234,9 +237,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["net462"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -314,9 +318,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["netstandard2.0"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -379,9 +384,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                   SourceFilePath: "my.csproj"
                 }],
                 TargetFrameworks: ["netstandard2.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }],
-              ImportedFiles: [],
               GlobalJson: nil,
               DotNetToolsJson: nil
             }
@@ -422,7 +428,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: true,
             Projects: [], # not relevant for this test
-            ImportedFiles: [],
             GlobalJson: {
               FilePath: "global.json",
               IsSuccess: true,
@@ -478,7 +483,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: true,
             Projects: [], # not relevant for this test
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: {
               FilePath: ".config/dotnet-tools.json",
@@ -545,25 +549,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: true,
             Projects: [{
-              FilePath: "commonprops.props",
-              Dependencies: [{
-                Name: "Serilog",
-                Version: "2.3.0",
-                Type: "PackageReference",
-                EvaluationResult: nil,
-                TargetFrameworks: nil,
-                IsDevDependency: false,
-                IsDirect: true,
-                IsTransitive: false,
-                IsOverride: false,
-                IsUpdate: false,
-                InfoUrl: nil
-              }],
-              IsSuccess: true,
-              Properties: [],
-              TargetFrameworks: [],
-              ReferencedProjectPaths: []
-            }, {
               FilePath: "my.csproj",
               Dependencies: [{
                 Name: "Serilog",
@@ -585,9 +570,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["netstandard1.6"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: ["commonprops.props"],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -604,11 +590,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             expect(dependency.version).to eq("2.3.0")
             expect(dependency.requirements).to eq(
               [{
-                requirement: "2.3.0",
-                file: "/commonprops.props",
-                groups: ["dependencies"],
-                source: nil
-              }, {
                 requirement: "2.3.0",
                 file: "/my.csproj",
                 groups: ["dependencies"],
@@ -667,28 +648,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["netstandard1.6"],
-              ReferencedProjectPaths: []
-            }, {
-              FilePath: "packages.props",
-              Dependencies: [{
-                Name: "System.WebCrawler",
-                Version: "1.1.1",
-                Type: "PackageReference",
-                EvaluationResult: nil,
-                TargetFrameworks: nil,
-                IsDevDependency: false,
-                IsDirect: true,
-                IsTransitive: false,
-                IsOverride: false,
-                IsUpdate: true,
-                InfoUrl: nil
-              }],
-              IsSuccess: true,
-              Properties: [],
-              TargetFrameworks: [],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: ["packages.props"],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -706,11 +669,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
               [{
                 requirement: "1.1.1",
                 file: "/my.csproj",
-                groups: ["dependencies"],
-                source: nil
-              }, {
-                requirement: "1.1.1",
-                file: "/packages.props",
                 groups: ["dependencies"],
                 source: nil
               }]
@@ -772,9 +730,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["netstandard1.6"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: ["Directory.Packages.props"],
+              AdditionalFiles: []
             }],
-            ImportedFiles: ["Directory.Packages.props"],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -847,7 +806,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: true,
             Projects: [],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -859,7 +817,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
           _dependencies = parser.parse # the result doesn't matter, but it forces discovery to run
           expect(Dependabot.logger).to have_received(:info).with(
             <<~INFO
-              Discovery JSON content: {"Path":"","IsSuccess":true,"Projects":[],"ImportedFiles":[],"GlobalJson":null,"DotNetToolsJson":null}
+              Discovery JSON content: {"Path":"","IsSuccess":true,"Projects":[],"GlobalJson":null,"DotNetToolsJson":null}
             INFO
             .chomp
           )
@@ -905,25 +863,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: true,
             Projects: [{
-              FilePath: "Directory.Build.targets",
-              Dependencies: [{
-                Name: "Package.B",
-                Version: "4.5.6",
-                Type: "PackageReference",
-                EvaluationResult: nil,
-                TargetFrameworks: nil,
-                IsDevDependency: false,
-                IsDirect: true,
-                IsTransitive: false,
-                IsOverride: false,
-                IsUpdate: false,
-                InfoUrl: nil
-              }],
-              IsSuccess: true,
-              Properties: [],
-              TargetFrameworks: [],
-              ReferencedProjectPaths: []
-            }, {
               FilePath: "my.csproj",
               Dependencies: [{
                 Name: "Package.A",
@@ -957,9 +896,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["net8.0"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: ["Directory.Build.targets"],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -1069,9 +1009,10 @@ RSpec.describe Dependabot::Nuget::FileParser do
                 SourceFilePath: "my.csproj"
               }],
               TargetFrameworks: ["net8.0"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           }
@@ -1111,7 +1052,6 @@ RSpec.describe Dependabot::Nuget::FileParser do
             Path: "",
             IsSuccess: false,
             Projects: [],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil,
             ErrorType: "AuthenticationFailure",

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -235,10 +235,11 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
                 SourceFilePath: "Proj1/Proj1/Proj1.csproj"
               }],
               TargetFrameworks: ["net461"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }
           ],
-          ImportedFiles: [],
           GlobalJson: nil,
           DotNetToolsJson: nil
         }
@@ -316,7 +317,9 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
                 SourceFilePath: "Proj1/Proj1/Proj1.csproj"
               }],
               TargetFrameworks: ["net461"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }, {
               FilePath: "Proj2/Proj2.csproj",
               Dependencies: [{
@@ -339,10 +342,11 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
                 SourceFilePath: "Proj2/Proj2.csproj"
               }],
               TargetFrameworks: ["net461"],
-              ReferencedProjectPaths: []
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
             }
           ],
-          ImportedFiles: [],
           GlobalJson: nil,
           DotNetToolsJson: nil
         }

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -193,10 +193,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net462", "netstandard1.6"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -240,10 +241,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net462", "netstandard1.6"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -299,10 +301,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net462", "netstandard1.6"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -346,7 +349,6 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
             Path: "",
             IsSuccess: false,
             Projects: [],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -402,10 +404,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -471,10 +474,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -552,10 +556,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -633,10 +638,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -712,10 +718,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },
@@ -793,10 +800,11 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   }
                 ],
                 TargetFrameworks: ["net8.0"],
-                ReferencedProjectPaths: []
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
               }
             ],
-            ImportedFiles: [],
             GlobalJson: nil,
             DotNetToolsJson: nil
           },


### PR DESCRIPTION
Project dependency discovery already tracked its own `ImportedFiles` property, but that was suppressed during serialization and lifted to the workspace discovery result.

This PR is the first step in a larger refactoring.  The `ImportedFiles` property is removed from the workspace discovery and instead reported on the project discovery.  The data was already there, we're just writing it now.

Also report a new field `AdditionalFiles` on project discovery.  This contains files not directly evaluated by MSBuild, but still used in the package update process, e.g., `packages.config`, `app.config`, `web.config`, and `packages.lock.json`.  Currently these files aren't used anywhere, but they will be soon.

The tests were updated to always require the `ImportedFiles` and `AddtionalFiles` properties just so we don't accidentally avoid testing something.