### PR TITLE
Running `yarn install` before running the update checkoer

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -101,11 +101,12 @@ module Dependabot
         fetched_npm_files
       end
 
+      sig { void }
       def create_yarn_cache
         if repo_contents_path.nil?
           Dependabot.logger.info("Repository contents path is nil")
-        elsif Dir.exist?(repo_contents_path)
-          Dir.chdir(repo_contents_path) do
+        elsif Dir.exist?(T.must(repo_contents_path))
+          Dir.chdir(T.must(repo_contents_path)) do
             FileUtils.mkdir_p(".yarn/cache")
           end
         else

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "timeout"
 require "sorbet-runtime"
 require "dependabot/experiments"
 require "dependabot/logger"
@@ -101,12 +102,21 @@ module Dependabot
         fetched_npm_files
       end
 
+      def run_yarn_install
+        Dir.chdir("repo") do
+          # --refresh-lockfile    Refresh the package metadata stored in the lockfile
+          # --immutable           without modifying the lockfile itself
+          system('yarn install --immutable --refresh-lockfile > /dev/null 2>&1')
+        end
+      end
+
       sig { returns(T::Array[DependencyFile]) }
       def yarn_files
         fetched_yarn_files = []
         fetched_yarn_files << yarn_lock if yarn_lock
         fetched_yarn_files << yarnrc if yarnrc
         fetched_yarn_files << yarnrc_yml if yarnrc_yml
+        run_yarn_install
         fetched_yarn_files
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -663,22 +663,11 @@ module Dependabot
           Dependabot.logger.info("Repository contents path is nil")
         elsif Dir.exist?(T.must(repo_contents_path))
           Dir.chdir(T.must(repo_contents_path)) do
-            if monorepo?
-              FileUtils.mkdir_p(".yarn/cache")
-            else
-              Dependabot.logger.info("Repository is not a monorepo")
-            end
+            FileUtils.mkdir_p(".yarn/cache")
           end
         else
           Dependabot.logger.info("Repository contents path does not exist")
         end
-      end
-
-      sig { returns(T::Boolean) }
-      def monorepo?
-        package_json_files = Dir.glob(File.join(T.must(repo_contents_path), "**", "package.json"))
-        lerna_json_file = File.join(T.must(repo_contents_path), "lerna.json")
-        package_json_files.size > 1 || File.exist?(lerna_json_file)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -101,12 +101,15 @@ module Dependabot
         fetched_npm_files
       end
 
-      sig { returns(T.nilable(T::Boolean)) }
-      def run_yarn_install
-        Dir.chdir("repo") do
-          # --refresh-lockfile    Refresh the package metadata stored in the lockfile
-          # --immutable           without modifying the lockfile itself
-          system("yarn install --immutable --refresh-lockfile > /dev/null 2>&1")
+      def create_yarn_cache
+        if repo_contents_path.nil?
+          Dependabot.logger.info("Repository contents path is nil")
+        elsif Dir.exist?(repo_contents_path)
+          Dir.chdir(repo_contents_path) do
+            FileUtils.mkdir_p(".yarn/cache")
+          end
+        else
+          Dependabot.logger.info("Repository contents path does not exist")
         end
       end
 
@@ -116,7 +119,7 @@ module Dependabot
         fetched_yarn_files << yarn_lock if yarn_lock
         fetched_yarn_files << yarnrc if yarnrc
         fetched_yarn_files << yarnrc_yml if yarnrc_yml
-        run_yarn_install
+        create_yarn_cache
         fetched_yarn_files
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "timeout"
 require "sorbet-runtime"
 require "dependabot/experiments"
 require "dependabot/logger"
@@ -106,7 +105,7 @@ module Dependabot
         Dir.chdir("repo") do
           # --refresh-lockfile    Refresh the package metadata stored in the lockfile
           # --immutable           without modifying the lockfile itself
-          system('yarn install --immutable --refresh-lockfile > /dev/null 2>&1')
+          system("yarn install --immutable --refresh-lockfile > /dev/null 2>&1")
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -101,6 +101,7 @@ module Dependabot
         fetched_npm_files
       end
 
+      sig { returns(T.nilable(T::Boolean)) }
       def run_yarn_install
         Dir.chdir("repo") do
           # --refresh-lockfile    Refresh the package metadata stored in the lockfile

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -90,6 +90,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           File.join(repo_contents_path, ".pnp.cjs")
         )
       ).to start_with("version https://git-lfs.github.com/spec/v1")
+
+      # Ensure .yarn directory contains .cache directory
+      expect(Dir.exist?(File.join(repo_contents_path, ".yarn", "cache"))).to be true
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Rel : https://github.com/github/dependabot-updates/issues/7169

Root cause of above issue is `yarn add/upgrade <package-name>@version` is failing

Creating a cache folder under .yarn file fixes this issue.

### Anything you want to highlight for special attention from reviewers?

I have ran the cli against [the repo where I recreated the error](https://github.com/dsp-testing/yarn_monorepo_core) and solved it by this update.

### How will you know you've accomplished your goal?

I have ran the cli against [the repo where I recreated the error](https://github.com/dsp-testing/yarn_monorepo_core) and solved it by this update.


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
