### PR TITLE
Prevent forks from trying (and failing) to push latest images to GHCR

### DIFF
--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -11,6 +11,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   date-version:
     runs-on: ubuntu-latest
+    if: github.repository == 'dependabot/dependabot-core'
     outputs:
       date: ${{ steps.date.outputs.DATE_BASED_VERSION }}
     steps:


### PR DESCRIPTION
I noticed on a recent commit to `main` on my personal fork that it's trying/failing to push images to GHCR due to permissions errors: https://github.com/jeffwidman/dependabot-core/actions/runs/12593801189

There's no point in forks doing that--they will never have the proper permissions to publish images to the real GitHub GHCR Dependabot image.

We already prevent forks from trying to publish the base updater image here: https://github.com/dependabot/dependabot-core/blob/53178c5d340c7fcb171d5aec7e640d350f3f837c/.github/workflows/images-updater-core.yml#L14

We just forgot to also do it in this workflow for the final ecosystem images.

So this rectifies that.
