### PR TITLE
Add support for cargo ecosystem metrics collection

### DIFF
--- a/cargo/lib/dependabot/cargo/language.rb
+++ b/cargo/lib/dependabot/cargo/language.rb
@@ -1,0 +1,24 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/cargo/version"
+
+module Dependabot
+  module Cargo
+    LANGUAGE = "rust"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          LANGUAGE,
+          Version.new(raw_version)
+        )
+      end
+    end
+  end
+end

--- a/cargo/lib/dependabot/cargo/package_manager.rb
+++ b/cargo/lib/dependabot/cargo/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/cargo/version"
+
+module Dependabot
+  module Cargo
+    ECOSYSTEM = "rust"
+    PACKAGE_MANAGER = "cargo"
+    SUPPORTED_CARGO_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_CARGO_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_CARGO_VERSIONS,
+          SUPPORTED_CARGO_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -854,4 +854,32 @@ RSpec.describe Dependabot::Cargo::FileParser do
       end
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "rust"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "cargo"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "1.82.0"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "rust"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "1.82.0"
+      end
+    end
+  end
 end

--- a/cargo/spec/dependabot/cargo/language_spec.rb
+++ b/cargo/spec/dependabot/cargo/language_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/cargo/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Cargo::Language do
+  let(:language) { described_class.new(version) }
+  let(:version) { "3.0.0" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::Cargo::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Cargo::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/cargo/spec/dependabot/cargo/package_manager_spec.rb
+++ b/cargo/spec/dependabot/cargo/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/cargo/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Cargo::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "1.12" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version).to eq(Dependabot::Cargo::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Cargo::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Cargo::DEPRECATED_CARGO_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Cargo::SUPPORTED_CARGO_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the cargo / rust ecosystem to add support for gathering ecosystem metrics. These metrics are eventually being persisted in datadog via `POST /update_jobs/:id/record_ecosystem_meta`

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

#### How will you know you've accomplished your goal?

- I'll be able to see Rust / Cargo ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
