### PR TITLE
Add support for language deprecation notices, warnings and errors

### DIFF
--- a/common/spec/dependabot/notices_spec.rb
+++ b/common/spec/dependabot/notices_spec.rb
@@ -5,9 +5,10 @@ require "dependabot/version"
 require "dependabot/experiments"
 require "dependabot/ecosystem"
 require "dependabot/notices"
+require "debug"
 
 # A stub package manager for testing purposes.
-class StubPackageManager < Dependabot::Ecosystem::VersionManager
+class StubVersionManager < Dependabot::Ecosystem::VersionManager
   def initialize(name:, version:, deprecated_versions: [], supported_versions: [],
                  support_later_versions: false)
     @support_later_versions = support_later_versions
@@ -23,7 +24,7 @@ class StubPackageManager < Dependabot::Ecosystem::VersionManager
 
   sig { override.returns(T::Boolean) }
   def unsupported?
-    # Determine if the Bundler version is unsupported.
+    # Determine if the version is unsupported.
     version < supported_versions.first
   end
 
@@ -99,19 +100,31 @@ RSpec.describe Dependabot::Notice do
       let(:supported_versions) { [] }
       let(:support_later_versions) { false }
 
-      it "returns nil" do
+      it "returns the correct description" do
         expect(generate_supported_versions_description).to eq("Please upgrade your package manager version")
+      end
+
+      context "when the entity being deprecated is the language" do
+        subject(:generate_supported_versions_description) do
+          described_class.generate_supported_versions_description(
+            supported_versions, support_later_versions, :language
+          )
+        end
+
+        it "returns the correct description" do
+          expect(generate_supported_versions_description).to eq("Please upgrade your language version")
+        end
       end
     end
   end
 
-  describe ".generate_pm_deprecation_notice" do
-    subject(:generate_pm_deprecation_notice) do
-      described_class.generate_pm_deprecation_notice(package_manager)
+  describe ".generate_deprecation_notice" do
+    subject(:package_manager_deprecation_notice) do
+      described_class.generate_deprecation_notice(package_manager)
     end
 
     let(:package_manager) do
-      StubPackageManager.new(
+      StubVersionManager.new(
         name: "bundler",
         version: Dependabot::Version.new("1"),
         deprecated_versions: [Dependabot::Version.new("1")],
@@ -121,7 +134,7 @@ RSpec.describe Dependabot::Notice do
 
     it "returns the correct deprecation notice" do
       allow(package_manager).to receive(:unsupported?).and_return(false)
-      expect(generate_pm_deprecation_notice.to_hash)
+      expect(package_manager_deprecation_notice.to_hash)
         .to eq({
           mode: "WARN",
           type: "bundler_deprecated_warn",
@@ -132,6 +145,36 @@ RSpec.describe Dependabot::Notice do
           show_in_pr: true,
           show_alert: true
         })
+    end
+
+    context "when generating a notice for a deprecated language" do
+      subject(:deprecation_notice) do
+        described_class.generate_deprecation_notice(language_manager, :language)
+      end
+
+      let(:language_manager) do
+        StubVersionManager.new(
+          name: "python",
+          version: Dependabot::Version.new("3.8"),
+          deprecated_versions: [Dependabot::Version.new("3.8")],
+          supported_versions: [Dependabot::Version.new("3.9")]
+        )
+      end
+
+      it "returns the correct deprecation notice" do
+        allow(language_manager).to receive(:unsupported?).and_return(false)
+        expect(deprecation_notice.to_hash)
+          .to eq({
+            mode: "WARN",
+            type: "python_deprecated_warn",
+            package_manager_name: "python",
+            title: "Language deprecation notice",
+            description: "Dependabot will stop supporting `python v3.8`!" \
+                         "\n\nPlease upgrade to version `v3.9`.\n",
+            show_in_pr: true,
+            show_alert: true
+          })
+      end
     end
   end
 end

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -245,6 +245,8 @@ module Dependabot
       ecosystem = parser.ecosystem
       # Raise an error if the package manager version is unsupported
       ecosystem&.raise_if_unsupported!
+      # Raise an error if the language version is unsupported
+      ecosystem&.language&.raise_if_unsupported!
 
       @ecosystem[@current_directory] = ecosystem
 
@@ -255,8 +257,18 @@ module Dependabot
       # add deprecation notices for the package manager
       add_deprecation_notice(
         notices: notices_for_current_directory,
-        package_manager: ecosystem&.package_manager
+        version_manager: ecosystem&.package_manager
       )
+
+      if ecosystem&.language
+        # add deprecation notices for the language
+        add_deprecation_notice(
+          notices: notices_for_current_directory,
+          version_manager: ecosystem.language,
+          version_manager_type: :language
+        )
+      end
+
       @notices[@current_directory] = notices_for_current_directory
 
       parser

--- a/updater/lib/dependabot/notices_helpers.rb
+++ b/updater/lib/dependabot/notices_helpers.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 require "dependabot/notices"
 require "dependabot/ecosystem"
+require "debug"
 
 # This module extracts helpers for notice generations that can be used
 # for showing notices in logs, pr messages and alert ui page.
@@ -14,19 +15,20 @@ module Dependabot
 
     abstract!
 
-    # Add a deprecation notice to the notice list if the package manager is deprecated
-    # if the package manager is deprecated.
+    # Add a deprecation notice to the notice list if the version manager is deprecated
+    # if the version manager is deprecated.
     #  notices << deprecation_notices if deprecation_notices
     sig do
       params(
         notices: T::Array[Dependabot::Notice],
-        package_manager: T.nilable(Ecosystem::VersionManager)
+        version_manager: T.nilable(Ecosystem::VersionManager),
+        version_manager_type: Symbol
       )
         .void
     end
-    def add_deprecation_notice(notices:, package_manager:)
-      # Create a deprecation notice if the package manager is deprecated
-      deprecation_notice = create_deprecation_notice(package_manager)
+    def add_deprecation_notice(notices:, version_manager:, version_manager_type: :package_manager)
+      # Create a deprecation notice if the version manager is deprecated
+      deprecation_notice = create_deprecation_notice(version_manager, version_manager_type)
 
       return unless deprecation_notice
 
@@ -58,15 +60,16 @@ module Dependabot
 
     private
 
-    sig { params(package_manager: T.nilable(Ecosystem::VersionManager)).returns(T.nilable(Dependabot::Notice)) }
-    def create_deprecation_notice(package_manager)
-      return unless package_manager
+    sig do
+      params(version_manager: T.nilable(Ecosystem::VersionManager),
+             version_manager_type: Symbol).returns(T.nilable(Dependabot::Notice))
+    end
+    def create_deprecation_notice(version_manager, version_manager_type)
+      return unless version_manager
 
-      return unless package_manager.is_a?(Ecosystem::VersionManager)
+      return unless version_manager.is_a?(Ecosystem::VersionManager)
 
-      Notice.generate_pm_deprecation_notice(
-        package_manager
-      )
+      Notice.generate_deprecation_notice(version_manager, version_manager_type)
     end
   end
 end

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         end
 
         it "creates a pull request with deprecation notice" do
-          allow(Dependabot::Notice).to receive(:generate_pm_deprecation_notice).and_return([{
+          allow(Dependabot::Notice).to receive(:generate_deprecation_notice).and_return([{
             mode: "WARN",
             type: "bundler_deprecated_warn",
             package_manager_name: "bundler",


### PR DESCRIPTION
### What are you trying to accomplish?
We already have a feature to display deprecation notices for package managers. These can be warnings for deprecated package managers or errors for unsupported package managers. We now have a new use case: displaying similar notices but for language deprecations.

This PR generalises the code for package manager notices so that it can be used for language deprecations as well. In most cases this just involves passing in a new optional param `version_manager_type` in method calls and using it to generate the correct notice messages. To minimise the number of changes and to reduce the risk of breaking existing functionality, this param has a default value of `:package_manager.

Code comments, method arguments and variable names have also been updated accordingly so that they make sense for both package manager and language deprecations.

### How will you know you've accomplished your goal?
I should be able to see both package manager and language deprecation warnings on the insights page as well as in the dependabot logs.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
