### PR TITLE
Update Rubygems to 3.6.1 and Bundler to 2.6.1

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -119,7 +119,7 @@ WORKDIR $DEPENDABOT_HOME/dependabot-updater
 # Note that RubyGems & Bundler versions are currently released in sync, but
 # RubyGems version is one major ahead. So when bumping to RubyGems 3.y.z, Bundler
 # version will jump to 2.y.z
-ARG RUBYGEMS_VERSION=3.5.16
+ARG RUBYGEMS_VERSION=3.6.1
 RUN gem update --system $RUBYGEMS_VERSION
 
 RUN bundle config set --global build.psych --with-libyaml-source-dir=$DEPENDABOT_HOME/src/libyaml/yaml-$LIBYAML_VERSION && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,4 +415,4 @@ DEPENDENCIES
   webrick (>= 1.7)
 
 BUNDLED WITH
-   2.5.16
+   2.6.1

--- a/bundler/helpers/v2/monkey_patches/git_source_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/git_source_patch.rb
@@ -55,7 +55,7 @@ module Bundler
           spec = Bundler.load_gemspec(spec_path)
           next unless spec
 
-          Bundler.rubygems.set_installed_by_version(spec)
+          spec.installed_by_version = Gem::VERSION
           Bundler.rubygems.validate(spec)
           File.binwrite(spec_path, spec.to_ruby)
         end

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -462,4 +462,4 @@ DEPENDENCIES
   webrick (>= 1.7)
 
 BUNDLED WITH
-   2.5.16
+   2.6.1


### PR DESCRIPTION
### What are you trying to accomplish?

Make sure new versions of Bundler & RubyGems play nice with Dependabot.

### Anything you want to highlight for special attention from reviewers?

Bundler 2.6.0 reverted the changes in the most recent 2.5.x that affected Dependabot, see https://github.com/dependabot/dependabot-core/pull/10746. We should now be fine in that regard at least.

### How will you know you've accomplished your goal?

CI passes.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
