### PR TITLE
Bump poetry version from 1.8.3 to 1.8.5

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -4,7 +4,7 @@ flake8==7.1.0
 hashin==1.0.1
 pipenv==2024.0.2
 plette==2.1.0
-poetry==1.8.3
+poetry==1.8.5
 # TODO: Replace 3p package `toml` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
 toml==0.10.2
 


### PR DESCRIPTION
PR https://github.com/dependabot/dependabot-core/pull/11079 is failing because of grouping. Not sure grouping is mandatory.