### PR TITLE
add concrete types to job deserializer

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -41,12 +41,6 @@ public partial class EntryPointTests
                 ],
                 job: new Job()
                 {
-                    AllowedUpdates = [
-                        new()
-                        {
-                            UpdateType = "all"
-                        }
-                    ],
                     Source = new()
                     {
                         Provider = "github",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -30,11 +30,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "some-dir",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             files:
             [
@@ -237,11 +233,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "some-dir",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             files:
             [
@@ -483,11 +475,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "/",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             files:
             [
@@ -550,11 +538,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "some-dir",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             files:
             [
@@ -886,11 +870,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "some-dir/ProjectA",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             files:
             [
@@ -1438,11 +1418,7 @@ public class RunWorkerTests
                     Provider = "github",
                     Repo = "test/repo",
                     Directory = "/",
-                },
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ]
+                }
             },
             packages:
             [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -1,5 +1,9 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test.Utilities;
 
 using Xunit;
 
@@ -273,6 +277,9 @@ public class SerializationTests
                   {
                     "dependency-name": "Package.1",
                     "source": "some-file",
+                    "update-types": [
+                      "version-update:semver-major"
+                    ],
                     "version-requirement": "> 1.2.3"
                   },
                   {
@@ -288,7 +295,7 @@ public class SerializationTests
 
         Assert.Equal("Package.1", jobWrapper.Job.IgnoreConditions[0].DependencyName);
         Assert.Equal("some-file", jobWrapper.Job.IgnoreConditions[0].Source);
-        Assert.Empty(jobWrapper.Job.IgnoreConditions[0].UpdateTypes);
+        Assert.Equal("version-update:semver-major", jobWrapper.Job.IgnoreConditions[0].UpdateTypes.Single());
         Assert.Null(jobWrapper.Job.IgnoreConditions[0].UpdatedAt);
         Assert.Equal("> 1.2.3", jobWrapper.Job.IgnoreConditions[0].VersionRequirement?.ToString());
 
@@ -297,6 +304,297 @@ public class SerializationTests
         Assert.Empty(jobWrapper.Job.IgnoreConditions[1].UpdateTypes);
         Assert.Equal(new DateTime(2024, 12, 5, 15, 47, 12), jobWrapper.Job.IgnoreConditions[1].UpdatedAt);
         Assert.Null(jobWrapper.Job.IgnoreConditions[1].VersionRequirement);
+    }
+
+    [Theory]
+    [MemberData(nameof(DeserializeAllowedUpdatesData))]
+    public void DeserializeAllowedUpdates(string? allowedUpdatesJsonBody, AllowedUpdate[] expectedAllowedUpdates)
+    {
+        string? allowedUpdatesJson = allowedUpdatesJsonBody is null
+            ? null
+            : $$"""
+                ,
+                "allowed-updates": {{allowedUpdatesJsonBody}}
+                """;
+        var jobWrapperJson = $$"""
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    }
+                    {{allowedUpdatesJson}}
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jobWrapperJson)!;
+        AssertEx.Equal(expectedAllowedUpdates, jobWrapper.Job.AllowedUpdates);
+    }
+
+    [Fact]
+    public void DeserializeDependencyGroups()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "dependency-groups": [
+                        {
+                            "name": "Some.Dependency",
+                            "rules": {
+                                "patterns": ["1.2.3", "4.5.6"]
+                            }
+                        },
+                        {
+                            "name": "Some.Other.Dependency",
+                            "applies-to": "something"
+                        }
+                    ]
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Equal(2, jobWrapper.Job.DependencyGroups.Length);
+
+        Assert.Equal("Some.Dependency", jobWrapper.Job.DependencyGroups[0].Name);
+        Assert.Null(jobWrapper.Job.DependencyGroups[0].AppliesTo);
+        Assert.Single(jobWrapper.Job.DependencyGroups[0].Rules);
+        Assert.Equal("[\"1.2.3\", \"4.5.6\"]", jobWrapper.Job.DependencyGroups[0].Rules["patterns"].ToString());
+
+        Assert.Equal("Some.Other.Dependency", jobWrapper.Job.DependencyGroups[1].Name);
+        Assert.Equal("something", jobWrapper.Job.DependencyGroups[1].AppliesTo);
+        Assert.Empty(jobWrapper.Job.DependencyGroups[1].Rules);
+    }
+
+    [Fact]
+    public void DeserializeExistingPullRequests()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "existing-pull-requests": [
+                        [
+                            {
+                                "dependency-name": "Some.Package",
+                                "dependency-version": "1.2.3"
+                            }
+                        ]
+                    ]
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Single(jobWrapper.Job.ExistingPullRequests);
+        Assert.Single(jobWrapper.Job.ExistingPullRequests[0]);
+        Assert.Equal("Some.Package", jobWrapper.Job.ExistingPullRequests[0][0].DependencyName);
+        Assert.Equal(NuGetVersion.Parse("1.2.3"), jobWrapper.Job.ExistingPullRequests[0][0].DependencyVersion);
+        Assert.False(jobWrapper.Job.ExistingPullRequests[0][0].DependencyRemoved);
+        Assert.Null(jobWrapper.Job.ExistingPullRequests[0][0].Directory);
+    }
+
+    [Fact]
+    public void DeserializeExistingGroupPullRequests()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "existing-group-pull-requests": [
+                        {
+                            "dependency-group-name": "Some-Group-Name",
+                            "dependencies": [
+                                {
+                                    "dependency-name": "Some.Package",
+                                    "dependency-version": "1.2.3"
+                                },
+                                {
+                                    "dependency-name": "Some.Other.Package",
+                                    "dependency-version": "4.5.6",
+                                    "directory": "/some-dir"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Single(jobWrapper.Job.ExistingGroupPullRequests);
+        Assert.Equal("Some-Group-Name", jobWrapper.Job.ExistingGroupPullRequests[0].DependencyGroupName);
+        Assert.Equal(2, jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies.Length);
+        Assert.Equal("Some.Package", jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[0].DependencyName);
+        Assert.Equal("1.2.3", jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[0].DependencyVersion.ToString());
+        Assert.Null(jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[0].Directory);
+        Assert.Equal("Some.Other.Package", jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[1].DependencyName);
+        Assert.Equal("4.5.6", jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[1].DependencyVersion.ToString());
+        Assert.Equal("/some-dir", jobWrapper.Job.ExistingGroupPullRequests[0].Dependencies[1].Directory);
+    }
+
+    [Theory]
+    [InlineData("null", null)]
+    [InlineData("\"bump_versions\"", RequirementsUpdateStrategy.BumpVersions)]
+    [InlineData("\"lockfile_only\"", RequirementsUpdateStrategy.LockfileOnly)]
+    public void DeserializeRequirementsUpdateStrategy(string requirementsUpdateStrategyStringJson, RequirementsUpdateStrategy? expectedRequirementsUpdateStrategy)
+    {
+        var jsonWrapperJson = $$"""
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "requirements-update-strategy": {{requirementsUpdateStrategyStringJson}}
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        var actualRequirementsUpdateStrategy = jobWrapper.Job.RequirementsUpdateStrategy;
+        Assert.Equal(expectedRequirementsUpdateStrategy, actualRequirementsUpdateStrategy);
+    }
+
+    [Fact]
+    public void DeserializeSecurityAdvisories()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "security-advisories": [
+                        {
+                            "dependency-name": "Some.Package",
+                            "affected-versions": [
+                                ">= 1.0.0, < 1.2.0"
+                            ],
+                            "patched-versions": null
+                        }
+                    ]
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Single(jobWrapper.Job.SecurityAdvisories);
+        Assert.Equal("Some.Package", jobWrapper.Job.SecurityAdvisories[0].DependencyName);
+        Assert.Equal(">= 1.0.0, < 1.2.0", jobWrapper.Job.SecurityAdvisories[0].AffectedVersions!.Value.Single().ToString());
+        Assert.Null(jobWrapper.Job.SecurityAdvisories[0].PatchedVersions);
+        Assert.Null(jobWrapper.Job.SecurityAdvisories[0].PatchedVersions);
+    }
+
+    [Fact]
+    public void DeserializeCommitOptions()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "commit-message-options": {
+                        "prefix": "[SECURITY] "
+                    }
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Equal("[SECURITY] ", jobWrapper.Job.CommitMessageOptions!.Prefix);
+        Assert.Null(jobWrapper.Job.CommitMessageOptions!.PrefixDevelopment);
+        Assert.Null(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
+    }
+
+    public static IEnumerable<object?[]> DeserializeAllowedUpdatesData()
+    {
+        // common default value - most job files look like this
+        yield return
+        [
+            // allowedUpdatesJsonBody
+            """
+            [
+                {
+                    "update-type": "all"
+                }
+            ]
+            """,
+            // expectedAllowedUpdates
+            new[]
+            {
+                new AllowedUpdate()
+                {
+                    DependencyType = Core.Run.ApiModel.DependencyType.All,
+                    DependencyName = null,
+                    UpdateType = UpdateType.All
+                }
+            }
+        ];
+
+        // allowed updates is missing - ensure proper defaults
+        yield return
+        [
+            // allowedUpdatesJsonBody
+            null,
+            // expectedAllowedUpdates
+            new[]
+            {
+                new AllowedUpdate()
+            }
+        ];
+
+        // multiple non-default values
+        yield return
+        [
+            // allowedUpdatesJsonBody
+            """
+            [
+                {
+                    "dependency-type": "indirect",
+                    "dependency-name": "Dependency.One",
+                    "update-type": "security"
+                },
+                {
+                    "dependency-type": "production",
+                    "dependency-name": "Dependency.Two",
+                    "update-type": "all"
+                },
+                {
+                    "dependency-type": "indirect",
+                    "update-type": "security"
+                }
+            ]
+            """,
+            new[]
+            {
+                new AllowedUpdate()
+                {
+                    DependencyType = Core.Run.ApiModel.DependencyType.Indirect,
+                    DependencyName = "Dependency.One",
+                    UpdateType = UpdateType.Security
+                },
+                new AllowedUpdate()
+                {
+                    DependencyType = Core.Run.ApiModel.DependencyType.Production,
+                    DependencyName = "Dependency.Two",
+                    UpdateType = UpdateType.All
+                },
+                new AllowedUpdate()
+                {
+                    DependencyType = Core.Run.ApiModel.DependencyType.Indirect,
+                    DependencyName = null,
+                    UpdateType = UpdateType.Security
+                }
+            }
+        ];
     }
 
     private class CapturingTestLogger : ILogger

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -272,10 +272,6 @@ public abstract class UpdateWorkerTestBase : TestBase
         {
             Job = new()
             {
-                AllowedUpdates =
-                [
-                    new() { UpdateType = "all" }
-                ],
                 Source = new()
                 {
                     Provider = "github",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Advisory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Advisory.cs
@@ -1,0 +1,13 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Analyze;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record Advisory
+{
+    public required string DependencyName { get; init; }
+    public ImmutableArray<Requirement>? AffectedVersions { get; init; } = null;
+    public ImmutableArray<Requirement>? PatchedVersions { get; init; } = null;
+    public ImmutableArray<Requirement>? UnaffectedVersions { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/AllowedUpdate.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/AllowedUpdate.cs
@@ -2,5 +2,22 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record AllowedUpdate
 {
-    public string UpdateType { get; init; } = "all";
+    public DependencyType DependencyType { get; init; } = DependencyType.All;
+    public string? DependencyName { get; init; } = null;
+    public UpdateType UpdateType { get; init; } = UpdateType.All;
+}
+
+public enum DependencyType
+{
+    All,
+    Direct,
+    Indirect,
+    Development,
+    Production,
+}
+
+public enum UpdateType
+{
+    All,
+    Security,
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
@@ -1,0 +1,8 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record CommitOptions
+{
+    public string? Prefix { get; init; } = null;
+    public string? PrefixDevelopment { get; init; } = null;
+    public string? IncludeScope { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
@@ -1,0 +1,8 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record DependencyGroup
+{
+    public required string Name { get; init; }
+    public string? AppliesTo { get; init; }
+    public Dictionary<string, object> Rules { get; init; } = new();
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/GroupPullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/GroupPullRequest.cs
@@ -1,0 +1,9 @@
+using System.Collections.Immutable;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record GroupPullRequest
+{
+    public required string DependencyGroupName { get; init; }
+    public required ImmutableArray<PullRequest> Dependencies { get; init; }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -1,25 +1,28 @@
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+
+using NuGet.Credentials;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record Job
 {
     public string PackageManager { get; init; } = "nuget";
-    public AllowedUpdate[]? AllowedUpdates { get; init; } = null;
+    public ImmutableArray<AllowedUpdate> AllowedUpdates { get; init; } = [new AllowedUpdate()];
 
     [JsonConverter(typeof(NullAsBoolConverter))]
     public bool Debug { get; init; } = false;
-    public object[]? DependencyGroups { get; init; } = null;
-    public object[]? Dependencies { get; init; } = null;
+    public ImmutableArray<DependencyGroup> DependencyGroups { get; init; } = [];
+    public ImmutableArray<string>? Dependencies { get; init; } = null;
     public string? DependencyGroupToRefresh { get; init; } = null;
-    public object[]? ExistingPullRequests { get; init; } = null;
-    public object[]? ExistingGroupPullRequests { get; init; } = null;
+    public ImmutableArray<ImmutableArray<PullRequest>> ExistingPullRequests { get; init; } = [];
+    public ImmutableArray<GroupPullRequest> ExistingGroupPullRequests { get; init; } = [];
     public Dictionary<string, object>? Experiments { get; init; } = null;
     public Condition[] IgnoreConditions { get; init; } = [];
     public bool LockfileOnly { get; init; } = false;
-    public string? RequirementsUpdateStrategy { get; init; } = null;
-    public object[]? SecurityAdvisories { get; init; } = null;
+    public RequirementsUpdateStrategy? RequirementsUpdateStrategy { get; init; } = null;
+    public ImmutableArray<Advisory> SecurityAdvisories { get; init; } = [];
     public bool SecurityUpdatesOnly { get; init; } = false;
     public required JobSource Source { get; init; }
     public bool UpdateSubdependencies { get; init; } = false;
@@ -27,8 +30,8 @@ public sealed record Job
     public bool VendorDependencies { get; init; } = false;
     public bool RejectExternalCode { get; init; } = false;
     public bool RepoPrivate { get; init; } = false;
-    public object? CommitMessageOptions { get; init; } = null;
-    public object[]? CredentialsMetadata { get; init; } = null;
+    public CommitOptions? CommitMessageOptions { get; init; } = null;
+    public ImmutableArray<Dictionary<string, string>>? CredentialsMetadata { get; init; } = null;
     public int MaxUpdaterRunTime { get; init; } = 0;
 
     public IEnumerable<string> GetAllDirectories()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
@@ -1,0 +1,11 @@
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PullRequest
+{
+    public required string DependencyName { get; init; }
+    public required NuGetVersion DependencyVersion { get; init; }
+    public bool DependencyRemoved { get; init; } = false;
+    public string? Directory { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/RequirementsUpdateStrategy.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/RequirementsUpdateStrategy.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public enum RequirementsUpdateStrategy
+{
+    [JsonStringEnumMemberName("bump_versions")]
+    BumpVersions,
+    [JsonStringEnumMemberName("bump_versions_if_necessary")]
+    BumpVersionsIfNecessary,
+    [JsonStringEnumMemberName("lockfile_only")]
+    LockfileOnly,
+    [JsonStringEnumMemberName("widen_ranges")]
+    WidenRanges,
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -22,7 +22,7 @@ public class RunWorker
     {
         PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
         WriteIndented = true,
-        Converters = { new JsonStringEnumConverter(), new RequirementConverter() },
+        Converters = { new JsonStringEnumConverter(), new RequirementConverter(), new VersionConverter() },
     };
 
     public RunWorker(IApiHandler apiHandler, IDiscoveryWorker discoverWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updateWorker, ILogger logger)
@@ -124,9 +124,8 @@ public class RunWorker
         // TODO: pull out relevant dependencies, then check each for updates and track the changes
         // TODO: for each top-level dependency, _or_ specific dependency (if security, use transitive)
         var originalDependencyFileContents = new Dictionary<string, string>();
-        var allowedUpdates = job.AllowedUpdates ?? [];
         var actualUpdatedDependencies = new List<ReportedDependency>();
-        if (allowedUpdates.Any(a => a.UpdateType == "all"))
+        if (job.AllowedUpdates.Any(a => a.UpdateType == UpdateType.All))
         {
             await _apiHandler.IncrementMetric(new()
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/VersionConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/VersionConverter.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Analyze;
+
+public class VersionConverter : JsonConverter<NuGetVersion>
+{
+    public override NuGetVersion? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return NuGetVersion.Parse(reader.GetString()!);
+    }
+
+    public override void Write(Utf8JsonWriter writer, NuGetVersion value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}


### PR DESCRIPTION
The job deserializer had a bunch of `string`, `object`, etc. for properties that we don't yet use.

This PR adds concrete types for everything in the job file so it'll be usable when necessary.  The shape of the job file was pulled from [the CLI](https://github.com/dependabot/cli/blob/4e7612fe884683ade8c54ad8fd137fc6da92bb84/internal/model/job.go) as well as [this repo](https://github.com/dependabot/dependabot-core/blob/fa9831f094e1a575ace3444769de7e57bee4f5a2/updater/lib/dependabot/job.rb).