### PR TITLE
Treat Python Package managers as distinct groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,13 +123,15 @@ updates:
     groups:
       common:
         patterns:
-          - pip
+          - hashin
           - cython
           - flake8
-      poetry:
+      # Keep the package managers themselves separate because they are higher risk
+      # and also higher visibility--ie, users generally want latest, so we don't
+      # want breakage in the `common` group to prevent updating package manager versions
+      pip:
         patterns:
-          - poetry
-          - hashin
+          - pip
       pip-tools:
         patterns:
           - pip-tools
@@ -137,6 +139,9 @@ updates:
         patterns:
           - pipfile
           - pipenv
+      poetry:
+        patterns:
+          - poetry
   - package-ecosystem: "pub"
     directory: "/pub/helpers"
     schedule:


### PR DESCRIPTION
We grouped the Python PR's to avoid noise. However, what I've observed in practice is we (and our users) care more about staying up to date on the package managers and not so much if the internal libraries used in our helpers stay up to date.

So by breaking the package managers themselves out as distinct groups, it allows us to quickly move forward on those, without getting blocked if there's a breaking change in a minor helper library.

Here's an example of exactly this problem:
* https://github.com/dependabot/dependabot-core/pull/11107#issue-2735504252