### PR TITLE
don't continue checking a non-existant feed for a package

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -62,23 +62,24 @@ internal static class VersionFinder
 
         foreach (var source in sources)
         {
-            var sourceRepository = Repository.Factory.GetCoreV3(source);
-            var feed = await sourceRepository.GetResourceAsync<MetadataResource>();
-            if (feed is null)
-            {
-                logger.Warn($"Failed to get {nameof(MetadataResource)} for [{source.Source}]");
-                continue;
-            }
-
-            var packageFinder = await sourceRepository.GetResourceAsync<FindPackageByIdResource>();
-            if (packageFinder is null)
-            {
-                logger.Warn($"Failed to get {nameof(FindPackageByIdResource)} for [{source.Source}]");
-                continue;
-            }
-
+            MetadataResource? feed = null;
             try
             {
+                var sourceRepository = Repository.Factory.GetCoreV3(source);
+                feed = await sourceRepository.GetResourceAsync<MetadataResource>();
+                if (feed is null)
+                {
+                    logger.Warn($"Failed to get {nameof(MetadataResource)} for [{source.Source}]");
+                    continue;
+                }
+
+                var packageFinder = await sourceRepository.GetResourceAsync<FindPackageByIdResource>();
+                if (packageFinder is null)
+                {
+                    logger.Warn($"Failed to get {nameof(FindPackageByIdResource)} for [{source.Source}]");
+                    continue;
+                }
+
                 // a non-compliant v2 API returning 404 can cause this to throw
                 var existsInFeed = await feed.Exists(
                     packageId,


### PR DESCRIPTION
Issue found when scanning internal logs.

If a feed is specified with an internal-only URL, checking that feed for possible updates will obviously fail.  We don't want to fail the entire update process, though, because it's entirely possible for a repo to list both public and internal feeds and to only want dependabot to run for public packages.

The fix is to broaden the scope of the `try` block so that if fetching the service index fails, we simply continue onto the next source.