### PR TITLE
Widen strategy, ranged versions update fix

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
           context "when the latest version satisfies" do
             let(:package_json_req_string) { "^1.2.3" }
 
-            its([:requirement]) { is_expected.to eq("^1.2.3") }
+            its([:requirement]) { is_expected.to eq("^1.5.0") }
           end
 
           context "when the latest version does not satisfy" do
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
           context "when the latest version satisfies" do
             let(:package_json_req_string) { "~>2.5.1" }
 
-            its([:requirement]) { is_expected.to eq("~>2.5.1") }
+            its([:requirement]) { is_expected.to eq("~>2.5.3") }
           end
 
           context "when the latest version does not satisfy" do
@@ -550,7 +550,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
           context "when the latest version satisfies" do
             let(:package_json_req_string) { "~2.5.1" }
 
-            its([:requirement]) { is_expected.to eq("~2.5.1") }
+            its([:requirement]) { is_expected.to eq("~2.5.3") }
           end
 
           context "when the latest version does not satisfy" do
@@ -619,7 +619,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
           it "updates the requirement that needs to be updated" do
             expect(updater.updated_requirements).to contain_exactly({
               file: "package.json",
-              requirement: "^1.2.3",
+              requirement: "^1.5.0",
               groups: [],
               source: nil
             }, {


### PR DESCRIPTION
### What are you trying to accomplish?

As per the documentation 

```
In Dependabot configuration, the versioning-strategy option determines how Dependabot updates dependencies. The widen strategy means that Dependabot will widen the version range of the dependency to include the latest version, rather than updating to a specific version.

For example, if your current dependency version is ^1.0.0 and the latest version is 1.2.0, Dependabot will update the version range to ^1.2.0 to include the latest version.
```

But currently, the `widen_requirement` method is not updating the version range to include the latest version.

This PR fixes the issue by updating the `widen_requirement` method to include the latest version in the version range.

### Anything you want to highlight for special attention from reviewers?

Ref: https://github.com/github/dependabot-updates/issues/7084

### How will you know you've accomplished your goal?

Ran the CLI against [repo where I recreated the problem.](https://github.com/dsp-testing/ranged-version-with-widen-strategy)

After fixing the issue, I have ensured which generates PR's as expected

```
+----------------------------------------------------+
|        Changes to Dependabot Pull Requests         |
+---------+------------------------------------------+
| created | react ( from 18.2.0 to 18.3.1 )          |
| created | lucide-react ( from 0.441.0 to 0.468.0 ) |
+---------+------------------------------------------+

```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
