### PR TITLE
download nuget packages to well-known location

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -441,8 +441,6 @@ public partial class DiscoveryWorkerTests
                             ReferencedProjectPaths = [],
                             ImportedFiles = [
                                 "Directory.Build.targets",
-                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
-                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
                                 "Packages.props",
                             ],
                             AdditionalFiles = [],
@@ -513,8 +511,6 @@ public partial class DiscoveryWorkerTests
                             ReferencedProjectPaths = [],
                             ImportedFiles = [
                                 "Directory.Build.targets",
-                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.props", // this is an artifact of the package cache existing next to the csproj
-                                "NUGET_PACKAGES/microsoft.build.centralpackageversions/2.1.3/Sdk/Sdk.targets", // this is an artifact of the package cache existing next to the csproj
                                 "Packages.props",
                             ],
                             AdditionalFiles = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -315,14 +315,6 @@ public abstract class UpdateWorkerTestBase : TestBase
                 """
             );
         }
-
-        // override various nuget locations
-        foreach (var envName in new[] { "NUGET_PACKAGES", "NUGET_HTTP_CACHE_PATH", "NUGET_SCRATCH", "NUGET_PLUGINS_CACHE_PATH" })
-        {
-            string dir = Path.Join(temporaryDirectory, envName);
-            Directory.CreateDirectory(dir);
-            Environment.SetEnvironmentVariable(envName, dir);
-        }
     }
 
     protected static async Task<TestFile[]> RunUpdate(TestFile[] files, Func<string, Task> action)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -2160,12 +2160,6 @@ public partial class UpdateWorkerTests
                 };
             }
             using var cache = new TemporaryDirectory();
-            using var env = new TemporaryEnvironment([
-                ("NUGET_PACKAGES", Path.Join(cache.DirectoryPath, "NUGET_PACKAGES")),
-                ("NUGET_HTTP_CACHE_PATH", Path.Join(cache.DirectoryPath, "NUGET_HTTP_CACHE_PATH")),
-                ("NUGET_SCRATCH", Path.Join(cache.DirectoryPath, "NUGET_SCRATCH")),
-                ("NUGET_PLUGINS_CACHE_PATH", Path.Join(cache.DirectoryPath, "NUGET_PLUGINS_CACHE_PATH")),
-            ]);
             using var http = TestHttpServer.CreateTestServer(TestHttpHandler);
             await TestUpdateForProject("Some.Package", "1.0.0", "2.0.0",
                 // existing

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -342,106 +342,70 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task GetAllPackageDependencies_NugetConfigInvalid_DoesNotThrow()
     {
-        var nugetPackagesDirectory = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        var nugetHttpCacheDirectory = Environment.GetEnvironmentVariable("NUGET_HTTP_CACHE_PATH");
+        using var temp = new TemporaryDirectory();
 
-        try
-        {
-            using var temp = new TemporaryDirectory();
+        // Write the NuGet.config with a missing "/>"
+        await File.WriteAllTextAsync(
+            Path.Combine(temp.DirectoryPath, "NuGet.Config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+                <packageSources>
+                <clear />
+                <add key="contoso" value="https://contoso.com/v3/index.json"
+                </packageSources>
+            </configuration>
+            """);
 
-            // It is important to have empty NuGet caches for this test, so override them with temp directories.
-            var tempNuGetPackagesDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "packages");
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", tempNuGetPackagesDirectory);
-            var tempNuGetHttpCacheDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "v3-cache");
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", tempNuGetHttpCacheDirectory);
-
-            // Write the NuGet.config with a missing "/>"
-            await File.WriteAllTextAsync(
-                Path.Combine(temp.DirectoryPath, "NuGet.Config"), """
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                  <packageSources>
-                    <clear />
-                    <add key="contoso" value="https://contoso.com/v3/index.json"
-                  </packageSources>
-                </configuration>
-                """);
-
-            // Asserting it didn't throw
-            var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
-                temp.DirectoryPath,
-                temp.DirectoryPath,
-                "net8.0",
-                [new Dependency("Some.Package", "4.5.11", DependencyType.Unknown)],
-                new TestLogger()
-            );
-        }
-        finally
-        {
-            // Restore the NuGet caches.
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetPackagesDirectory);
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", nugetHttpCacheDirectory);
-        }
+        // Asserting it didn't throw
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+            temp.DirectoryPath,
+            temp.DirectoryPath,
+            "net8.0",
+            [new Dependency("Some.Package", "4.5.11", DependencyType.Unknown)],
+            new TestLogger()
+        );
     }
 
     [Fact]
     public async Task LocalPackageSourcesAreHonored()
     {
-        var nugetPackagesDirectory = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        var nugetHttpCacheDirectory = Environment.GetEnvironmentVariable("NUGET_HTTP_CACHE_PATH");
+        using var temp = new TemporaryDirectory();
 
-        try
-        {
-            using var temp = new TemporaryDirectory();
+        // create two local package sources with different packages available in each
+        string localSource1 = Path.Combine(temp.DirectoryPath, "local", "source1");
+        Directory.CreateDirectory(localSource1);
+        string localSource2 = Path.Combine(temp.DirectoryPath, "local", "source2");
+        Directory.CreateDirectory(localSource2);
 
-            // It is important to have empty NuGet caches for this test, so override them with temp directories.
-            var tempNuGetPackagesDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "packages");
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", tempNuGetPackagesDirectory);
-            var tempNuGetHttpCacheDirectory = Path.Combine(temp.DirectoryPath, ".nuget", "v3-cache");
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", tempNuGetHttpCacheDirectory);
+        // `Package.A` will only live in `local\source1` and uses Windows-style directory separators and will have
+        // a dependency on `Package.B` which is only available in `local/source2` and uses Unix-style directory
+        // separators.
+        MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net8.0", [(null, [("Package.B", "2.0.0")])]).WriteToDirectory(localSource1);
+        MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net8.0").WriteToDirectory(localSource2);
+        await File.WriteAllTextAsync(Path.Join(temp.DirectoryPath, "NuGet.Config"), """
+            <configuration>
+                <packageSources>
+                <add key="localSource1" value="local\source1" />
+                <add key="localSource2" value="local/source2" />
+                </packageSources>
+            </configuration>
+            """);
 
-            // create two local package sources with different packages available in each
-            string localSource1 = Path.Combine(temp.DirectoryPath, "local", "source1");
-            Directory.CreateDirectory(localSource1);
-            string localSource2 = Path.Combine(temp.DirectoryPath, "local", "source2");
-            Directory.CreateDirectory(localSource2);
+        Dependency[] expectedDependencies =
+        [
+            new("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+            new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
+        ];
 
-            // `Package.A` will only live in `local\source1` and uses Windows-style directory separators and will have
-            // a dependency on `Package.B` which is only available in `local/source2` and uses Unix-style directory
-            // separators.
-            MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net8.0", [(null, [("Package.B", "2.0.0")])]).WriteToDirectory(localSource1);
-            MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net8.0").WriteToDirectory(localSource2);
-            await File.WriteAllTextAsync(Path.Join(temp.DirectoryPath, "NuGet.Config"), """
-                <configuration>
-                  <packageSources>
-                    <add key="localSource1" value="local\source1" />
-                    <add key="localSource2" value="local/source2" />
-                  </packageSources>
-                </configuration>
-                """);
+        Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+            temp.DirectoryPath,
+            temp.DirectoryPath,
+            "net8.0",
+            [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)],
+            new TestLogger()
+        );
 
-            Dependency[] expectedDependencies =
-            [
-                new("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
-                new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
-            ];
-
-            Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
-                temp.DirectoryPath,
-                temp.DirectoryPath,
-                "net8.0",
-                [new Dependency("Package.A", "1.0.0", DependencyType.Unknown)],
-                new TestLogger()
-            );
-
-            AssertEx.Equal(expectedDependencies, actualDependencies);
-        }
-        finally
-        {
-            // Restore the NuGet caches.
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", nugetPackagesDirectory);
-            Environment.SetEnvironmentVariable("NUGET_HTTP_CACHE_PATH", nugetHttpCacheDirectory);
-        }
+        AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
     [Fact]
@@ -544,91 +508,75 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingTopLevelPackage()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewUpdatingTopLevelPackage)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="CS-Script.Core" Version="1.3.1" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="3.4.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="CS-Script.Core" Version="1.3.1" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="3.4.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                // Add comment about root and dependencies
-                new Dependency("CS-Script.Core", "1.3.1", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "3.4.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Scripting.Common", "3.4.0", DependencyType.PackageReference),
-            };
-            var update = new[]
-            {
-                new Dependency("CS-Script.Core", "2.0.0", DependencyType.PackageReference),
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(3, resolvedDependencies.Length);
-            Assert.Equal("CS-Script.Core", resolvedDependencies[0].Name);
-            Assert.Equal("2.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
-            Assert.Equal("3.6.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Scripting.Common", resolvedDependencies[2].Name);
-            Assert.Equal("3.6.0", resolvedDependencies[2].Version);
-        }
-        finally
+            // Add comment about root and dependencies
+            new Dependency("CS-Script.Core", "1.3.1", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "3.4.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Scripting.Common", "3.4.0", DependencyType.PackageReference),
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("CS-Script.Core", "2.0.0", DependencyType.PackageReference),
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(3, resolvedDependencies.Length);
+        Assert.Equal("CS-Script.Core", resolvedDependencies[0].Name);
+        Assert.Equal("2.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
+        Assert.Equal("3.6.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Scripting.Common", resolvedDependencies[2].Name);
+        Assert.Equal("3.6.0", resolvedDependencies[2].Version);
     }
 
     // Updating a dependency (Microsoft.Bcl.AsyncInterfaces) of the root package (Azure.Core) will require the root package to also update, but since the dependency is not in the existing list, we do not include it
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingNonExistingDependency()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewUpdatingNonExistingDependency)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Azure.Core" Version="1.21.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Azure.Core" Version="1.21.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.1.1", DependencyType.Unknown)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Single(resolvedDependencies);
-            Assert.Equal("Azure.Core", resolvedDependencies[0].Name);
-            Assert.Equal("1.22.0", resolvedDependencies[0].Version);
-        }
-        finally
+            new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.1.1", DependencyType.Unknown)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Single(resolvedDependencies);
+        Assert.Equal("Azure.Core", resolvedDependencies[0].Name);
+        Assert.Equal("1.22.0", resolvedDependencies[0].Version);
     }
 
     // Adding a reference
@@ -637,43 +585,35 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingNonExistentDependencyAndKeepingReference()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewUpdatingNonExistentDependencyAndKeepingReference)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(2, resolvedDependencies.Length);
-            Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[0].Name);
-            Assert.Equal("1.0.2", resolvedDependencies[0].Version);
-            Assert.Equal("Newtonsoft.Json", resolvedDependencies[1].Name);
-            Assert.Equal("13.0.1", resolvedDependencies[1].Version);
-        }
-        finally
+            new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(2, resolvedDependencies.Length);
+        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[0].Name);
+        Assert.Equal("1.0.2", resolvedDependencies[0].Version);
+        Assert.Equal("Newtonsoft.Json", resolvedDependencies[1].Name);
+        Assert.Equal("13.0.1", resolvedDependencies[1].Version);
     }
 
     // Updating unreferenced dependency
@@ -683,49 +623,41 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewTransitiveDependencyNotExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewTransitiveDependencyNotExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(3, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-        }
-        finally
+            new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(3, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
     }
 
     // Updating referenced dependency
@@ -733,53 +665,45 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewSingleTransitiveDependencyExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewSingleTransitiveDependencyExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(4, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[3].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[3].Version);
-        }
-        finally
+            new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(4, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[3].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[3].Version);
     }
 
     // A combination of the third and fourth test, to measure efficiency of updating separate families
@@ -788,56 +712,48 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewSelectiveAdditionPackages()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewSelectiveAdditionPackages)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+                <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+                <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-                    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference),
-                new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
-                new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(5, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-            Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[3].Name);
-            Assert.Equal("1.0.2", resolvedDependencies[3].Version);
-            Assert.Equal("Newtonsoft.Json", resolvedDependencies[4].Name);
-            Assert.Equal("13.0.1", resolvedDependencies[4].Version);
-        }
-        finally
+            new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference),
+            new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
+            new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(5, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
+        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[3].Name);
+        Assert.Equal("1.0.2", resolvedDependencies[3].Version);
+        Assert.Equal("Newtonsoft.Json", resolvedDependencies[4].Name);
+        Assert.Equal("13.0.1", resolvedDependencies[4].Version);
     }
 
     // Two top level packages (Buildalyzer), (Microsoft.CodeAnalysis.CSharp.Scripting) that share a dependency (Microsoft.CodeAnalysis.Csharp)
@@ -848,53 +764,45 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewSharingDependency()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewSharingDependency)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Buildalyzer" Version="6.0.4" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Csharp.Scripting" Version="3.10.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Buildalyzer" Version="6.0.4" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Csharp.Scripting" Version="3.10.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Buildalyzer", "6.0.4", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "3.10.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "3.10.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "3.10.0", DependencyType.PackageReference),
-            };
-            var update = new[]
-            {
-                new Dependency("Buildalyzer", "7.0.1", DependencyType.PackageReference),
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(4, resolvedDependencies.Length);
-            Assert.Equal("Buildalyzer", resolvedDependencies[0].Name);
-            Assert.Equal("7.0.1", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
-            Assert.Equal("4.0.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
-            Assert.Equal("4.0.0", resolvedDependencies[2].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[3].Name);
-            Assert.Equal("4.0.0", resolvedDependencies[3].Version);
-        }
-        finally
+            new Dependency("Buildalyzer", "6.0.4", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "3.10.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "3.10.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "3.10.0", DependencyType.PackageReference),
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Buildalyzer", "7.0.1", DependencyType.PackageReference),
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(4, resolvedDependencies.Length);
+        Assert.Equal("Buildalyzer", resolvedDependencies[0].Name);
+        Assert.Equal("7.0.1", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
+        Assert.Equal("4.0.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
+        Assert.Equal("4.0.0", resolvedDependencies[2].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[3].Name);
+        Assert.Equal("4.0.0", resolvedDependencies[3].Version);
     }
 
     // Updating two families at once to test efficiency
@@ -903,114 +811,98 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingEntireFamily()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewUpdatingEntireFamily)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+                <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+                <PackageReference Include="Azure.Core" Version="1.21.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
-                    <PackageReference Include="Azure.Core" Version="1.21.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+            new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
+            new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
 
-            var dependencies = new[]
-            {
-                new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
-                new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
-
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
-                new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(4, resolvedDependencies.Length);
-            Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[2].Name);
-            Assert.Equal("1.1.1", resolvedDependencies[2].Version);
-            Assert.Equal("Azure.Core", resolvedDependencies[3].Name);
-            Assert.Equal("1.22.0", resolvedDependencies[3].Version);
-        }
-        finally
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
+            new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(4, resolvedDependencies.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[2].Name);
+        Assert.Equal("1.1.1", resolvedDependencies[2].Version);
+        Assert.Equal("Azure.Core", resolvedDependencies[3].Name);
+        Assert.Equal("1.22.0", resolvedDependencies[3].Version);
     }
 
     // Similar to the last test, except Microsoft.CodeAnalysis.Common is in the existing list
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingTopLevelAndDependency()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewUpdatingTopLevelAndDependency)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+                <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+                <PackageReference Include="Azure.Core" Version="1.21.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
-                    <PackageReference Include="Azure.Core" Version="1.21.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+            new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
+            new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
 
-            var dependencies = new[]
-            {
-                new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
-                new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
-
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
-                new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(5, resolvedDependencies.Length);
-            Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
-            Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-            Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[3].Name);
-            Assert.Equal("1.1.1", resolvedDependencies[3].Version);
-            Assert.Equal("Azure.Core", resolvedDependencies[4].Name);
-            Assert.Equal("1.22.0", resolvedDependencies[4].Version);
-        }
-        finally
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
+            new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(5, resolvedDependencies.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
+        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[3].Name);
+        Assert.Equal("1.1.1", resolvedDependencies[3].Version);
+        Assert.Equal("Azure.Core", resolvedDependencies[4].Name);
+        Assert.Equal("1.22.0", resolvedDependencies[4].Version);
     }
 
     // Out of scope test: AutoMapper.Extensions.Microsoft.DependencyInjection's versions are not yet compatible
@@ -1019,94 +911,78 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewOutOfScope()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewOutOfScope)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+                <PackageReference Include="AutoMapper" Version="12.0.1" />
+                <PackageReference Include="AutoMapper.Collection" Version="9.0.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-                    <PackageReference Include="AutoMapper" Version="12.0.1" />
-                    <PackageReference Include="AutoMapper.Collection" Version="9.0.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("AutoMapper.Extensions.Microsoft.DependencyInjection", "12.0.1", DependencyType.PackageReference),
-                new Dependency("AutoMapper", "12.0.1", DependencyType.PackageReference),
-                new Dependency("AutoMapper.Collection", "9.0.0", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("AutoMapper.Collection", "10.0.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(3, resolvedDependencies.Length);
-            Assert.Equal("AutoMapper.Extensions.Microsoft.DependencyInjection", resolvedDependencies[0].Name);
-            Assert.Equal("12.0.1", resolvedDependencies[0].Version);
-            Assert.Equal("AutoMapper", resolvedDependencies[1].Name);
-            Assert.Equal("12.0.1", resolvedDependencies[1].Version);
-            Assert.Equal("AutoMapper.Collection", resolvedDependencies[2].Name);
-            Assert.Equal("9.0.0", resolvedDependencies[2].Version);
-        }
-        finally
+            new Dependency("AutoMapper.Extensions.Microsoft.DependencyInjection", "12.0.1", DependencyType.PackageReference),
+            new Dependency("AutoMapper", "12.0.1", DependencyType.PackageReference),
+            new Dependency("AutoMapper.Collection", "9.0.0", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("AutoMapper.Collection", "10.0.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(3, resolvedDependencies.Length);
+        Assert.Equal("AutoMapper.Extensions.Microsoft.DependencyInjection", resolvedDependencies[0].Name);
+        Assert.Equal("12.0.1", resolvedDependencies[0].Version);
+        Assert.Equal("AutoMapper", resolvedDependencies[1].Name);
+        Assert.Equal("12.0.1", resolvedDependencies[1].Version);
+        Assert.Equal("AutoMapper.Collection", resolvedDependencies[2].Name);
+        Assert.Equal("9.0.0", resolvedDependencies[2].Version);
     }
 
     // Two dependencies (Microsoft.Extensions.Caching.Memory), (Microsoft.EntityFrameworkCore.Analyzers) used by the same parent (Microsoft.EntityFrameworkCore), updating one of the dependencies
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewTwoDependenciesShareSameParent()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewTwoDependenciesShareSameParent)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="7.0.11" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="7.0.11" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.EntityFrameworkCore", "7.0.11", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.11", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.Extensions.Caching.Memory", "8.0.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(2, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[0].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[1].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[1].Version);
-        }
-        finally
+            new Dependency("Microsoft.EntityFrameworkCore", "7.0.11", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.11", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.Extensions.Caching.Memory", "8.0.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(2, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[1].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[1].Version);
     }
 
     // Updating referenced package
@@ -1114,53 +990,45 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewFamilyOfFourExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewFamilyOfFourExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+                <PackageReference Include= "Microsoft.EntityFrameworkCore" Version="7.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="7.0.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-                    <PackageReference Include= "Microsoft.EntityFrameworkCore" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="7.0.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.EntityFrameworkCore.Design", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.0", DependencyType.PackageReference)
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(4, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
-            Assert.Equal("7.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
-            Assert.Equal("7.0.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
-            Assert.Equal("7.0.0", resolvedDependencies[2].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[3].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[3].Version);
-        }
-        finally
+            new Dependency("Microsoft.EntityFrameworkCore.Design", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.0", DependencyType.PackageReference)
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(4, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
+        Assert.Equal("7.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
+        Assert.Equal("7.0.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
+        Assert.Equal("7.0.0", resolvedDependencies[2].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[3].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[3].Version);
     }
 
     // Updating unreferenced package
@@ -1168,49 +1036,41 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewFamilyOfFourNotInExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewFamilyOfFourNotInExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.EntityFrameworkCore.Design", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
-            };
-            var update = new[]
-            {
-                new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(3, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[2].Version);
-        }
-        finally
+            new Dependency("Microsoft.EntityFrameworkCore.Design", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(3, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[2].Version);
     }
 
     // Updating a referenced transitive dependency
@@ -1218,103 +1078,87 @@ public class MSBuildHelperTests : TestBase
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewFamilyOfFourSpecificExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewFamilyOfFourSpecificExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-                  </ItemGroup>
-                </Project>
-                """);
-
-            var dependencies = new[]
-            {
-                new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
-            };
-            var update = new[]
-            {
-                new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(4, resolvedDependencies.Length);
-            Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-            Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[1].Name);
-            Assert.Equal("4.8.0", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
-            Assert.Equal("4.8.0", resolvedDependencies[2].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[3].Name);
-            Assert.Equal("4.8.0", resolvedDependencies[3].Version);
-        }
-        finally
+            new Dependency("System.Collections.Immutable", "7.0.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(4, resolvedDependencies.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[1].Name);
+        Assert.Equal("4.8.0", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
+        Assert.Equal("4.8.0", resolvedDependencies[2].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[3].Name);
+        Assert.Equal("4.8.0", resolvedDependencies[3].Version);
     }
 
     // Similar to the last test, with the "grandchild" (System.Collections.Immutable) not in the existing list
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewFamilyOfFourSpecificNotInExisting()
     {
-        var repoRoot = Directory.CreateTempSubdirectory($"test_{nameof(DependencyConflictsCanBeResolvedNewFamilyOfFourSpecificNotInExisting)}_");
+        using var tempDirectory = new TemporaryDirectory();
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+                <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+                </ItemGroup>
+            </Project>
+            """);
 
-        try
+        var dependencies = new[]
         {
-            var projectPath = Path.Join(repoRoot.FullName, "project.csproj");
-            await File.WriteAllTextAsync(projectPath, """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-                    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-                  </ItemGroup>
-                </Project>
-                """);
+            new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
+            new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
 
-            var dependencies = new[]
-            {
-                new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
-                new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
-
-            };
-            var update = new[]
-            {
-                new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
-            };
-
-            var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(repoRoot.FullName, projectPath, "net8.0", dependencies, update, new TestLogger());
-            Assert.NotNull(resolvedDependencies);
-            Assert.Equal(3, resolvedDependencies.Length);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[0].Name);
-            Assert.Equal("4.9.2", resolvedDependencies[0].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-            Assert.Equal("4.9.2", resolvedDependencies[1].Version);
-            Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
-            Assert.Equal("4.9.2", resolvedDependencies[2].Version);
-        }
-        finally
+        };
+        var update = new[]
         {
-            repoRoot.Delete(recursive: true);
-        }
+            new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
+        };
+
+        var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(tempDirectory.DirectoryPath, projectPath, "net8.0", dependencies, update, new TestLogger());
+        Assert.NotNull(resolvedDependencies);
+        Assert.Equal(3, resolvedDependencies.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[0].Name);
+        Assert.Equal("4.9.2", resolvedDependencies[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
+        Assert.Equal("4.9.2", resolvedDependencies[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
+        Assert.Equal("4.9.2", resolvedDependencies[2].Version);
     }
     #endregion
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -80,9 +80,9 @@ internal static class CompatibilityChecker
         NuGetContext nugetContext,
         CancellationToken cancellationToken)
     {
-        var tempPackagePath = GetTempPackagePath(package, nugetContext);
-        var readers = File.Exists(tempPackagePath)
-            ? ReadPackage(tempPackagePath)
+        var packagePath = GetPackagePath(package, nugetContext);
+        var readers = File.Exists(packagePath)
+            ? ReadPackage(packagePath)
             : await DownloadPackageAsync(package, nugetContext, cancellationToken);
         return readers;
     }
@@ -134,10 +134,10 @@ internal static class CompatibilityChecker
         return (isDevDependency, tfms.ToImmutableArray());
     }
 
-    internal static PackageReaders ReadPackage(string tempPackagePath)
+    internal static PackageReaders ReadPackage(string packagePath)
     {
         var stream = new FileStream(
-              tempPackagePath,
+              packagePath,
               FileMode.Open,
               FileAccess.Read,
               FileShare.Read,
@@ -194,8 +194,8 @@ internal static class CompatibilityChecker
                 context.Logger,
                 cancellationToken);
 
-            var tempPackagePath = GetTempPackagePath(package, context);
-            var isDownloaded = await downloader.CopyNupkgFileToAsync(tempPackagePath, cancellationToken);
+            var packagePath = GetPackagePath(package, context);
+            var isDownloaded = await downloader.CopyNupkgFileToAsync(packagePath, cancellationToken);
             if (!isDownloaded)
             {
                 continue;
@@ -207,6 +207,21 @@ internal static class CompatibilityChecker
         return null;
     }
 
-    internal static string GetTempPackagePath(PackageIdentity package, NuGetContext context)
-        => Path.Combine(context.TempPackageDirectory, package.Id + "." + package.Version + ".nupkg");
+    internal static string GetPackagePath(PackageIdentity package, NuGetContext context)
+    {
+        // https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
+        var nugetPackagesPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (nugetPackagesPath is null)
+        {
+            // n.b., this path should never be hit during a unit test
+            nugetPackagesPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+        }
+
+        var normalizedName = package.Id.ToLowerInvariant();
+        var normalizedVersion = package.Version.ToNormalizedString().ToLowerInvariant();
+        var packageDirectory = Path.Join(nugetPackagesPath, normalizedName, normalizedVersion);
+        Directory.CreateDirectory(packageDirectory);
+        var packagePath = Path.Join(packageDirectory, $"{normalizedName}.{normalizedVersion}.nupkg");
+        return packagePath;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -20,7 +20,6 @@ internal record NuGetContext : IDisposable
     public IMachineWideSettings MachineWideSettings { get; }
     public ImmutableArray<PackageSource> PackageSources { get; }
     public NuGet.Common.ILogger Logger { get; }
-    public string TempPackageDirectory { get; }
 
     public NuGetContext(string? currentDirectory = null, NuGet.Common.ILogger? logger = null)
     {
@@ -37,23 +36,11 @@ internal record NuGetContext : IDisposable
             .Where(p => p.IsEnabled)
             .ToImmutableArray();
         Logger = logger ?? NullLogger.Instance;
-        TempPackageDirectory = Path.Combine(Path.GetTempPath(), $"dependabot-packages_{Guid.NewGuid():d}");
-        Directory.CreateDirectory(TempPackageDirectory);
     }
 
     public void Dispose()
     {
         SourceCacheContext.Dispose();
-        if (Directory.Exists(TempPackageDirectory))
-        {
-            try
-            {
-                Directory.Delete(TempPackageDirectory, recursive: true);
-            }
-            catch
-            {
-            }
-        }
     }
 
     private readonly Dictionary<PackageIdentity, string?> _packageInfoUrlCache = new();


### PR DESCRIPTION
NuGet package analysis needs to download the packages to examine the dependencies.  This was previously done with `$TMP` but that could result in duplicate package downloads, using extra network bandwidth as well as disk space.

In the worst case scenario, the initial package would be downloaded to 2 places on disk and the updated package would be downloaded to 3.  E.g., if updating `Newtonsoft.Json` from `11.0.1` to `13.0.1` there would be 1 copy of `Newtonsoft.Json/11.0.1` in `$TMP` and 1 copy in the global package cache.  There would then be 2 copies of `Newtonsoft.Json/13.0.1` in `$TMP` and 1 in the global package cache.  With these changes there is now only 1 copy of `11.0.1` and 1 copy of `13.0.1`, both in the global package cache.  Assuming a similar size between different versions of the same package, we're now downloading only 40% of what we were before.

The behavior now is to use this well-known global package cache location as the download location.  This meant that the unit tests needed to be updated to always have their own global package cache so they didn't pollute each other.  To make this more consistent, the `TemporaryDirectory` class was modified to also set the appropriate `NUGET_*` environment variables.  Now as long as a test or test helper has `using var tempDirectory = new TemporaryDirectory();` that test will get its own global package cache location.