### PR TITLE
Increase default timeout for helper subprocess commands from 2 minutes to 15 minutes

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -11,11 +11,11 @@ module Dependabot
     extend T::Sig
 
     module TIMEOUTS
-      NO_TIME_OUT = -1
-      LOCAL = 30
-      NETWORK = 120
-      LONG_RUNNING = 300
-      DEFAULT = NETWORK
+      NO_TIME_OUT = -1 # No timeout
+      LOCAL = 30 # 30 seconds
+      NETWORK = 120 # 2 minutes
+      LONG_RUNNING = 300 # 5 minutes
+      DEFAULT = 900 # 15 minutes
     end
 
     class ProcessStatus

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -159,7 +159,7 @@ module Dependabot
 
       env_cmd = [env, cmd].compact
       if Experiments.enabled?(:enable_shared_helpers_command_timeout)
-        stdout, stderr, process, _elapsed_time = CommandHelpers.capture3_with_timeout(
+        stdout, stderr, process = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stdin_data: stdin_data,
           timeout: timeout
@@ -453,7 +453,7 @@ module Dependabot
 
       env_cmd = [env || {}, cmd, opts].compact
       if Experiments.enabled?(:enable_shared_helpers_command_timeout)
-        stdout, stderr, process, _elapsed_time = CommandHelpers.capture3_with_timeout(
+        stdout, stderr, process = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stderr_to_stdout: stderr_to_stdout,
           timeout: timeout

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -159,7 +159,7 @@ module Dependabot
 
       env_cmd = [env, cmd].compact
       if Experiments.enabled?(:enable_shared_helpers_command_timeout)
-        stdout, stderr, process = CommandHelpers.capture3_with_timeout(
+        stdout, stderr, process, _elapsed_time = CommandHelpers.capture3_with_timeout(
           env_cmd,
           stdin_data: stdin_data,
           timeout: timeout


### PR DESCRIPTION
### What are you trying to accomplish?

The purpose of this change is to increase the default timeout for helper subprocess commands from 2 minutes to 15 minutes. This adjustment is intended to address cases where the previous timeout was insufficient for certain processes, causing premature failures.

This update aims to ensure that helper subprocess commands have adequate time to complete under normal conditions, reducing the likelihood of timeout-related errors.

### Anything you want to highlight for special attention from reviewers?

- This is a global change to the default timeout value for helper subprocess commands. Reviewers should evaluate whether the new timeout value is appropriate across all use cases.
- If there are scenarios where the longer timeout could cause issues, alternative solutions (e.g., a configurable timeout) might be considered.

### How will you know you've accomplished your goal?

- Timeout-related errors for helper subprocess commands will no longer occur under normal operating conditions.
- Logs and monitoring will confirm successful execution of commands that previously timed out.
- Test cases covering edge scenarios (e.g., long-running commands) will pass without issues.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
