### PR TITLE
capture and report job deserialization errors

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -83,6 +83,11 @@ module Dependabot
       # and responsibility for fixing it is on them, not us. As a result we
       # quietly log these as errors
       { "error-type": "server_error" }
+    when BadRequirementError
+      {
+        "error-type": "illformed_requirement",
+        "error-detail": { message: error.message }
+      }
     when *Octokit::RATE_LIMITED_ERRORS
       # If we get a rate-limited error we let dependabot-api handle the
       # retry by re-enqueing the update job after the reset

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Analyze.cs
@@ -345,7 +345,8 @@ public partial class EntryPointTests
                     {
                         if (args[i] == "--job-path")
                         {
-                            experimentsManager = await ExperimentsManager.FromJobFileAsync(args[i + 1], new TestLogger());
+                            var experimentsResult = await ExperimentsManager.FromJobFileAsync(args[i + 1]);
+                            experimentsManager = experimentsResult.ExperimentsManager;
                         }
                     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/AnalyzeCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/AnalyzeCommand.cs
@@ -29,7 +29,7 @@ internal static class AnalyzeCommand
         command.SetHandler(async (jobPath, repoRoot, discoveryPath, dependencyPath, analysisDirectory) =>
         {
             var logger = new ConsoleLogger();
-            var experimentsManager = await ExperimentsManager.FromJobFileAsync(jobPath.FullName, logger);
+            var (experimentsManager, _errorResult) = await ExperimentsManager.FromJobFileAsync(jobPath.FullName);
             var worker = new AnalyzeWorker(experimentsManager, logger);
             await worker.RunAsync(repoRoot.FullName, discoveryPath.FullName, dependencyPath.FullName, analysisDirectory.FullName);
         }, JobPathOption, RepoRootOption, DiscoveryFilePathOption, DependencyFilePathOption, AnalysisFolderOption);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
@@ -30,7 +30,7 @@ internal static class CloneCommand
             var apiHandler = new HttpApiHandler(apiUrl.ToString(), jobId);
             var logger = new ConsoleLogger();
             var gitCommandHandler = new ShellGitCommandHandler(logger);
-            var worker = new CloneWorker(apiHandler, gitCommandHandler, logger);
+            var worker = new CloneWorker(jobId, apiHandler, gitCommandHandler);
             var exitCode = await worker.RunAsync(jobPath, repoContentsPath);
             setExitCode(exitCode);
         }, JobPathOption, RepoContentsPathOption, ApiUrlOption, JobIdOption);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
@@ -33,12 +33,12 @@ internal static class RunCommand
         command.SetHandler(async (jobPath, repoContentsPath, apiUrl, jobId, outputPath, baseCommitSha) =>
         {
             var apiHandler = new HttpApiHandler(apiUrl.ToString(), jobId);
+            var (experimentsManager, _errorResult) = await ExperimentsManager.FromJobFileAsync(jobPath.FullName);
             var logger = new ConsoleLogger();
-            var experimentsManager = await ExperimentsManager.FromJobFileAsync(jobPath.FullName, logger);
             var discoverWorker = new DiscoveryWorker(experimentsManager, logger);
             var analyzeWorker = new AnalyzeWorker(experimentsManager, logger);
             var updateWorker = new UpdaterWorker(experimentsManager, logger);
-            var worker = new RunWorker(apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
+            var worker = new RunWorker(jobId, apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
             await worker.RunAsync(jobPath, repoContentsPath, baseCommitSha, outputPath);
         }, JobPathOption, RepoContentsPathOption, ApiUrlOption, JobIdOption, OutputPathOption, BaseCommitShaOption);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/UpdateCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/UpdateCommand.cs
@@ -33,8 +33,8 @@ internal static class UpdateCommand
 
         command.SetHandler(async (jobPath, repoRoot, solutionOrProjectFile, dependencyName, newVersion, previousVersion, isTransitive, resultOutputPath) =>
         {
+            var (experimentsManager, _errorResult) = await ExperimentsManager.FromJobFileAsync(jobPath.FullName);
             var logger = new ConsoleLogger();
-            var experimentsManager = await ExperimentsManager.FromJobFileAsync(jobPath.FullName, logger);
             var worker = new UpdaterWorker(experimentsManager, logger);
             await worker.RunAsync(repoRoot.FullName, solutionOrProjectFile.FullName, dependencyName, previousVersion, newVersion, isTransitive, resultOutputPath);
             setExitCode(0);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -45,7 +45,16 @@ public class DiscoveryWorkerTestBase : TestBase
         ValidateProjectResults(expectedResult.Projects, actualResult.Projects, experimentsManager);
         Assert.Equal(expectedResult.ExpectedProjectCount ?? expectedResult.Projects.Length, actualResult.Projects.Length);
         Assert.Equal(expectedResult.ErrorType, actualResult.ErrorType);
-        Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
+        if (expectedResult.ErrorDetailsPattern is not null)
+        {
+            var errorDetails = actualResult.ErrorDetails?.ToString();
+            Assert.NotNull(errorDetails);
+            Assert.Matches(expectedResult.ErrorDetailsPattern, errorDetails);
+        }
+        else
+        {
+            Assert.Equal(expectedResult.ErrorDetails, actualResult.ErrorDetails);
+        }
 
         return;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -12,6 +12,7 @@ public record ExpectedWorkspaceDiscoveryResult : NativeResult
     public int? ExpectedProjectCount { get; init; }
     public ExpectedDependencyDiscoveryResult? GlobalJson { get; init; }
     public ExpectedDependencyDiscoveryResult? DotNetToolsJson { get; init; }
+    public string? ErrorDetailsPattern { get; init; } = null;
 }
 
 public record ExpectedSdkProjectDiscoveryResult : ExpectedDependencyDiscoveryResult

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1733,7 +1733,7 @@ public class RunWorkerTests
         analyzeWorker ??= new AnalyzeWorker(experimentsManager, logger);
         updaterWorker ??= new UpdaterWorker(experimentsManager, logger);
 
-        var worker = new RunWorker(testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
+        var worker = new RunWorker("TEST-JOB-ID", testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
         var repoContentsPathDirectoryInfo = new DirectoryInfo(tempDirectory.DirectoryPath);
         var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA");
         var actualApiMessages = testApiHandler.ReceivedMessages.ToArray();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -1,6 +1,5 @@
 using NuGet.Versioning;
 
-using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Test.Utilities;
@@ -228,37 +227,33 @@ public class SerializationTests
         Assert.False(experimentsManager.UseDirectDiscovery);
     }
 
-    [Fact]
-    public async Task DeserializeExperimentsManager_UnsupportedJobFileShape_InfoIsReportedAndEmptyExperimentSetIsReturned()
+    [Theory]
+    [MemberData(nameof(DeserializeErrorTypesData))]
+    public void SerializeError(JobErrorBase error, string expectedSerialization)
     {
-        // arrange
-        using var tempDir = new TemporaryDirectory();
-        var jobFilePath = Path.Combine(tempDir.DirectoryPath, "job.json");
-        var jobContent = """
-            {
-              "this-is-not-a-job-and-parsing-will-fail-but-an-empty-experiment-set-should-sill-be-returned": {
-              }
-            }
-            """;
-        await File.WriteAllTextAsync(jobFilePath, jobContent);
-        var capturingTestLogger = new CapturingTestLogger();
+        if (error is UnknownError unknown)
+        {
+            // special case the exception's call stack to make it testable
+            unknown.Details["error-backtrace"] = "TEST-BACKTRACE";
+        }
 
-        // act - this is the entrypoint the update command uses to parse the job file
-        var experimentsManager = await ExperimentsManager.FromJobFileAsync(jobFilePath, capturingTestLogger);
-
-        // assert
-        Assert.False(experimentsManager.UseLegacyDependencySolver);
-        Assert.False(experimentsManager.UseDirectDiscovery);
-        Assert.Single(capturingTestLogger.Messages, m => m.Contains("Error deserializing job file"));
+        var actual = HttpApiHandler.Serialize(error);
+        Assert.Equal(expectedSerialization, actual);
     }
 
     [Fact]
-    public void SerializeError()
+    public void SerializeError_AllErrorTypesHaveSerializationTests()
     {
-        var error = new JobRepoNotFound("some message");
-        var actual = HttpApiHandler.Serialize(error);
-        var expected = """{"data":{"error-type":"job_repo_not_found","error-details":{"message":"some message"}}}""";
-        Assert.Equal(expected, actual);
+        var untestedTypes = typeof(JobErrorBase).Assembly.GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(JobErrorBase)))
+            .ToHashSet();
+        foreach (object?[] data in DeserializeErrorTypesData())
+        {
+            var testedErrorType = data[0]!.GetType();
+            untestedTypes.Remove(testedErrorType);
+        }
+
+        Assert.Empty(untestedTypes.Select(t => t.Name));
     }
 
     [Fact]
@@ -514,6 +509,57 @@ public class SerializationTests
         Assert.Null(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
     }
 
+    public static IEnumerable<object?[]> DeserializeErrorTypesData()
+    {
+        yield return
+        [
+            new BadRequirement("some message"),
+            """
+            {"data":{"error-type":"illformed_requirement","error-details":{"message":"some message"}}}
+            """
+        ];
+
+        yield return
+        [
+            new DependencyFileNotFound("some message", "/some/file"),
+            """
+            {"data":{"error-type":"dependency_file_not_found","error-details":{"message":"some message","file-path":"/some/file"}}}
+            """
+        ];
+
+        yield return
+        [
+            new JobRepoNotFound("some message"),
+            """
+            {"data":{"error-type":"job_repo_not_found","error-details":{"message":"some message"}}}
+            """
+        ];
+
+        yield return
+        [
+            new PrivateSourceAuthenticationFailure(["url1", "url2"]),
+            """
+            {"data":{"error-type":"private_source_authentication_failure","error-details":{"source":"(url1|url2)"}}}
+            """
+        ];
+
+        yield return
+        [
+            new UnknownError(new Exception("some message"), "JOB-ID"),
+            """
+            {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"some message","error-backtrace":"TEST-BACKTRACE","package-manager":"nuget","job-id":"JOB-ID"}}}
+            """
+        ];
+
+        yield return
+        [
+            new UpdateNotPossible(["dep1", "dep2"]),
+            """
+            {"data":{"error-type":"update_not_possible","error-details":{"dependencies":["dep1","dep2"]}}}
+            """
+        ];
+    }
+
     public static IEnumerable<object?[]> DeserializeAllowedUpdatesData()
     {
         // common default value - most job files look like this
@@ -595,17 +641,5 @@ public class SerializationTests
                 }
             }
         ];
-    }
-
-    private class CapturingTestLogger : ILogger
-    {
-        private readonly List<string> _messages = new();
-
-        public IReadOnlyList<string> Messages => _messages;
-
-        public void LogRaw(string message)
-        {
-            _messages.Add(message);
-        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
@@ -7,10 +7,15 @@ public class RequirementConverter : JsonConverter<Requirement>
 {
     public override Requirement? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new BadRequirementException($"Expected token type {nameof(JsonTokenType.String)}, but found {reader.TokenType}.");
+        }
+
         var text = reader.GetString();
         if (text is null)
         {
-            throw new ArgumentNullException(nameof(text));
+            throw new BadRequirementException("Unexpected null token.");
         }
 
         try

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/RequirementConverter.cs
@@ -7,7 +7,20 @@ public class RequirementConverter : JsonConverter<Requirement>
 {
     public override Requirement? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return Requirement.Parse(reader.GetString()!);
+        var text = reader.GetString();
+        if (text is null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        try
+        {
+            return Requirement.Parse(text);
+        }
+        catch
+        {
+            throw new BadRequirementException(text);
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, Requirement value, JsonSerializerOptions options)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/BadRequirementException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/BadRequirementException.cs
@@ -1,0 +1,9 @@
+namespace NuGetUpdater.Core;
+
+internal class BadRequirementException : Exception
+{
+    public BadRequirementException(string details)
+        : base(details)
+    {
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -31,6 +31,10 @@ public class CloneWorker
         try
         {
             jobFile = RunWorker.Deserialize(jobFileContent);
+            if (jobFile is null)
+            {
+                parseError = new UnknownError(new Exception("Job file could not be deserialized"), _jobId);
+            }
         }
         catch (BadRequirementException ex)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -57,6 +57,16 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 Projects = [],
             };
         }
+        catch (Exception ex)
+        {
+            result = new WorkspaceDiscoveryResult
+            {
+                ErrorType = ErrorType.Unknown,
+                ErrorDetails = ex.ToString(),
+                Path = workspacePath,
+                Projects = [],
+            };
+        }
 
         return result;
     }
@@ -397,6 +407,6 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
 
         var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
-        await File.WriteAllTextAsync(path: resultPath, resultJson);
+        await File.WriteAllTextAsync(resultPath, resultJson);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ErrorType.cs
@@ -4,6 +4,7 @@ public enum ErrorType
 {
     None,
     AuthenticationFailure,
+    BadRequirement,
     MissingFile,
     UpdateNotPossible,
     DependencyFileNotParseable,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NuGetUpdater.Cli" />
     <InternalsVisibleTo Include="NuGetUpdater.Cli.Test" />
     <InternalsVisibleTo Include="NuGetUpdater.Core.Test" />
   </ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/BadRequirement.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/BadRequirement.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record BadRequirement : JobErrorBase
+{
+    public BadRequirement(string details)
+        : base("illformed_requirement")
+    {
+        Details["message"] = details;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyFileNotFound.cs
@@ -2,9 +2,10 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record DependencyFileNotFound : JobErrorBase
 {
-    public DependencyFileNotFound(string filePath)
+    public DependencyFileNotFound(string message, string filePath)
         : base("dependency_file_not_found")
     {
-        Details = filePath;
+        Details["message"] = message;
+        Details["file-path"] = filePath;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -13,6 +13,5 @@ public abstract record JobErrorBase
     public string Type { get; }
 
     [JsonPropertyName("error-details")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public object? Details { get; init; } = null;
+    public Dictionary<string, object> Details { get; init; } = new();
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobRepoNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobRepoNotFound.cs
@@ -5,9 +5,6 @@ public record JobRepoNotFound : JobErrorBase
     public JobRepoNotFound(string message)
         : base("job_repo_not_found")
     {
-        Details = new Dictionary<string, string>()
-        {
-            ["message"] = message
-        };
+        Details["message"] = message;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceAuthenticationFailure.cs
@@ -5,6 +5,6 @@ public record PrivateSourceAuthenticationFailure : JobErrorBase
     public PrivateSourceAuthenticationFailure(string[] urls)
         : base("private_source_authentication_failure")
     {
-        Details = $"({string.Join("|", urls)})";
+        Details["source"] = $"({string.Join("|", urls)})";
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -2,9 +2,13 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record UnknownError : JobErrorBase
 {
-    public UnknownError(string details)
+    public UnknownError(Exception ex, string jobId)
         : base("unknown_error")
     {
-        Details = details;
+        Details["error-class"] = ex.GetType().Name;
+        Details["error-message"] = ex.Message;
+        Details["error-backtrace"] = ex.StackTrace ?? "<unknown>";
+        Details["package-manager"] = "nuget";
+        Details["job-id"] = jobId;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdateNotPossible.cs
@@ -5,6 +5,6 @@ public record UpdateNotPossible : JobErrorBase
     public UpdateNotPossible(string[] dependencies)
         : base("update_not_possible")
     {
-        Details = dependencies;
+        Details["dependencies"] = dependencies;
     }
 }

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -301,6 +301,8 @@ module Dependabot
           raise DependencyFileNotParseable, T.must(T.let(error_details, T.nilable(String)))
         when "AuthenticationFailure"
           raise PrivateSourceAuthenticationFailure, T.let(error_details, T.nilable(String))
+        when "BadRequirement"
+          raise BadRequirementError, T.let(error_details, T.nilable(String))
         when "MissingFile"
           raise DependencyFileNotFound, T.let(error_details, T.nilable(String))
         when "UpdateNotPossible"


### PR DESCRIPTION
The `job.json` file is passed to all update steps which means we need to be able to report all parsing errors as they occur.

Originally this work started because a requirement was specified in the job file that could not be parsed, so part of this PR is to return the well-known error `illformed_requirement`, represented as `BadRequirementError`.

Most of this PR was to make testing possible, but ultimately it comes down to 2 major changes:

1. For the current hybrid Ruby/C# updater, only validate and report job file parsing errors in the `discover` command.  All subsequent commands also parse the job file, but any failure to parse is fatal so we only need to actually report it there; all other instances can assume it's acceptable.
2. For the new end-to-end updater, the `clone` command is the first time the job file is parsed, so the error handling was expanded there to specifically report the parse error and fail the entire update process.

While performing some manual tests, I discovered that the shape of the error objects returned by the end-to-end parser wasn't always correct, so I checked in the `dependabot/cli` repo to ensure the errors had the correct shape and added serialization tests for all error types to ensure this doesn't regress.