### PR TITLE
Type the workflow input as a number, not a string

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -14,7 +14,7 @@ on: # yamllint disable-line rule:truthy
     inputs:
       pr:
         required: true
-        type: string
+        type: number
         description: PR number
 
 jobs:


### PR DESCRIPTION
This input is a number, so although it's functioning fine currently as a string, by typing it properly as a number it removes a vector for string injection attacks if an attacker were to get escalated privileges on the repo.

To be clear: this doesn't close an active vulnerability, but is just wise defense-in-depth.

🎩 💁‍♂️ to the person who pointed this out, you know who you are. 😁
