### PR TITLE
merge SDK and packages.config references in discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -115,5 +115,61 @@ public partial class DiscoveryWorkerTests
                 }
             );
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DiscoveryIsMergedWithPackageReferences(bool useDirectDiscovery)
+        {
+            await TestDiscoveryAsync(
+                experimentsManager: new ExperimentsManager() { UseDirectDiscovery = useDirectDiscovery },
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net46"),
+                    MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net46"),
+                ],
+                workspacePath: "src",
+                files: [
+                    ("src/myproj.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net46</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="..\unexpected-directory\packages.config" />
+                            <PackageReference Include="Package.B" Version="2.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("unexpected-directory/packages.config", """
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <packages>
+                          <package id="Package.A" version="1.0.0" targetFramework="net46" />
+                        </packages>
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "myproj.csproj",
+                            Properties = [new("TargetFramework", "net46", "src/myproj.csproj")],
+                            TargetFrameworks = ["net46"],
+                            Dependencies = [
+                                new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
+                                new("Package.B", "2.0.0", DependencyType.PackageReference, IsDirect: true, TargetFrameworks: ["net46"]),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [
+                                "../unexpected-directory/packages.config"
+                            ],
+                        }
+                    ],
+                }
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/ProjectHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/ProjectHelperTests.cs
@@ -1,0 +1,65 @@
+using NuGetUpdater.Core.Utilities;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class ProjectHelperTests : TestBase
+{
+    [Theory]
+    [MemberData(nameof(AdditionalFile))]
+    public async Task GetAdditionalFilesFromProject(string projectPath, (string Name, string Content)[] files, string[] expectedAdditionalFiles)
+    {
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(files);
+        var fullProjectPath = Path.Join(tempDirectory.DirectoryPath, projectPath);
+
+        var actualAdditionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(fullProjectPath, ProjectHelper.PathFormat.Relative);
+        AssertEx.Equal(expectedAdditionalFiles, actualAdditionalFiles);
+    }
+
+    public static IEnumerable<object[]> AdditionalFile()
+    {
+        // no additional files
+        yield return
+        [
+            // project path
+            "src/project.csproj",
+            // files
+            new[]
+            {
+                ("src/project.csproj", """
+                    <Project>
+                    </Project>
+                    """)
+            },
+            // expected additional files
+            Array.Empty<string>()
+        ];
+
+        // files with relative paths
+        yield return
+        [
+            // project path
+            "src/project.csproj",
+            // files
+            new[]
+            {
+                ("src/project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <None Include="..\unexpected-path\packages.config" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("unexpected-path/packages.config", """
+                    <packages></packages>
+                    """)
+            },
+            // expected additional files
+            new[]
+            {
+                "../unexpected-path/packages.config"
+            }
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProjectHelper.cs
@@ -77,11 +77,11 @@ internal static class ProjectHelper
         var itemPath = projectRootElement.Items
             .Where(i => i.ElementName.Equals("None", StringComparison.OrdinalIgnoreCase) ||
                         i.ElementName.Equals("Content", StringComparison.OrdinalIgnoreCase))
-            .Where(i => Path.GetFileName(i.Include).Equals(itemFileName, StringComparison.OrdinalIgnoreCase))
-            .Select(i => Path.GetFullPath(Path.Combine(projectDirectory, i.Include)))
+            .Where(i => !string.IsNullOrEmpty(i.Include))
+            .Select(i => Path.GetFullPath(Path.Combine(projectDirectory, i.Include.NormalizePathToUnix())))
+            .Where(p => Path.GetFileName(p).Equals(itemFileName, StringComparison.OrdinalIgnoreCase))
             .Where(File.Exists)
-            .FirstOrDefault()
-            ?.NormalizePathToUnix();
+            .FirstOrDefault();
         return itemPath;
     }
 


### PR DESCRIPTION
It's possible for a C# project to contain both SDK-style refernces (via `<PackageReference .../>` elements) as well as `packages.config`.  Previously only the `packages.config` style references would be considered if there were no SDK-style references.

This PR allows both to exist and merges the results, including the `AdditionalFiles` property.