### PR TITLE
Add support for hex ecosystem metrics collection

### DIFF
--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -164,7 +164,7 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def language
         @language ||= T.let(
-          Language.new(elixir_version, language_requirement),
+          Language.new(elixir_version, nil),
           T.nilable(Dependabot::Hex::Language)
         )
       end

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -164,7 +164,7 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def language
         @language ||= T.let(
-          Language.new(elixir_version, nil),
+          Language.new(elixir_version),
           T.nilable(Dependabot::Hex::Language)
         )
       end
@@ -188,15 +188,6 @@ module Dependabot
             elixir_version: version.match(/Elixir: \s*(\d+\.\d+(.\d+)*)/)&.captures&.first
           }
         end, T.nilable(T::Hash[Symbol, T.nilable(String)]))
-      end
-
-      sig { returns(T.nilable(Dependabot::Hex::Requirement)) }
-      def language_requirement
-        command = "mix run --eval 'Mix.Project.config()[:elixir] |> IO.puts()'"
-        requirement = SharedHelpers.run_shell_command(command)
-        return if requirement.empty? || requirement.nil?
-
-        Dependabot::Hex::Requirement.new(requirement)
       end
     end
   end

--- a/hex/lib/dependabot/hex/language.rb
+++ b/hex/lib/dependabot/hex/language.rb
@@ -1,0 +1,21 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/hex/version"
+
+module Dependabot
+  module Hex
+    LANGUAGE = "elixir"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
+      def initialize(raw_version, requirement = nil)
+        super(LANGUAGE, Version.new(raw_version), [], [], requirement)
+      end
+    end
+  end
+end

--- a/hex/lib/dependabot/hex/language.rb
+++ b/hex/lib/dependabot/hex/language.rb
@@ -12,9 +12,9 @@ module Dependabot
     class Language < Dependabot::Ecosystem::VersionManager
       extend T::Sig
 
-      sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
-      def initialize(raw_version, requirement = nil)
-        super(LANGUAGE, Version.new(raw_version), [], [], requirement)
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(LANGUAGE, Version.new(raw_version))
       end
     end
   end

--- a/hex/lib/dependabot/hex/package_manager.rb
+++ b/hex/lib/dependabot/hex/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/hex/version"
+
+module Dependabot
+  module Hex
+    ECOSYSTEM = "hex"
+    PACKAGE_MANAGER = "hex"
+    SUPPORTED_HEX_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_HEX_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_HEX_VERSIONS,
+          SUPPORTED_HEX_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -452,4 +452,32 @@ RSpec.describe Dependabot::Hex::FileParser do
       end
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "hex"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "hex"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "2.1.1"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "elixir"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "1.17.3"
+      end
+    end
+  end
 end

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       it "returns the correct package manager" do
         expect(package_manager.name).to eq "hex"
         expect(package_manager.requirement).to be_nil
-        expect(package_manager.version.to_s).to eq "2.1.1"
+        expect(package_manager.version.to_s).to eq "2.0.6"
       end
     end
 
@@ -476,7 +476,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "elixir"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "1.17.3"
+        expect(language.version.to_s).to eq "1.14.4"
       end
     end
   end

--- a/hex/spec/dependabot/hex/language_spec.rb
+++ b/hex/spec/dependabot/hex/language_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/hex/requirement"
+require "dependabot/hex/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Hex::Language do
+  subject(:language) { described_class.new(version, requirement) }
+
+  let(:version) { "1.17.3" }
+  let(:requirement) { Dependabot::Hex::Requirement.new("~> 1.5") }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::Hex::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Hex::LANGUAGE)
+    end
+  end
+
+  describe "#requirement" do
+    it "returns the requirement" do
+      expect(language.requirement).to eq(requirement)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/hex/spec/dependabot/hex/language_spec.rb
+++ b/hex/spec/dependabot/hex/language_spec.rb
@@ -1,16 +1,14 @@
 # typed: false
 # frozen_string_literal: true
 
-require "dependabot/hex/requirement"
 require "dependabot/hex/language"
 require "dependabot/ecosystem"
 require "spec_helper"
 
 RSpec.describe Dependabot::Hex::Language do
-  subject(:language) { described_class.new(version, requirement) }
+  subject(:language) { described_class.new(version) }
 
   let(:version) { "1.17.3" }
-  let(:requirement) { Dependabot::Hex::Requirement.new("~> 1.5") }
 
   describe "#version" do
     it "returns the version" do
@@ -21,12 +19,6 @@ RSpec.describe Dependabot::Hex::Language do
   describe "#name" do
     it "returns the name" do
       expect(language.name).to eq(Dependabot::Hex::LANGUAGE)
-    end
-  end
-
-  describe "#requirement" do
-    it "returns the requirement" do
-      expect(language.requirement).to eq(requirement)
     end
   end
 

--- a/hex/spec/dependabot/hex/package_manager_spec.rb
+++ b/hex/spec/dependabot/hex/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/hex/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Hex::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "2.1.1" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version).to eq(Dependabot::Hex::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Hex::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Hex::DEPRECATED_HEX_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Hex::SUPPORTED_HEX_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the hex / elixir ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

#### How will you know you've accomplished your goal?

- I'll be able to see hex / elixir ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
