### PR TITLE
don't use transitive dependency version as top level version

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -3075,14 +3075,14 @@ public partial class UpdateWorkerTests
         public async Task UpdatingTransitiveDependencyWithNewSolverCanUpdateJustTheTopLevelPackage()
         {
             // we've been asked to explicitly update a transitive dependency, but we can solve it by updating the top-level package instead
-            await TestUpdateForProject("Transitive.Package", "1.0.0", "2.0.0",
+            await TestUpdateForProject("Transitive.Package", "7.0.0", "8.0.0",
                 isTransitive: true,
                 packages:
                 [
-                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", [("net8.0", [("Transitive.Package", "[1.0.0]")])]),
-                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net8.0", [("net8.0", [("Transitive.Package", "[2.0.0]")])]),
-                    MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net8.0"),
-                    MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", [("net8.0", [("Transitive.Package", "[7.0.0]")])]),
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net8.0", [("net8.0", [("Transitive.Package", "[8.0.0]")])]),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Package", "7.0.0", "net8.0"),
+                    MockNuGetPackage.CreateSimplePackage("Transitive.Package", "8.0.0", "net8.0"),
                 ],
                 projectContents: """
                     <Project Sdk="Microsoft.NET.Sdk">

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
@@ -395,7 +395,6 @@ public class PackageManager
                                     if (await AreAllParentsCompatibleAsync(existingPackages, existingPackage, targetFramework, projectDirectory, logger) == true)
                                     {
                                         existingPackage.CurrentVersion = dependencyOldVersion;
-                                        string NewVersion = dependency.CurrentVersion;
                                         existingPackage.NewVersion = dependency.CurrentVersion;
                                         await UpdateVersion(existingPackages, existingPackage, targetFramework, projectDirectory, logger);
                                     }
@@ -591,12 +590,6 @@ public class PackageManager
         if (CurrentVersion == latestVersion)
         {
             return null;
-        }
-
-        // If the current version of the parent is less than the current version of the dependency
-        else if (CurrentVersion < currentVersionDependency)
-        {
-            return currentVersionDependency;
         }
 
         // Loop from the current version to the latest version, use next patch as a limit (unless there's a limit) so it doesn't look for versions that don't exist


### PR DESCRIPTION
When trying to update a top level dependency instead of pinning a transitive dependency, don't report the transitive version as a possible solution for the top level package.

This required an update to a test where the minimum version of a dependency doesn't exist.  To get around this, the test was updated to use faked local packages with the correct versions.  Issue #11150 was filed for the future work.