### PR TITLE
pass job file path to analyze command

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Discover.cs
@@ -393,7 +393,8 @@ public partial class EntryPointTests
             TestFile[] initialFiles,
             ExpectedWorkspaceDiscoveryResult expectedResult,
             MockNuGetPackage[]? packages = null,
-            ExperimentsManager? experimentsManager = null)
+            ExperimentsManager? experimentsManager = null
+        )
         {
             experimentsManager ??= new ExperimentsManager();
             var actualResult = await RunDiscoveryAsync(initialFiles, async path =>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
@@ -36,7 +36,7 @@ internal static class RunCommand
             var logger = new ConsoleLogger();
             var experimentsManager = await ExperimentsManager.FromJobFileAsync(jobPath.FullName, logger);
             var discoverWorker = new DiscoveryWorker(experimentsManager, logger);
-            var analyzeWorker = new AnalyzeWorker(logger);
+            var analyzeWorker = new AnalyzeWorker(experimentsManager, logger);
             var updateWorker = new UpdaterWorker(experimentsManager, logger);
             var worker = new RunWorker(apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
             await worker.RunAsync(jobPath, repoContentsPath, baseCommitSha, outputPath);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTestBase.cs
@@ -19,7 +19,9 @@ public class AnalyzeWorkerTestBase
         DependencyInfo dependencyInfo,
         ExpectedAnalysisResult expectedResult,
         MockNuGetPackage[]? packages = null,
-        TestFile[]? extraFiles = null)
+        TestFile[]? extraFiles = null,
+        ExperimentsManager? experimentsManager = null
+    )
     {
         var relativeDependencyPath = $"./dependabot/dependency/{dependencyInfo.Name}.json";
 
@@ -28,6 +30,7 @@ public class AnalyzeWorkerTestBase
             (relativeDependencyPath, JsonSerializer.Serialize(dependencyInfo, AnalyzeWorker.SerializerOptions)),
         ];
 
+        experimentsManager ??= new ExperimentsManager();
         var allFiles = files.Concat(extraFiles ?? []).ToArray();
         var actualResult = await RunAnalyzerAsync(dependencyInfo.Name, allFiles, async directoryPath =>
         {
@@ -36,7 +39,7 @@ public class AnalyzeWorkerTestBase
             var discoveryPath = Path.GetFullPath(DiscoveryWorker.DiscoveryResultFileName, directoryPath);
             var dependencyPath = Path.GetFullPath(relativeDependencyPath, directoryPath);
 
-            var worker = new AnalyzeWorker(new TestLogger());
+            var worker = new AnalyzeWorker(experimentsManager, new TestLogger());
             var result = await worker.RunWithErrorHandlingAsync(directoryPath, discoveryPath, dependencyPath);
             return result;
         });

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1730,7 +1730,7 @@ public class RunWorkerTests
         var testApiHandler = new TestApiHandler();
         var logger = new TestLogger();
         discoveryWorker ??= new DiscoveryWorker(experimentsManager, logger);
-        analyzeWorker ??= new AnalyzeWorker(logger);
+        analyzeWorker ??= new AnalyzeWorker(experimentsManager, logger);
         updaterWorker ??= new UpdaterWorker(experimentsManager, logger);
 
         var worker = new RunWorker(testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -16,6 +16,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
 {
     public const string AnalysisDirectoryName = "./.dependabot/analysis";
 
+    private readonly ExperimentsManager _experimentsManager;
     private readonly ILogger _logger;
 
     internal static readonly JsonSerializerOptions SerializerOptions = new()
@@ -24,8 +25,9 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         Converters = { new JsonStringEnumConverter(), new RequirementArrayConverter() },
     };
 
-    public AnalyzeWorker(ILogger logger)
+    public AnalyzeWorker(ExperimentsManager experimentsManager, ILogger logger)
     {
+        _experimentsManager = experimentsManager;
         _logger = logger;
     }
 

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -81,6 +81,8 @@ module Dependabot
         fingerprint = [
           exe_path,
           "discover",
+          "--job-path",
+          "<job-path>",
           "--repo-root",
           "<repo-root>",
           "--workspace",
@@ -116,15 +118,17 @@ module Dependabot
       end
 
       sig do
-        params(repo_root: String, discovery_file_path: String, dependency_file_path: String,
+        params(job_path: String, repo_root: String, discovery_file_path: String, dependency_file_path: String,
                analysis_folder_path: String).returns([String, String])
       end
-      def self.get_nuget_analyze_tool_command(repo_root:, discovery_file_path:, dependency_file_path:,
+      def self.get_nuget_analyze_tool_command(job_path:, repo_root:, discovery_file_path:, dependency_file_path:,
                                               analysis_folder_path:)
         exe_path = File.join(native_helpers_root, "NuGetUpdater", "NuGetUpdater.Cli")
         command_parts = [
           exe_path,
           "analyze",
+          "--job-path",
+          job_path,
           "--repo-root",
           repo_root,
           "--discovery-file-path",
@@ -140,6 +144,8 @@ module Dependabot
         fingerprint = [
           exe_path,
           "analyze",
+          "--job-path",
+          "<job-path>",
           "--discovery-file-path",
           "<discovery-file-path>",
           "--dependency-file-path",
@@ -153,13 +159,14 @@ module Dependabot
 
       sig do
         params(
-          repo_root: String, discovery_file_path: String, dependency_file_path: String,
+          job_path: String, repo_root: String, discovery_file_path: String, dependency_file_path: String,
           analysis_folder_path: String, credentials: T::Array[Dependabot::Credential]
         ).void
       end
-      def self.run_nuget_analyze_tool(repo_root:, discovery_file_path:, dependency_file_path:,
+      def self.run_nuget_analyze_tool(job_path:, repo_root:, discovery_file_path:, dependency_file_path:,
                                       analysis_folder_path:, credentials:)
-        (command, fingerprint) = get_nuget_analyze_tool_command(repo_root: repo_root,
+        (command, fingerprint) = get_nuget_analyze_tool_command(job_path: job_path,
+                                                                repo_root: repo_root,
                                                                 discovery_file_path: discovery_file_path,
                                                                 dependency_file_path: dependency_file_path,
                                                                 analysis_folder_path: analysis_folder_path)
@@ -205,6 +212,8 @@ module Dependabot
         fingerprint = [
           exe_path,
           "update",
+          "--job-path",
+          "<job-path>",
           "--repo-root",
           "<repo-root>",
           "--solution-or-project",

--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -72,6 +72,11 @@ module Dependabot
 
       private
 
+      sig { returns(String) }
+      def job_file_path
+        ENV.fetch("DEPENDABOT_JOB_PATH")
+      end
+
       sig { returns(AnalysisJsonReader) }
       def update_analysis
         @update_analysis ||= T.let(request_analysis, T.nilable(AnalysisJsonReader))
@@ -103,7 +108,8 @@ module Dependabot
 
         write_dependency_info
 
-        NativeHelpers.run_nuget_analyze_tool(repo_root: T.must(repo_contents_path),
+        NativeHelpers.run_nuget_analyze_tool(job_path: job_file_path,
+                                             repo_root: T.must(repo_contents_path),
                                              discovery_file_path: discovery_file_path,
                                              dependency_file_path: dependency_file_path,
                                              analysis_folder_path: analysis_folder_path,


### PR DESCRIPTION
The `discover` and `update` NuGet tool commands both have a `--job-path` argument so that the current set of experiments can be parsed.

This PR adds the same behavior to the `analyze` command.  We don't yet need the experiments for this command, but we will soon so this is front loading some of the work.