### PR TITLE
WIP: Set timeout for helper subprocesses to enhance stability

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -61,13 +61,6 @@ module Dependabot
       end
     end
 
-    DEFAULT_TIMEOUTS = T.let({
-      no_time_out: -1,  # No timeout
-      local: 30,        # Local commands
-      network: 120,     # Network-dependent commands
-      long_running: 300 # Long-running tasks (e.g., builds)
-    }.freeze, T::Hash[T.untyped, T.untyped])
-
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -119,9 +119,9 @@ module Dependabot
 
             # Process ready IO streams
             ready_ios&.first&.each do |io|
-              data = io.read_nonblock(1024)
+              io.set_encoding("UTF-8", "UTF-8")
 
-              data.force_encoding("UTF-8").scrub! # Normalize to UTF-8 and replace invalid characters
+              data = io.read_nonblock(1024)
 
               last_output_time = Time.now
               if io == stdout_io

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -63,6 +63,7 @@ module Dependabot
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity
     sig do
       params(
         env_cmd: T::Array[T.any(T::Hash[String, String], String)],
@@ -149,6 +150,8 @@ module Dependabot
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity
+
     sig { params(pid: T.nilable(Integer)).void }
     def self.terminate_process(pid)
       return unless pid

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -133,7 +133,9 @@ module Dependabot
               data = data.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
 
               # Reset the timeout if data is received
-              last_output_time = Time.now if data
+              last_output_time = Time.now unless data.empty?
+
+              # 4. Append data to the appropriate stream
               if io == stdout_io
                 stdout += data
               else

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -120,6 +120,9 @@ module Dependabot
             # Process ready IO streams
             ready_ios&.first&.each do |io|
               data = io.read_nonblock(1024)
+
+              data.force_encoding("UTF-8").scrub! # Normalize to UTF-8 and replace invalid characters
+
               last_output_time = Time.now
               if io == stdout_io
                 stdout += data

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -1,0 +1,196 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "open3"
+require "timeout"
+require "sorbet-runtime"
+require "shellwords"
+
+module Dependabot
+  module CommandHelpers
+    extend T::Sig
+
+    class ProcessStatus
+      extend T::Sig
+
+      sig { params(process_status: Process::Status, custom_exitstatus: T.nilable(Integer)).void }
+      def initialize(process_status, custom_exitstatus = nil)
+        @process_status = process_status
+        @custom_exitstatus = custom_exitstatus
+      end
+
+      # Return the exit status, either from the process status or the custom one
+      sig { returns(Integer) }
+      def exitstatus
+        @custom_exitstatus || @process_status.exitstatus || 0
+      end
+
+      # Determine if the process was successful
+      sig { returns(T::Boolean) }
+      def success?
+        @custom_exitstatus.nil? ? @process_status.success? || false : @custom_exitstatus.zero?
+      end
+
+      # Return the PID of the process (if available)
+      sig { returns(T.nilable(Integer)) }
+      def pid
+        @process_status.pid
+      end
+
+      sig { returns(T.nilable(Integer)) }
+      def termsig
+        @process_status.termsig
+      end
+
+      # String representation of the status
+      sig { returns(String) }
+      def to_s
+        if @custom_exitstatus
+          "pid #{pid || 'unknown'}: exit #{@custom_exitstatus} (custom status)"
+        else
+          @process_status.to_s
+        end
+      end
+    end
+
+    DEFAULT_TIMEOUTS = T.let({
+      no_time_out: -1,  # No timeout
+      local: 30,        # Local commands
+      network: 120,     # Network-dependent commands
+      long_running: 300 # Long-running tasks (e.g., builds)
+    }.freeze, T::Hash[T.untyped, T.untyped])
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/PerceivedComplexity
+    sig do
+      params(
+        env_cmd: T::Array[T.any(T::Hash[String, String], String)],
+        stdin_data: T.nilable(String),
+        stderr_to_stdout: T::Boolean,
+        command_type: Symbol,
+        timeout: Integer
+      ).returns([T.nilable(String), T.nilable(String), T.nilable(ProcessStatus), Float])
+    end
+    def self.capture3_with_timeout(
+      env_cmd,
+      stdin_data: nil,
+      stderr_to_stdout: false,
+      command_type: :network,
+      timeout: -1
+    )
+      # Assign default timeout based on command type if timeout < 0
+      timeout = DEFAULT_TIMEOUTS[command_type] if timeout.negative?
+
+      stdout = T.let("", String)
+      stderr = T.let("", String)
+      status = T.let(nil, T.nilable(ProcessStatus))
+      pid = T.let(nil, T.untyped)
+      start_time = Time.now
+
+      begin
+        T.unsafe(Open3).popen3(*env_cmd) do |stdin, stdout_io, stderr_io, wait_thr|
+          pid = wait_thr.pid
+          stdin&.write(stdin_data) if stdin_data
+          stdin&.close
+
+          stdout_io.sync = true
+          stderr_io.sync = true
+
+          # Array to monitor both stdout and stderr
+          ios = [stdout_io, stderr_io]
+
+          last_output_time = Time.now # Track the last time output was received
+
+          until ios.empty?
+            # Calculate remaining timeout dynamically
+            remaining_timeout = timeout - (Time.now - last_output_time)
+
+            # Raise an error if timeout is exceeded
+            if remaining_timeout <= 0
+              terminate_process(pid)
+              status = ProcessStatus.new(wait_thr.value, 124)
+              raise Timeout::Error, "Timed out due to inactivity after #{timeout} seconds"
+            end
+
+            # Use IO.select with a dynamically calculated short timeout
+            ready_ios = IO.select(ios, nil, nil, [0.1, remaining_timeout].min)
+
+            # Process ready IO streams
+            ready_ios&.first&.each do |io|
+              data = io.read_nonblock(1024)
+              last_output_time = Time.now
+              if io == stdout_io
+                stdout += data
+              else
+                stderr += data unless stderr_to_stdout
+                stdout += data if stderr_to_stdout
+              end
+            rescue EOFError
+              ios.delete(io)
+            rescue IO::WaitReadable
+              next
+            end
+          end
+
+          status = ProcessStatus.new(wait_thr.value)
+        end
+      rescue Timeout::Error => e
+        stderr += e.message unless stderr_to_stdout
+        stdout += e.message if stderr_to_stdout
+      rescue Errno::ENOENT => e
+        stderr += e.message unless stderr_to_stdout
+        stdout += e.message if stderr_to_stdout
+      end
+
+      elapsed_time = Time.now - start_time
+      [stdout, stderr, status, elapsed_time]
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/PerceivedComplexity
+    sig { params(pid: T.nilable(Integer)).void }
+    def self.terminate_process(pid)
+      return unless pid
+
+      begin
+        if process_alive?(pid)
+          Process.kill("TERM", pid) # Attempt graceful termination
+          sleep(0.5) # Allow process to terminate
+        end
+        if process_alive?(pid)
+          Process.kill("KILL", pid) # Forcefully kill if still running
+        end
+      rescue Errno::EPERM
+        Dependabot.logger.error("Insufficient permissions to terminate process: #{pid}")
+      ensure
+        begin
+          Process.waitpid(pid)
+        rescue Errno::ESRCH, Errno::ECHILD
+          # Process has already exited
+        end
+      end
+    end
+
+    sig { params(pid: T.nilable(Integer)).returns(T::Boolean) }
+    def self.process_alive?(pid)
+      return false if pid.nil? # No PID, consider process not alive
+
+      begin
+        Process.kill(0, pid) # Check if the process exists
+        true # Process is still alive
+      rescue Errno::ESRCH
+        false # Process does not exist (terminated successfully)
+      rescue Errno::EPERM
+        Dependabot.logger.error("Insufficient permissions to check process: #{pid}")
+        false # Assume process not alive due to lack of permissions
+      end
+    end
+
+    sig { params(command: String).returns(String) }
+    def self.escape_command(command)
+      command_parts = command.split.map(&:strip).reject(&:empty?)
+      Shellwords.join(command_parts)
+    end
+  end
+end

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -458,14 +458,12 @@ module Dependabot
 
       env_cmd = [env || {}, cmd, opts].compact
       if Experiments.enabled?(:enable_shared_helpers_command_timeout)
-
         stdout, stderr, process, _elapsed_time = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stderr_to_stdout: stderr_to_stdout,
           command_type: command_type,
           timeout: timeout
         )
-
       elsif stderr_to_stdout
         stdout, process = Open3.capture2e(env || {}, cmd, opts)
       else

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -135,7 +135,6 @@ module Dependabot
         stderr_to_stdout: T::Boolean,
         allow_unsafe_shell_command: T::Boolean,
         error_class: T.class_of(HelperSubprocessFailed),
-        command_type: Symbol,
         timeout: Integer
       )
         .returns(T.nilable(T.any(String, T::Hash[String, T.untyped], T::Array[T::Hash[String, T.untyped]])))
@@ -144,8 +143,7 @@ module Dependabot
                                    stderr_to_stdout: false,
                                    allow_unsafe_shell_command: false,
                                    error_class: HelperSubprocessFailed,
-                                   command_type: :network,
-                                   timeout: -1)
+                                   timeout: CommandHelpers::TIMEOUTS::DEFAULT)
       start = Time.now
       stdin_data = JSON.dump(function: function, args: args)
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
@@ -164,7 +162,6 @@ module Dependabot
         stdout, stderr, process = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stdin_data: stdin_data,
-          command_type: command_type,
           timeout: timeout
         )
       else
@@ -436,7 +433,6 @@ module Dependabot
         env: T.nilable(T::Hash[String, String]),
         fingerprint: T.nilable(String),
         stderr_to_stdout: T::Boolean,
-        command_type: Symbol,
         timeout: Integer
       ).returns(String)
     end
@@ -446,8 +442,7 @@ module Dependabot
                                env: {},
                                fingerprint: nil,
                                stderr_to_stdout: true,
-                               command_type: :network,
-                               timeout: -1)
+                               timeout: CommandHelpers::TIMEOUTS::DEFAULT)
       start = Time.now
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
 
@@ -461,7 +456,6 @@ module Dependabot
         stdout, stderr, process, _elapsed_time = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stderr_to_stdout: stderr_to_stdout,
-          command_type: command_type,
           timeout: timeout
         )
       elsif stderr_to_stdout

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -1,0 +1,87 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/command_helpers"
+
+RSpec.describe Dependabot::CommandHelpers do
+  describe ".capture3_with_timeout" do
+    let(:success_cmd) { command_fixture("success.sh") }
+    let(:error_cmd) { command_fixture("error.sh") }
+    let(:output_hang_cmd) { command_fixture("output_hang.sh") }
+    let(:error_hang_cmd) { command_fixture("error_hang.sh") }
+    let(:invalid_cmd) { "non_existent_command" }
+    let(:timeout) { 2 } # Timeout for hanging commands
+
+    context "when the command runs successfully" do
+      it "captures stdout and exits successfully" do
+        stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
+          [success_cmd],
+          timeout: timeout
+        )
+
+        expect(stdout).to eq("This is a successful command.\n")
+        expect(stderr).to eq("")
+        expect(status.exitstatus).to eq(0)
+        expect(elapsed_time).to be > 0
+      end
+    end
+
+    context "when the command runs with an error" do
+      it "captures stderr and returns an error status" do
+        stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
+          [error_cmd],
+          timeout: timeout
+        )
+
+        expect(stdout).to eq("")
+        expect(stderr).to eq("This is an error message.\n")
+        expect(status.exitstatus).to eq(1)
+        expect(elapsed_time).to be > 0
+      end
+    end
+
+    context "when the command runs with output but hangs" do
+      it "times out and appends a timeout message to stderr" do
+        stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
+          [output_hang_cmd],
+          timeout: timeout
+        )
+
+        expect(stdout).to eq("This is a hanging command.\n")
+        expect(stderr).to include("Timed out due to inactivity after #{timeout} seconds")
+        expect(status.exitstatus).to eq(124) # Timeout-specific status code
+        expect(elapsed_time).to be_within(1).of(timeout)
+      end
+    end
+
+    context "when the command runs with an error but hangs" do
+      it "times out and appends a timeout message to stderr" do
+        stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
+          [error_hang_cmd],
+          timeout: timeout
+        )
+
+        expect(stdout).to eq("")
+        expect(stderr).to include("This is a hanging error command.")
+        expect(stderr).to include("Timed out due to inactivity after #{timeout} seconds")
+        expect(status.exitstatus).to eq(124)
+        expect(elapsed_time).to be_within(1).of(timeout)
+      end
+    end
+
+    context "when the command is invalid" do
+      it "raises an error and captures stderr" do
+        stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
+          [invalid_cmd],
+          timeout: timeout
+        )
+
+        expect(stdout).to eq("")
+        expect(stderr).to include("No such file or directory - non_existent_command") if stderr
+        expect(status).to be_nil
+        expect(elapsed_time).to be > 0
+      end
+    end
+  end
+end

--- a/common/spec/fixtures/commands/error.sh
+++ b/common/spec/fixtures/commands/error.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This is an error message." >&2
+exit 1

--- a/common/spec/fixtures/commands/error_hang.sh
+++ b/common/spec/fixtures/commands/error_hang.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This is a hanging error command." >&2
+sleep 30

--- a/common/spec/fixtures/commands/error_hang.sh
+++ b/common/spec/fixtures/commands/error_hang.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-echo "This is a hanging error command." >&2
+echo "This is a output for command error command."
+
+# Simulate an error output to stderr
+echo "This is an error message." >&2
+
+# Simulate a hang
 sleep 30

--- a/common/spec/fixtures/commands/no_timeout.sh
+++ b/common/spec/fixtures/commands/no_timeout.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "This is a command result."
+sleep 3
+exit 0

--- a/common/spec/fixtures/commands/output_hang.sh
+++ b/common/spec/fixtures/commands/output_hang.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This is a hanging command."
+sleep 30

--- a/common/spec/fixtures/commands/success.sh
+++ b/common/spec/fixtures/commands/success.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "This is a successful command."
+exit 0

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -194,3 +194,11 @@ def github_credentials
     }]
   end
 end
+
+# Load a command from the fixtures/commands directory
+def command_fixture(name)
+  path = File.join("spec", "fixtures", "commands", name)
+  raise "Command fixture '#{name}' does not exist" unless File.exist?(path)
+
+  File.expand_path(path)
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout).and_return(true)
   end
 
   after do

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe Dependabot::DependencySnapshot do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:add_deprecation_warn_to_pr_message)
       .and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout)
+      .and_return(true)
   end
 
   after do

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -158,6 +158,10 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
       .and_return(stub_dependency_change)
 
     allow(mock_service).to receive(:close_pull_request)
+
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout)
+      .and_return(true)
   end
 
   after do

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -140,16 +140,15 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
 
   before do
     allow(Dependabot::Experiments).to receive(:enabled?).with(:lead_security_dependency).and_return(false)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout)
+      .and_return(true)
 
     allow(Dependabot::UpdateCheckers).to receive(:for_package_manager).and_return(stub_update_checker_class)
     allow(Dependabot::DependencyChangeBuilder)
       .to receive(:create_from)
       .and_return(stub_dependency_change)
     allow(dependency_snapshot).to receive(:ecosystem).and_return(ecosystem)
-
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_shared_helpers_command_timeout)
-      .and_return(true)
   end
 
   after do

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -146,6 +146,10 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
       .to receive(:create_from)
       .and_return(stub_dependency_change)
     allow(dependency_snapshot).to receive(:ecosystem).and_return(ecosystem)
+
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_shared_helpers_command_timeout)
+      .and_return(true)
   end
 
   after do


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces a timeout mechanism for running helper subprocesses to ensure they do not run indefinitely, enhancing system stability and robustness. The change is gated behind the **feature flag**: `enable_shared_helpers_command_timeout`.

---

#### What and Why:
- Added the `capture3_with_timeout` method to manage subprocess execution with a configurable timeout.  
- Integrated the timeout mechanism into the `run_helper_subprocess` method by replacing the existing `Open3.capture3` call with `capture3_with_timeout`.  
- Set the default timeout for helper subprocesses to 120 seconds to prevent indefinite blocking.  
**Note**: The timeout applies to **the time between** outputs to `stdout` or `stderr`, **not the overall execution duration of the command**. Each time the command produces output, the timeout is reset, and it waits for the next response.
- **Feature Flag:** The timeout mechanism is gated behind the `enable_shared_helpers_command_timeout` feature flag. This ensures no impact to existing workflows unless the flag is enabled.

---

#### Related Issues:
- Ensures reliability in subprocess management, addressing potential issues with stuck or long-running processes.  
- Allows gradual rollout via the feature flag to validate its impact.

---

### Anything you want to highlight for special attention from reviewers?

- **Feature Flag Implementation:** The change is controlled by the `enable_shared_helpers_command_timeout` feature flag to ensure it can be toggled on/off safely.  
- **Exception Handling:** Proper exception handling for terminated processes and cleanup mechanisms (`Process.kill` and `Process.wait`) to avoid zombie processes.  
- **Timeout Behavior:** The timeout resets on progressive outputs to accommodate long-running processes that produce regular outputs.  

---

### How will you know you've accomplished your goal?

- Unit tests verifying that subprocesses terminate correctly after exceeding the timeout when the feature flag is enabled.  
- Manual testing with simulated long-running and progressive commands to validate timeout behavior and exception handling.  
- Ensuring all existing functionality dependent on subprocess calls works as expected when the feature flag is disabled.

---

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.  
- [ ] I have thoroughly tested my code changes, including adding additional tests for new functionality and testing with the feature flag enabled/disabled.  
- [x] I have written clear and descriptive commit messages.  
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.  
- [x] I have ensured that the code is well-documented and easy to understand.  