### PR TITLE
store discovery files under $HOME so they're not cleaned up by the OS

### DIFF
--- a/nuget/lib/dependabot/nuget/analysis/analysis_json_reader.rb
+++ b/nuget/lib/dependabot/nuget/analysis/analysis_json_reader.rb
@@ -14,7 +14,9 @@ module Dependabot
 
       sig { returns(String) }
       def self.temp_directory
-        File.join(NativeDiscoveryJsonReader.temp_directory, "analysis")
+        d = File.join(Dir.tmpdir, "analysis")
+        FileUtils.mkdir_p(d)
+        d
       end
 
       sig { params(dependency_name: String).returns(String) }

--- a/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
@@ -35,6 +35,12 @@ module Dependabot
         cache_dependency_file_paths_to_discovery_json_path.clear
       end
 
+      sig { void }
+      def self.testonly_clear_discovery_files
+        # this will get recreated when necessary
+        FileUtils.rm_rf(discovery_directory)
+      end
+
       # Runs NuGet dependency discovery in the given directory and returns a new instance of NativeDiscoveryJsonReader.
       # The location of the resultant JSON file is saved.
       sig do
@@ -99,7 +105,7 @@ module Dependabot
 
       sig { returns(String) }
       def self.discovery_map_file_path
-        File.join(temp_directory, "discovery_map.json")
+        File.join(discovery_directory, "discovery_map.json")
       end
 
       sig { params(workspace_path: String).returns(String) }
@@ -124,7 +130,7 @@ module Dependabot
         discovery_json_counter = 1
         new_discovery_json_path = ""
         loop do
-          new_discovery_json_path = File.join(temp_directory, "discovery.#{discovery_json_counter}.json")
+          new_discovery_json_path = File.join(discovery_directory, "discovery.#{discovery_json_counter}.json")
           break unless File.exist?(new_discovery_json_path)
 
           discovery_json_counter += 1
@@ -144,8 +150,8 @@ module Dependabot
       end
 
       sig { returns(String) }
-      def self.temp_directory
-        t = File.join(Dir.tmpdir, ".dependabot")
+      def self.discovery_directory
+        t = File.join(Dir.home, ".dependabot")
         FileUtils.mkdir_p(t)
         t
       end
@@ -155,7 +161,7 @@ module Dependabot
         discovery_file_path = discovery_file_path_from_workspace_path(workspace_path)
         discovery_json = DependencyFile.new(
           name: Pathname.new(discovery_file_path).cleanpath.to_path,
-          directory: temp_directory,
+          directory: discovery_directory,
           type: "file",
           content: File.read(discovery_file_path)
         )

--- a/nuget/lib/dependabot/nuget/native_update_checker/native_update_checker.rb
+++ b/nuget/lib/dependabot/nuget/native_update_checker/native_update_checker.rb
@@ -89,7 +89,9 @@ module Dependabot
 
       sig { returns(String) }
       def dependency_file_path
-        File.join(NativeDiscoveryJsonReader.temp_directory, "dependency", "#{dependency.name}.json")
+        d = File.join(Dir.tmpdir, "dependency")
+        FileUtils.mkdir_p(d)
+        File.join(d, "#{dependency.name}.json")
       end
 
       sig { returns(T::Array[String]) }

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -42,10 +42,7 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
   it_behaves_like "a dependency file fetcher"
 
   def clean_common_files
-    # deletes `discovery_map.json` and `discovery.1.json`, etc.
-    Dir.glob(File.join(Dependabot::Nuget::NativeDiscoveryJsonReader.temp_directory, "discovery*.json")).each do |f|
-      File.delete(f)
-    end
+    Dependabot::Nuget::NativeDiscoveryJsonReader.testonly_clear_discovery_files
   end
 
   def clean_repo_files

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -69,10 +69,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
   end
 
   def clean_common_files
-    # deletes `discovery_map.json` and `discovery.1.json`, etc.
-    Dir.glob(File.join(Dependabot::Nuget::NativeDiscoveryJsonReader.temp_directory, "discovery*.json")).each do |f|
-      File.delete(f)
-    end
+    Dependabot::Nuget::NativeDiscoveryJsonReader.testonly_clear_discovery_files
   end
 
   def run_parser_test(&_block)

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -100,10 +100,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
   end
 
   def clean_common_files
-    # deletes `discovery_map.json` and `discovery.1.json`, etc.
-    Dir.glob(File.join(Dependabot::Nuget::NativeDiscoveryJsonReader.temp_directory, "discovery*.json")).each do |f|
-      File.delete(f)
-    end
+    Dependabot::Nuget::NativeDiscoveryJsonReader.testonly_clear_discovery_files
   end
 
   def run_update_test(&_block)

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -95,10 +95,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
   end
 
   def clean_common_files
-    # deletes `discovery_map.json` and `discovery.1.json`, etc.
-    Dir.glob(File.join(Dependabot::Nuget::NativeDiscoveryJsonReader.temp_directory, "discovery*.json")).each do |f|
-      File.delete(f)
-    end
+    Dependabot::Nuget::NativeDiscoveryJsonReader.testonly_clear_discovery_files
   end
 
   def run_analyze_test(&_block)


### PR DESCRIPTION
A recent PR wrote discovery JSON files to `/tmp` but telemetry is reporting that sometimes an expected file is missing.  This appears in the logs as:

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/.dependabot/discovery.1.json
```

Ultimately, I don't know exactly what's happening, but here's a guess.

1. An update job consists of [two processes](https://github.com/dependabot/cli/blob/4e7612fe884683ade8c54ad8fd137fc6da92bb84/internal/infra/run.go#L422): `bin/run fetch_files` and `bin/run update_files`.
2. The recent PR (#11026) writes discovery JSON files during the `fetch_files` step to `/tmp/.dependabot/dependabot*`.
3. That same PR then reads those discovery files during the `update_files` step.

According to the logs, all instances of `discovery.1.json` not being found all happen during `update_files`, but the log also confirms that the files were written during `fetch_files`.  The explanation is that the OS/container is cleaning files in `/tmp` after the `fetch_files` process ends and before the `update_files` process starts.

The fix is to write these files to `$HOME/.dependabot/dependabot*` so they're not marked for cleanup by the OS/container on process exit.  There are other instances (e.g., during analysis and checking for updates) where we still write to `/tmp`, but we're not crossing a process lifetime boundary, so those are safe.