### PR TITLE
Ignore terraform GCS source

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -235,7 +235,8 @@ module Dependabot
             git_source_details_from(bare_source)
           when :registry
             registry_source_details_from(bare_source)
-          when :interpolation
+          # Interpolation and GCS sources are not supported
+          when :interpolation, :gcs
             return nil
           end
 
@@ -339,6 +340,7 @@ module Dependabot
         return :git if source_string.start_with?("git::", "git@")
         return :mercurial if source_string.start_with?("hg::")
         return :s3 if source_string.start_with?("s3::")
+        return :gcs if source_string.start_with?("gcs::")
 
         raise "Unknown src: #{source_string}" if source_string.split("/").first&.include?("::")
 

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -1227,6 +1227,14 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "when the source type is a GCS bucket" do
+      let(:source_string) { "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip" }
+
+      it "returns the correct source type" do
+        expect(source_type).to eq(:gcs)
+      end
+    end
+
     context "when the source type is unknown" do
       let(:source_string) { "unknown_source" }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Related to https://github.com/dependabot/dependabot-core/issues/5603

Terraform supports GCS bucket as module source https://developer.hashicorp.com/terraform/language/modules/sources#gcs-bucket

But currently dependabot fails with error
```log
Unknown src: gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip
```

This PR fixes the `Unknown src` error but also ignore `GCS` source as it usually requires authentication and can be somewhat complex. Based on https://github.com/dependabot/dependabot-core/issues/5603 S3 doesn't seems to work currently either.

### Anything you want to highlight for special attention from reviewers?
I had a test for `#source_type`. However I couldn't find any tests for `#source_from`

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
