### PR TITLE
make directory crawling unit-testable

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -51,11 +51,11 @@ public class PathHelperTests
 
         var expected = new[]
         {
-            Path.Combine(temp.DirectoryPath, "src", "a", "packages.config").NormalizePathToUnix(),
             Path.Combine(temp.DirectoryPath, "src", "A", "packages.config").NormalizePathToUnix(),
+            Path.Combine(temp.DirectoryPath, "src", "a", "packages.config").NormalizePathToUnix(),
         };
 
-        Assert.Equal(expected, resolvedPaths!);
+        AssertEx.Equal(expected, resolvedPaths!);
     }
 
     [LinuxOnlyFact]

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -2,6 +2,12 @@
 
 set -e
 
+# PowerShell unit tests
+pushd ./updater
+pwsh ./test.ps1
+popd
+
+# C# unit tests
 pushd ./helpers/lib/NuGetUpdater
 dotnet restore
 dotnet format --no-restore --exclude ../NuGet.Client --verify-no-changes -v diag
@@ -10,5 +16,6 @@ dotnet test --configuration Release --no-restore --no-build --logger "console;ve
 dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
 popd
 
+# Ruby unit tests
 bundle install
 bundle exec rspec spec

--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -1,0 +1,26 @@
+# Walk from each update directory to the root reporting all global.json files.
+function Get-DirectoriesForSdkInstall([string] $repoRoot, [string[]]$updateDirectories) {
+    $repoRoot = Convert-Path $repoRoot
+    $repoRootParent = Split-Path -Parent $repoRoot
+    $globalJsonPaths = @()
+    foreach ($updateDirectory in $updateDirectories) {
+        $candidateDir = Convert-Path "$repoRoot/$updateDirectory"
+        if (Test-Path $candidateDir) {
+            while ($true) {
+                $globalJsonPath = Join-Path $candidateDir "global.json"
+                if (Test-Path $globalJsonPath) {
+                    $repoRelativeGlobalJsonPath = [System.IO.Path]::GetRelativePath($repoRoot, $globalJsonPath).Replace("\", "/")
+                    $globalJsonPaths += $repoRelativeGlobalJsonPath
+                }
+
+                $candidateDir = Split-Path -Parent $candidateDir
+                if ($null -eq $candidateDir -or `
+                    $candidateDir -eq $repoRootParent) {
+                    break
+                }
+            }
+        }
+    }
+
+    return ,$globalJsonPaths
+}

--- a/nuget/updater/test-data/global-json-discovery-2-values/global.json
+++ b/nuget/updater/test-data/global-json-discovery-2-values/global.json
@@ -1,0 +1,3 @@
+{
+    "comment": "content unimportant for test"
+}

--- a/nuget/updater/test-data/global-json-discovery-2-values/src/global.json
+++ b/nuget/updater/test-data/global-json-discovery-2-values/src/global.json
@@ -1,0 +1,3 @@
+{
+    "comment": "content unimportant for test"
+}

--- a/nuget/updater/test-data/global-json-discovery-none/src/.gitignore
+++ b/nuget/updater/test-data/global-json-discovery-none/src/.gitignore
@@ -1,0 +1,1 @@
+# empty to force directory creation

--- a/nuget/updater/test-data/global-json-discovery-root-no-file/.gitignore
+++ b/nuget/updater/test-data/global-json-discovery-root-no-file/.gitignore
@@ -1,0 +1,1 @@
+# empty to force directory creation

--- a/nuget/updater/test-data/global-json-discovery-root-with-file/global.json
+++ b/nuget/updater/test-data/global-json-discovery-root-with-file/global.json
@@ -1,0 +1,3 @@
+{
+    "comment": "content unimportant for test"
+}

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -1,0 +1,54 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+. $PSScriptRoot\common.ps1
+
+function Assert-ArraysEqual([string[]]$expected, [string[]]$actual) {
+    $expectedText = $expected -join ", "
+    $actualText = $actual -join ", "
+    if ($expected.Length -ne $actual.Length) {
+        throw "Expected array length $($expected.Length) but was $($actual.Length).  Values: [$expectedText] vs [$actualText]"
+    }
+    for ($i = 0; $i -lt $expected.Length; $i++) {
+        if ($expected[$i] -ne $actual[$i]) {
+            throw "Expected array element at index $i to be '$($expected[$i])' but was '$($actual[$i])'"
+        }
+    }
+}
+
+function Test-GlobalJsonDiscovery([string]$testDirectory, [string[]]$directories, [string[]]$expectedPaths) {
+    Write-Host "Test-GlobalJsonDiscovery in $testDirectory ... " -NoNewline
+    $testDirectoryFull = "$PSScriptRoot/test-data/$testDirectory"
+    $actualPaths = Get-DirectoriesForSdkInstall -repoRoot $testDirectoryFull -updateDirectories $directories
+    Assert-ArraysEqual -expected $expectedPaths -actual $actualPaths
+    Write-Host "OK"
+}
+
+try {
+    # verify SDK updater directories
+    Test-GlobalJsonDiscovery `
+        -testDirectory "global-json-discovery-root-no-file" `
+        -directories @("/") `
+        -expectedPaths @()
+
+    Test-GlobalJsonDiscovery `
+        -testDirectory "global-json-discovery-root-with-file" `
+        -directories @("/") `
+        -expectedPaths @("global.json")
+
+    Test-GlobalJsonDiscovery `
+        -testDirectory "global-json-discovery-none" `
+        -directories @("src") `
+        -expectedPaths @()
+
+    Test-GlobalJsonDiscovery `
+        -testDirectory "global-json-discovery-2-values" `
+        -directories @("src") `
+        -expectedPaths @("src/global.json", "global.json")
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
For the eventual end-to-end C# NuGet updater, a PowerShell script is used to crawl the directories for `global.json` files for SDK installation prior to the job running.  This PR makes that behavior testable and fixes a bug where this logic would previously throw when trying to navigate past the update root directory.