### PR TITLE
remove unnecessary log messages

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -32,7 +32,6 @@ module Dependabot
           credentials: credentials
         )
 
-        NativeDiscoveryJsonReader.debug_report_discovery_files(error_if_missing: false)
         discovery_json_reader.dependency_file_paths.map do |p|
           relative_path = Pathname.new(p).relative_path_from(directory).to_path
           fetch_file_from_host(relative_path)

--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -27,7 +27,6 @@ module Dependabot
       sig { returns(T::Array[Dependabot::Dependency]) }
       def dependencies
         @dependencies ||= T.let(begin
-          NativeDiscoveryJsonReader.debug_report_discovery_files(error_if_missing: true)
           directory = source&.directory || "/"
           discovery_json_reader = NativeDiscoveryJsonReader.run_discovery_in_directory(
             repo_contents_path: T.must(repo_contents_path),

--- a/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
+++ b/nuget/lib/dependabot/nuget/native_discovery/native_discovery_json_reader.rb
@@ -41,17 +41,6 @@ module Dependabot
         FileUtils.rm_rf(discovery_directory)
       end
 
-      sig { params(error_if_missing: T::Boolean).void }
-      def self.debug_report_discovery_files(error_if_missing:)
-        if File.exist?(discovery_map_file_path)
-          Dependabot.logger.info("Discovery map file (#{discovery_map_file_path}) contents: " \
-                                 "#{File.read(discovery_map_file_path)}")
-          Dependabot.logger.info("Discovery files: #{Dir.glob(File.join(discovery_directory, '*'))}")
-        elsif error_if_missing
-          Dependabot.logger.error("discovery map file missing")
-        end
-      end
-
       # Runs NuGet dependency discovery in the given directory and returns a new instance of NativeDiscoveryJsonReader.
       # The location of the resultant JSON file is saved.
       sig do

--- a/nuget/script/run
+++ b/nuget/script/run
@@ -7,19 +7,5 @@ echo "NuGet native updater experiment value: $nuget_experiment_value"
 if echo "$nuget_experiment_value" | grep -q 'true'; then
     pwsh "$DEPENDABOT_HOME/dependabot-updater/bin/main.ps1" $*
 else
-    operation=$1
-    dot_dependabot_directory="$DEPENDABOT_HOME/.dependabot"
-    discovery_map_path="$dot_dependabot_directory/discovery_map.json"
-
-    # ensure discovery file exists before running update
-    if [[ "$operation" == "update_files" && ! -f $discovery_map_path ]]; then
-        echo "ERROR running update_files without discovery_map.json"
-    fi
-
     "$DEPENDABOT_HOME/dependabot-updater/bin/run-original" $*
-
-    # ensure discovery file exists after running fetch
-    if [[ "$operation" == "fetch_files" && ! -f $discovery_map_path ]]; then
-        echo "ERROR ran fetch_files without producing discovery_map.json"
-    fi
 fi


### PR DESCRIPTION
Clean up log messages added in #11055.

Originally the log messages were to debug why a file generated during `fetch_files` wasn't present for the subsequent call to `update_files`.  I've since learned that in certain instances, update jobs can run those two commands in separate containers with no shared filesystem.

The fix to re-run discovery if needed is still the correct choice, so this only backs off the logging.

Recent telemetry shows that re-running the discovery has fixed the original issue.