### PR TITLE
align C# log messages with Ruby

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -263,7 +263,7 @@ public class SerializationTests
 
         public IReadOnlyList<string> Messages => _messages;
 
-        public void Log(string message)
+        public void LogRaw(string message)
         {
             _messages.Add(message);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestLogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestLogger.cs
@@ -4,7 +4,7 @@ namespace NuGetUpdater.Core.Test;
 
 public class TestLogger : ILogger
 {
-    public void Log(string message)
+    public void LogRaw(string message)
     {
         Debug.WriteLine(message);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -172,7 +172,8 @@ public class MSBuildHelperTests : TestBase
             temp.DirectoryPath,
             temp.DirectoryPath,
             "netstandard2.0",
-            [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)]
+            [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)],
+            new TestLogger()
         );
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
@@ -300,7 +301,7 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Package.2A", "1.0.0", DependencyType.Unknown),
             new Dependency("Package.2R", "18.0.0", DependencyType.Unknown),
         };
-        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages);
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages, new TestLogger());
         for (int i = 0; i < actualDependencies.Length; i++)
         {
             var ad = actualDependencies[i];
@@ -334,7 +335,7 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
             new Dependency("Package.C", "3.0.0", DependencyType.Unknown, IsUpdate: true)
         };
-        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages);
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(temp.DirectoryPath, temp.DirectoryPath, "net8.0", packages, new TestLogger());
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
@@ -371,7 +372,8 @@ public class MSBuildHelperTests : TestBase
                 temp.DirectoryPath,
                 temp.DirectoryPath,
                 "net8.0",
-                [new Dependency("Some.Package", "4.5.11", DependencyType.Unknown)]
+                [new Dependency("Some.Package", "4.5.11", DependencyType.Unknown)],
+                new TestLogger()
             );
         }
         finally
@@ -428,7 +430,8 @@ public class MSBuildHelperTests : TestBase
                 temp.DirectoryPath,
                 temp.DirectoryPath,
                 "net8.0",
-                [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)]
+                [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)],
+                new TestLogger()
             );
 
             AssertEx.Equal(expectedDependencies, actualDependencies);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -68,7 +68,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
     {
         var startingDirectory = PathHelper.JoinPath(repoRoot, discovery.Path);
 
-        _logger.Log($"Starting analysis of {dependencyInfo.Name}...");
+        _logger.Info($"Starting analysis of {dependencyInfo.Name}...");
 
         // We need to find all projects which have the given dependency. Even in cases that they
         // have it transitively may require that peer dependencies be updated in the project.
@@ -97,7 +97,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         AnalysisResult analysisResult;
         if (isUpdateNecessary)
         {
-            _logger.Log($"  Determining multi-dependency property.");
+            _logger.Info($"  Determining multi-dependency property.");
             var multiDependencies = DetermineMultiDependencyDetails(
                 discovery,
                 dependencyInfo.Name,
@@ -117,7 +117,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
                     .ToImmutableArray()
                 : projectFrameworks;
 
-            _logger.Log($"  Finding updated version.");
+            _logger.Info($"  Finding updated version.");
             updatedVersion = await FindUpdatedVersionAsync(
                 startingDirectory,
                 dependencyInfo,
@@ -127,7 +127,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
                 _logger,
                 CancellationToken.None);
 
-            _logger.Log($"  Finding updated peer dependencies.");
+            _logger.Info($"  Finding updated peer dependencies.");
             if (updatedVersion is null)
             {
                 updatedDependencies = [];
@@ -173,7 +173,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             UpdatedDependencies = updatedDependencies,
         };
 
-        _logger.Log($"Analysis complete.");
+        _logger.Info($"Analysis complete.");
         return analysisResult;
     }
 
@@ -468,7 +468,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
 
         var resultPath = Path.Combine(analysisDirectory, $"{dependencyName}.json");
 
-        logger.Log($"  Writing analysis result to [{resultPath}].");
+        logger.Info($"  Writing analysis result to [{resultPath}].");
 
         var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
         await File.WriteAllTextAsync(path: resultPath, resultJson);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -68,7 +68,7 @@ internal static class CompatibilityChecker
         var incompatibleFrameworks = projectFrameworks.Where(f => !compatibleFrameworks.Contains(f)).ToArray();
         if (incompatibleFrameworks.Length > 0)
         {
-            logger.Log($"The package {package} is not compatible. Incompatible project frameworks: {string.Join(", ", incompatibleFrameworks.Select(f => f.GetShortFolderName()))}");
+            logger.Info($"The package {package} is not compatible. Incompatible project frameworks: {string.Join(", ", incompatibleFrameworks.Select(f => f.GetShortFolderName()))}");
             return false;
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -62,7 +62,7 @@ internal static class VersionFinder
             var feed = await sourceRepository.GetResourceAsync<MetadataResource>();
             if (feed is null)
             {
-                logger.Log($"Failed to get MetadataResource for [{source.Source}]");
+                logger.Warn($"Failed to get MetadataResource for [{source.Source}]");
                 continue;
             }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
@@ -13,7 +13,7 @@ public class ShellGitCommandHandler : IGitCommandHandler
 
     public async Task RunGitCommandAsync(IReadOnlyCollection<string> args, string? workingDirectory = null)
     {
-        _logger.Log($"Running command: git {string.Join(" ", args)}{(workingDirectory is null ? "" : $" in directory {workingDirectory}")}");
+        _logger.Info($"Running command: git {string.Join(" ", args)}{(workingDirectory is null ? "" : $" in directory {workingDirectory}")}");
         var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("git", args, workingDirectory);
         HandleErrorsFromOutput(stdout, stderr);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -82,7 +82,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
         if (Directory.Exists(workspacePath))
         {
-            _logger.Log($"Discovering build files in workspace [{workspacePath}].");
+            _logger.Info($"Discovering build files in workspace [{workspacePath}].");
 
             dotNetToolsJsonDiscovery = DotNetToolsJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
             globalJsonDiscovery = GlobalJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
@@ -97,7 +97,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
         else
         {
-            _logger.Log($"Workspace path [{workspacePath}] does not exist.");
+            _logger.Info($"Workspace path [{workspacePath}] does not exist.");
         }
 
         result = new WorkspaceDiscoveryResult
@@ -108,7 +108,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             Projects = projectResults.OrderBy(p => p.FilePath).ToImmutableArray(),
         };
 
-        _logger.Log("Discovery complete.");
+        _logger.Info("Discovery complete.");
         _processedProjectPaths.Clear();
 
         return result;
@@ -135,19 +135,19 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
         _restoredMSBuildSdks.AddRange(keys);
 
-        _logger.Log($"  Restoring MSBuild SDKs: {string.Join(", ", keys)}");
+        _logger.Info($"  Restoring MSBuild SDKs: {string.Join(", ", keys)}");
 
         return await NuGetHelper.DownloadNuGetPackagesAsync(repoRootPath, workspacePath, msbuildSdks, logger);
     }
 
     private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForDirectoryAsnyc(string repoRootPath, string workspacePath)
     {
-        _logger.Log($"  Discovering projects beneath [{Path.GetRelativePath(repoRootPath, workspacePath)}].");
+        _logger.Info($"  Discovering projects beneath [{Path.GetRelativePath(repoRootPath, workspacePath)}].");
         var entryPoints = FindEntryPoints(workspacePath);
         var projects = ExpandEntryPointsIntoProjects(entryPoints);
         if (projects.IsEmpty)
         {
-            _logger.Log("  No project files found.");
+            _logger.Info("  No project files found.");
             return [];
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DotNetToolsJsonDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DotNetToolsJsonDiscovery.cs
@@ -8,13 +8,13 @@ internal static class DotNetToolsJsonDiscovery
     {
         if (!MSBuildHelper.TryGetDotNetToolsJsonPath(repoRootPath, workspacePath, out var dotnetToolsJsonPath))
         {
-            logger.Log("  No dotnet-tools.json file found.");
+            logger.Info("  No dotnet-tools.json file found.");
             return null;
         }
 
         var dotnetToolsJsonFile = DotNetToolsJsonBuildFile.Open(workspacePath, dotnetToolsJsonPath, logger);
 
-        logger.Log($"  Discovered [{dotnetToolsJsonFile.RelativePath}] file.");
+        logger.Info($"  Discovered [{dotnetToolsJsonFile.RelativePath}] file.");
 
         var dependencies = BuildFile.GetDependencies(dotnetToolsJsonFile)
             .OrderBy(d => d.Name)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/GlobalJsonDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/GlobalJsonDiscovery.cs
@@ -8,13 +8,13 @@ internal static class GlobalJsonDiscovery
     {
         if (!MSBuildHelper.TryGetGlobalJsonPath(repoRootPath, workspacePath, out var globalJsonPath))
         {
-            logger.Log("  No global.json file found.");
+            logger.Info("  No global.json file found.");
             return null;
         }
 
         var globalJsonFile = GlobalJsonBuildFile.Open(workspacePath, globalJsonPath, logger);
 
-        logger.Log($"  Discovered [{globalJsonFile.RelativePath}] file.");
+        logger.Info($"  Discovered [{globalJsonFile.RelativePath}] file.");
 
         var dependencies = BuildFile.GetDependencies(globalJsonFile)
             .OrderBy(d => d.Name)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscovery.cs
@@ -14,13 +14,13 @@ internal static class PackagesConfigDiscovery
 
         if (packagesConfigPath is null)
         {
-            logger.Log("  No packages.config file found.");
+            logger.Info("  No packages.config file found.");
             return null;
         }
 
         var packagesConfigFile = PackagesConfigBuildFile.Open(workspacePath, packagesConfigPath);
 
-        logger.Log($"  Discovered [{packagesConfigFile.RelativePath}] file.");
+        logger.Info($"  Discovered [{packagesConfigFile.RelativePath}] file.");
 
         var dependencies = BuildFile.GetDependencies(packagesConfigFile)
             .OrderBy(d => d.Name)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -117,7 +117,7 @@ internal static class SdkProjectDiscovery
                 if (exitCode != 0)
                 {
                     // log error, but still try to resolve what we can
-                    logger.Log($"  Error determining dependencies from `{startingProjectPath}`:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
+                    logger.Warn($"  Error determining dependencies from `{startingProjectPath}`:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
                 }
 
                 var buildRoot = BinaryLog.ReadBuild(binLogPath);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -37,8 +37,7 @@ public record ExperimentsManager
         }
         catch (JsonException ex)
         {
-            // the following message has been specifically designed to match the format of `Dependabot.logger.info(...)` from Ruby
-            logger.Log($"{DateTime.UtcNow:yyyy/MM/dd HH:mm:ss} INFO Error deserializing job file: {ex.ToString()}: {jobFileContent}");
+            logger.Info($"Error deserializing job file: {ex.ToString()}: {jobFileContent}");
             return new ExperimentsManager();
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/JsonBuildFile.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/JsonBuildFile.cs
@@ -39,7 +39,7 @@ internal abstract class JsonBuildFile : BuildFile<string>
             {
                 // We can't police that people have legal JSON files.
                 // If they don't, we just return null.
-                logger.Log($"Failed to parse JSON file: {RelativePath}, got {ex}");
+                logger.Warn($"Failed to parse JSON file: {RelativePath}, got {ex}");
                 FailedToParse = true;
                 return null;
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/CompatabilityChecker.cs
@@ -15,11 +15,11 @@ public class CompatibilityChecker
         var incompatibleFrameworks = projectFrameworks.Where(f => !compatibleFrameworks.Contains(f)).ToArray();
         if (incompatibleFrameworks.Length > 0)
         {
-            logger.Log($"The package is not compatible. Incompatible project frameworks: {string.Join(", ", incompatibleFrameworks.Select(f => f.GetShortFolderName()))}");
+            logger.Warn($"The package is not compatible. Incompatible project frameworks: {string.Join(", ", incompatibleFrameworks.Select(f => f.GetShortFolderName()))}");
             return false;
         }
 
-        logger.Log("The package is compatible.");
+        logger.Info("The package is compatible.");
         return true;
 
         static NuGetFramework ParseFramework(string tfm)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -113,8 +113,8 @@ public class RunWorker
     {
         var discoveryResult = await _discoveryWorker.RunAsync(repoContentsPath.FullName, repoDirectory);
 
-        _logger.Log("Discovery JSON content:");
-        _logger.Log(JsonSerializer.Serialize(discoveryResult, DiscoveryWorker.SerializerOptions));
+        _logger.Info("Discovery JSON content:");
+        _logger.Info(JsonSerializer.Serialize(discoveryResult, DiscoveryWorker.SerializerOptions));
 
         // report dependencies
         var discoveredUpdatedDependencies = GetUpdatedDependencyListFromDiscovery(discoveryResult, repoContentsPath.FullName);
@@ -155,7 +155,7 @@ public class RunWorker
             }
 
             // do update
-            _logger.Log($"Running update in directory {repoDirectory}");
+            _logger.Info($"Running update in directory {repoDirectory}");
             foreach (var project in discoveryResult.Projects)
             {
                 foreach (var dependency in project.Dependencies.Where(d => !d.IsTransitive))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/DotNetToolsJsonUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/DotNetToolsJsonUpdater.cs
@@ -12,18 +12,18 @@ internal static class DotNetToolsJsonUpdater
     {
         if (!MSBuildHelper.TryGetDotNetToolsJsonPath(repoRootPath, workspacePath, out var dotnetToolsJsonPath))
         {
-            logger.Log("  No dotnet-tools.json file found.");
+            logger.Info("  No dotnet-tools.json file found.");
             return;
         }
 
         var dotnetToolsJsonFile = DotNetToolsJsonBuildFile.Open(repoRootPath, dotnetToolsJsonPath, logger);
 
-        logger.Log($"  Updating [{dotnetToolsJsonFile.RelativePath}] file.");
+        logger.Info($"  Updating [{dotnetToolsJsonFile.RelativePath}] file.");
 
         var containsDependency = dotnetToolsJsonFile.GetDependencies().Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
         if (!containsDependency)
         {
-            logger.Log($"    Dependency [{dependencyName}] not found.");
+            logger.Info($"    Dependency [{dependencyName}] not found.");
             return;
         }
 
@@ -39,7 +39,7 @@ internal static class DotNetToolsJsonUpdater
 
             if (await dotnetToolsJsonFile.SaveAsync())
             {
-                logger.Log($"    Saved [{dotnetToolsJsonFile.RelativePath}].");
+                logger.Info($"    Saved [{dotnetToolsJsonFile.RelativePath}].");
             }
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/GlobalJsonUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/GlobalJsonUpdater.cs
@@ -12,25 +12,25 @@ internal static class GlobalJsonUpdater
     {
         if (!MSBuildHelper.TryGetGlobalJsonPath(repoRootPath, workspacePath, out var globalJsonPath))
         {
-            logger.Log("  No global.json file found.");
+            logger.Info("  No global.json file found.");
             return;
         }
 
         var globalJsonFile = GlobalJsonBuildFile.Open(repoRootPath, globalJsonPath, logger);
 
-        logger.Log($"  Updating [{globalJsonFile.RelativePath}] file.");
+        logger.Info($"  Updating [{globalJsonFile.RelativePath}] file.");
 
         var containsDependency = globalJsonFile.GetDependencies().Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
         if (!containsDependency)
         {
-            logger.Log($"    Dependency [{dependencyName}] not found.");
+            logger.Info($"    Dependency [{dependencyName}] not found.");
             return;
         }
 
         if (globalJsonFile.MSBuildSdks?.TryGetPropertyValue(dependencyName, out var version) != true
             || version?.GetValue<string>() is not string versionString)
         {
-            logger.Log("    Unable to determine dependency version.");
+            logger.Info("    Unable to determine dependency version.");
             return;
         }
 
@@ -43,7 +43,7 @@ internal static class GlobalJsonUpdater
 
         if (await globalJsonFile.SaveAsync())
         {
-            logger.Log($"    Saved [{globalJsonFile.RelativePath}].");
+            logger.Info($"    Saved [{globalJsonFile.RelativePath}].");
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
@@ -13,7 +13,7 @@ internal static class LockFileUpdater
             var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("dotnet", ["restore", "--force-evaluate", projectPath], workingDirectory: projectDirectory);
             if (exitCode != 0)
             {
-                logger.Log($"      Lock file update failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+                logger.Error($"      Lock file update failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
             }
             return (exitCode, stdout, stderr);
         }, logger, retainMSBuildSdks: true);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -36,18 +36,18 @@ internal static class PackagesConfigUpdater
     )
     {
         // packages.config project; use NuGet.exe to perform update
-        logger.Log($"  Found '{ProjectHelper.PackagesConfigFileName}' project; running NuGet.exe update");
+        logger.Info($"  Found '{ProjectHelper.PackagesConfigFileName}' project; running NuGet.exe update");
 
         // ensure local packages directory exists
         var projectBuildFile = ProjectBuildFile.Open(repoRootPath, projectPath);
         var packagesSubDirectory = GetPathToPackagesDirectory(projectBuildFile, dependencyName, previousDependencyVersion, packagesConfigPath);
         if (packagesSubDirectory is null)
         {
-            logger.Log($"    Project [{projectPath}] does not reference this dependency.");
+            logger.Info($"    Project [{projectPath}] does not reference this dependency.");
             return;
         }
 
-        logger.Log($"    Using packages directory [{packagesSubDirectory}] for project [{projectPath}].");
+        logger.Info($"    Using packages directory [{packagesSubDirectory}] for project [{projectPath}].");
 
         var projectDirectory = Path.GetDirectoryName(projectPath);
         var packagesDirectory = PathHelper.JoinPath(projectDirectory, packagesSubDirectory);
@@ -75,7 +75,7 @@ internal static class PackagesConfigUpdater
             "-NonInteractive",
         };
 
-        logger.Log("    Finding MSBuild...");
+        logger.Info("    Finding MSBuild...");
         var msbuildDirectory = MSBuildHelper.MSBuildPath;
         if (msbuildDirectory is not null)
         {
@@ -97,7 +97,7 @@ internal static class PackagesConfigUpdater
         // Update binding redirects
         await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, dependencyName, newDependencyVersion);
 
-        logger.Log("    Writing project file back to disk");
+        logger.Info("    Writing project file back to disk");
         await projectBuildFile.SaveAsync();
     }
 
@@ -119,12 +119,12 @@ internal static class PackagesConfigUpdater
             var retryingAfterRestore = false;
 
         doRestore:
-            logger.Log($"    Running NuGet.exe with args: {string.Join(" ", updateArgs)}");
+            logger.Info($"    Running NuGet.exe with args: {string.Join(" ", updateArgs)}");
             outputBuilder.Clear();
             var result = Program.Main(updateArgs.ToArray());
             var fullOutput = outputBuilder.ToString();
-            logger.Log($"    Result: {result}");
-            logger.Log($"    Output:\n{fullOutput}");
+            logger.Info($"    Result: {result}");
+            logger.Info($"    Output:\n{fullOutput}");
             if (result != 0)
             {
                 // The initial `update` command can fail for several reasons:
@@ -141,7 +141,7 @@ internal static class PackagesConfigUpdater
                 if (!retryingAfterRestore && OutputIndicatesRestoreIsRequired(fullOutput))
                 {
                     retryingAfterRestore = true;
-                    logger.Log($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
+                    logger.Info($"    Running NuGet.exe with args: {string.Join(" ", restoreArgs)}");
                     outputBuilder.Clear();
                     var exitCodeAgain = Program.Main(restoreArgs.ToArray());
                     var restoreOutput = outputBuilder.ToString();
@@ -165,7 +165,7 @@ internal static class PackagesConfigUpdater
         }
         catch (Exception e)
         {
-            logger.Log($"Error: {e}");
+            logger.Info($"Error: {e}");
             throw;
         }
         finally
@@ -179,7 +179,7 @@ internal static class PackagesConfigUpdater
             var deltaSpawnedProcesses = currentSpawnedProcesses.Except(existingSpawnedProcesses).ToArray();
             foreach (var credProvider in deltaSpawnedProcesses)
             {
-                logger.Log($"Ending spawned credential provider process");
+                logger.Info($"Ending spawned credential provider process");
                 credProvider.Kill();
             }
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -115,11 +115,11 @@ public class UpdaterWorker : IUpdaterWorker
                 await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             default:
-                _logger.Log($"File extension [{extension}] is not supported.");
+                _logger.Info($"File extension [{extension}] is not supported.");
                 break;
         }
 
-        _logger.Log("Update complete.");
+        _logger.Info("Update complete.");
 
         _processedProjectPaths.Clear();
         return new UpdateOperationResult();
@@ -127,7 +127,7 @@ public class UpdaterWorker : IUpdaterWorker
 
     internal static async Task WriteResultFile(UpdateOperationResult result, string resultOutputPath, ILogger logger)
     {
-        logger.Log($"  Writing update result to [{resultOutputPath}].");
+        logger.Info($"  Writing update result to [{resultOutputPath}].");
 
         var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
         await File.WriteAllTextAsync(resultOutputPath, resultJson);
@@ -141,7 +141,7 @@ public class UpdaterWorker : IUpdaterWorker
         string newDependencyVersion,
         bool isTransitive)
     {
-        _logger.Log($"Running for solution [{Path.GetRelativePath(repoRootPath, solutionPath)}]");
+        _logger.Info($"Running for solution [{Path.GetRelativePath(repoRootPath, solutionPath)}]");
         var projectPaths = MSBuildHelper.GetProjectPathsFromSolution(solutionPath);
         foreach (var projectPath in projectPaths)
         {
@@ -157,10 +157,10 @@ public class UpdaterWorker : IUpdaterWorker
         string newDependencyVersion,
         bool isTransitive)
     {
-        _logger.Log($"Running for proj file [{Path.GetRelativePath(repoRootPath, projFilePath)}]");
+        _logger.Info($"Running for proj file [{Path.GetRelativePath(repoRootPath, projFilePath)}]");
         if (!File.Exists(projFilePath))
         {
-            _logger.Log($"File [{projFilePath}] does not exist.");
+            _logger.Info($"File [{projFilePath}] does not exist.");
             return;
         }
 
@@ -183,10 +183,10 @@ public class UpdaterWorker : IUpdaterWorker
         string newDependencyVersion,
         bool isTransitive)
     {
-        _logger.Log($"Running for project file [{Path.GetRelativePath(repoRootPath, projectPath)}]");
+        _logger.Info($"Running for project file [{Path.GetRelativePath(repoRootPath, projectPath)}]");
         if (!File.Exists(projectPath))
         {
-            _logger.Log($"File [{projectPath}] does not exist.");
+            _logger.Info($"File [{projectPath}] does not exist.");
             return;
         }
 
@@ -216,7 +216,7 @@ public class UpdaterWorker : IUpdaterWorker
 
         _processedProjectPaths.Add(projectPath);
 
-        _logger.Log($"Updating project [{projectPath}]");
+        _logger.Info($"Updating project [{projectPath}]");
 
         var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(projectPath, ProjectHelper.PathFormat.Full);
         var packagesConfigFullPath = additionalFiles.Where(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesConfigFileName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ConsoleLogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ConsoleLogger.cs
@@ -2,7 +2,7 @@ namespace NuGetUpdater.Core;
 
 public sealed class ConsoleLogger : ILogger
 {
-    public void Log(string message)
+    public void LogRaw(string message)
     {
         Console.WriteLine(message);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
@@ -235,24 +235,24 @@ public class PackageManager
             }
             else
             {
-                logger.Log("No compatible framework found.");
+                logger.Info("No compatible framework found.");
             }
         }
         catch (HttpRequestException ex)
         {
-            logger.Log($"HTTP error occurred: {ex.Message}");
+            logger.Error($"HTTP error occurred: {ex.Message}");
         }
         catch (ArgumentNullException ex)
         {
-            logger.Log($"Argument is null error: {ex.ParamName}, {ex.Message}");
+            logger.Error($"Argument is null error: {ex.ParamName}, {ex.Message}");
         }
         catch (InvalidOperationException ex)
         {
-            logger.Log($"Invalid operation exception: {ex.Message}");
+            logger.Error($"Invalid operation exception: {ex.Message}");
         }
         catch (Exception ex)
         {
-            logger.Log($"An error occurred: {ex.Message}");
+            logger.Error($"An error occurred: {ex.Message}");
         }
 
         return dependencyList;
@@ -499,7 +499,7 @@ public class PackageManager
 
             else
             {
-                logger.Log("Current version is >= latest version");
+                logger.Info("Current version is >= latest version");
             }
         }
         catch
@@ -680,7 +680,7 @@ public class PackageManager
             }
             else
             {
-                logger.Log($"Package {packageToUpdate.PackageName} not found in existing packages");
+                logger.Info($"Package {packageToUpdate.PackageName} not found in existing packages");
             }
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
@@ -2,5 +2,15 @@ namespace NuGetUpdater.Core;
 
 public interface ILogger
 {
-    void Log(string message);
+    void LogRaw(string message);
+}
+
+public static class LoggerExtensions
+{
+    public static void Info(this ILogger logger, string message) => logger.LogWithLevel("INFO", message);
+    public static void Warn(this ILogger logger, string message) => logger.LogWithLevel("WARN", message);
+    public static void Error(this ILogger logger, string message) => logger.LogWithLevel("ERROR", message);
+
+    private static void LogWithLevel(this ILogger logger, string level, string message) => logger.LogRaw($"{GetCurrentTimestamp()} {level} {message}");
+    private static string GetCurrentTimestamp() => DateTime.UtcNow.ToString("yyyy/MM/dd HH:mm:ss");
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -51,7 +51,7 @@ internal static partial class MSBuildHelper
         var globalJsonPaths = candidateDirectories.Select(d => Path.Combine(d, "global.json")).Where(File.Exists).Select(p => (p, p + Guid.NewGuid().ToString())).ToArray();
         foreach (var (globalJsonPath, tempGlobalJsonPath) in globalJsonPaths)
         {
-            logger.Log($"Temporarily removing `global.json` from `{Path.GetDirectoryName(globalJsonPath)}`{(retainMSBuildSdks ? " and retaining MSBuild SDK declarations" : string.Empty)}.");
+            logger.Info($"Temporarily removing `global.json` from `{Path.GetDirectoryName(globalJsonPath)}`{(retainMSBuildSdks ? " and retaining MSBuild SDK declarations" : string.Empty)}.");
             File.Move(globalJsonPath, tempGlobalJsonPath);
             if (retainMSBuildSdks)
             {
@@ -80,7 +80,7 @@ internal static partial class MSBuildHelper
         {
             foreach (var (globalJsonpath, tempGlobalJsonPath) in globalJsonPaths)
             {
-                logger.Log($"Restoring `global.json` to `{Path.GetDirectoryName(globalJsonpath)}`.");
+                logger.Info($"Restoring `global.json` to `{Path.GetDirectoryName(globalJsonpath)}`.");
                 File.Move(tempGlobalJsonPath, globalJsonpath, overwrite: retainMSBuildSdks);
             }
         }
@@ -638,8 +638,8 @@ internal static partial class MSBuildHelper
         }
         catch (NuGetConfigurationException ex)
         {
-            logger.Log("Error while parsing NuGet.config");
-            logger.Log(ex.Message);
+            logger.Warn("Error while parsing NuGet.config");
+            logger.Warn(ex.Message);
 
             // Nuget.config is invalid. Won't be able to do anything with specific sources.
             return null;
@@ -762,7 +762,7 @@ internal static partial class MSBuildHelper
         ThrowOnUnauthenticatedFeed(stdOut);
         if (exitCode != 0)
         {
-            logger.Log($"Error determining target frameworks.\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
+            logger.Warn($"Error determining target frameworks.\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
         }
 
         // There are 3 return values, all uses slightly differently.  Only one will be set, the others will be blank
@@ -806,7 +806,7 @@ internal static partial class MSBuildHelper
         string projectPath,
         string targetFramework,
         IReadOnlyCollection<Dependency> packages,
-        ILogger? logger = null)
+        ILogger logger)
     {
         var tempDirectory = Directory.CreateTempSubdirectory("package-dependency-resolution_");
         try
@@ -837,7 +837,7 @@ internal static partial class MSBuildHelper
             }
             else
             {
-                logger?.Log($"dotnet build in {nameof(GetAllPackageDependenciesAsync)} failed. STDOUT: {stdout} STDERR: {stderr}");
+                logger?.Warn($"dotnet build in {nameof(GetAllPackageDependenciesAsync)} failed. STDOUT: {stdout} STDERR: {stderr}");
                 return [];
             }
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/NuGetHelper.cs
@@ -9,7 +9,7 @@ internal static class NuGetHelper
         var tempDirectory = Directory.CreateTempSubdirectory("msbuild_sdk_restore_");
         try
         {
-            var tempProjectPath = await MSBuildHelper.CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, "netstandard2.0", packages, usePackageDownload: true);
+            var tempProjectPath = await MSBuildHelper.CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, "netstandard2.0", packages, logger, usePackageDownload: true);
             var (exitCode, stdOut, stdErr) = await ProcessEx.RunAsync("dotnet", ["restore", tempProjectPath]);
 
             return exitCode == 0;


### PR DESCRIPTION
Replace `logger.Log(...)` with `logger.Info(...)`, etc. where the formatting matches the messages produced by the Ruby logger call `Dependabot.logger.info(...)`.  This is to ensure consistent log messages, no matter what code produced it.

There were also a few instances of `Console.WriteLine` that were replaced with the appropriate `logger` call.