### PR TITLE
handles build_num as comparable to year_month or year_month_day in docker tags

### DIFF
--- a/bundler/lib/dependabot/bundler/language.rb
+++ b/bundler/lib/dependabot/bundler/language.rb
@@ -14,7 +14,10 @@ module Dependabot
 
       sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(raw_version, requirement = nil)
-        super(LANGUAGE, Version.new(raw_version), [], [], requirement)
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version),
+          requirement: requirement)
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/package_manager.rb
+++ b/bundler/lib/dependabot/bundler/package_manager.rb
@@ -31,11 +31,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_BUNDLER_VERSIONS,
-          SUPPORTED_BUNDLER_VERSIONS,
-          requirement,
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_BUNDLER_VERSIONS,
+          supported_versions: SUPPORTED_BUNDLER_VERSIONS,
+          requirement: requirement,
        )
       end
     end

--- a/cargo/lib/dependabot/cargo/language.rb
+++ b/cargo/lib/dependabot/cargo/language.rb
@@ -15,8 +15,8 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          LANGUAGE,
-          Version.new(raw_version)
+          name: LANGUAGE,
+          version: Version.new(raw_version)
         )
       end
     end

--- a/cargo/lib/dependabot/cargo/package_manager.rb
+++ b/cargo/lib/dependabot/cargo/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_CARGO_VERSIONS,
-          SUPPORTED_CARGO_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_CARGO_VERSIONS,
+          supported_versions: SUPPORTED_CARGO_VERSIONS
         )
       end
 

--- a/common/lib/dependabot/ecosystem.rb
+++ b/common/lib/dependabot/ecosystem.rb
@@ -17,30 +17,38 @@ module Dependabot
       abstract!
       # Initialize version information for a package manager or language.
       # @param name [String] the name of the package manager or language (e.g., "bundler", "ruby").
-      # @param version [Dependabot::Version] the parsed current version.
+      # @param detected_version [Dependabot::Version] the detected version of the package manager or language.
+      # @param version [Dependabot::Version] the version dependabots run on.
       # @param deprecated_versions [Array<Dependabot::Version>] an array of deprecated versions.
       # @param supported_versions [Array<Dependabot::Version>] an array of supported versions.
       # @param requirement [Dependabot::Requirement] an array of requirements.
       # @example
-      #   VersionManager.new("bundler", "2.1.4", nil)
+      #   VersionManager.new(
+      #   name: "bundler",
+      #   version: Version.new("2.1.4"),
+      #   requirement: nil
+      # )
       sig do
         params(
           name: String,
-          version: Dependabot::Version,
+          detected_version: T.nilable(Dependabot::Version),
+          version: T.nilable(Dependabot::Version),
           deprecated_versions: T::Array[Dependabot::Version],
           supported_versions: T::Array[Dependabot::Version],
           requirement: T.nilable(Dependabot::Requirement)
         ).void
       end
       def initialize(
-        name,
-        version,
-        deprecated_versions = [],
-        supported_versions = [],
-        requirement = nil
+        name:,
+        detected_version: nil,
+        version: nil,
+        deprecated_versions: [],
+        supported_versions: [],
+        requirement: nil
       )
         @name = T.let(name, String)
-        @version = T.let(version, Dependabot::Version)
+        @detected_version = T.let(detected_version || version, T.nilable(Dependabot::Version))
+        @version = T.let(version, T.nilable(Dependabot::Version))
         @deprecated_versions = T.let(deprecated_versions, T::Array[Dependabot::Version])
         @supported_versions = T.let(supported_versions, T::Array[Dependabot::Version])
         @requirement = T.let(requirement, T.nilable(Dependabot::Requirement))
@@ -54,8 +62,14 @@ module Dependabot
 
       # The current version of the package manager or language.
       # @example
+      #   detected_version #=> Dependabot::Version.new("2")
+      sig { returns(T.nilable(Dependabot::Version)) }
+      attr_reader :detected_version
+
+      # The current version of the package manager or language.
+      # @example
       #   version #=> Dependabot::Version.new("2.1.4")
-      sig { returns(Dependabot::Version) }
+      sig { returns(T.nilable(Dependabot::Version)) }
       attr_reader :version
 
       # Returns an array of deprecated versions of the package manager.
@@ -82,10 +96,12 @@ module Dependabot
       #   deprecated? #=> true
       sig { returns(T::Boolean) }
       def deprecated?
+        return false unless detected_version
+
         # If the version is unsupported, the unsupported error is getting raised separately.
         return false if unsupported?
 
-        deprecated_versions.include?(version)
+        deprecated_versions.include?(detected_version)
       end
 
       # Checks if the current version is unsupported.
@@ -93,16 +109,20 @@ module Dependabot
       #   unsupported? #=> false
       sig { returns(T::Boolean) }
       def unsupported?
+        return false unless detected_version
+
         return false if supported_versions.empty?
 
         # Check if the version is not supported
-        supported_versions.all? { |supported| supported > version }
+        supported_versions.all? { |supported| supported > detected_version }
       end
 
       # Raises an error if the current package manager or language version is unsupported.
       # If the version is unsupported, it raises a ToolVersionNotSupported error.
       sig { void }
       def raise_if_unsupported!
+        return unless detected_version
+
         return unless unsupported?
 
         # Example: v2.*, v3.*
@@ -110,7 +130,7 @@ module Dependabot
 
         raise ToolVersionNotSupported.new(
           name,
-          version.to_s,
+          detected_version.to_s,
           supported_versions_message
         )
       end

--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -120,7 +120,7 @@ module Dependabot
       )
       notice_type = "#{version_manager.name}_deprecated_warn"
       title = version_manager_type == :language ? "Language deprecation notice" : "Package manager deprecation notice"
-      description = "Dependabot will stop supporting `#{version_manager.name} v#{version_manager.version}`!"
+      description = "Dependabot will stop supporting `#{version_manager.name} v#{version_manager.detected_version}`!"
 
       ## Add the supported versions to the description
       description += "\n\n#{supported_versions_description}\n" unless supported_versions_description.empty?

--- a/common/spec/dependabot/ecosystem_spec.rb
+++ b/common/spec/dependabot/ecosystem_spec.rb
@@ -13,35 +13,44 @@ RSpec.describe Dependabot::Ecosystem do
   let(:deprecated_versions) { [Dependabot::Version.new("1")] }
   let(:requirement) { TestRequirement.new(">= 1.0") }
 
+  let(:package_manager_detected_version) { "1.0.0" }
   let(:package_manager_raw_version) { "1.0.0" }
+  let(:language_detected_version) { "3.0.0" }
   let(:language_raw_version) { "3.0.0" }
 
   let(:package_manager) do
     Class.new(Dependabot::Ecosystem::VersionManager) do
-      def initialize(raw_version, deprecated_versions, supported_versions, requirement)
+      def initialize(detected_version, raw_version, deprecated_versions, supported_versions, requirement)
         super(
-          "bundler", # name
-          Dependabot::Version.new(raw_version), # version
-          deprecated_versions, # deprecated_versions
-          supported_versions, # supported_versions
-          requirement # requirement
+          name: "bundler", # name
+          detected_version: Dependabot::Version.new(detected_version), # version
+          version: Dependabot::Version.new(raw_version), # version
+          deprecated_versions: deprecated_versions, # deprecated_versions
+          supported_versions: supported_versions, # supported_versions
+          requirement: requirement # requirement
         )
       end
-    end.new(package_manager_raw_version, deprecated_versions, supported_versions, requirement)
+    end.new(
+      package_manager_detected_version,
+      package_manager_raw_version,
+      deprecated_versions,
+      supported_versions,
+      requirement
+    )
   end
 
   let(:language) do
     Class.new(Dependabot::Ecosystem::VersionManager) do
-      def initialize(raw_version)
+      def initialize(detected_version, raw_version)
         super(
-          "ruby", # name
-          Dependabot::Version.new(raw_version), # version
-          [], # deprecated_versions
-          [], # supported_versions
-          nil # requirement
+          name: "ruby", # name
+          detected_version: Dependabot::Version.new(detected_version), # version
+          version: Dependabot::Version.new(raw_version), # version
+          deprecated_versions: [], # deprecated_versions
+          supported_versions: [], # supported_versions
         )
       end
-    end.new(language_raw_version)
+    end.new(language_detected_version, language_raw_version)
   end
 
   describe "#initialize" do
@@ -56,6 +65,7 @@ RSpec.describe Dependabot::Ecosystem do
 
   describe "#deprecated?" do
     context "when the package manager version is deprecated" do
+      let(:package_manager_detected_version) { "1" }
       let(:package_manager_raw_version) { "1" }
 
       it "returns true" do
@@ -65,6 +75,7 @@ RSpec.describe Dependabot::Ecosystem do
     end
 
     context "when the package manager version is not deprecated" do
+      let(:package_manager_detected_version) { "2.0.0" }
       let(:package_manager_raw_version) { "2.0.0" }
 
       it "returns false" do
@@ -76,6 +87,7 @@ RSpec.describe Dependabot::Ecosystem do
 
   describe "#unsupported?" do
     context "when the package manager version is unsupported" do
+      let(:package_manager_detected_version) { "0.8.0" }
       let(:package_manager_raw_version) { "0.8.0" }
 
       it "returns true" do
@@ -85,6 +97,7 @@ RSpec.describe Dependabot::Ecosystem do
     end
 
     context "when the package manager version is supported" do
+      let(:package_manager_detected_version) { "2.0.0" }
       let(:package_manager_raw_version) { "2.0.0" }
 
       it "returns false" do
@@ -96,6 +109,7 @@ RSpec.describe Dependabot::Ecosystem do
 
   describe "#raise_if_unsupported!" do
     context "when the package manager version is unsupported" do
+      let(:package_manager_detected_version) { "0.8.0" }
       let(:package_manager_raw_version) { "0.8.0" }
 
       it "raises a ToolVersionNotSupported error" do
@@ -105,6 +119,7 @@ RSpec.describe Dependabot::Ecosystem do
     end
 
     context "when the package manager version is supported" do
+      let(:package_manager_detected_version) { "2.0.0" }
       let(:package_manager_raw_version) { "2.0.0" }
 
       it "does not raise an error" do

--- a/common/spec/dependabot/file_parsers/base_spec.rb
+++ b/common/spec/dependabot/file_parsers/base_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe Dependabot::FileParsers::Base do
       def initialize
         raw_version = "1.0.0"
         super(
-          "bundler", # name
-          Dependabot::Version.new(raw_version), # version
-          [Dependabot::Version.new("1.0.0")], # deprecated_versions
-          [Dependabot::Version.new("1.1.0"), Dependabot::Version.new("2.0.0")] # supported_versions
+          name: "bundler", # name
+          version: Dependabot::Version.new(raw_version), # version
+          deprecated_versions: [Dependabot::Version.new("1.0.0")], # deprecated_versions
+          supported_versions: [Dependabot::Version.new("1.1.0"), Dependabot::Version.new("2.0.0")] # supported_versions
         )
       end
 

--- a/common/spec/dependabot/notices_spec.rb
+++ b/common/spec/dependabot/notices_spec.rb
@@ -9,14 +9,15 @@ require "debug"
 
 # A stub package manager for testing purposes.
 class StubVersionManager < Dependabot::Ecosystem::VersionManager
-  def initialize(name:, version:, deprecated_versions: [], supported_versions: [],
+  def initialize(name:, detected_version:, raw_version:, deprecated_versions: [], supported_versions: [],
                  support_later_versions: false)
     @support_later_versions = support_later_versions
     super(
-      name,
-     Dependabot::Version.new(version),
-     deprecated_versions,
-     supported_versions
+      name: name,
+      detected_version: Dependabot::Version.new(detected_version),
+      version: Dependabot::Version.new(raw_version),
+      deprecated_versions: deprecated_versions,
+      supported_versions: supported_versions
    )
   end
 
@@ -126,7 +127,8 @@ RSpec.describe Dependabot::Notice do
     let(:package_manager) do
       StubVersionManager.new(
         name: "bundler",
-        version: Dependabot::Version.new("1"),
+        detected_version: Dependabot::Version.new("1"),
+        raw_version: Dependabot::Version.new("1"),
         deprecated_versions: [Dependabot::Version.new("1")],
         supported_versions: [Dependabot::Version.new("2"), Dependabot::Version.new("3")]
       )
@@ -155,7 +157,8 @@ RSpec.describe Dependabot::Notice do
       let(:language_manager) do
         StubVersionManager.new(
           name: "python",
-          version: Dependabot::Version.new("3.8"),
+          detected_version: Dependabot::Version.new("3.8"),
+          raw_version: Dependabot::Version.new("3.8"),
           deprecated_versions: [Dependabot::Version.new("3.8")],
           supported_versions: [Dependabot::Version.new("3.9")]
         )

--- a/common/spec/dependabot/version_manager_spec.rb
+++ b/common/spec/dependabot/version_manager_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Dependabot::Ecosystem::VersionManager do # rubocop:disable RSpec/
   let(:concrete_class) do
     Class.new(Dependabot::Ecosystem::VersionManager) do
       def initialize
+        detected_version = "1.0.0"
         raw_version = "1.0.0"
         super(
-          "bundler", # name
-          Dependabot::Version.new(raw_version), # version
-          [Dependabot::Version.new("1")], # deprecated_versions
-          [Dependabot::Version.new("1"), Dependabot::Version.new("2")] # supported_versions
+          name: "bundler", # name
+          detected_version: Dependabot::Version.new(detected_version), # version
+          version: Dependabot::Version.new(raw_version), # version
+          deprecated_versions: [Dependabot::Version.new("1")], # deprecated_versions
+          supported_versions: [Dependabot::Version.new("1"), Dependabot::Version.new("2")] # supported_versions
         )
       end
 
@@ -26,10 +28,12 @@ RSpec.describe Dependabot::Ecosystem::VersionManager do # rubocop:disable RSpec/
   let(:default_concrete_class) do
     Class.new(Dependabot::Ecosystem::VersionManager) do
       def initialize
+        detected_version = "1.0.0"
         raw_version = "1.0.0"
         super(
-          "bundler", # name
-          Dependabot::Version.new(raw_version)
+          name: "bundler", # name
+          detected_version: Dependabot::Version.new(detected_version),
+          version: Dependabot::Version.new(raw_version)
         )
       end
     end
@@ -90,10 +94,12 @@ RSpec.describe Dependabot::Ecosystem::VersionManager do # rubocop:disable RSpec/
     end
 
     context "when version is unsupported" do
-      let(:version) { Dependabot::Version.new("0.9.0") }
+      let(:detected_version) { Dependabot::Version.new("0.9") }
+      let(:raw_version) { Dependabot::Version.new("0.9.0") }
 
       it "returns false as unsupported takes precedence" do
-        package_manager.instance_variable_set(:@version, version)
+        package_manager.instance_variable_set(:@detected_version, detected_version)
+        package_manager.instance_variable_set(:@version, raw_version)
         package_manager.instance_variable_set(:@supported_versions,
                                               [Dependabot::Version.new("1"), Dependabot::Version.new("2")])
         expect(package_manager.deprecated?).to be false
@@ -103,10 +109,12 @@ RSpec.describe Dependabot::Ecosystem::VersionManager do # rubocop:disable RSpec/
 
   describe "#unsupported?" do
     context "when version is unsupported" do
-      let(:version) { Dependabot::Version.new("0.9.0") }
+      let(:detected_version) { Dependabot::Version.new("0.9") }
+      let(:raw_version) { Dependabot::Version.new("0.9.0") }
 
       it "returns true" do
-        package_manager.instance_variable_set(:@version, version)
+        package_manager.instance_variable_set(:@detected_version, detected_version)
+        package_manager.instance_variable_set(:@version, raw_version)
         package_manager.instance_variable_set(:@supported_versions,
                                               [Dependabot::Version.new("1"), Dependabot::Version.new("2")])
         expect(package_manager.unsupported?).to be true

--- a/composer/lib/dependabot/composer/language.rb
+++ b/composer/lib/dependabot/composer/language.rb
@@ -16,11 +16,9 @@ module Dependabot
       sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(raw_version, requirement: nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          [],
-          [],
-          requirement
+          name: NAME,
+          version: Version.new(raw_version),
+          requirement: requirement
        )
       end
 

--- a/composer/lib/dependabot/composer/package_manager.rb
+++ b/composer/lib/dependabot/composer/package_manager.rb
@@ -36,10 +36,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          NAME,
-          Version.new(raw_version),
-          DEPRECATED_COMPOSER_VERSIONS,
-          SUPPORTED_COMPOSER_VERSIONS,
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_COMPOSER_VERSIONS,
+          supported_versions: SUPPORTED_COMPOSER_VERSIONS,
        )
       end
     end

--- a/devcontainers/lib/dependabot/devcontainers/language.rb
+++ b/devcontainers/lib/dependabot/devcontainers/language.rb
@@ -14,7 +14,9 @@ module Dependabot
 
       sig { params(raw_version: String).void }
       def initialize(raw_version)
-        super(LANGUAGE, Version.new(raw_version))
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version))
       end
     end
   end

--- a/devcontainers/lib/dependabot/devcontainers/package_manager.rb
+++ b/devcontainers/lib/dependabot/devcontainers/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_DEVCONTAINER_VERSIONS,
-          SUPPORTED_DEVCONTAINER_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_DEVCONTAINER_VERSIONS,
+          supported_versions: SUPPORTED_DEVCONTAINER_VERSIONS
         )
       end
 

--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -42,6 +42,17 @@ module Dependabot
         numeric_version&.match?(/[a-zA-Z]/)
       end
 
+      sig do
+        params(other_format: Symbol, other_prefix: T.nilable(String),
+               other_suffix: T.nilable(String)).returns(T::Boolean)
+      end
+      def comparable_formats(other_format, other_prefix, other_suffix)
+        return false unless prefix.nil? && suffix.nil? && other_prefix.nil? && other_suffix.nil?
+
+        formats = %i(year_month year_month_day)
+        (format == :build_num && formats.include?(other_format)) || (formats.include?(format) && other_format == :build_num) # rubocop:disable Layout/LineLength
+      end
+
       sig { params(other: Tag).returns(T::Boolean) }
       def comparable_to?(other)
         return false unless comparable?
@@ -52,10 +63,11 @@ module Dependabot
 
         equal_prefix = prefix == other_prefix
         equal_format = format == other_format
+        comparable_format = comparable_formats(other.format, other.prefix, other.suffix)
         return equal_prefix && equal_format if other_format == :sha_suffixed
 
         equal_suffix = suffix == other_suffix
-        equal_prefix && equal_format && equal_suffix
+        (equal_prefix && equal_format && equal_suffix) || comparable_format
       end
 
       sig { returns(T::Boolean) }

--- a/elm/lib/dependabot/elm/language.rb
+++ b/elm/lib/dependabot/elm/language.rb
@@ -14,7 +14,11 @@ module Dependabot
 
       sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(raw_version, requirement = nil)
-        super(LANGUAGE, Version.new(raw_version), [], [], requirement)
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version),
+          requirement: requirement
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/elm/lib/dependabot/elm/package_manager.rb
+++ b/elm/lib/dependabot/elm/package_manager.rb
@@ -34,11 +34,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_ELM_VERSIONS,
-          SUPPORTED_ELM_VERSIONS,
-          requirement,
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_ELM_VERSIONS,
+          supported_versions: SUPPORTED_ELM_VERSIONS,
+          requirement: requirement,
        )
       end
 

--- a/git_submodules/lib/dependabot/git_submodules/package_manager.rb
+++ b/git_submodules/lib/dependabot/git_submodules/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_GIT_VERSIONS,
-          SUPPORTED_GIT_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_GIT_VERSIONS,
+          supported_versions: SUPPORTED_GIT_VERSIONS
         )
       end
 

--- a/go_modules/lib/dependabot/go_modules/language.rb
+++ b/go_modules/lib/dependabot/go_modules/language.rb
@@ -16,8 +16,8 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          LANGUAGE,
-          Version.new(raw_version)
+          name: LANGUAGE,
+          version: Version.new(raw_version)
         )
       end
     end

--- a/go_modules/lib/dependabot/go_modules/package_manager.rb
+++ b/go_modules/lib/dependabot/go_modules/package_manager.rb
@@ -21,10 +21,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_GO_VERSIONS,
-          SUPPORTED_GO_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_GO_VERSIONS,
+          supported_versions: SUPPORTED_GO_VERSIONS
         )
       end
 

--- a/gradle/lib/dependabot/gradle/language.rb
+++ b/gradle/lib/dependabot/gradle/language.rb
@@ -15,8 +15,8 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          LANGUAGE,
-          Version.new(raw_version)
+          name: LANGUAGE,
+          version: Version.new(raw_version)
         )
       end
     end

--- a/gradle/lib/dependabot/gradle/package_manager.rb
+++ b/gradle/lib/dependabot/gradle/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_GRADLE_VERSIONS,
-          SUPPORTED_GRADLE_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_GRADLE_VERSIONS,
+          supported_versions: SUPPORTED_GRADLE_VERSIONS
         )
       end
 

--- a/hex/lib/dependabot/hex/language.rb
+++ b/hex/lib/dependabot/hex/language.rb
@@ -14,7 +14,10 @@ module Dependabot
 
       sig { params(raw_version: String).void }
       def initialize(raw_version)
-        super(LANGUAGE, Version.new(raw_version))
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version)
+        )
       end
     end
   end

--- a/hex/lib/dependabot/hex/package_manager.rb
+++ b/hex/lib/dependabot/hex/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_HEX_VERSIONS,
-          SUPPORTED_HEX_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_HEX_VERSIONS,
+          supported_versions: SUPPORTED_HEX_VERSIONS
         )
       end
 

--- a/maven/lib/dependabot/maven/language.rb
+++ b/maven/lib/dependabot/maven/language.rb
@@ -16,8 +16,8 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          LANGUAGE,
-          Version.new(raw_version)
+          name: LANGUAGE,
+          version: Version.new(raw_version)
         )
       end
     end

--- a/maven/lib/dependabot/maven/package_manager.rb
+++ b/maven/lib/dependabot/maven/package_manager.rb
@@ -28,11 +28,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_MAVEN_VERSIONS,
-          SUPPORTED_MAVEN_VERSIONS,
-          requirement,
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_MAVEN_VERSIONS,
+          supported_versions: SUPPORTED_MAVEN_VERSIONS,
+          requirement: requirement,
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -78,11 +78,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement: nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          DEPRECATED_VERSIONS,
-          SUPPORTED_VERSIONS,
-          requirement
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement
         )
       end
 
@@ -129,11 +129,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement: nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          DEPRECATED_VERSIONS,
-          SUPPORTED_VERSIONS,
-          requirement
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement
         )
       end
 
@@ -174,11 +174,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement: nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          DEPRECATED_VERSIONS,
-          SUPPORTED_VERSIONS,
-          requirement
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement
         )
       end
 
@@ -290,11 +290,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement: nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          DEPRECATED_VERSIONS,
-          SUPPORTED_VERSIONS,
-          requirement
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement
         )
       end
 

--- a/nuget/lib/dependabot/nuget/language.rb
+++ b/nuget/lib/dependabot/nuget/language.rb
@@ -12,7 +12,11 @@ module Dependabot
 
       sig { params(language: String, raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(language, raw_version, requirement = nil)
-        super(language, Version.new(raw_version), [], [], requirement)
+        super(
+          name: language,
+          version: Version.new(raw_version),
+          requirement: requirement,
+       )
       end
     end
 
@@ -28,7 +32,10 @@ module Dependabot
 
       sig { params(language: String, requirement: T.nilable(Requirement)).void }
       def initialize(language, requirement = nil)
-        super(language, Version.new(nil), [], [], requirement)
+        super(
+          name: language,
+          requirement: requirement,
+       )
       end
     end
 
@@ -44,7 +51,10 @@ module Dependabot
 
       sig { params(language: String, requirement: T.nilable(Requirement)).void }
       def initialize(language, requirement = nil)
-        super(language, Version.new(nil), [], [], requirement)
+        super(
+          name: language,
+          requirement: requirement,
+       )
       end
     end
 
@@ -60,7 +70,10 @@ module Dependabot
 
       sig { params(language: String, requirement: T.nilable(Requirement)).void }
       def initialize(language, requirement = nil)
-        super(language, Version.new(nil), [], [], requirement)
+        super(
+          name: language,
+          requirement: requirement,
+       )
       end
     end
 
@@ -75,7 +88,10 @@ module Dependabot
 
       sig { params(language: String, requirement: T.nilable(Requirement)).void }
       def initialize(language, requirement = nil)
-        super(language, Version.new(nil), [], [], requirement)
+        super(
+          name: language,
+          requirement: requirement,
+       )
       end
     end
   end

--- a/nuget/lib/dependabot/nuget/package_manager.rb
+++ b/nuget/lib/dependabot/nuget/package_manager.rb
@@ -30,10 +30,10 @@ module Dependabot
       end
       def initialize(raw_version)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS
        )
       end
 

--- a/pub/lib/dependabot/pub/language.rb
+++ b/pub/lib/dependabot/pub/language.rb
@@ -14,7 +14,10 @@ module Dependabot
 
       sig { params(raw_version: String).void }
       def initialize(raw_version)
-        super(LANGUAGE, Version.new(raw_version))
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version)
+       )
       end
     end
   end

--- a/pub/lib/dependabot/pub/package_manager.rb
+++ b/pub/lib/dependabot/pub/package_manager.rb
@@ -31,10 +31,10 @@ module Dependabot
       end
       def initialize(raw_version)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS
        )
       end
 

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -32,7 +32,13 @@ module Dependabot
 
       sig { params(raw_version: String, requirement: T.nilable(Requirement)).void }
       def initialize(raw_version, requirement = nil)
-        super(LANGUAGE, Version.new(raw_version), DEPRECATED_VERSIONS, SUPPORTED_VERSIONS, requirement)
+        super(
+          name: LANGUAGE,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement,
+       )
       end
 
       sig { override.returns(T::Boolean) }

--- a/python/lib/dependabot/python/package_manager.rb
+++ b/python/lib/dependabot/python/package_manager.rb
@@ -31,11 +31,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS,
-          requirement,
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement,
        )
       end
 
@@ -69,11 +69,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS,
-          requirement,
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement,
        )
       end
 
@@ -106,11 +106,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS,
-          requirement,
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement,
        )
       end
 
@@ -145,11 +145,11 @@ module Dependabot
       end
       def initialize(raw_version, requirement = nil)
         super(
-          NAME,
-          Version.new(raw_version),
-          SUPPORTED_VERSIONS,
-          DEPRECATED_VERSIONS,
-          requirement,
+          name: NAME,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_VERSIONS,
+          supported_versions: SUPPORTED_VERSIONS,
+          requirement: requirement,
        )
       end
 

--- a/silent/lib/dependabot/silent/package_manager.rb
+++ b/silent/lib/dependabot/silent/package_manager.rb
@@ -19,10 +19,10 @@ module Dependabot
       sig { params(version: T.any(String, Dependabot::Version)).void }
       def initialize(version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(version),
-          DEPRECATED_SILENT_VERSIONS,
-          SUPPORTED_SILENT_VERSIONS,
+          name: PACKAGE_MANAGER,
+          version: Version.new(version),
+          deprecated_versions: DEPRECATED_SILENT_VERSIONS,
+          supported_versions: SUPPORTED_SILENT_VERSIONS,
        )
       end
     end

--- a/swift/lib/dependabot/swift/language.rb
+++ b/swift/lib/dependabot/swift/language.rb
@@ -15,8 +15,8 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          LANGUAGE,
-          Version.new(raw_version)
+          name: LANGUAGE,
+          version: Version.new(raw_version)
         )
       end
     end

--- a/swift/lib/dependabot/swift/package_manager.rb
+++ b/swift/lib/dependabot/swift/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_SWIFT_VERSIONS,
-          SUPPORTED_SWIFT_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_SWIFT_VERSIONS,
+          supported_versions: SUPPORTED_SWIFT_VERSIONS
         )
       end
 

--- a/terraform/lib/dependabot/terraform/package_manager.rb
+++ b/terraform/lib/dependabot/terraform/package_manager.rb
@@ -20,10 +20,10 @@ module Dependabot
       sig { params(raw_version: String).void }
       def initialize(raw_version)
         super(
-          PACKAGE_MANAGER,
-          Version.new(raw_version),
-          DEPRECATED_TERRAFORM_VERSIONS,
-          SUPPORTED_TERRAFORM_VERSIONS
+          name: PACKAGE_MANAGER,
+          version: Version.new(raw_version),
+          deprecated_versions: DEPRECATED_TERRAFORM_VERSIONS,
+          supported_versions: SUPPORTED_TERRAFORM_VERSIONS
         )
       end
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -330,10 +330,13 @@ module Dependabot
     def version_manager_json(version_manager)
       return nil unless version_manager
 
+      raw_version = version_manager.version&.to_semver.to_s
+      version = version_manager.version&.to_semver.to_s
+
       {
         name: version_manager.name,
-        raw_version: version_manager.version.to_semver.to_s,
-        version: version_manager.version.to_s,
+        raw_version: raw_version.empty? ? "N/A" : raw_version,
+        version: version.empty? ? "N/A" : version,
         requirement: version_manager_requirement_json(version_manager)
       }
     end

--- a/updater/spec/dependabot/notices_helpers_spec.rb
+++ b/updater/spec/dependabot/notices_helpers_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe Dependabot::NoticesHelpers do
   let(:package_manager) do
     Class.new(Dependabot::Ecosystem::VersionManager) do
       def initialize
+        detected_version = "1"
         raw_version = "1"
         super(
-          "bundler", # name
-          Dependabot::Version.new(raw_version), # version
-          [Dependabot::Version.new("1")], # deprecated_versions
-          [Dependabot::Version.new("2"), Dependabot::Version.new("3")] # supported_versions
+          name: "bundler", # name
+          detected_version: Dependabot::Version.new(detected_version), # detected_version
+          version: Dependabot::Version.new(raw_version), # version
+          deprecated_versions: [Dependabot::Version.new("1")], # deprecated_versions
+          supported_versions: [Dependabot::Version.new("2"), Dependabot::Version.new("3")] # supported_versions
         )
       end
     end.new
@@ -81,12 +83,14 @@ RSpec.describe Dependabot::NoticesHelpers do
       let(:package_manager) do
         Class.new(Dependabot::Ecosystem::VersionManager) do
           def initialize
+            detected_version = "2"
             raw_version = "2"
             super(
-              "bundler", # name
-              Dependabot::Version.new(raw_version), # version
-              [Dependabot::Version.new("1")], # deprecated_versions
-              [Dependabot::Version.new("2"), Dependabot::Version.new("3")] # supported_versions
+              name: "bundler", # name
+              detected_version: Dependabot::Version.new(detected_version),
+              version: Dependabot::Version.new(raw_version), # version
+              deprecated_versions: [Dependabot::Version.new("1")], # deprecated_versions
+              supported_versions: [Dependabot::Version.new("2"), Dependabot::Version.new("3")] # supported_versions
             )
           end
         end.new
@@ -105,10 +109,11 @@ RSpec.describe Dependabot::NoticesHelpers do
         Class.new(Dependabot::Ecosystem::VersionManager) do
           def initialize
             super(
-              "python", # name
-              Dependabot::Version.new("3.8"), # version
-              [Dependabot::Version.new("3.8")], # deprecated_versions
-              [Dependabot::Version.new("3.9"), Dependabot::Version.new("3.10")] # supported_versions
+              name: "python", # name
+              detected_version: Dependabot::Version.new("3.8"), # version
+              version: Dependabot::Version.new("3.8"), # version
+              deprecated_versions: [Dependabot::Version.new("3.8")], # deprecated_versions
+              supported_versions: [Dependabot::Version.new("3.9"), Dependabot::Version.new("3.10")] # supported_versions
             )
           end
         end.new

--- a/updater/spec/support/dummy_pkg_helpers.rb
+++ b/updater/spec/support/dummy_pkg_helpers.rb
@@ -67,10 +67,11 @@ module DummyPkgHelpers
   class StubPackageManager < Dependabot::Ecosystem::VersionManager
     def initialize(name:, version:, deprecated_versions: [], supported_versions: [])
       super(
-        name,
-        Dependabot::Version.new(version),
-        deprecated_versions,
-        supported_versions
+        name: name,
+        detected_version: Dependabot::Version.new(version),
+        version: Dependabot::Version.new(version),
+        deprecated_versions: deprecated_versions,
+        supported_versions: supported_versions
       )
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

docker images tagged with name:999 and name:1007 should be comparable. ATM they are not.

see https://github.com/dependabot/dependabot-core/issues/11198

### Anything you want to highlight for special attention from reviewers?

I'm pretty certain, that this is the wrong way. The PR is more to illustrate the linked issue.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ❌ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ❌ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ✅ ] I have written clear and descriptive commit messages.
- [ ✅ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ❌ ] I have ensured that the code is well-documented and easy to understand.
