### PR TITLE
Throwing an appropriate error, when private registry response with 200 status and empty array response

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -143,8 +143,8 @@ module Dependabot
           return [] unless response.status == 200
 
           listing = JSON.parse(response.body)
-          raise Dependabot::PrivateSourceAuthenticationFailure, url if listing.is_a?(Array) && listing.empty?
           return [] if listing.nil?
+          return [] unless listing.is_a?(Hash)
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -143,8 +143,9 @@ module Dependabot
           return [] unless response.status == 200
 
           listing = JSON.parse(response.body)
+          raise Dependabot::PrivateSourceAuthenticationFailure, url if listing.is_a?(Array) && listing.empty?
           return [] if listing.nil?
-          return [] unless listing.is_a?(Hash)
+          T.assert_type!(listing, T::Hash[String, T.untyped])
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -148,6 +148,13 @@ module Dependabot
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)
 
+          extract_versions(listing)
+        rescue JSON::ParserError
+          msg = "'#{url}' does not contain valid JSON"
+          raise DependencyFileNotResolvable, msg
+        end
+
+        def extract_versions(listing)
           # Packagist's Metadata API format:
           # v1: "packages": {<package name>: {<version_number>: {hash of metadata for a particular release version}}}
           # v2: "packages": {<package name>: [{hash of metadata for a particular release version}]}
@@ -165,9 +172,6 @@ module Dependabot
           else
             []
           end
-        rescue JSON::ParserError
-          msg = "'#{url}' does not contain valid JSON"
-          raise DependencyFileNotResolvable, msg
         end
 
         def registry_credentials

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -144,6 +144,7 @@ module Dependabot
 
           listing = JSON.parse(response.body)
           return [] if listing.nil?
+          return [] unless listing.is_a?(Hash)
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -144,8 +144,8 @@ module Dependabot
 
           listing = JSON.parse(response.body)
           raise Dependabot::PrivateSourceAuthenticationFailure, url if listing.is_a?(Array) && listing.empty?
-          return [] if listing.nil?
           T.assert_type!(listing, T::Hash[String, T.untyped])
+          return [] if listing.nil?
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -144,7 +144,6 @@ module Dependabot
 
           listing = JSON.parse(response.body)
           raise Dependabot::PrivateSourceAuthenticationFailure, url if listing.is_a?(Array) && listing.empty?
-          T.assert_type!(listing, T::Hash[String, T.untyped])
           return [] if listing.nil?
           return [] if listing.fetch("packages", []) == []
           return [] unless listing.dig("packages", dependency.name.downcase)

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -394,4 +394,17 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
 
     it { is_expected.to eq(Gem::Version.new("1.12.0")) }
   end
+
+  context "when the response status is 200 && the body is an empty array" do
+    let(:url) { "https://example.com/packages.json" }
+    let(:response) { instance_double(Excon::Response, status: 200, body: '[]') }
+
+    before do
+      allow(Dependabot::RegistryClient).to receive(:get).and_return(response)
+    end
+
+    it "raises an unauthorized error" do
+      expect { finder.send(:fetch_registry_versions_from_url, url) }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+    end
+  end
 end

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -397,14 +397,16 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
 
   context "when the response status is 200 && the body is an empty array" do
     let(:url) { "https://example.com/packages.json" }
-    let(:response) { instance_double(Excon::Response, status: 200, body: '[]') }
+    let(:response) { instance_double(Excon::Response, status: 200, body: "[]") }
 
     before do
       allow(Dependabot::RegistryClient).to receive(:get).and_return(response)
     end
 
     it "raises an unauthorized error" do
-      expect { finder.send(:fetch_registry_versions_from_url, url) }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+      expect do
+        finder.send(:fetch_registry_versions_from_url, url)
+      end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
     end
   end
 end

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -403,10 +403,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       allow(Dependabot::RegistryClient).to receive(:get).and_return(response)
     end
 
-    it "raises an unauthorized error" do
-      expect do
-        finder.send(:fetch_registry_versions_from_url, url)
-      end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+    it "returns an empty array" do
+      expect(finder.send(:fetch_registry_versions_from_url, url)).to eq([])
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Ref: https://github.com/github/dependabot-updates/issues/7609

Throwing an appropriate error, when private registry response with 200 status and empty array response.

### Anything you want to highlight for special attention from reviewers?

Used Dependabot::PrivateSourceAuthenticationFailure error message for this failure

### How will you know you've accomplished your goal?

Ran the dependabot client and confirmed `The error no implicit conversion of String into Integer` is not there.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
