### PR TITLE
elevate formatting issues to build failure

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/.editorconfig
+++ b/nuget/helpers/lib/NuGetUpdater/.editorconfig
@@ -26,6 +26,7 @@ end_of_line = lf
 [*.{cs,vb}]
 
 max_line_length = 0
+dotnet_diagnostic.IDE0055.severity = error
 
 # Organize usings
 dotnet_separate_import_directive_groups = true

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <Import Project="Directory.Common.props" />

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -10,7 +10,6 @@ popd
 # C# unit tests
 pushd ./helpers/lib/NuGetUpdater
 dotnet restore
-dotnet format --no-restore --exclude ../NuGet.Client --verify-no-changes -v diag
 dotnet build --configuration Release
 dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./NuGetUpdater.Cli.Test/NuGetUpdater.Cli.Test.csproj
 dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj


### PR DESCRIPTION
The NuGet updater already enforces code formatting as a CI check, but this ensures the formatting failures are raised as errors in the build and appear in the IDE.  This makes finding and fixing them much easier so a CI cycle isn't wasted.

~~This PR contains a temporary commit that introduces a formatting error to verify the CI fails as expected.  Onec verified this commit will be removed.~~
Temporary commit resulted in the expected build error in CI.