### PR TITLE
Add support for git-submodules ecosystem metrics collection

### DIFF
--- a/git_submodules/lib/dependabot/git_submodules/package_manager.rb
+++ b/git_submodules/lib/dependabot/git_submodules/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/git_submodules/version"
+
+module Dependabot
+  module GitSubmodules
+    ECOSYSTEM = "git_submodules"
+    PACKAGE_MANAGER = "git_submodules"
+    SUPPORTED_GIT_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_GIT_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_GIT_VERSIONS,
+          SUPPORTED_GIT_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/git_submodules/spec/dependabot/git_submodules/file_parser_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/file_parser_spec.rb
@@ -121,5 +121,23 @@ RSpec.describe Dependabot::GitSubmodules::FileParser do
           end
       end
     end
+
+    describe "#ecosystem" do
+      subject(:ecosystem) { parser.ecosystem }
+
+      it "has the correct name" do
+        expect(ecosystem.name).to eq "git_submodules"
+      end
+
+      describe "#package_manager" do
+        subject(:package_manager) { ecosystem.package_manager }
+
+        it "returns the correct package manager" do
+          expect(package_manager.name).to eq "git_submodules"
+          expect(package_manager.requirement).to be_nil
+          expect(package_manager.version.to_s).to eq "2.34.1"
+        end
+      end
+    end
   end
 end

--- a/git_submodules/spec/dependabot/git_submodules/package_manager_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/git_submodules/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::GitSubmodules::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "2.1.1" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version.to_s).to eq version
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::GitSubmodules::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::GitSubmodules::DEPRECATED_GIT_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::GitSubmodules::SUPPORTED_GIT_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the git-submodules ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

These metrics don't include language information because language does not seem to be applicable to git-submodules.

#### How will you know you've accomplished your goal?

- I'll be able to see git-submodules ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
