### PR TITLE
Adding retries interval to registry client

### DIFF
--- a/common/lib/dependabot/registry_client.rb
+++ b/common/lib/dependabot/registry_client.rb
@@ -30,7 +30,9 @@ module Dependabot
       Excon.get(
         url,
         idempotent: true,
-        **SharedHelpers.excon_defaults({ headers: headers }.merge(options))
+        **SharedHelpers.excon_defaults({ headers: headers }.merge(options)),
+        retry_limit: 3,
+        retry_interval: 5
       )
     rescue Excon::Error::Timeout => e
       cache_error(url, e)

--- a/common/lib/dependabot/registry_client.rb
+++ b/common/lib/dependabot/registry_client.rb
@@ -31,7 +31,6 @@ module Dependabot
         url,
         idempotent: true,
         **SharedHelpers.excon_defaults({ headers: headers }.merge(options)),
-        retry_limit: 3,
         retry_interval: 5
       )
     rescue Excon::Error::Timeout => e

--- a/common/spec/dependabot/registry_client_spec.rb
+++ b/common/spec/dependabot/registry_client_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe Dependabot::RegistryClient do
     { idempotent: true }
   end
   let(:dependabot_defaults) do
-    Dependabot::SharedHelpers.excon_defaults
+    Dependabot::SharedHelpers.excon_defaults.merge(
+        retry_limit: 3,
+        retry_interval: 5
+    )
   end
 
   before do

--- a/common/spec/dependabot/registry_client_spec.rb
+++ b/common/spec/dependabot/registry_client_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Dependabot::RegistryClient do
     { idempotent: true }
   end
   let(:dependabot_defaults) do
-    Dependabot::SharedHelpers.excon_defaults.merge(
-        retry_interval: 5
-    )
+    Dependabot::SharedHelpers.excon_defaults
   end
 
   before do
@@ -22,23 +20,26 @@ RSpec.describe Dependabot::RegistryClient do
   describe "delegation to Excon" do
     describe "::get" do
       it "delegates requests using Dependabot defaults" do
-        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults)
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge({ retry_interval: 5 }))
 
         described_class.get(url: url)
       end
 
       it "delegates headers correctly" do
         headers = { "Foo" => "Bar" }
-        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
-          "Foo" => "Bar",
-          "User-Agent" => anything
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge({
+          headers: {
+            "Foo" => "Bar",
+            "User-Agent" => anything
+          },
+          retry_interval: 5
         }))
 
         described_class.get(url: url, headers: headers)
       end
 
       it "delegates options correctly" do
-        options = { foo: "bar" }
+        options = { foo: "bar", retry_interval: 5 }
         expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(options))
 
         described_class.get(url: url, options: options)
@@ -52,7 +53,8 @@ RSpec.describe Dependabot::RegistryClient do
             "Foo" => "Bar",
             "User-Agent" => anything
           },
-          bar: "baaz"
+          bar: "baaz",
+          retry_interval: 5
         ))
 
         described_class.get(url: url, headers: headers, options: options)
@@ -61,10 +63,10 @@ RSpec.describe Dependabot::RegistryClient do
       it "ignores headers that are passed as options" do
         headers = { "Foo" => "Bar" }
         options = { headers: headers }
-        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge({ headers: {
           "Foo" => "Bar",
           "User-Agent" => anything
-        }))
+        }, retry_interval: 5 }))
 
         described_class.get(url: url, options: options)
       end
@@ -88,7 +90,7 @@ RSpec.describe Dependabot::RegistryClient do
       end
 
       it "delegates options correctly" do
-        options = { foo: "bar" }
+        options = { foo: "bar", retry_interval: 5 }
         expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults.merge(options))
 
         described_class.head(url: url, options: options)

--- a/common/spec/dependabot/registry_client_spec.rb
+++ b/common/spec/dependabot/registry_client_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Dependabot::RegistryClient do
   end
   let(:dependabot_defaults) do
     Dependabot::SharedHelpers.excon_defaults.merge(
-        retry_limit: 3,
         retry_interval: 5
     )
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Adding a retry interval to registry client Excon GET requests to better handle transient socket EOF errors affecting Maven and Terraform dependency updates by spacing out retry attempts.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The change spaces out retry attempts by 5 seconds, working with Excon's default of 4 retries for idempotent requests. This should help prevent rapid consecutive failures while still maintaining the existing retry behavior.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

* Error rate monitoring shows reduction in EOFError failures
* Failbot metrics confirm retried requests succeed

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
