### PR TITLE
Stop checking for Composer 1 dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,6 @@ updates:
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"
     directories:
-      - "/composer/helpers/v1"
       - "/composer/helpers/v2"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### What are you trying to accomplish?

Composer 1 was removed in:
* https://github.com/dependabot/dependabot-core/pull/10934

But we've still got a Dependabot job looking for PHP dependencies in the V1 folder, which no longer exists.

So delete that job.