### PR TITLE
Revert "Improve error handling for missing dependency versions for github actions"

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -149,11 +149,6 @@ module Dependabot
         "error-type": "git_dependencies_not_reachable",
         "error-detail": { "dependency-urls": error.dependency_urls }
       }
-    when Dependabot::UnresolvableVersionError
-      {
-        "error-type": "unresolvable_version",
-        "error-detail": { dependencies: error.dependencies }
-      }
     when Dependabot::NotImplemented
       {
         "error-type": "not_implemented",
@@ -667,23 +662,6 @@ module Dependabot
       @dependencies = dependencies
 
       msg = "The following dependencies could not be updated: #{@dependencies.join(', ')}"
-      super(msg)
-    end
-  end
-
-  class UnresolvableVersionError < DependabotError
-    extend T::Sig
-
-    sig { returns(T::Array[String]) }
-    attr_reader :dependencies
-
-    sig { params(dependencies: T::Array[String]).void }
-    def initialize(dependencies)
-      @dependencies = dependencies
-
-      msg = "Unable to determine semantic version from tags or commits for dependencies. " \
-            "Dependencies must have a tag or commit that references a semantic version. " \
-            "Affected dependencies: #{@dependencies.join(', ')}"
       super(msg)
     end
   end

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -30,12 +30,6 @@ module Dependabot
           dependency_set += workfile_file_dependencies(file)
         end
 
-        dependencies_without_version = dependency_set.dependencies.select { |dep| dep.version.nil? }
-        unless dependencies_without_version.empty?
-          raise UnresolvableVersionError,
-                dependencies_without_version.map(&:name)
-        end
-
         dependency_set.dependencies
       end
 

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -560,27 +560,6 @@ RSpec.describe Dependabot::GithubActions::FileParser do
         end
       end
     end
-
-    context "with an unresolvable version" do
-      let(:workflow_file_fixture_name) { "unresolved_version.yml" }
-      let(:service_pack_url) do
-        "https://github.com/taiki-e/install-action.git/info/refs" \
-          "?service=git-upload-pack"
-      end
-
-      before do
-        mock_service_pack_request("taiki-e/install-action")
-      end
-
-      it "raises an UnresolvableVersionError error" do
-        expect { parser.parse }.to raise_error(
-          Dependabot::UnresolvableVersionError,
-          "Unable to determine semantic version from tags or commits for dependencies. " \
-          "Dependencies must have a tag or commit that references a semantic version. " \
-          "Affected dependencies: taiki-e/install-action"
-        )
-      end
-    end
   end
 
   describe "#ecosystem" do

--- a/github_actions/spec/fixtures/workflow_files/unresolved_version.yml
+++ b/github_actions/spec/fixtures/workflow_files/unresolved_version.yml
@@ -1,7 +1,0 @@
-on: [push]
-
-name: Integration
-jobs:
-  chore:
-    steps:
-    - uses: taiki-e/install-action@nextest


### PR DESCRIPTION
Reverts dependabot/dependabot-core#11144

Temporarily reverting as this causing more issues than it solves.