### PR TITLE
Add argument to parser to allow trailing comma in json.

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.DotNetToolsJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.DotNetToolsJson.cs
@@ -51,6 +51,50 @@ public partial class DiscoveryWorkerTests
         }
 
         [Fact]
+        public async Task DiscoversDependenciesTrailingComma()
+        {
+            await TestDiscoveryAsync(
+                packages: [],
+                workspacePath: "",
+                files: [
+                    (".config/dotnet-tools.json", """
+                        {
+                          "version": 1,
+                          "isRoot": true,
+                          "tools": {
+                            "botsay": {
+                              "version": "1.0.0",
+                              "commands": [
+                                "botsay"
+                              ],
+                            },
+                            "dotnetsay": {
+                              "version": "1.0.0",
+                              "commands": [
+                                "dotnetsay"
+                              ],
+                            }
+                          }
+                        }
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    DotNetToolsJson = new()
+                    {
+                        FilePath = ".config/dotnet-tools.json",
+                        Dependencies = [
+                            new("botsay", "1.0.0", DependencyType.DotNetTool),
+                            new("dotnetsay", "1.0.0", DependencyType.DotNetTool),
+                        ]
+                    },
+                    ExpectedProjectCount = 0,
+                }
+            );
+        }
+
+        [Fact]
         public async Task ReportsFailure()
         {
             await TestDiscoveryAsync(
@@ -74,7 +118,7 @@ public partial class DiscoveryWorkerTests
                                 "dotnetsay"
                               ]
                             }
-                          }
+                          } INVALID JSON
                         }
                         """),
                 ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
@@ -41,6 +41,40 @@ public partial class DiscoveryWorkerTests
         }
 
         [Fact]
+        public async Task DiscoversDependencies_HandlesTrailingComma()
+        {
+            await TestDiscoveryAsync(
+                packages: [],
+                workspacePath: "",
+                files: [
+                    ("global.json", """
+                        {
+                          "sdk": {
+                            "version": "2.2.104"
+                          },
+                          "msbuild-sdks": {
+                            "Microsoft.Build.Traversal": "1.0.45"
+                          },
+                        }
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    GlobalJson = new()
+                    {
+                        FilePath = "global.json",
+                        Dependencies = [
+                            new("Microsoft.NET.Sdk", "2.2.104", DependencyType.MSBuildSdk),
+                            new("Microsoft.Build.Traversal", "1.0.45", DependencyType.MSBuildSdk),
+                        ]
+                    },
+                    ExpectedProjectCount = 0,
+                }
+            );
+        }
+
+        [Fact]
         public async Task ReportsFailure()
         {
             await TestDiscoveryAsync(
@@ -50,7 +84,7 @@ public partial class DiscoveryWorkerTests
                     ("global.json", """
                         {
                           "sdk": {
-                            "version": "2.2.104",
+                            "version": "2.2.104", INVALID JSON
                           },
                           "msbuild-sdks": {
                             "Microsoft.Build.Traversal": "1.0.45"

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.DotNetTools.cs
@@ -287,5 +287,89 @@ public partial class UpdateWorkerTests
                 ]
             );
         }
+
+        [Fact]
+        public async Task UpdateSingleDependencyWithTrailingComma()
+        {
+            await TestUpdateForProject("Some.DotNet.Tool", "1.0.0", "1.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.0.0", "net8.0"),
+                    MockNuGetPackage.CreateDotNetToolPackage("Some.DotNet.Tool", "1.1.0", "net8.0"),
+                ],
+                // initial
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFiles:
+                [
+                    (".config/dotnet-tools.json", """
+                        {
+                          "version": 1,
+                          "isRoot": true,
+                          "tools": {
+                            "some.dotnet.tool": {
+                              "version": "1.0.0",
+                              "commands": [
+                                "some.dotnet.tool"
+                              ],
+                            },
+                            "some-other-tool": {
+                              "version": "2.1.3",
+                              "commands": [
+                                "some-other-tool"
+                              ],
+                            }
+                          }
+                        }
+                        """)
+                ],
+                // expected
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                // expected files no longer have trailing commas in the json
+                additionalFilesExpected:
+                [
+                    (".config/dotnet-tools.json", """
+                        {
+                          "version": 1,
+                          "isRoot": true,
+                          "tools": {
+                            "some.dotnet.tool": {
+                              "version": "1.1.0",
+                              "commands": [
+                                "some.dotnet.tool"
+                              ]
+                            },
+                            "some-other-tool": {
+                              "version": "2.1.3",
+                              "commands": [
+                                "some-other-tool"
+                              ]
+                            }
+                          }
+                        }
+                        """)
+                ]
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
@@ -226,5 +226,71 @@ public partial class UpdateWorkerTests
                 ]
             );
         }
+
+        [Fact]
+        public async Task UpdateDependencyWithTrailingComma()
+        {
+            await TestUpdateForProject("Some.MSBuild.Sdk", "3.2.0", "4.1.0",
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.3", "net8.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "3.2.0"),
+                    MockNuGetPackage.CreateMSBuildSdkPackage("Some.MSBuild.Sdk", "4.1.0"),
+                ],
+                // initial
+                projectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                additionalFiles:
+                [
+                    ("global.json", """
+                        {
+                          "sdk": {
+                            "version": "6.0.405",
+                            "rollForward": "latestPatch"
+                          },
+                          "msbuild-sdks": {
+                            "Some.MSBuild.Sdk": "3.2.0"
+                          },
+                        }
+                        """)
+                ],
+                // expected
+                expectedProjectContents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="13.0.3" />
+                      </ItemGroup>
+                    </Project>
+                    """,
+                // expected file no longer has the trailing comma because the parser removes it.
+                additionalFilesExpected:
+                [
+                    ("global.json", """
+                        {
+                          "sdk": {
+                            "version": "6.0.405",
+                            "rollForward": "latestPatch"
+                          },
+                          "msbuild-sdks": {
+                            "Some.MSBuild.Sdk": "4.1.0"
+                          }
+                        }
+                        """)
+                ]
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/JsonHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/JsonHelper.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+
 namespace NuGetUpdater.Core.Utilities
 {
     internal static class JsonHelper

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/JsonHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/JsonHelper.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-
 namespace NuGetUpdater.Core.Utilities
 {
     internal static class JsonHelper
@@ -11,6 +10,7 @@ namespace NuGetUpdater.Core.Utilities
         public static JsonDocumentOptions DocumentOptions { get; } = new JsonDocumentOptions
         {
             CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
         };
 
         public static JsonNode? ParseNode(string content)
@@ -24,6 +24,7 @@ namespace NuGetUpdater.Core.Utilities
             var readerOptions = new JsonReaderOptions
             {
                 CommentHandling = JsonCommentHandling.Allow,
+                AllowTrailingCommas = true,
             };
             var bytes = Encoding.UTF8.GetBytes(json);
             var reader = new Utf8JsonReader(bytes, readerOptions);


### PR DESCRIPTION
Fixes #11050. The error was being thrown when trying to parse a JSON file with trailing commas. This PR adds an argument to the parser to allow trailing commas in JSON as well as the corresponding tests in the Updater and the Discovery.