### PR TITLE
Handle calling captures method on nil

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -338,7 +338,7 @@ module Dependabot
       end
 
       def evaluate_condition(condition, python_version)
-        operator, version = condition.match(/([<>=!]=?)\s*"?([\d.]+)"?/).captures
+        operator, version = condition.match(/([<>=!]=?)\s*"?([\d.]+)"?/)&.captures
 
         case operator
         when "<"

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Dependabot::Python::FileParser do
 
         let(:requirements_fixture_name) { "malformed_markers.txt" }
 
-        it "then the dependency version should be 1.0.4" do
+        it "does not return any dependencies" do
           expect(dependencies).to be_empty
         end
       end

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -206,6 +206,18 @@ RSpec.describe Dependabot::Python::FileParser do
           )
         end
       end
+
+      context "when the marker is malformed" do
+        before do
+          allow(parser).to receive(:python_raw_version).and_return("3.13.3")
+        end
+
+        let(:requirements_fixture_name) { "malformed_markers.txt" }
+
+        it "then the dependency version should be 1.0.4" do
+          expect(dependencies).to be_empty
+        end
+      end
     end
 
     context "with extras" do

--- a/python/spec/fixtures/requirements/malformed_markers.txt
+++ b/python/spec/fixtures/requirements/malformed_markers.txt
@@ -1,0 +1,1 @@
+arrow==1.3.0; python_version ~= 'fred'


### PR DESCRIPTION
### What are you trying to accomplish?
Sentry Issue: https://github.sentry.io/issues/6202418024/?project=1451818&referrer=github_integration
Github Issue: https://github.com/github/dependabot-updates/issues/8056

```
NoMethodError: undefined method `captures' for nil
  python/lib/dependabot/python/file_parser.rb:341:in `evaluate_condition'
  python/lib/dependabot/python/file_parser.rb:328:in `marker_satisfied?'
  python/lib/dependabot/python/file_parser.rb:310:in `blocking_marker?'
  python/lib/dependabot/python/file_parser.rb:257:in `block in requirement_dependencies'
  python/lib/dependabot/python/file_parser.rb:254:in `each'
...
(26 additional frame(s) were not displayed)
```
For some python requirements.txt files with markers, the marker condition is malformed, causing the `captures` method to be called on a `nil` object.

### Anything you want to highlight for special attention from reviewers?
There is an additional issue with [the regex that extracts the requirement from the condition](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/file_parser.rb#L341) being incomplete but this will be addressed as a separate issue.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
Occurrences of the issue in sentry should drop to zero.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
