### PR TITLE
Add fallback to local package manager when Corepack installation fails

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -9,7 +9,7 @@ require "sorbet-runtime"
 
 module Dependabot
   module NpmAndYarn
-    module Helpers
+    module Helpers # rubocop:disable Metrics/ModuleLength
       extend T::Sig
 
       YARN_PATH_NOT_FOUND =

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -332,7 +332,7 @@ module Dependabot
           version.strip.delete_prefix("v") # Remove the "v" prefix if present
         end
       rescue StandardError => e
-        Dependabot.logger.info("Error retrieving Node.js version: #{e.message}")
+        Dependabot.logger.error("Error retrieving Node.js version: #{e.message}")
         nil
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_return("7.0.0/n")
       expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
         "corepack prepare npm@7.0.0 --activate",
-        fingerprint: "corepack prepare --activate"
+        fingerprint: "corepack prepare <name>@<version> --activate"
       )
       described_class.package_manager_activate("npm", "7.0.0")
     end
@@ -193,15 +193,126 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
   end
 
   describe "::install" do
-    it "installs, activates, and retrieves the version of the package manager" do
-      expect(described_class).to receive(:package_manager_install).with("npm", "7.0.0")
-      expect(described_class).to receive(:package_manager_activate).with("npm", "7.0.0")
-      allow(described_class).to receive(:package_manager_version).with("npm").and_return("7.0.0")
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+    end
 
-      expect(Dependabot.logger).to receive(:info).with("Installing \"npm@7.0.0\"")
-      expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 7.0.0")
+    context "when corepack succeeds" do
+      it "installs, activates, and retrieves the version of the package manager" do
+        # Mock for `package_manager_install("npm", "8.0.0")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack install npm@8.0.0 --global --cache-only",
+          fingerprint: "corepack install <name>@<version> --global --cache-only"
+        ).and_return("Adding npm@8.0.0 to the cache")
 
-      described_class.install("npm", "7.0.0")
+        # Mock for `package_manager_activate("npm", "8.0.0")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack prepare npm@8.0.0 --activate",
+          fingerprint: "corepack prepare <name>@<version> --activate"
+        ).and_return("")
+
+        # Mock for `local_package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "npm -v",
+          fingerprint: "npm -v"
+        ).and_return("10.8.2")
+
+        # Mock for `package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack npm -v",
+          fingerprint: "corepack npm -v"
+        ).and_return("8.0.0")
+
+        # Log expectations
+        expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
+        expect(Dependabot.logger).to receive(:info).with("npm@8.0.0 successfully installed.")
+        expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
+        expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 8.0.0")
+
+        # Test the result
+        result = described_class.install("npm", "8.0.0")
+        expect(result).to eq("8.0.0")
+      end
+    end
+
+    context "when corepack fails with unexpected output" do
+      it "falls back to the local package manager" do
+        # Mock for `package_manager_install("npm", "8.0.0")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack install npm@8.0.0 --global --cache-only",
+          fingerprint: "corepack install <name>@<version> --global --cache-only"
+        ).and_return("Unexpected output")
+
+        # Mock for `package_manager_activate("npm", "10.8.2")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack prepare npm@10.8.2 --activate",
+          fingerprint: "corepack prepare <name>@<version> --activate"
+        ).and_return("")
+
+        # Mock for `local_package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "npm -v",
+          fingerprint: "npm -v"
+        ).and_return("10.8.2")
+
+        # Mock for `package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack npm -v",
+          fingerprint: "corepack npm -v"
+        ).and_return("10.8.2")
+
+        # Log expectations
+        expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
+        expect(Dependabot.logger).to receive(:error).with("Corepack installation output unexpected: Unexpected output")
+        expect(Dependabot.logger).to receive(:info).with("Falling back to activate the currently installed version of npm.")
+        expect(Dependabot.logger).to receive(:info).with("Activating currently installed version of npm: 10.8.2")
+        expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
+        expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 10.8.2")
+
+        # Test the result
+        result = described_class.install("npm", "8.0.0")
+        expect(result).to eq("10.8.2")
+      end
+    end
+
+    context "when corepack fails with an error" do
+      it "falls back to the local package manager" do
+        # Mock for `package_manager_install("npm", "8.0.0")` (raises an error)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack install npm@8.0.0 --global --cache-only",
+          fingerprint: "corepack install <name>@<version> --global --cache-only"
+        ).and_raise(StandardError, "Corepack failed")
+
+        # Mock for `package_manager_activate("npm", "10.8.2")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack prepare npm@10.8.2 --activate",
+          fingerprint: "corepack prepare <name>@<version> --activate"
+        ).and_return("")
+
+        # Mock for `local_package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "npm -v",
+          fingerprint: "npm -v"
+        ).and_return("10.8.2")
+
+        # Mock for `package_manager_version("npm")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack npm -v",
+          fingerprint: "corepack npm -v"
+        ).and_return("10.8.2")
+
+        # Log expectations
+        expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
+        expect(Dependabot.logger).to receive(:error).with("Error installing npm@8.0.0: Corepack failed")
+        expect(Dependabot.logger).to receive(:info).with("Falling back to activate the currently installed version of npm.")
+        expect(Dependabot.logger).to receive(:info).with("Activating currently installed version of npm: 10.8.2")
+        expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
+        expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 10.8.2")
+
+        # Test the result
+        result = described_class.install("npm", "8.0.0")
+        expect(result).to eq("10.8.2")
+      end
     end
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -264,7 +264,9 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         # Log expectations
         expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
         expect(Dependabot.logger).to receive(:error).with("Corepack installation output unexpected: Unexpected output")
-        expect(Dependabot.logger).to receive(:info).with("Falling back to activate the currently installed version of npm.")
+        expect(Dependabot.logger).to receive(:info).with(
+          "Falling back to activate the currently installed version of npm."
+        )
         expect(Dependabot.logger).to receive(:info).with("Activating currently installed version of npm: 10.8.2")
         expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
         expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 10.8.2")
@@ -304,7 +306,9 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         # Log expectations
         expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
         expect(Dependabot.logger).to receive(:error).with("Error installing npm@8.0.0: Corepack failed")
-        expect(Dependabot.logger).to receive(:info).with("Falling back to activate the currently installed version of npm.")
+        expect(Dependabot.logger).to receive(:info).with(
+          "Falling back to activate the currently installed version of npm."
+        )
         expect(Dependabot.logger).to receive(:info).with("Activating currently installed version of npm: 10.8.2")
         expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
         expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 10.8.2")


### PR DESCRIPTION
### What are you trying to accomplish?

This PR implements a fallback mechanism for situations where Corepack fails to install a specified package manager version, typically due to private registry issues. 

The fallback ensures that:
1. The system-installed version of the package manager is detected.
2. Corepack prepares and activates this version for use.

This change improves reliability and ensures seamless dependency management even when registry issues occur.

### Anything you want to highlight for special attention from reviewers?

- The approach prioritizes simplicity by leveraging existing system-installed versions of package managers.
- Is there any potential edge case that might require additional validation (e.g., missing binaries or incompatible versions)?
- Logging has been added to trace both installation and fallback processes—feedback on log clarity is welcome.

### How will you know you've accomplished your goal?

- The fallback mechanism is triggered correctly when Corepack fails, as verified by tests and local runs.
- The appropriate version of the package manager is activated and functions as expected.
- Logs clearly reflect the steps taken during installation and fallback.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.