### PR TITLE
Update `npm_and_yarn` deprecation and unsupported checks for `npm`, `pnpm`, and `yarn` package managers

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -41,9 +41,7 @@ module Dependabot
       # Otherwise, we are going to use old versionining npm 6
       sig { params(lockfile: T.nilable(DependencyFile)).returns(Integer) }
       def self.npm_version_numeric(lockfile)
-        if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
-          return npm_version_numeric_latest(lockfile)
-        end
+        return npm_version_numeric_latest(lockfile) if Dependabot::Experiments.enabled?(:npm_v6_deprecation_warning)
 
         fallback_version_npm8 = Dependabot::Experiments.enabled?(:npm_fallback_version_above_v6)
 
@@ -174,7 +172,7 @@ module Dependabot
       def self.npm8?(package_lock)
         return true unless package_lock&.content
 
-        if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
+        if Dependabot::Experiments.enabled?(:npm_v6_deprecation_warning)
           return npm_version_numeric_latest(package_lock) >= NPM_V8
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -92,29 +92,29 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       )
     end
 
-    it "returns flattened list of dependencies populated with :all_versions metadata" do
-      dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
-      dependency_set << foo_a << bar_a << foo_c << bar_c << foo_b << bar_b
-
-      expect(described_class.dependencies_with_all_versions_metadata(dependency_set)).to eq([
-        Dependabot::Dependency.new(
-          name: "foo",
-          version: "0.0.1",
-          requirements: (foo_a.requirements + foo_c.requirements + foo_b.requirements).uniq,
-          package_manager: "npm_and_yarn",
-          metadata: { all_versions: [foo_a, foo_c, foo_b] }
-        ),
-        Dependabot::Dependency.new(
-          name: "bar",
-          version: "0.2.1",
-          requirements: (bar_a.requirements + bar_c.requirements + bar_b.requirements).uniq,
-          package_manager: "npm_and_yarn",
-          metadata: { all_versions: [bar_a, bar_c, bar_b] }
-        )
-      ])
-    end
-
     context "when dependencies in set already have :all_versions metadata" do
+      it "returns flattened list of dependencies populated with :all_versions metadata" do
+        dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
+        dependency_set << foo_a << bar_a << foo_c << bar_c << foo_b << bar_b
+
+        expect(described_class.dependencies_with_all_versions_metadata(dependency_set)).to eq([
+          Dependabot::Dependency.new(
+            name: "foo",
+            version: "0.0.1",
+            requirements: (foo_a.requirements + foo_c.requirements + foo_b.requirements).uniq,
+            package_manager: "npm_and_yarn",
+            metadata: { all_versions: [foo_a, foo_c, foo_b] }
+          ),
+          Dependabot::Dependency.new(
+            name: "bar",
+            version: "0.2.1",
+            requirements: (bar_a.requirements + bar_c.requirements + bar_b.requirements).uniq,
+            package_manager: "npm_and_yarn",
+            metadata: { all_versions: [bar_a, bar_c, bar_b] }
+          )
+        ])
+      end
+
       it "correctly merges existing metadata into new metadata" do
         dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
         dependency_set << foo_a
@@ -338,6 +338,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
     context "when the feature flag :enable_corepack_for_npm_and_yarn is enabled" do
       before do
         allow(Dependabot::Experiments).to receive(:enabled?).with(:enable_corepack_for_npm_and_yarn).and_return(true)
+        allow(Dependabot::Experiments).to receive(:enabled?).with(:npm_v6_deprecation_warning).and_return(true)
       end
 
       it "returns true if lockfileVersion is 3 or higher" do
@@ -360,11 +361,17 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
     context "when the feature flag :enable_corepack_for_npm_and_yarn is disabled" do
       before do
         allow(Dependabot::Experiments).to receive(:enabled?).with(:enable_corepack_for_npm_and_yarn).and_return(false)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:npm_v6_deprecation_warning)
+          .and_return(true)
       end
 
       context "when :npm_fallback_version_above_v6 is enabled" do
         before do
           allow(Dependabot::Experiments).to receive(:enabled?).with(:npm_fallback_version_above_v6).and_return(true)
+          allow(Dependabot::Experiments).to receive(:enabled?)
+            .with(:npm_v6_deprecation_warning)
+            .and_return(true)
         end
 
         it "returns true if lockfileVersion is 2 or higher" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/language_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/language_spec.rb
@@ -1,12 +1,17 @@
 # typed: false
 # frozen_string_literal: true
 
-require "dependabot/ecosystem"
 require "dependabot/npm_and_yarn/package_manager"
+require "dependabot/ecosystem"
 require "spec_helper"
 
 RSpec.describe Dependabot::NpmAndYarn::Language do
-  let(:language) { described_class.new(raw_version, requirement: requirement) }
+  let(:language) do
+    described_class.new(
+      raw_version: raw_version,
+      requirement: requirement
+    )
+  end
   let(:raw_version) { "16.13.1" }
   let(:requirement) { nil }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/npm_package_manager_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/npm_package_manager_spec.rb
@@ -6,14 +6,24 @@ require "dependabot/ecosystem"
 require "spec_helper"
 
 RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
-  let(:package_manager) { described_class.new(version) }
+  let(:package_manager) do
+    described_class.new(
+      detected_version: detected_version,
+      raw_version: raw_version
+    )
+  end
+
+  let(:detected_version) { "8" }
+  let(:raw_version) { "9.5.1" }
 
   describe "#initialize" do
     context "when version is a String" do
-      let(:version) { "8" }
+      let(:detected_version) { "8" }
+      let(:raw_version) {  "9.5.1" }
 
       it "sets the version correctly" do
-        expect(package_manager.version).to eq(Dependabot::Version.new(version))
+        expect(package_manager.detected_version).to eq(Dependabot::Version.new(detected_version))
+        expect(package_manager.version).to eq(Dependabot::Version.new(raw_version))
       end
 
       it "sets the name correctly" do
@@ -33,7 +43,8 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
   end
 
   describe "#deprecated?" do
-    let(:version) { "6" }
+    let(:detected_version) { "6" }
+    let(:raw_version) { "8.0.1" }
 
     it "returns false" do
       expect(package_manager.deprecated?).to be false
@@ -59,7 +70,7 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
       end
 
       context "when npm_v6_deprecation_warning is enabled but version is not deprecated" do
-        let(:version) { "9" }
+        let(:detected_version) { "9" }
         let(:deprecation_enabled) { true }
         let(:unsupported_enabled) { false }
 
@@ -89,7 +100,8 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
   end
 
   describe "#unsupported?" do
-    let(:version) { "5" }
+    let(:detected_version) { "5" }
+    let(:raw_version) { "8.0.1" }
 
     it "returns false for supported versions" do
       expect(package_manager.unsupported?).to be false
@@ -103,7 +115,9 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
       end
 
       context "when npm_v6_unsupported_error is enabled and version is unsupported" do
-        let(:version) { "6" }
+        let(:detected_version) { "6" }
+        let(:raw_version) { "8.0.1" }
+
         let(:unsupported_enabled) { true }
 
         it "returns true" do
@@ -112,7 +126,9 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
       end
 
       context "when npm_v6_unsupported_error is enabled but version is supported" do
-        let(:version) { "7" }
+        let(:detected_version) { "7" }
+        let(:raw_version) { "8.0.1" }
+
         let(:unsupported_enabled) { true }
 
         it "returns false" do
@@ -138,7 +154,7 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
     end
 
     context "when npm_v6_unsupported_error is enabled and version is unsupported" do
-      let(:version) { "6" }
+      let(:detected_version) { "6" }
       let(:unsupported_enabled) { true }
 
       it "raises a ToolVersionNotSupported error" do
@@ -147,7 +163,7 @@ RSpec.describe Dependabot::NpmAndYarn::NpmPackageManager do
     end
 
     context "when npm_v6_unsupported_error is disabled" do
-      let(:version) { "6" }
+      let(:detected_version) { "6" }
       let(:unsupported_enabled) { false }
 
       it "does not raise an error" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/pnpm_package_manager_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/pnpm_package_manager_spec.rb
@@ -6,14 +6,24 @@ require "dependabot/ecosystem"
 require "spec_helper"
 
 RSpec.describe Dependabot::NpmAndYarn::PNPMPackageManager do
-  let(:package_manager) { described_class.new(version) }
+  let(:package_manager) do
+    described_class.new(
+      detected_version: detected_version,
+      raw_version: raw_version
+    )
+  end
+
+  let(:detected_version) { "8" }
+  let(:raw_version) { "9.0.0" }
 
   describe "#initialize" do
     context "when version is a String" do
-      let(:version) { "9" }
+      let(:detected_version) { "9" }
+      let(:raw_version) { "9.0.0" }
 
       it "sets the version correctly" do
-        expect(package_manager.version).to eq(Dependabot::Version.new(version))
+        expect(package_manager.detected_version).to eq(Dependabot::Version.new(detected_version))
+        expect(package_manager.version).to eq(Dependabot::Version.new(raw_version))
       end
 
       it "sets the name correctly" do
@@ -33,18 +43,36 @@ RSpec.describe Dependabot::NpmAndYarn::PNPMPackageManager do
   end
 
   describe "#deprecated?" do
-    let(:version) { "7" }
+    let(:detected_version) { "7" }
+    let(:raw_version) { "8.0.0" }
 
-    it "returns false" do
+    it "always returns false" do
       expect(package_manager.deprecated?).to be false
     end
   end
 
   describe "#unsupported?" do
-    let(:version) { "6" }
+    let(:detected_version) { "6" }
+    let(:raw_version) { "7.0.0" }
 
-    it "returns true for unsupported versions" do
+    it "always returns false" do
       expect(package_manager.unsupported?).to be false
+    end
+
+    context "with supported versions" do
+      let(:detected_version) { "8" }
+
+      it "still returns false" do
+        expect(package_manager.unsupported?).to be false
+      end
+    end
+  end
+
+  describe "#raise_if_unsupported!" do
+    let(:detected_version) { "6" }
+
+    it "does not raise an error" do
+      expect { package_manager.raise_if_unsupported! }.not_to raise_error
     end
   end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .with(:npm_fallback_version_above_v6).and_return(npm_fallback_version_above_v6_enabled)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:npm_v6_deprecation_warning).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_package_manager_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/yarn_package_manager_spec.rb
@@ -6,14 +6,24 @@ require "dependabot/ecosystem"
 require "spec_helper"
 
 RSpec.describe Dependabot::NpmAndYarn::YarnPackageManager do
-  let(:package_manager) { described_class.new(version) }
+  let(:package_manager) do
+    described_class.new(
+      detected_version: detected_version,
+      raw_version: raw_version
+    )
+  end
+
+  let(:detected_version) { "3" }
+  let(:raw_version) { "3.5.0" }
 
   describe "#initialize" do
     context "when version is a String" do
-      let(:version) { "2" }
+      let(:detected_version) { "2" }
+      let(:raw_version) { "2.8.0" }
 
       it "sets the version correctly" do
-        expect(package_manager.version).to eq(Dependabot::Version.new(version))
+        expect(package_manager.detected_version).to eq(Dependabot::Version.new(detected_version))
+        expect(package_manager.version).to eq(Dependabot::Version.new(raw_version))
       end
 
       it "sets the name correctly" do
@@ -33,18 +43,37 @@ RSpec.describe Dependabot::NpmAndYarn::YarnPackageManager do
   end
 
   describe "#deprecated?" do
-    let(:version) { "1" }
+    let(:detected_version) { "1" }
+    let(:raw_version) { "1.22.10" }
 
-    it "returns false" do
+    it "always returns false" do
       expect(package_manager.deprecated?).to be false
     end
   end
 
   describe "#unsupported?" do
-    let(:version) { "4" }
+    let(:detected_version) { "4" }
+    let(:raw_version) { "4.0.0" }
 
-    it "returns false for supported versions" do
+    it "always returns false" do
       expect(package_manager.unsupported?).to be false
+    end
+
+    context "with supported versions" do
+      let(:detected_version) { "2" }
+      let(:raw_version) { "2.8.0" }
+
+      it "still returns false" do
+        expect(package_manager.unsupported?).to be false
+      end
+    end
+  end
+
+  describe "#raise_if_unsupported!" do
+    let(:detected_version) { "1" }
+
+    it "does not raise an error" do
+      expect { package_manager.raise_if_unsupported! }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### **What are you trying to accomplish?**

This PR updates the handling of deprecation and unsupported checks for the `npm_and_yarn` ecosystem's package managers: `npm`, `pnpm`, and `yarn`.

The changes include:
- Implementing a unified and comprehensive version detection mechanism for `npm` that prioritizes checking the `packageManager` field, `engines`, and lockfiles in that order to determine the version.
- Refining deprecation and unsupported logic for `npm` to ensure alignment with the ecosystem's requirements.
- Ensuring `pnpm` and `yarn` consistently return `false` for deprecation and unsupported checks, as no such logic applies to them.

**Why?**
- To improve consistency and accuracy in how version detection and deprecation/unsupported checks are performed across package managers.
- To address gaps in version detection by incorporating `packageManager` and `engines` fields along with lockfiles for `npm`.
- To enhance clarity and reliability for all `npm_and_yarn` ecosystem package managers in Dependabot.

---

### **Anything you want to highlight for special attention from reviewers?**

- **Version Detection for `npm`**:
  - A new mechanism detects the version by evaluating the `packageManager` field, `engines` field, and lockfiles in sequence.
  - Ensures accurate detection even in cases where lockfiles alone are insufficient.

- **Deprecation and Unsupported Logic**:
  - `npm`: Adjusted logic to use the detected version for determining deprecation and unsupported status.
  - `pnpm` and `yarn`: Explicitly set deprecation and unsupported checks to always return `false`.

- **Test Updates**:
  - For `npm`, tests now cover cases where versions are determined using `packageManager`, `engines`, or lockfiles.
  - Comprehensive tests for `pnpm` and `yarn` validate consistent return values (`false`) for deprecation and unsupported checks.

---

### **How will you know you've accomplished your goal?**

- All tests for `npm_and_yarn` ecosystem package managers pass successfully.
- Deprecation and unsupported checks align with the requirements for each package manager:
  - Correct and reliable detection of supported, deprecated, and unsupported versions for `npm`.
  - Fixed, consistent behavior (`false`) for `pnpm` and `yarn`.

---

### **Checklist**

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.