### PR TITLE
Add support for devcontainers ecosystem metrics collection

### DIFF
--- a/common/lib/dependabot/ecosystem.rb
+++ b/common/lib/dependabot/ecosystem.rb
@@ -12,6 +12,8 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
+      DEFAULT_VERSION_PATTERN = /(\d+\.\d+(.\d+)*)/
+
       abstract!
       # Initialize version information for a package manager or language.
       # @param name [String] the name of the package manager or language (e.g., "bundler", "ruby").

--- a/devcontainers/lib/dependabot/devcontainers/file_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser.rb
@@ -90,7 +90,7 @@ module Dependabot
         @devcontainer_version ||= T.let(
           begin
             version = SharedHelpers.run_shell_command("devcontainer --version")
-            version.match(/(\d+\.\d+(.\d+)*)/)&.captures&.first
+            version.match(Dependabot::Ecosystem::VersionManager::DEFAULT_VERSION_PATTERN)&.captures&.first
           end,
           T.nilable(String)
         )
@@ -101,7 +101,7 @@ module Dependabot
         @node_version ||= T.let(
           begin
             version = SharedHelpers.run_shell_command("node --version")
-            version.match(/(\d+\.\d+(.\d+)*)/)&.captures&.first
+            version.match(Dependabot::Ecosystem::VersionManager::DEFAULT_VERSION_PATTERN)&.captures&.first
           end,
           T.nilable(String)
         )

--- a/devcontainers/lib/dependabot/devcontainers/language.rb
+++ b/devcontainers/lib/dependabot/devcontainers/language.rb
@@ -1,0 +1,21 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/devcontainers/version"
+
+module Dependabot
+  module Devcontainers
+    LANGUAGE = "node"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(LANGUAGE, Version.new(raw_version))
+      end
+    end
+  end
+end

--- a/devcontainers/lib/dependabot/devcontainers/package_manager.rb
+++ b/devcontainers/lib/dependabot/devcontainers/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/devcontainers/version"
+
+module Dependabot
+  module Devcontainers
+    ECOSYSTEM = "devcontainers"
+    PACKAGE_MANAGER = "devcontainers"
+    SUPPORTED_DEVCONTAINER_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_DEVCONTAINER_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_DEVCONTAINER_VERSIONS,
+          SUPPORTED_DEVCONTAINER_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -217,4 +217,35 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
       expect(dependencies).to be_empty
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    let(:project_name) { "config_in_root" }
+    let(:directory) { "/" }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "devcontainers"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "devcontainers"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "0.72.0"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "node"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "18.20.5"
+      end
+    end
+  end
 end

--- a/devcontainers/spec/dependabot/devcontainers/language_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/language_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/devcontainers/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Devcontainers::Language do
+  subject(:language) { described_class.new(version) }
+
+  let(:version) { "1.17.3" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version.to_s).to eq version
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Devcontainers::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/devcontainers/spec/dependabot/devcontainers/package_manager_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/devcontainers/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Devcontainers::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "2.1.1" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version.to_s).to eq version
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Devcontainers::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Devcontainers::DEPRECATED_DEVCONTAINER_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Devcontainers::SUPPORTED_DEVCONTAINER_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the devcontainers ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

#### How will you know you've accomplished your goal?

- I'll be able to see devcontainers ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
