### PR TITLE
Skip earlier when run on forks

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -19,6 +19,10 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   approval:
+    # Skip when triggered by pull request events on PR's from forks because the GITHUB_TOKEN on
+    # those PR's does not have write access, and thus cannot deploy to GHCR.
+    # Running this workflow against PR's from forks requires manually triggering it via `workflow_dispatch`.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     outputs:
       decision: ${{ steps.decision.outputs.decision }}
@@ -32,7 +36,7 @@ jobs:
         run: echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
         if: github.event_name != 'workflow_dispatch'
 
-      - name: Set PR (forks)
+      - name: Set PR when manually triggered (intended for forks)
         run: echo "PR=${{ inputs.pr }}" >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch'
 
@@ -46,7 +50,7 @@ jobs:
   push-updater-images:
     runs-on: ubuntu-latest
     needs: approval
-    if: needs.approval.outputs.decision == 'APPROVED:OPEN' && !github.event.pull_request.head.repo.fork
+    if: needs.approval.outputs.decision == 'APPROVED:OPEN'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What are you trying to accomplish?

I found the original code confusing because it _always_ checks if the PR is approved, even when run on forks. Yet the job still bails if run on a fork, _even if the PR is approved_.

So I pulled the `if` conditional that bypasses forks up into the first job. This works because if the `approval` job gets skipped, then the subsequent job will also be skipped since it `needs: approval` ([docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds)).

So this should hopefully be both more readable within the code, more readable in CI output on PR's, and also more performant. 🥂 

### Anything you want to highlight for special attention from reviewers?

Originally, I wasn't 100% sure this works... perhaps there was a reason why the fork-check conditional needed to be attached to the second job.

However, when I checked `git blame` I see that originally this was a single job, and then split in two:
* https://github.com/dependabot/dependabot-core/pull/8651

And looking at the commit history on that PR, I think these two commits indicate the author was focused on simplifying two steps into one, so didn't consider the possibility of skipping earlier:
* https://github.com/dependabot/dependabot-core/pull/8651/commits/ede644b4af3fb5ba8cd28c3f9f014d89f7b218b3
* https://github.com/dependabot/dependabot-core/pull/8651/commits/c7069e6a9db7914da9a570181eaa2b80b8282941

In order to test this, I've opened this PR from my personal fork, rather than the main Dependabot repo... 