### PR TITLE
gracefully exit if we can't solve an issue with peer dependencies

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -77,7 +77,8 @@ public abstract class UpdateWorkerTestBase : TestBase
         TestFile[]? additionalFiles = null,
         MockNuGetPackage[]? packages = null,
         ExperimentsManager? experimentsManager = null,
-        string projectFilePath = "test-project.csproj")
+        string projectFilePath = "test-project.csproj",
+        ExpectedUpdateOperationResult? expectedResult = null)
         => TestUpdateForProject(
             dependencyName,
             oldVersion,
@@ -88,7 +89,8 @@ public abstract class UpdateWorkerTestBase : TestBase
             additionalFiles,
             additionalFilesExpected: additionalFiles,
             packages: packages,
-            experimentsManager: experimentsManager);
+            experimentsManager: experimentsManager,
+            expectedResult: expectedResult);
 
     protected static Task TestUpdateForProject(
         string dependencyName,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -61,6 +61,11 @@ internal static class PackageReferenceUpdater
         }
         else
         {
+            if (peerDependencies is null)
+            {
+                return;
+            }
+
             await UpdateDependencyWithConflictResolution(repoRootPath, buildFiles, tfms, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, peerDependencies, logger);
         }
 


### PR DESCRIPTION
When attempting to perform an update, we currently can't do it if we detect a difference in the peer dependencies.  Eventually this is a situation that should be solvable, but since it's currently not, it's better to gracefully exit the updater instead of throwing an error.

This is currently one of the biggest error traces in the telemetry.