### PR TITLE
allow for differing package and assembly names when finding packages path

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
@@ -169,5 +169,29 @@ public class PackagesConfigUpdaterTests : TestBase
             // expected packages directory path
             null
         ];
+
+        // project with differing package name and assembly name
+        yield return
+        [
+            // project contents
+            """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <ItemGroup>
+                <Reference Include="Assembly.For.Some.Package, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                  <HintPath>..\packages\Some.Package.1.0.0\lib\net45\Assembly.For.Some.Package.dll</HintPath>
+                  <Private>True</Private>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """,
+            // packages.config contents
+            null,
+            // dependency name
+            "Some.Package",
+            // dependency version
+            "1.0.0",
+            // expected packages directory path
+            "../packages"
+        ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -60,7 +60,8 @@ internal static class BindingRedirectManager
         // finally we pull out the assembly `HintPath` values for _all_ references relative to the project file in a unix-style value
         //    e.g., ../packages/Some.Other.Package/4.5.6/lib/net45/Some.Other.Package.dll
         // all of that is passed to `AddBindingRedirects()` so we can ensure binding redirects for the relevant assemblies
-        var packagesDirectory = PackagesConfigUpdater.GetPathToPackagesDirectory(projectBuildFile, updatedPackageName, updatedPackageVersion, packagesConfigPath: null)!;
+        var packagesConfigPath = ProjectHelper.GetPackagesConfigPathFromProject(projectBuildFile.Path, ProjectHelper.PathFormat.Full);
+        var packagesDirectory = PackagesConfigUpdater.GetPathToPackagesDirectory(projectBuildFile, updatedPackageName, updatedPackageVersion, packagesConfigPath)!;
         var assemblyPathPrefix = Path.Combine(packagesDirectory, $"{updatedPackageName}.{updatedPackageVersion}").NormalizePathToUnix().EnsureSuffix("/");
         var assemblyPaths = references.Select(static x => x.HintPath).Select(x => Path.GetRelativePath(Path.GetDirectoryName(projectBuildFile.Path)!, x).NormalizePathToUnix()).ToList();
         var bindingsAndAssemblyPaths = bindings.Zip(assemblyPaths);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
@@ -74,7 +74,7 @@ internal static class ProjectHelper
     private static string? GetItemPathWithFileName(this ProjectRootElement projectRootElement, string itemFileName)
     {
         var projectDirectory = Path.GetDirectoryName(projectRootElement.FullPath)!;
-        var packagesConfigPath = projectRootElement.Items
+        var itemPath = projectRootElement.Items
             .Where(i => i.ElementName.Equals("None", StringComparison.OrdinalIgnoreCase) ||
                         i.ElementName.Equals("Content", StringComparison.OrdinalIgnoreCase))
             .Where(i => Path.GetFileName(i.Include).Equals(itemFileName, StringComparison.OrdinalIgnoreCase))
@@ -82,7 +82,7 @@ internal static class ProjectHelper
             .Where(File.Exists)
             .FirstOrDefault()
             ?.NormalizePathToUnix();
-        return packagesConfigPath;
+        return itemPath;
     }
 
     private static string? GetPathWithRegardsToProjectFile(string fullProjectPath, string fileName)


### PR DESCRIPTION
Found during a manual scan of the logs.

When determining if a `.csproj` has an assembly reference to a package, an incorrect assumption was made that the name of the assembly would match the name of the package, but that's not correct.

The correct behavior is to match the `HintPath` with the package name, because that will always match.  We had an existing regular expression that did the correct matching, so this was lifted higher in the class so it could be re-used.