### PR TITLE
[BUG FIX] Only use the major.patch version to check deprecation status

### DIFF
--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -34,7 +34,7 @@ module Dependabot
       def initialize(raw_version, requirement = nil)
         super(
           name: LANGUAGE,
-          version: Version.new(raw_version),
+          version: major_minor_version(raw_version),
           deprecated_versions: DEPRECATED_VERSIONS,
           supported_versions: SUPPORTED_VERSIONS,
           requirement: requirement,
@@ -54,6 +54,15 @@ module Dependabot
         return false unless Dependabot::Experiments.enabled?(:python_3_8_unsupported_error)
 
         supported_versions.all? { |supported| supported > version }
+      end
+
+      private
+
+      sig { params(version: String).returns(Dependabot::Python::Version) }
+      def major_minor_version(version)
+        major_minor = T.let(T.must(Version.new(version).segments[0..1]&.join(".")), String)
+
+        Version.new(major_minor)
       end
     end
   end

--- a/python/spec/dependabot/python/language_spec.rb
+++ b/python/spec/dependabot/python/language_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dependabot::Python::Language do
   subject(:language) { described_class.new(version) }
 
   describe "#deprecated?" do
-    let(:version) { "3.8" }
+    let(:version) { "3.8.20" }
 
     before do
       allow(::Dependabot::Experiments).to receive(:enabled?)


### PR DESCRIPTION
### What are you trying to accomplish?
Fix a bug where we compare a python version in major.minor.patch format against a list of python versions in major.minor format to check whether the version is deprecated. For example, 3.8.20 was coming up as not deprecated because we were comparing it against `[3.8]`. My solution is to only use the major.minor version to check deprecation status.

### How will you know you've accomplished your goal?
I'll see a language deprecation warning, in the logs, for a repo with a python version greater than 3.8 but less than 3.9

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
