### PR TITLE
Add support for NPM V6 deprecation warning and unsupported error

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -62,14 +62,13 @@ module Dependabot
 
       # Keep versions in ascending order
       SUPPORTED_VERSIONS = T.let([
-        Version.new(NPM_V6),
         Version.new(NPM_V7),
         Version.new(NPM_V8),
         Version.new(NPM_V9),
         Version.new(NPM_V10)
       ].freeze, T::Array[Dependabot::Version])
 
-      DEPRECATED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+      DEPRECATED_VERSIONS = T.let([Version.new(NPM_V6)].freeze, T::Array[Dependabot::Version])
 
       sig do
         params(
@@ -89,12 +88,17 @@ module Dependabot
 
       sig { override.returns(T::Boolean) }
       def deprecated?
-        false
+        return false if unsupported?
+        return false unless Dependabot::Experiments.enabled?(:npm_v6_deprecation_warning)
+
+        deprecated_versions.include?(version)
       end
 
       sig { override.returns(T::Boolean) }
       def unsupported?
-        false
+        return false unless Dependabot::Experiments.enabled?(:npm_v6_unsupported_error)
+
+        supported_versions.all? { |supported| supported > version }
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/npm_package_manager_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/npm_package_manager_spec.rb
@@ -38,6 +38,54 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
     it "returns false" do
       expect(package_manager.deprecated?).to be false
     end
+
+    context "with feature flag npm_v6_deprecation_warning" do
+      before do
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:npm_v6_deprecation_warning)
+          .and_return(deprecation_enabled)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:npm_v6_unsupported_error)
+          .and_return(unsupported_enabled)
+      end
+
+      context "when npm_v6_deprecation_warning is enabled and version is deprecated" do
+        let(:deprecation_enabled) { true }
+        let(:unsupported_enabled) { false }
+
+        it "returns true" do
+          expect(package_manager.deprecated?).to be true
+        end
+      end
+
+      context "when npm_v6_deprecation_warning is enabled but version is not deprecated" do
+        let(:version) { "9" }
+        let(:deprecation_enabled) { true }
+        let(:unsupported_enabled) { false }
+
+        it "returns false" do
+          expect(package_manager.deprecated?).to be false
+        end
+      end
+
+      context "when npm_v6_deprecation_warning is disabled" do
+        let(:deprecation_enabled) { false }
+        let(:unsupported_enabled) { false }
+
+        it "returns false" do
+          expect(package_manager.deprecated?).to be false
+        end
+      end
+
+      context "when version is unsupported" do
+        let(:deprecation_enabled) { true }
+        let(:unsupported_enabled) { true }
+
+        it "returns false, as unsupported takes precedence" do
+          expect(package_manager.deprecated?).to be false
+        end
+      end
+    end
   end
 
   describe "#unsupported?" do
@@ -45,6 +93,66 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
 
     it "returns false for supported versions" do
       expect(package_manager.unsupported?).to be false
+    end
+
+    context "with feature flag npm_v6_unsupported_error" do
+      before do
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:npm_v6_unsupported_error)
+          .and_return(unsupported_enabled)
+      end
+
+      context "when npm_v6_unsupported_error is enabled and version is unsupported" do
+        let(:version) { "6" }
+        let(:unsupported_enabled) { true }
+
+        it "returns true" do
+          expect(package_manager.unsupported?).to be true
+        end
+      end
+
+      context "when npm_v6_unsupported_error is enabled but version is supported" do
+        let(:version) { "7" }
+        let(:unsupported_enabled) { true }
+
+        it "returns false" do
+          expect(package_manager.unsupported?).to be false
+        end
+      end
+
+      context "when npm_v6_unsupported_error is disabled" do
+        let(:unsupported_enabled) { false }
+
+        it "returns false" do
+          expect(package_manager.unsupported?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#raise_if_unsupported!" do
+    before do
+      allow(Dependabot::Experiments).to receive(:enabled?)
+        .with(:npm_v6_unsupported_error)
+        .and_return(unsupported_enabled)
+    end
+
+    context "when npm_v6_unsupported_error is enabled and version is unsupported" do
+      let(:version) { "6" }
+      let(:unsupported_enabled) { true }
+
+      it "raises a ToolVersionNotSupported error" do
+        expect { package_manager.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)
+      end
+    end
+
+    context "when npm_v6_unsupported_error is disabled" do
+      let(:version) { "6" }
+      let(:unsupported_enabled) { false }
+
+      it "does not raise an error" do
+        expect { package_manager.raise_if_unsupported! }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Add changes to set NPM v6 as deprecated and unsupported. The deprecation warning and unsupported error are controlled by the following feature flags:
- `npm_v6_deprecation_warning`
- `npm_v6_unsupported_error`

Feature Flags PR: https://github.com/github/dependabot-api/pull/5763

This mirrors the approach used for Bundler v1 and composer 1, allowing us to guide users towards migrating to NPM v9 while providing a controlled rollout.

### Anything you want to highlight for special attention from reviewers?

The deprecation and unsupported checks for NPM v6 are controlled by feature flags. Please focus on verifying that the logic tied to the feature flags works as expected.

### How will you know you've accomplished your goal?

We will monitor logs and metrics to ensure:
- NPM v6 users see the deprecation warning when the feature flag is enabled.
- Actions using NPM v6 are blocked when the unsupported error flag is enabled.
- Tests have been added to validate the behaviour of both feature flags.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.