### PR TITLE
expand pattern to filter out `Microsoft.WebApplication.targets`

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -159,6 +159,10 @@ public abstract class UpdateWorkerTestBase : TestBase
             {
                 ValidateUpdateOperationResult(expectedResult, actualResult!);
             }
+            else if ((actualResult.ErrorType ?? ErrorType.None) != ErrorType.None)
+            {
+                throw new Exception($"Result indicates failure: ErrorType={actualResult.ErrorType}, ErrorDetails={actualResult.ErrorDetails}");
+            }
 
             if (additionalChecks is not null)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.GlobalJson.cs
@@ -69,10 +69,10 @@ public partial class UpdateWorkerTests
                       <PropertyGroup>
                         <TargetFramework>netstandard2.0</TargetFramework>
                       </PropertyGroup>
-                
+
                       <ItemGroup>
                         <PackageReference Include="Some.Package" Version="13.0.3" />
-                      </ItemGroup>>
+                      </ItemGroup>
                     </Project>
                     """,
                 additionalFiles:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -495,7 +495,7 @@ public partial class UpdateWorkerTests
                     MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
                 ],
                 projectContents: $"""
-                    <Project Sdk="Microsoft.NET.Sdk">">
+                    <Project Sdk="Microsoft.NET.Sdk">
                       <PropertyGroup>
                         <TargetFramework>net8.0</TargetFramework>
                         <SomePackageVersion>9.0.1</SomePackageVersion>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1969,7 +1969,7 @@ public partial class UpdateWorkerTests
                         <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
                       </PropertyGroup>
                       <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <Import Project="$(VSToolsPath)\SomeSubPath\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
                       <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
                             Other similar extension points exist, see Microsoft.Common.targets.
                       <Target Name="BeforeBuild">
@@ -2050,7 +2050,7 @@ public partial class UpdateWorkerTests
                         <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
                       </PropertyGroup>
                       <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-                      <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+                      <Import Project="$(VSToolsPath)\SomeSubPath\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
                       <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
                             Other similar extension points exist, see Microsoft.Common.targets.
                       <Target Name="BeforeBuild">

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/WebApplicationTargetsConditionPatcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/WebApplicationTargetsConditionPatcher.cs
@@ -13,7 +13,18 @@ namespace NuGetUpdater.Core.Updater
                 getContent: () => File.ReadAllText(projectFilePath),
                 setContent: s => File.WriteAllText(projectFilePath, s),
                 nodeFinder: doc => doc.Descendants()
-                    .FirstOrDefault(e => e.Name == "Import" && e.GetAttributeValue("Project") == @"$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets")
+                    .Where(e => e.Name == "Import")
+                    .FirstOrDefault(e =>
+                    {
+                        var projectPath = e.GetAttributeValue("Project");
+                        if (projectPath is not null)
+                        {
+                            var projectFileName = Path.GetFileName(projectPath.NormalizePathToUnix());
+                            return projectFileName.Equals("Microsoft.WebApplication.targets", StringComparison.OrdinalIgnoreCase);
+                        }
+
+                        return false;
+                    })
                     as XmlNodeSyntax,
                 preProcessor: n =>
                 {


### PR DESCRIPTION
Previously we'd only filter out an imported project if its path was _exactly_ `$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets`, however in looking through the logs I've also seen instances of `$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\WebApplications\Microsoft.WebApplication.targets` so I've simply expanded the pattern to match on any import with a file name of `Microsoft.WebApplication.targets`.

While working on this I also found that if a test does fail, it's not reported in the log very well, so I've addressed that.  With this additional fix, I found 2 unit tests that had some merge conflict artifacts.  These tests were expected to fail, just not in the way that they were, so they've now been fixed to fail in the expected way again.