### PR TITLE
Ensure additional commits after approval are rejected

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -44,13 +44,15 @@ jobs:
       - name: Check if pull request is approved
         id: decision
         run: |
-          DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state -t '{{.reviewDecision}}:{{.state}}')
+          # For security, the `gh` call that retrieves the PR approval status *must* also retrieve the commit at the
+          # tip of the PR to ensure that any subsequent unreviewed commits are not pulled into this action workflow.
+          DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state,commits --jq '"\(.reviewDecision):\(.state):\(.commits | last .oid)"')
           echo "decision=$DECISION" >> $GITHUB_OUTPUT
 
   push-updater-images:
     runs-on: ubuntu-latest
     needs: approval
-    if: needs.approval.outputs.decision == 'APPROVED:OPEN'
+    if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +97,12 @@ jobs:
       - name: Prepare tag (forks)
         run: |
           gh pr checkout ${{ inputs.pr }}
+
+          # Ensure the commit we've checked out matches our expected SHA from when we checked the PR's approval status above.
+          # This is a security measure to prevent any unreviewed commits from getting pulled into this action workflow.
+          # The format is "APPROVED:OPEN:<PR_COMMIT_SHA>", so compare the end of the string to the current commit.
+          [[ ${{needs.approval.outputs.decision}} =~ $(git rev-parse HEAD)$ ]]
+
           git fetch origin main
           git merge origin/main --ff-only || exit 1
           git submodule update --init --recursive


### PR DESCRIPTION
When running this workflow manually (signalled via the `workflow_dispatch` event), we need to ensure that we are operating on commits that have been reviewed/approved. This is a safety measure to prevent:

1. Accidental pushes that might cause bugs.
2. Malicious pushes that might do nefarious things.

I considered implementing this by re-checking for approval at the time we checkout the code, but because the `gh` call to check for approval is a separate call from the checkout, we will always need to do this SHA comparison to avoid a race. So the simplest thing was to memoize the SHA as part of the output from the first job and avoid another `gh` call.

Lastly, this validation relies on `Dismiss stale pull request approvals when new commits are pushed` being set in the repo settings. It's already configured that way here in `dependabot-core`.