### PR TITLE
expand pattern to report unauthorized feed

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -2347,16 +2347,18 @@ public partial class UpdateWorkerTests
             Assert.Equal("$(MSBuildExtensionsPath32)/Microsoft/VisualStudio/v$(VisualStudioVersion)/Some.Visual.Studio.Component.props", result.ErrorDetails!.ToString().NormalizePathToUnix());
         }
 
-        [Fact]
-        public async Task ReportsPrivateSourceAuthenticationFailure()
+        [Theory]
+        [InlineData(401)]
+        [InlineData(403)]
+        public async Task ReportsPrivateSourceAuthenticationFailure(int httpStatusCode)
         {
-            static (int, string) TestHttpHandler(string uriString)
+            (int, string) TestHttpHandler(string uriString)
             {
                 var uri = new Uri(uriString, UriKind.Absolute);
                 var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
                 return uri.PathAndQuery switch
                 {
-                    _ => (401, "{}"), // everything is unauthorized
+                    _ => (httpStatusCode, "{}"), // everything is unauthorized
                 };
             }
             using var http = TestHttpServer.CreateTestStringServer(TestHttpHandler);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -886,6 +886,7 @@ internal static partial class MSBuildHelper
             "The plugin credential provider could not acquire credentials",
             "401 (Unauthorized)",
             "error NU1301: Unable to load the service index for source",
+            "Response status code does not indicate success: 403",
         };
         if (unauthorizedMessageSnippets.Any(stdout.Contains))
         {


### PR DESCRIPTION
Looking through the logs I found an instance where we weren't detecting an unauthorized package feed.