### PR TITLE
change type of property `job.commit-message-options.include-scope` to `bool`

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -498,7 +498,9 @@ public class SerializationTests
                         "repo": "some/repo"
                     },
                     "commit-message-options": {
-                        "prefix": "[SECURITY] "
+                        "prefix": "[SECURITY] ",
+                        "prefix-development": null,
+                        "include-scope": true
                     }
                 }
             }
@@ -506,7 +508,7 @@ public class SerializationTests
         var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
         Assert.Equal("[SECURITY] ", jobWrapper.Job.CommitMessageOptions!.Prefix);
         Assert.Null(jobWrapper.Job.CommitMessageOptions!.PrefixDevelopment);
-        Assert.Null(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
+        Assert.True(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
     }
 
     public static IEnumerable<object?[]> DeserializeErrorTypesData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
@@ -4,5 +4,5 @@ public record CommitOptions
 {
     public string? Prefix { get; init; } = null;
     public string? PrefixDevelopment { get; init; } = null;
-    public string? IncludeScope { get; init; } = null;
+    public bool? IncludeScope { get; init; } = null;
 }


### PR DESCRIPTION
Despite the CLI claiming that the job property [`commit-message-options.include-scope` is a `string` pointer](https://github.com/dependabot/cli/blob/4e7612fe884683ade8c54ad8fd137fc6da92bb84/internal/model/job.go#L133), in reality it's [serialized and used as a `bool`](https://github.com/dependabot/dependabot-core/blob/be5f774e7b9a86976b5d8e88db7aea25641e4bd3/common/lib/dependabot/config/update_config.rb#L105).  This PR just fixes that issue and updates a test to reflect job files seen in the wild.

Issue found by looking through the logs after recent error reporting improvements.