### PR TITLE
Add support for swift ecosystem metrics collection

### DIFF
--- a/swift/lib/dependabot/swift/file_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser.rb
@@ -6,6 +6,8 @@ require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/swift/file_parser/dependency_parser"
 require "dependabot/swift/file_parser/manifest_parser"
+require "dependabot/swift/package_manager"
+require "dependabot/swift/language"
 
 module Dependabot
   module Swift
@@ -36,6 +38,17 @@ module Dependabot
         dependency_set.dependencies
       end
 
+      sig { returns(Ecosystem) }
+      def ecosystem
+        @ecosystem ||= T.let(begin
+          Ecosystem.new(
+            name: ECOSYSTEM,
+            language: language,
+            package_manager: package_manager
+          )
+        end, T.nilable(Dependabot::Ecosystem))
+      end
+
       private
 
       def dependency_parser
@@ -53,6 +66,44 @@ module Dependabot
       def package_manifest_file
         # TODO: Select version-specific manifest
         @package_manifest_file ||= get_original_file("Package.swift")
+      end
+
+      sig { returns(Ecosystem::VersionManager) }
+      def package_manager
+        @package_manager ||= T.let(
+          PackageManager.new(T.must(package_manager_version)),
+          T.nilable(Dependabot::Swift::PackageManager)
+        )
+      end
+
+      sig { returns(T.nilable(String)) }
+      def package_manager_version
+        @package_manager_version ||= T.let(
+          begin
+            version = SharedHelpers.run_shell_command("swift package --version")
+            version.strip.gsub(/Swift Package Manager - Swift \s*/, "")
+          end,
+          T.nilable(String)
+        )
+      end
+
+      sig { returns(T.nilable(Ecosystem::VersionManager)) }
+      def language
+        @language ||= T.let(begin
+          Language.new(T.must(swift_version))
+        end, T.nilable(Dependabot::Swift::Language))
+      end
+
+      sig { returns(T.nilable(String)) }
+      def swift_version
+        @swift_version ||= T.let(
+          begin
+            version = SharedHelpers.run_shell_command("swift --version")
+            pattern = Dependabot::Ecosystem::VersionManager::DEFAULT_VERSION_PATTERN
+            version.match(/Swift version\s*#{pattern}/)&.captures&.first
+          end,
+          T.nilable(String)
+        )
       end
     end
   end

--- a/swift/lib/dependabot/swift/language.rb
+++ b/swift/lib/dependabot/swift/language.rb
@@ -1,0 +1,24 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/swift/version"
+
+module Dependabot
+  module Swift
+    LANGUAGE = "swift"
+
+    class Language < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          LANGUAGE,
+          Version.new(raw_version)
+        )
+      end
+    end
+  end
+end

--- a/swift/lib/dependabot/swift/package_manager.rb
+++ b/swift/lib/dependabot/swift/package_manager.rb
@@ -1,0 +1,41 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/ecosystem"
+require "dependabot/swift/version"
+
+module Dependabot
+  module Swift
+    ECOSYSTEM = "swift"
+    PACKAGE_MANAGER = "swift"
+    SUPPORTED_SWIFT_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    # When a version is going to be unsupported, it will be added here
+    DEPRECATED_SWIFT_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+
+    class PackageManager < Dependabot::Ecosystem::VersionManager
+      extend T::Sig
+
+      sig { params(raw_version: String).void }
+      def initialize(raw_version)
+        super(
+          PACKAGE_MANAGER,
+          Version.new(raw_version),
+          DEPRECATED_SWIFT_VERSIONS,
+          SUPPORTED_SWIFT_VERSIONS
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def deprecated?
+        false
+      end
+
+      sig { returns(T::Boolean) }
+      def unsupported?
+        false
+      end
+    end
+  end
+end

--- a/swift/lib/dependabot/swift/version.rb
+++ b/swift/lib/dependabot/swift/version.rb
@@ -1,6 +1,9 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "dependabot/utils"
+require "dependabot/version"
+
 module Dependabot
   module Swift
     class Version < Dependabot::Version

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -305,6 +305,26 @@ RSpec.describe Dependabot::Swift::FileParser do
       end
     end
 
+    describe "#package_manager_version" do
+      # If this test starts failing, the format of the output of `swing package --version` has
+      # changed and you'll need to update the code to extract the version correctly.
+      subject(:package_manager_version) { parser.send(:package_manager_version) }
+
+      it "has the correct format" do
+        expect(package_manager_version.match(/^\d+(?:\.\d+)*/)).to be_truthy
+      end
+    end
+
+    describe "#swift_version" do
+      # If this test starts failing, the format of the output of `swing --version` has
+      # changed and you'll need to update the code to extract the version correctly.
+      subject(:swift_version) { parser.send(:swift_version) }
+
+      it "has the correct format" do
+        expect(swift_version.match(/^\d+(?:\.\d+)*$/)).to be_truthy
+      end
+    end
+
     describe "#language" do
       subject(:language) { ecosystem.language }
 

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -285,4 +285,34 @@ RSpec.describe Dependabot::Swift::FileParser do
 
     it_behaves_like "parse"
   end
+
+  describe "#ecosystem" do
+    subject(:ecosystem) { parser.ecosystem }
+
+    let(:project_name) { "Example" }
+
+    it "has the correct name" do
+      expect(ecosystem.name).to eq "swift"
+    end
+
+    describe "#package_manager" do
+      subject(:package_manager) { ecosystem.package_manager }
+
+      it "returns the correct package manager" do
+        expect(package_manager.name).to eq "swift"
+        expect(package_manager.requirement).to be_nil
+        expect(package_manager.version.to_s).to eq "6.0.1.pre.dev"
+      end
+    end
+
+    describe "#language" do
+      subject(:language) { ecosystem.language }
+
+      it "returns the correct language" do
+        expect(language.name).to eq "swift"
+        expect(language.requirement).to be_nil
+        expect(language.version.to_s).to eq "6.0.1"
+      end
+    end
+  end
 end

--- a/swift/spec/dependabot/swift/language_spec.rb
+++ b/swift/spec/dependabot/swift/language_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/swift/language"
+require "dependabot/ecosystem"
+require "spec_helper"
+
+RSpec.describe Dependabot::Swift::Language do
+  let(:language) { described_class.new(version) }
+  let(:version) { "3.0.0" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(language.version).to eq(Dependabot::Swift::Version.new(version))
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(language.name).to eq(Dependabot::Swift::LANGUAGE)
+    end
+  end
+
+  describe "#unsupported?" do
+    it "returns false by default" do
+      expect(language.unsupported?).to be false
+    end
+  end
+
+  describe "#deprecated?" do
+    it "returns false by default" do
+      expect(language.deprecated?).to be false
+    end
+  end
+end

--- a/swift/spec/dependabot/swift/package_manager_spec.rb
+++ b/swift/spec/dependabot/swift/package_manager_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/swift/package_manager"
+require "dependabot/ecosystem"
+
+RSpec.describe Dependabot::Swift::PackageManager do
+  subject(:package_manager) { described_class.new(version) }
+
+  let(:version) { "6.0.2" }
+
+  describe "#version" do
+    it "returns the version" do
+      expect(package_manager.version.to_s).to eq version
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(package_manager.name).to eq(Dependabot::Swift::PACKAGE_MANAGER)
+    end
+  end
+
+  describe "#deprecated_versions" do
+    it "returns deprecated versions" do
+      expect(package_manager.deprecated_versions).to eq(Dependabot::Swift::DEPRECATED_SWIFT_VERSIONS)
+    end
+  end
+
+  describe "#supported_versions" do
+    it "returns supported versions" do
+      expect(package_manager.supported_versions).to eq(Dependabot::Swift::SUPPORTED_SWIFT_VERSIONS)
+    end
+  end
+end


### PR DESCRIPTION
#### What are you trying to accomplish?

Update the swift ecosystem to add support for gathering ecosystem metrics.

#### Anything you want to highlight for special attention from reviewers?
This is one in a series of PRs to gather ecosystem meta data and persist it in datadog.

#### How will you know you've accomplished your goal?

- I'll be able to see swift ecosystem metrics in datadog

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
