### PR TITLE
Fix Composer v1 Unsupported Error Handling in Dependabot Core

### DIFF
--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -57,9 +57,13 @@ module Dependabot
 
       sig { returns(Ecosystem::VersionManager) }
       def package_manager
-        raw_composer_version = env_versions[:composer] || composer_version
+        if composer_version == Helpers::V1
+          return PackageManager.new(
+            composer_version
+          )
+        end
         PackageManager.new(
-          raw_composer_version
+          env_versions[:composer] || composer_version
         )
       end
 
@@ -320,8 +324,10 @@ module Dependabot
 
       sig { returns(String) }
       def composer_version
-        @composer_version ||= T.let(Helpers.composer_version(parsed_composer_json, parsed_lockfile),
-                                    T.nilable(String))
+        @composer_version ||= T.let(
+          Helpers.composer_version(parsed_composer_json, parsed_lockfile),
+          T.nilable(String)
+        )
       end
     end
   end


### PR DESCRIPTION
#### What are you trying to accomplish?

This PR addresses an issue where Dependabot Core attempts to use Composer v1, which has been deleted. The problem occurs because the unsupported error is not being thrown properly. As a result, the system attempts to invoke Composer v1, leading to failures such as:

```
php -d memory_limit=-1 /opt/composer/v1/bin/run
```

**Why:**  
Composer v1 is no longer supported, and Dependabot Core should ensure the unsupported error is thrown correctly to prevent attempts to use it. This fix will enforce the proper handling of unsupported versions and redirect processes as required.

#### What issues does this affect or fix?

---

#### Anything you want to highlight for special attention from reviewers?

- The issue lies in the error-handling logic for Composer v1. The changes ensure that unsupported versions throw appropriate errors to prevent execution.  
- Reviewers may want to double-check areas where the unsupported error should propagate to confirm correctness.

---

#### How will you know you've accomplished your goal?

- The unsupported error is thrown when Composer v1 is invoked, and no further attempts are made to execute v1 binaries.  
- Dependabot successfully handles scenarios with Composer v2 or higher.  
- All tests pass, ensuring no regression in functionality.

---

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.  
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.  
- [x] I have written clear and descriptive commit messages.  
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.  
- [x] I have ensured that the code is well-documented and easy to understand.