### PR TITLE
Add support for gradle ecosystem metrics collection

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -9,6 +9,8 @@ require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
 require "dependabot/gradle/version"
+require "dependabot/gradle/language"
+require "dependabot/gradle/package_manager"
 
 # The best Gradle documentation is at:
 # - https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.dsl.
@@ -71,7 +73,34 @@ module Dependabot
                   .filter_map { |f| dependency_files.find { |bf| bf.name == f } }
       end
 
+      sig { returns(Ecosystem) }
+      def ecosystem
+        @ecosystem ||= T.let(
+          Ecosystem.new(
+            name: ECOSYSTEM,
+            package_manager: package_manager,
+            language: language
+          ),
+          T.nilable(Ecosystem)
+        )
+      end
+
       private
+
+      sig { returns(Ecosystem::VersionManager) }
+      def package_manager
+        @package_manager ||= T.let(
+          PackageManager.new("NOT-AVAILABLE"),
+          T.nilable(Dependabot::Gradle::PackageManager)
+        )
+      end
+
+      sig { returns(T.nilable(Ecosystem::VersionManager)) }
+      def language
+        @language ||= T.let(begin
+          Language.new("NOT-AVAILABLE")
+        end, T.nilable(Dependabot::Gradle::Language))
+      end
 
       def version_catalog_dependencies(toml_file)
         dependency_set = DependencySet.new

--- a/gradle/lib/dependabot/gradle/language.rb
+++ b/gradle/lib/dependabot/gradle/language.rb
@@ -1,0 +1,24 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/gradle/version"
+
+module Dependabot
+  module Gradle
+    LANGUAGE = "jvm_languages"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          LANGUAGE,
+          Version.new(raw_version)
+        )
+      end
+    end
+  end
+end

--- a/gradle/lib/dependabot/gradle/package_manager.rb
+++ b/gradle/lib/dependabot/gradle/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/gradle/version"
+
+module Dependabot
+  module Gradle
+    ECOSYSTEM = "gradle"
+    PACKAGE_MANAGER = "gradle"
+    SUPPORTED_GRADLE_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_GRADLE_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_GRADLE_VERSIONS,
+          SUPPORTED_GRADLE_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -1068,4 +1068,32 @@ RSpec.describe Dependabot::Gradle::FileParser do
       its(:length) { is_expected.to eq(2) }
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "gradle"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "gradle"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "NOT-AVAILABLE"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "jvm_languages"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "NOT-AVAILABLE"
+      end
+    end
+  end
 end

--- a/gradle/spec/dependabot/gradle/language_spec.rb
+++ b/gradle/spec/dependabot/gradle/language_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/gradle/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Gradle::Language do
+  let(:language) { described_class.new(version) }
+  let(:version) { "3.0.0" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::Gradle::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Gradle::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/gradle/spec/dependabot/gradle/package_manager_spec.rb
+++ b/gradle/spec/dependabot/gradle/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/gradle/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Gradle::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "3.9.5" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version).to eq(Dependabot::Gradle::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Gradle::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Gradle::DEPRECATED_GRADLE_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Gradle::SUPPORTED_GRADLE_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the Gradle ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
As agreed at standup, in this PR, I'm returning `jvm_based_languages` as the language name. In addition, NOT-AVAILABLE is being returned for the language and gradle versions as there is no consistent way to extract this data based on the Gradle dependency file alone. In future, we might be able to improve on this but that will have to await the completion of [install Gradle on docker images](https://github.com/github/dependabot-updates/issues/7534).

#### How will you know you've accomplished your goal?

- I'll be able to see Gradle ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
