### PR TITLE
capture and report analyzer failures

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -62,6 +62,17 @@ public partial class AnalyzeWorker : IAnalyzeWorker
                 UpdatedDependencies = [],
             };
         }
+        catch (Exception ex)
+        {
+            analysisResult = new AnalysisResult
+            {
+                ErrorType = ErrorType.Unknown,
+                ErrorDetails = ex.ToString(),
+                UpdatedVersion = string.Empty,
+                CanUpdate = false,
+                UpdatedDependencies = [],
+            };
+        }
 
         return analysisResult;
     }


### PR DESCRIPTION
Looking through the logs I see some failures in the `analyze` command, but that part of the code is only set up to handle `private_source_authentication_failure` so this will explicitly report the exception text.

There will certainly be more fixes coming, but this should put the exception text and call stack in the telemetry.