### PR TITLE
Handle DependencyFileNotParseable error on Updater.run

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -166,7 +166,7 @@ module Dependabot
 
   # rubocop:disable Lint/RedundantCopDisableDirective
   # rubocop:disable Metrics/CyclomaticComplexity
-  # # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.updater_error_details(error)
     case error

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -166,6 +166,7 @@ module Dependabot
 
   # rubocop:disable Lint/RedundantCopDisableDirective
   # rubocop:disable Metrics/CyclomaticComplexity
+  # # rubocop:disable Metrics/AbcSize
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.updater_error_details(error)
     case error
@@ -178,6 +179,14 @@ module Dependabot
       {
         "error-type": "dependency_file_not_evaluatable",
         "error-detail": { message: error.message }
+      }
+    when Dependabot::DependencyFileNotParseable
+      {
+        "error-type": "dependency_file_not_parseable",
+        "error-detail": {
+          message: error.message,
+          "file-path": error.file_path
+        }
       }
     when Dependabot::GitDependenciesNotReachable
       {
@@ -294,6 +303,7 @@ module Dependabot
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Lint/RedundantCopDisableDirective
+  # rubocop:enable Metrics/AbcSize
 
   class DependabotError < StandardError
     extend T::Sig

--- a/silent/tests/testdata/vu-group-semver-error.txt
+++ b/silent/tests/testdata/vu-group-semver-error.txt
@@ -2,7 +2,6 @@
 
 ! dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
 # If this appears in the logs twice that means it tried to create a PR again
-stdout -count=1 DependencyFileNotParseable
 stdout -count=2 create_pull_request
 pr-created expected-group.json
 pr-created expected-individual.json

--- a/silent/tests/testdata/vu-group-semver-error.txt
+++ b/silent/tests/testdata/vu-group-semver-error.txt
@@ -2,7 +2,6 @@
 
 ! dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
 # If this appears in the logs twice that means it tried to create a PR again
-stderr -count=1 DependencyFileNotParseable
 stdout -count=2 create_pull_request
 pr-created expected-group.json
 pr-created expected-individual.json

--- a/silent/tests/testdata/vu-group-semver-error.txt
+++ b/silent/tests/testdata/vu-group-semver-error.txt
@@ -2,6 +2,7 @@
 
 ! dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/dependabot-updater-silent
 # If this appears in the logs twice that means it tried to create a PR again
+stdout -count=1 DependencyFileNotParseable
 stdout -count=2 create_pull_request
 pr-created expected-group.json
 pr-created expected-individual.json

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -37,11 +37,16 @@ module Dependabot
         #
         # As above, we can remove the responsibility for handling fatal/job halting
         # errors from Dependabot::Updater entirely.
-        Dependabot::Updater.new(
-          service: service,
-          job: job,
-          dependency_snapshot: dependency_snapshot
-        ).run
+        begin
+          Dependabot::Updater.new(
+            service: service,
+            job: job,
+            dependency_snapshot: dependency_snapshot
+          ).run
+        rescue StandardError => e
+          handle_parser_error(e)
+          return service.mark_job_as_processed(Environment.job_definition["base_commit_sha"])
+        end
 
         # Wait for all PRs to be created
         service.wait_for_calls_to_finish


### PR DESCRIPTION


### What are you trying to accomplish?

Handle a DependencyFileNotParseable error when running the Updater so that this error doesn't get propagated up the chain as an unknown error. It also won't appear in Sentry once it's been handled correctly.

We are already handling the exception on line https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/update_files_command.rb#L27 and this just reapplies the same logic.

<!-- Provide both a what and a _why_ for the change. -->


### How will you know you've accomplished your goal?
The Sentry issue specified above should cease to appear.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
