### PR TITLE
expand pattern to report missing files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -895,9 +895,13 @@ internal static partial class MSBuildHelper
 
     internal static string? GetMissingFile(string output)
     {
-        var missingFilePattern = new Regex(@"The imported project \""(?<FilePath>.*)\"" was not found");
-        var match = missingFilePattern.Match(output);
-        if (match.Success)
+        var missingFilePatterns = new[]
+        {
+            new Regex(@"The imported project \""(?<FilePath>.*)\"" was not found"),
+            new Regex(@"The imported file \""(?<FilePath>.*)\"" does not exist"),
+        };
+        var match = missingFilePatterns.Select(p => p.Match(output)).Where(m => m.Success).FirstOrDefault();
+        if (match is not null)
         {
             return match.Groups["FilePath"].Value;
         }


### PR DESCRIPTION
When reporting missing files from MSBuild, we previously only supported one error message pattern:

```
The imported project "<some-path>" was not found
```

but I've discovered that another pattern can occur:

```
The imported file "<some-path>" does not exist
```

This PR expands that pattern to report a missing file instead of getting classified as `unknown_error`.