### PR TITLE
install .NET SDKs as specified by repo's `global.json` files

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -26,6 +26,7 @@ module Dependabot
 
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files
+        NativeHelpers.install_dotnet_sdks
         discovery_json_reader = DiscoveryJsonReader.run_discovery_in_directory(
           repo_contents_path: T.must(repo_contents_path),
           directory: directory,

--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -27,6 +27,7 @@ module Dependabot
       sig { returns(T::Array[Dependabot::Dependency]) }
       def dependencies
         @dependencies ||= T.let(begin
+          NativeHelpers.install_dotnet_sdks
           directory = source&.directory || "/"
           discovery_json_reader = DiscoveryJsonReader.run_discovery_in_directory(
             repo_contents_path: T.must(repo_contents_path),

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -260,6 +260,27 @@ module Dependabot
         end
       end
 
+      sig { void }
+      def self.install_dotnet_sdks
+        return unless Dependabot::Experiments.enabled?(:nuget_install_dotnet_sdks)
+
+        # environment variables are required and the following will generate an actionable error message if they're not
+        _dependabot_job_path = ENV.fetch("DEPENDABOT_JOB_PATH")
+        _dependabot_repo_contents_path = ENV.fetch("DEPENDABOT_REPO_CONTENTS_PATH")
+        _dotnet_install_script_path = ENV.fetch("DOTNET_INSTALL_SCRIPT_PATH")
+        _dotnet_install_dir = ENV.fetch("DOTNET_INSTALL_DIR")
+
+        # this environment variable is directly used
+        dependabot_home = ENV.fetch("DEPENDABOT_HOME")
+
+        command = [
+          "pwsh",
+          "#{dependabot_home}/dependabot-updater/bin/install-sdks.ps1"
+        ].join(" ")
+        output = SharedHelpers.run_shell_command(command)
+        puts output
+      end
+
       sig { params(json: T::Hash[String, T.untyped]).void }
       def self.ensure_no_errors(json)
         error_type = T.let(json.fetch("ErrorType", nil), T.nilable(String))

--- a/nuget/updater/install-sdks.ps1
+++ b/nuget/updater/install-sdks.ps1
@@ -1,0 +1,18 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+. $PSScriptRoot\common.ps1
+
+try {
+    Install-Sdks `
+        -jobFilePath $env:DEPENDABOT_JOB_PATH `
+        -repoContentsPath $env:DEPENDABOT_REPO_CONTENTS_PATH `
+        -dotnetInstallScriptPath $env:DOTNET_INSTALL_SCRIPT_PATH `
+        -dotnetInstallDir $env:DOTNET_INSTALL_DIR
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
This PR adds new behavior behind the experiment flag `nuget_install_dotnet_sdks`.  This experiment is not yet enabled anywhere.

The NuGet updater currently has 2 installed .NET SDKs, `8.0.404` and `9.0.100`.

This PR crawls the directories specified in the job file to install the exact SDKs required by the target repo.

TODO: honor experiment flag in C# code