### PR TITLE
Add support for terraform ecosystem metrics collection

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -15,6 +15,7 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/terraform/file_selector"
 require "dependabot/terraform/registry_client"
+require "dependabot/terraform/package_manager"
 
 module Dependabot
   module Terraform
@@ -39,6 +40,16 @@ module Dependabot
         parse_terragrunt_files(dependency_set)
 
         dependency_set.dependencies.sort_by(&:name)
+      end
+
+      sig { returns(Ecosystem) }
+      def ecosystem
+        @ecosystem ||= T.let(begin
+          Ecosystem.new(
+            name: ECOSYSTEM,
+            package_manager: package_manager
+          )
+        end, T.nilable(Dependabot::Ecosystem))
       end
 
       private
@@ -419,6 +430,25 @@ module Dependabot
             lockfile ? parsed_file(lockfile) : {}
           end,
           T.nilable(T::Hash[String, T.untyped])
+        )
+      end
+
+      sig { returns(Ecosystem::VersionManager) }
+      def package_manager
+        @package_manager ||= T.let(
+          PackageManager.new(T.must(terraform_version)),
+          T.nilable(Dependabot::Terraform::PackageManager)
+        )
+      end
+
+      sig { returns(T.nilable(String)) }
+      def terraform_version
+        @terraform_version ||= T.let(
+          begin
+            version = SharedHelpers.run_shell_command("terraform --version")
+            version.match(Dependabot::Ecosystem::VersionManager::DEFAULT_VERSION_PATTERN)&.captures&.first
+          end,
+          T.nilable(String)
         )
       end
     end

--- a/terraform/lib/dependabot/terraform/package_manager.rb
+++ b/terraform/lib/dependabot/terraform/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/terraform/version"
+
+module Dependabot
+  module Terraform
+    ECOSYSTEM = "terraform"
+    PACKAGE_MANAGER = "terraform"
+    SUPPORTED_TERRAFORM_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_TERRAFORM_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_TERRAFORM_VERSIONS,
+          SUPPORTED_TERRAFORM_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/terraform/lib/dependabot/terraform/version.rb
+++ b/terraform/lib/dependabot/terraform/version.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/utils"
 require "dependabot/version"
 
 # Terraform pre-release versions use 1.0.1-rc1 syntax, which Gem::Version

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -1021,4 +1021,24 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    let(:files) { project_dependency_files("registry") }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "terraform"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "terraform"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "1.10.0"
+      end
+    end
+  end
 end

--- a/terraform/spec/dependabot/terraform/package_manager_spec.rb
+++ b/terraform/spec/dependabot/terraform/package_manager_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/terraform/package_manager"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Terraform::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "2.1.1" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version.to_s).to eq version
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Terraform::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Terraform::DEPRECATED_TERRAFORM_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Terraform::SUPPORTED_TERRAFORM_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the terraform ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

These metrics don't include language information because language does not seem to be applicable to git-submodules.

#### How will you know you've accomplished your goal?

- I'll be able to see terraform ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
