### PR TITLE
detect byte order mark in YAML and report error

### DIFF
--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -1134,6 +1134,16 @@ RSpec.describe Dependabot::Docker::FileParser do
         end
       end
     end
+
+    context "with an invalid yaml file" do
+      let(:podfile_fixture_name) { "with_bom.yaml" }
+
+      it "throws when the yaml starts with a byte order mark" do
+        expect do
+          _unused = dependencies
+        end.to raise_error(Dependabot::DependencyFileNotParseable)
+      end
+    end
   end
 
   describe "YAML parse" do

--- a/docker/spec/fixtures/kubernetes/yaml/with_bom.yaml
+++ b/docker/spec/fixtures/kubernetes/yaml/with_bom.yaml
@@ -1,0 +1,10 @@
+﻿apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
If a YAML file was saved with the encoding "UTF-8 with BOM" and parsed, only the first property will be reported, ignoring the rest of the file and ultimately resulting in no images found and nothing updatable.

This PR explicitly detects the byte order mark and reports `DependencyFileNotParseable` with a message so the user can correct it.

Bug was found during internal investigations.