### PR TITLE
Drop warnings from output of `git rev-parse HEAD`

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -311,7 +311,7 @@ module Dependabot
 
         SharedHelpers.with_git_configured(credentials: credentials) do
           Dir.chdir(T.must(repo_contents_path)) do
-            return SharedHelpers.run_shell_command("git rev-parse HEAD").strip
+            return SharedHelpers.run_shell_command("git rev-parse HEAD", stderr_to_stdout: false).strip
           end
         end
       end

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -87,7 +87,7 @@ module Dependabot
 
       sig { returns(String) }
       def head_sha
-        run_shell_command("git rev-parse HEAD").strip
+        run_shell_command("git rev-parse HEAD", stderr_to_stdout: false).strip
       end
 
       sig { returns(String) }

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -297,18 +297,11 @@ RSpec.describe Dependabot::FileFetchers::Base do
     end
 
     context "with a git repo" do
-      let(:repo_contents_path) { Dir.mktmpdir }
+      let(:repo_contents_path) { build_tmp_repo("simple", tmp_dir_path: Dir.tmpdir) }
       let(:head_sha) { File.read(File.join(repo_contents_path, ".git", "refs", "heads", "master")).strip }
 
-      before do
-        FileUtils.mkdir_p(repo_contents_path)
-        Dir.chdir(repo_contents_path) do
-          Dependabot::SharedHelpers.run_shell_command("git init")
-          Dependabot::SharedHelpers.run_shell_command("git commit --allow-empty -m first")
-        end
-      end
-
-      after do
+      around do |example|
+        Dir.chdir(repo_contents_path) { example.run }
         FileUtils.rm_rf(repo_contents_path)
       end
 

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -295,6 +295,39 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
       it { is_expected.to eq("0e8b8c801024c811d434660f8cf09809f9eb9540") }
     end
+
+    context "with a git repo" do
+      let(:repo_contents_path) { Dir.mktmpdir }
+      let(:head_sha) { File.read(File.join(repo_contents_path, ".git", "refs", "heads", "master")).strip }
+
+      before do
+        FileUtils.mkdir_p(repo_contents_path)
+        Dir.chdir(repo_contents_path) do
+          Dependabot::SharedHelpers.run_shell_command("git init")
+          Dependabot::SharedHelpers.run_shell_command("git commit --allow-empty -m first")
+        end
+      end
+
+      after do
+        FileUtils.rm_rf(repo_contents_path)
+      end
+
+      it { is_expected.to eq(head_sha) }
+
+      context "with warnings from git rev-parse" do
+        before do
+          # Git no longer allows you to create a branch or symbolic ref named HEAD
+          # so we need to manually hack a HEAD ref file to ensure that no warnings
+          # are included in the output of git rev-parse
+          FileUtils.cp(
+            File.join(repo_contents_path, ".git", "refs", "heads", "master"),
+            File.join(repo_contents_path, ".git", "refs", "heads", "HEAD")
+          )
+        end
+
+        it { is_expected.to eq(head_sha) }
+      end
+    end
   end
 
   describe "#files" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

The output from this command is used to set the base commit SHA in some scenarios.  For repos like https://github.com/GoogleCloudPlatform/agent-assist-integrations where the default/base branch is named `HEAD`, the output includes a warning.  This ends up causing issues downstream where Dependabot assumes the string `warning: refname 'HEAD' is ambiguous.\n<sha>` only contains a commit SHA.

```
➜  agent-assist-integrations git:(heads/HEAD) cd .git
➜  .git git:(heads/HEAD) git rev-parse HEAD
warning: refname 'HEAD' is ambiguous.
5abcecddb18427d227ee56c9c1a06cbe5f63e70f
```

The warning is output to stderr while the SHA is output to stdout, so a quick fix to bypass this error case is to not capture stderr in the returned command output.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I don't think there's any case for running this command where we'd want to capture any non-error, non-SHA output.  The shared helpers will raise an error for a non-zero exit status, so we can still rely on that to catch any real issues.

This could also be solved by checking splitting the string to individual lines and choosing the last one or matching the SHA against a regex like `/\w{40}/`.  Those involve custom parsing logic at the app level though, where it feels "more correct" ™️  to rely on existing mechanisms like ignoring stderr.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
