### PR TITLE
Reorders package managers for python ecosystem metric collection

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -93,11 +93,11 @@ module Dependabot
       def detected_package_manager
         setup_python_environment if Dependabot::Experiments.enabled?(:enable_file_parser_python_local)
 
+        return PipenvPackageManager.new(T.must(detect_pipenv_version)) if detect_pipenv_version
+
         return PoetryPackageManager.new(T.must(detect_poetry_version)) if detect_poetry_version
 
         return PipCompilePackageManager.new(T.must(detect_pipcompile_version)) if detect_pipcompile_version
-
-        return PipenvPackageManager.new(T.must(detect_pipenv_version)) if detect_pipenv_version
 
         PipPackageManager.new(detect_pip_version)
       end
@@ -206,6 +206,11 @@ module Dependabot
 
       sig { returns(String) }
       def python_raw_version
+        if Dependabot::Experiments.enabled?(:enable_file_parser_python_local)
+          Dependabot.logger.info("Detected python version: #{language_version_manager.python_version}")
+          Dependabot.logger.info("Detected python major minor version: #{language_version_manager.python_major_minor}")
+        end
+
         language_version_manager.python_version
       end
 

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -127,7 +127,7 @@ module Dependabot
       # Detects the version of pip-compile. If the version cannot be detected, it returns nil
       sig { returns(T.nilable(String)) }
       def detect_pipcompile_version
-        if pip_compile_files
+        if pipcompile_in_file
           package_manager = PipCompilePackageManager::NAME
 
           version = package_manager_version(package_manager)
@@ -149,7 +149,7 @@ module Dependabot
           package_manager = PipenvPackageManager::NAME
 
           version = package_manager_version(package_manager)
-                    .to_s.split("versions ").last&.strip
+                    .to_s.split("version ").last&.strip
 
           log_if_version_malformed(package_manager, version)
 
@@ -341,7 +341,7 @@ module Dependabot
       end
 
       def pipenv_files
-        requirement_files.any?(PipenvPackageManager::MANIFEST_FILENAME)
+        dependency_files.any? { |f| f.name == PipenvPackageManager::LOCKFILE_FILENAME }
       end
 
       def poetry_files

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -86,6 +86,10 @@ module Dependabot
 
       sig { returns(Ecosystem::VersionManager) }
       def package_manager
+        if Dependabot::Experiments.enabled?(:enable_file_parser_python_local)
+          Dependabot.logger.info("Detected package manager : #{detected_package_manager.name}")
+        end
+
         @package_manager ||= detected_package_manager
       end
 
@@ -174,7 +178,6 @@ module Dependabot
       sig { params(package_manager: String).returns(T.any(String, T.untyped)) }
       def package_manager_version(package_manager)
         version_info = SharedHelpers.run_shell_command("pyenv exec #{package_manager} --version")
-
         Dependabot.logger.info("Package manager #{package_manager}, Info : #{version_info}")
 
         version_info

--- a/python/lib/dependabot/python/package_manager.rb
+++ b/python/lib/dependabot/python/package_manager.rb
@@ -130,6 +130,7 @@ module Dependabot
       NAME = "pipenv"
 
       MANIFEST_FILENAME = "Pipfile"
+      LOCKFILE_FILENAME = "Pipfile.lock"
 
       SUPPORTED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
 

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -113,6 +113,10 @@ module Dependabot
       end
 
       def resolver
+        if Dependabot::Experiments.enabled?(:enable_file_parser_python_local)
+          Dependabot.logger.info("Python package resolver : #{resolver_type}")
+        end
+
         case resolver_type
         when :pip_compile then pip_compile_version_resolver
         when :pipenv then pipenv_version_resolver


### PR DESCRIPTION
### What are you trying to accomplish?

We are not able to see `pipenv` package manager in metric collection, experimenting if reordering package manager as per `update checker` resolves this issue. 

Adds more telemetry data to verify python version that is coming up in metric.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
