### PR TITLE
run full updater on all dependencies, including transitives

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1711,6 +1711,335 @@ public class RunWorkerTests
         );
     }
 
+    [Fact]
+    public async Task UpdatePackageWithDifferentVersionsInDifferentDirectories()
+    {
+        // this test passes `null` for discovery, analyze, and update workers to fully test the desired behavior
+
+        // the same dependency Some.Package is reported for 3 cases:
+        //   library1.csproj - top level dependency, already up to date
+        //   library2.csproj - top level dependency, needs direct update
+        //   library3.csproj - transitive dependency, needs pin
+        await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseDirectDiscovery = true },
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.With.Transitive.Dependency", "0.1.0", "net8.0", [(null, [("Some.Package", "1.0.0")])]),
+            ],
+            job: new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                    Directory = "/"
+                }
+            },
+            files: [
+                ("dirs.proj", """
+                    <Project>
+                      <ItemGroup>
+                        <ProjectFile Include="library1\library1.csproj" />
+                        <ProjectFile Include="library2\library2.csproj" />
+                        <ProjectFile Include="library3\library3.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                ("library1/library1.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("library2/library2.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("library3/library3.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.With.Transitive.Dependency" Version="0.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            discoveryWorker: null,
+            analyzeWorker: null,
+            updaterWorker: null,
+            expectedResult: new RunResult()
+            {
+                Base64DependencyFiles =
+                [
+                    new DependencyFile()
+                    {
+                        Directory = "/",
+                        Name = "Directory.Build.props",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("<Project />"))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/",
+                        Name = "Directory.Build.targets",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("<Project />"))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/",
+                        Name = "Directory.Packages.props",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project>
+                              <PropertyGroup>
+                                <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                              </PropertyGroup>
+                            </Project>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/library1",
+                        Name = "library1.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Some.Package" Version="2.0.0" />
+                              </ItemGroup>
+                            </Project>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/library2",
+                        Name = "library2.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Some.Package" Version="1.0.0" />
+                              </ItemGroup>
+                            </Project>
+                            """))
+                    },
+                    new DependencyFile()
+                    {
+                        Directory = "/library3",
+                        Name = "library3.csproj",
+                        Content = Convert.ToBase64String(Encoding.UTF8.GetBytes("""
+                            <Project Sdk="Microsoft.NET.Sdk">
+                              <PropertyGroup>
+                                <TargetFramework>net8.0</TargetFramework>
+                              </PropertyGroup>
+                              <ItemGroup>
+                                <PackageReference Include="Package.With.Transitive.Dependency" Version="0.1.0" />
+                              </ItemGroup>
+                            </Project>
+                            """))
+                    }
+                ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+            },
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/library1/library1.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/library2/library2.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new()
+                        {
+                            Name = "Package.With.Transitive.Dependency",
+                            Version = "0.1.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "0.1.0",
+                                    File = "/library3/library3.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/library3/library3.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                    ],
+                    DependencyFiles = [
+                        "/Directory.Build.props",
+                        "/Directory.Build.targets",
+                        "/Directory.Packages.props",
+                        "/library1/library1.csproj",
+                        "/library2/library2.csproj",
+                        "/library3/library3.csproj",
+                    ],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions"
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/library2/library2.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/library2/library2.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/library3/library3.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/library3/library3.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/library2",
+                            Name = "library2.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net8.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Some.Package" Version="2.0.0" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        },
+                        new()
+                        {
+                            Directory = "/library3",
+                            Name = "library3.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net8.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Package.With.Transitive.Dependency" Version="0.1.0" />
+                                    <PackageReference Include="Some.Package" Version="2.0.0" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = "TODO: message",
+                    PrTitle = "TODO: title",
+                    PrBody = "TODO: body"
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA")
+            ]
+        );
+    }
+
     private static async Task RunAsync(Job job, TestFile[] files, IDiscoveryWorker? discoveryWorker, IAnalyzeWorker? analyzeWorker, IUpdaterWorker? updaterWorker, RunResult expectedResult, object[] expectedApiMessages, MockNuGetPackage[]? packages = null, ExperimentsManager? experimentsManager = null, string? repoContentsPath = null)
     {
         // arrange

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -94,7 +94,15 @@ public class UpdatedDependencyListTests
                 {
                     Name = "System.Text.Json",
                     Version = "6.0.0",
-                    Requirements = [],
+                    Requirements =
+                    [
+                        new ReportedRequirement()
+                        {
+                            Requirement = "6.0.0",
+                            File = "/src/c/project.csproj",
+                            Groups = ["dependencies"],
+                        }
+                    ],
                 },
                 new ReportedDependency()
                 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -262,7 +262,8 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             }
         }
 
-        return expandedProjects.ToImmutableArray();
+        var result = expandedProjects.OrderBy(p => p).ToImmutableArray();
+        return result;
     }
 
     private static IEnumerable<string> ExpandItemGroupFilesFromProject(string projectPath, params string[] itemTypes)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -151,7 +151,7 @@ public class RunWorker
             _logger.Info($"Running update in directory {repoDirectory}");
             foreach (var project in discoveryResult.Projects)
             {
-                foreach (var dependency in project.Dependencies.Where(d => !d.IsTransitive))
+                foreach (var dependency in project.Dependencies)
                 {
                     if (dependency.Name == "Microsoft.NET.Sdk")
                     {
@@ -198,7 +198,7 @@ public class RunWorker
                         };
 
                         var dependencyFilePath = Path.Join(discoveryResult.Path, project.FilePath).FullyNormalizedRootedPath();
-                        var updateResult = await _updaterWorker.RunAsync(repoContentsPath.FullName, dependencyFilePath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, isTransitive: false);
+                        var updateResult = await _updaterWorker.RunAsync(repoContentsPath.FullName, dependencyFilePath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, isTransitive: dependency.IsTransitive);
                         // TODO: need to report if anything was actually updated
                         if (updateResult.Error is null)
                         {
@@ -375,7 +375,7 @@ public class RunWorker
                     new ReportedDependency()
                     {
                         Name = d.Name,
-                        Requirements = d.IsTransitive ? [] : [new ReportedRequirement()
+                        Requirements = [new ReportedRequirement()
                         {
                             File = GetFullRepoPath(p.FilePath),
                             Requirement = d.Version!,


### PR DESCRIPTION
This PR only updates the end-to-end NuGet updater which is not yet used in production.

It allows updates to happen on both top-level _and_ transitive dependencies.  The result is a scenario that the hybrid Ruby/C# updater can't handle, but the end-to-end updater can.

The test has a dependency reported from three locations:
1. As a top-level dependency - up to date.
2. As a top-level dependency - needs update.
3. As a transitive dependency - needs pinning.

The hybrid updater can only update scenario 2 and misses the transitive dependency.