### PR TITLE
Add support for python 3.8 deprecation warning and unsupported error

### DIFF
--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -11,10 +11,43 @@ module Dependabot
 
     class Language < Dependabot::Ecosystem::VersionManager
       extend T::Sig
+      # These versions should match the versions specified at the top of `python/Dockerfile`
+      PYTHON_3_13 = "3.13"
+      PYTHON_3_12 = "3.12"
+      PYTHON_3_11 = "3.11"
+      PYTHON_3_10 = "3.10"
+      PYTHON_3_9  = "3.9"
+      PYTHON_3_8  = "3.8"
+
+      DEPRECATED_VERSIONS = T.let([Version.new(PYTHON_3_8)].freeze, T::Array[Dependabot::Version])
+
+      # Keep versions in ascending order
+      SUPPORTED_VERSIONS = T.let([
+        Version.new(PYTHON_3_9),
+        Version.new(PYTHON_3_10),
+        Version.new(PYTHON_3_11),
+        Version.new(PYTHON_3_12),
+        Version.new(PYTHON_3_13)
+      ].freeze, T::Array[Dependabot::Version])
 
       sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(raw_version, requirement = nil)
-        super(LANGUAGE, Version.new(raw_version), [], [], requirement)
+        super(LANGUAGE, Version.new(raw_version), DEPRECATED_VERSIONS, SUPPORTED_VERSIONS, requirement)
+      end
+
+      sig { override.returns(T::Boolean) }
+      def deprecated?
+        return false if unsupported?
+        return false unless Dependabot::Experiments.enabled?(:python_3_8_deprecation_warning)
+
+        deprecated_versions.include?(version)
+      end
+
+      sig { override.returns(T::Boolean) }
+      def unsupported?
+        return false unless Dependabot::Experiments.enabled?(:python_3_8_unsupported_error)
+
+        supported_versions.all? { |supported| supported > version }
       end
     end
   end

--- a/python/spec/dependabot/python/language_spec.rb
+++ b/python/spec/dependabot/python/language_spec.rb
@@ -1,0 +1,121 @@
+# typed: false
+# frozen_string_literal: true
+
+require "dependabot/python/language"
+require "dependabot/ecosystem"
+require_relative "../../spec_helper"
+
+RSpec.describe Dependabot::Python::Language do
+  subject(:language) { described_class.new(version) }
+
+  describe "#deprecated?" do
+    let(:version) { "3.8" }
+
+    before do
+      allow(::Dependabot::Experiments).to receive(:enabled?)
+        .with(:python_3_8_deprecation_warning)
+        .and_return(deprecation_enabled)
+      allow(::Dependabot::Experiments).to receive(:enabled?)
+        .with(:python_3_8_unsupported_error)
+        .and_return(unsupported_enabled)
+    end
+
+    context "when python_3_8_deprecation_warning is enabled and version is deprecated" do
+      let(:deprecation_enabled) { true }
+      let(:unsupported_enabled) { false }
+
+      it "returns true" do
+        expect(language.deprecated?).to be true
+      end
+    end
+
+    context "when python_3_8_deprecation_warning is enabled but version is not deprecated" do
+      let(:version) { "3.13" }
+      let(:deprecation_enabled) { true }
+      let(:unsupported_enabled) { false }
+
+      it "returns false" do
+        expect(language.deprecated?).to be false
+      end
+    end
+
+    context "when python_3_8_deprecation_warning is disabled" do
+      let(:deprecation_enabled) { false }
+      let(:unsupported_enabled) { false }
+
+      it "returns false" do
+        expect(language.deprecated?).to be false
+      end
+    end
+
+    context "when version is unsupported" do
+      let(:deprecation_enabled) { true }
+      let(:unsupported_enabled) { true }
+
+      it "returns false, as unsupported takes precedence" do
+        expect(language.deprecated?).to be false
+      end
+    end
+  end
+
+  describe "#unsupported?" do
+    let(:version) { "3.8" }
+
+    before do
+      allow(::Dependabot::Experiments).to receive(:enabled?)
+        .with(:python_3_8_unsupported_error)
+        .and_return(unsupported_enabled)
+    end
+
+    context "when python_3_8_unsupported_error is enabled and version is unsupported" do
+      let(:unsupported_enabled) { true }
+
+      it "returns true" do
+        expect(language.unsupported?).to be true
+      end
+    end
+
+    context "when python_3_8_unsupported_error is enabled but version is supported" do
+      let(:version) { "3.13" }
+      let(:unsupported_enabled) { true }
+
+      it "returns false" do
+        expect(language.unsupported?).to be false
+      end
+    end
+
+    context "when python_3_8_unsupported_error is disabled" do
+      let(:unsupported_enabled) { false }
+
+      it "returns false" do
+        expect(language.unsupported?).to be false
+      end
+    end
+  end
+
+  describe "#raise_if_unsupported!" do
+    let(:version) { "3.8" }
+
+    before do
+      allow(Dependabot::Experiments).to receive(:enabled?)
+        .with(:python_3_8_unsupported_error)
+        .and_return(unsupported_enabled)
+    end
+
+    context "when python_3_8_unsupported_error is enabled and version is unsupported" do
+      let(:unsupported_enabled) { true }
+
+      it "raises a ToolVersionNotSupported error" do
+        expect { language.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)
+      end
+    end
+
+    context "when python_3_8_unsupported_error is disabled" do
+      let(:unsupported_enabled) { false }
+
+      it "does not raise an error" do
+        expect { language.raise_if_unsupported! }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Adds changes to set python 3.8 as deprecated and eventually unsupported. The deprecation warning and unsupported error are controlled by the following feature flags:
- `python_3_8_deprecation_warning`
- `python_3_8_unsupported_error`

Feature Flags PR: https://github.com/github/dependabot-api/pull/5763

This mirrors the approach used for Bundler v1, composer 1 etc allowing us to guide users towards migrating to python 3.13 while providing a controlled rollout.

### How will you know you've accomplished your goal?

We will monitor logs and metrics to ensure:
- Python 3.8 users see the deprecation warning when the feature flag is enabled.
- Actions using python 3.8 are blocked when the unsupported error flag is enabled.
- Tests have been added to validate the behaviour of both feature flags.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.