### PR TITLE
Return deprecated version if user requests it so that we can trigger warning or logging

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -393,8 +393,9 @@ module Dependabot
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/MethodLength
       sig { params(name: String).returns(T.nilable(T.any(Integer, String))) }
-      def setup(name) # rubocop:disable Metrics/MethodLength
+      def setup(name)
         # we prioritize version mentioned in "packageManager" instead of "engines"
         # i.e. if { engines : "pnpm" : "6" } and { packageManager: "pnpm@6.0.2" },
         # we go for the specificity mentioned in packageManager (6.0.2)
@@ -455,6 +456,7 @@ module Dependabot
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/MethodLength
 
       sig { params(name: T.nilable(String)).returns(Ecosystem::VersionManager) }
       def package_manager_by_name(name)


### PR DESCRIPTION
### What are you trying to accomplish?
This PR is a follow up to  [add support for NPM V6 deprecation warning and unsupported error](https://github.com/dependabot/dependabot-core/pull/11112). Basically, I'm trying to show warnings to the user if they are still using NPM v6 which has been deprecated and will soon no longer be supported. In the earlier PR (https://github.com/dependabot/dependabot-core/pull/11112) some setup code was missing so the warnings and errors could not successfully trigger. This PR fixes that.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
We will monitor logs and metrics to ensure:
- NPM v6 users see the deprecation warning when the feature flag is enabled.
- Actions using NPM v6 are blocked when the unsupported error flag is enabled.
- Tests have been added to validate the behaviour of both feature flags.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ x I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
