### PR TITLE
Update Composer deprecation unsupported check to use detected version

### DIFF
--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -59,11 +59,12 @@ module Dependabot
       def package_manager
         if composer_version == Helpers::V1
           return PackageManager.new(
-            composer_version
+            detected_version: composer_version
           )
         end
         PackageManager.new(
-          env_versions[:composer] || composer_version
+          detected_version: composer_version,
+          raw_version: env_versions[:composer]
         )
       end
 

--- a/composer/lib/dependabot/composer/package_manager.rb
+++ b/composer/lib/dependabot/composer/package_manager.rb
@@ -33,13 +33,21 @@ module Dependabot
       # DEPRECATED_COMPOSER_VERSIONS = T.let([Version.new("1")].freeze, T::Array[Dependabot::Version])
       DEPRECATED_COMPOSER_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
 
-      sig { params(raw_version: String).void }
-      def initialize(raw_version)
+      sig do
+        params(
+          detected_version: String,
+          raw_version: T.nilable(String),
+          requirement: T.nilable(Requirement)
+        ).void
+      end
+      def initialize(detected_version:, raw_version: nil, requirement: nil)
         super(
           name: NAME,
-          version: Version.new(raw_version),
+          detected_version: Version.new(detected_version),
+          version: raw_version ? Version.new(raw_version) : nil,
           deprecated_versions: DEPRECATED_COMPOSER_VERSIONS,
           supported_versions: SUPPORTED_COMPOSER_VERSIONS,
+          requirement: requirement,
        )
       end
     end

--- a/composer/spec/dependabot/composer/package_manager_spec.rb
+++ b/composer/spec/dependabot/composer/package_manager_spec.rb
@@ -8,46 +8,39 @@ require "spec_helper"
 ComposerPackageManager = Dependabot::Composer::PackageManager
 
 RSpec.describe Dependabot::Composer::PackageManager do
-  let(:package_manager) { described_class.new(version) }
+  let(:package_manager) do
+    described_class.new(
+      detected_version: detected_version,
+      raw_version: raw_version,
+      requirement: requirement
+    )
+  end
+  let(:requirement) { nil }
 
   describe "#initialize" do
-    context "when version is a String" do
-      let(:version) { "2" }
+    context "when versions are set" do
+      let(:detected_version) { "2" }
+      let(:raw_version) { "2.0.1" }
 
-      it "sets the version correctly" do
-        expect(package_manager.version).to eq(Dependabot::Version.new(version))
+      it "sets detected and raw versions correctly" do
+        expect(package_manager.detected_version).to eq(Dependabot::Composer::Version.new(detected_version))
+        expect(package_manager.version).to eq(Dependabot::Composer::Version.new(raw_version))
       end
 
       it "sets the name correctly" do
         expect(package_manager.name).to eq(ComposerPackageManager::NAME)
       end
 
-      it "sets the deprecated_versions correctly" do
-        expect(package_manager.deprecated_versions).to eq(ComposerPackageManager::DEPRECATED_COMPOSER_VERSIONS)
+      it "sets deprecated_versions correctly" do
+        expect(package_manager.deprecated_versions).to eq(
+          ComposerPackageManager::DEPRECATED_COMPOSER_VERSIONS
+        )
       end
 
-      it "sets the supported_versions correctly" do
-        expect(package_manager.supported_versions).to eq(ComposerPackageManager::SUPPORTED_COMPOSER_VERSIONS)
-      end
-    end
-
-    context "when version is a Dependabot::Version" do
-      let(:version) { "2" }
-
-      it "sets the version correctly" do
-        expect(package_manager.version).to eq(version)
-      end
-
-      it "sets the name correctly" do
-        expect(package_manager.name).to eq(ComposerPackageManager::NAME)
-      end
-
-      it "sets the deprecated_versions correctly" do
-        expect(package_manager.deprecated_versions).to eq(ComposerPackageManager::DEPRECATED_COMPOSER_VERSIONS)
-      end
-
-      it "sets the supported_versions correctly" do
-        expect(package_manager.supported_versions).to eq(ComposerPackageManager::SUPPORTED_COMPOSER_VERSIONS)
+      it "sets supported_versions correctly" do
+        expect(package_manager.supported_versions).to eq(
+          ComposerPackageManager::SUPPORTED_COMPOSER_VERSIONS
+        )
       end
     end
   end
@@ -60,52 +53,97 @@ RSpec.describe Dependabot::Composer::PackageManager do
   end
 
   describe "#deprecated?" do
-    context "when there is no deprecated version defined" do
-      let(:version) { "1" }
+    context "when detected_version is deprecated but raw_version is not" do
+      let(:detected_version) { "1" }
+      let(:raw_version) { "2.0.1" }
 
-      it "returns false" do
+      it "returns false because no deprecated versions exist" do
+        allow(package_manager).to receive(:unsupported?).and_return(false)
         expect(package_manager.deprecated?).to be false
       end
     end
 
-    context "when version is not deprecated" do
-      let(:version) { "2" }
+    context "when detected_version and raw_version are both deprecated" do
+      let(:detected_version) { "1" }
+      let(:raw_version) { "1.0.3" }
 
-      it "returns false" do
+      it "returns false because no deprecated versions exist" do
+        allow(package_manager).to receive(:unsupported?).and_return(false)
         expect(package_manager.deprecated?).to be false
       end
     end
 
-    context "when version is unsupported and takes precedence" do
-      let(:version) { "0.9" }
+    context "when detected_version is unsupported" do
+      let(:detected_version) { "0.9" }
+      let(:raw_version) { "1.0.4" }
 
       it "returns false, as unsupported takes precedence" do
+        expect(package_manager.deprecated?).to be false
+      end
+    end
+
+    context "when raw_version is nil" do
+      let(:detected_version) { "1" }
+      let(:raw_version) { nil }
+
+      it "returns false because no deprecated versions exist" do
+        allow(package_manager).to receive(:unsupported?).and_return(false)
         expect(package_manager.deprecated?).to be false
       end
     end
   end
 
   describe "#unsupported?" do
-    context "when is unsupported" do
-      let(:version) { "0.9" }
+    context "when detected_version is supported" do
+      let(:detected_version) { "2" }
+      let(:raw_version) { "2.1.3" }
+
+      it "returns false" do
+        expect(package_manager.unsupported?).to be false
+      end
+    end
+
+    context "when detected_version is unsupported" do
+      let(:detected_version) { "0.9" }
+      let(:raw_version) { "0.9.2" }
 
       it "returns true" do
         expect(package_manager.unsupported?).to be true
       end
     end
 
-    context "when version is supported" do
-      let(:version) { "2" }
+    context "when raw_version is nil" do
+      let(:detected_version) { "0.9" }
+      let(:raw_version) { nil }
 
-      it "returns false" do
-        expect(package_manager.unsupported?).to be false
+      it "returns true based on detected_version" do
+        expect(package_manager.unsupported?).to be true
       end
     end
   end
 
   describe "#raise_if_unsupported!" do
-    context "when feature flag is enabled and version is unsupported" do
-      let(:version) { "0.9" }
+    context "when detected_version is unsupported" do
+      let(:detected_version) { "0.9" }
+      let(:raw_version) { "0.9.2" }
+
+      it "raises a ToolVersionNotSupported error" do
+        expect { package_manager.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)
+      end
+    end
+
+    context "when detected_version is supported" do
+      let(:detected_version) { "2.1" }
+      let(:raw_version) { "2.1.4" }
+
+      it "does not raise an error" do
+        expect { package_manager.raise_if_unsupported! }.not_to raise_error
+      end
+    end
+
+    context "when raw_version is nil but detected_version is unsupported" do
+      let(:detected_version) { "0.9" }
+      let(:raw_version) { nil }
 
       it "raises a ToolVersionNotSupported error" do
         expect { package_manager.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)


### PR DESCRIPTION
### **What are you trying to accomplish?**

This PR updates the handling of deprecation and unsupported checks for Composer by ensuring that `detected_version` is consistently used instead of `raw_version`. 

This change improves the accuracy of deprecation notices and resolves edge cases where `raw_version` is either `nil` or different from `detected_version`.

**Why?**
- To ensure consistency and correctness of version checks for Composer in Dependabot's ecosystem.
- To address potential issues with mismatched version usage in deprecation and unsupported logic.
- To enhance the reliability and clarity of notices for deprecated and unsupported Composer versions.

---

### **Anything you want to highlight for special attention from reviewers?**

- The logic in `unsupported?` and related methods was updated to prioritize `detected_version` over `raw_version` and handle cases where `raw_version` is `nil`.
- Comprehensive test cases have been added to cover scenarios where:
  - `detected_version` is deprecated or unsupported.
  - `raw_version` is `nil`, deprecated, or different from `detected_version`.

---

### **How will you know you've accomplished your goal?**

- All tests, including the complete test suite for Composer deprecation logic, pass successfully.
- Deprecation and unsupported checks now consistently use `detected_version`, addressing any discrepancies.
- Edge cases for Composer versions are handled correctly in all scenarios.

---

### **Checklist**

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.