### PR TITLE
parse and honor `ignore-conditions` from job file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -1,0 +1,85 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class MiscellaneousTests
+{
+    [Theory]
+    [MemberData(nameof(RequirementsFromIgnoredVersionsData))]
+    public void RequirementsFromIgnoredVersions(string dependencyName, Condition[] ignoreConditions, Requirement[] expectedRequirements)
+    {
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "some/repo"
+            },
+            IgnoreConditions = ignoreConditions
+        };
+        var actualRequirements = RunWorker.GetIgnoredRequirementsForDependency(job, dependencyName);
+        var actualRequirementsStrings = string.Join("|", actualRequirements.Select(r => r.ToString()));
+        var expectedRequirementsStrings = string.Join("|", expectedRequirements.Select(r => r.ToString()));
+        Assert.Equal(expectedRequirementsStrings, actualRequirementsStrings);
+    }
+
+    public static IEnumerable<object?[]> RequirementsFromIgnoredVersionsData()
+    {
+        yield return
+        [
+            // dependencyName
+            "Some.Package",
+            // ignoredConditions
+            new Condition[]
+            {
+                new()
+                {
+                    DependencyName = "SOME.PACKAGE",
+                    VersionRequirement = Requirement.Parse("> 1.2.3")
+                },
+                new()
+                {
+                    DependencyName = "some.package",
+                    VersionRequirement = Requirement.Parse("<= 2.0.0")
+                },
+                new()
+                {
+                    DependencyName = "Unrelated.Package",
+                    VersionRequirement = Requirement.Parse("= 3.4.5")
+                }
+            },
+            // expectedRequirements
+            new Requirement[]
+            {
+                new IndividualRequirement(">", NuGetVersion.Parse("1.2.3")),
+                new IndividualRequirement("<=", NuGetVersion.Parse("2.0.0")),
+            }
+        ];
+
+        // version requirement is null => ignore all
+        yield return
+        [
+            // dependencyName
+            "Some.Package",
+            // ignoredConditions
+            new Condition[]
+            {
+                new()
+                {
+                    DependencyName = "Some.Package"
+                }
+            },
+            // expectedRequirements
+            new Requirement[]
+            {
+                new IndividualRequirement(">", NuGetVersion.Parse("0.0.0"))
+            }
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Analyze;
+
+public class RequirementConverter : JsonConverter<Requirement>
+{
+    public override Requirement? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return Requirement.Parse(reader.GetString()!);
+    }
+
+    public override void Write(Utf8JsonWriter writer, Requirement value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Condition.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Condition.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+using NuGetUpdater.Core.Analyze;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public sealed record Condition
+{
+    [JsonPropertyName("dependency-name")]
+    public required string DependencyName { get; init; }
+    [JsonPropertyName("source")]
+    public string? Source { get; init; } = null;
+    [JsonPropertyName("update-types")]
+    public string[] UpdateTypes { get; init; } = [];
+    [JsonPropertyName("updated-at")]
+    public DateTime? UpdatedAt { get; init; } = null;
+    [JsonPropertyName("version-requirement")]
+    public Requirement? VersionRequirement { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -16,7 +16,7 @@ public sealed record Job
     public object[]? ExistingPullRequests { get; init; } = null;
     public object[]? ExistingGroupPullRequests { get; init; } = null;
     public Dictionary<string, object>? Experiments { get; init; } = null;
-    public object[]? IgnoreConditions { get; init; } = null;
+    public Condition[] IgnoreConditions { get; init; } = [];
     public bool LockfileOnly { get; init; } = false;
     public string? RequirementsUpdateStrategy { get; init; } = null;
     public object[]? SecurityAdvisories { get; init; } = null;


### PR DESCRIPTION
This is part of the work to enable the end-to-end NuGet updater purely in C#.

This adds parsing for the job file's `ignore-conditions` property and passes those values through to the analyzer worker.

Since the end-to-end updater is not enabled, the only part of this code that will see production currently is the new parsing of the `Condition` type.  I modelled this after the [relevant type](https://github.com/dependabot/cli/blob/4e7612fe884683ade8c54ad8fd137fc6da92bb84/internal/model/job.go#L92) in the CLI.