### PR TITLE
Remove `cafile` hack used for NPM 6

### DIFF
--- a/updater/config/.npmrc
+++ b/updater/config/.npmrc
@@ -1,13 +1,6 @@
 # TODO: Remove these hacks once we've deprecated npm 6 support as it no longer
 # spwans a child process to npm install git dependencies.
 
-# Only set our custom CA cert for npm because the system ca's + our custom ca
-# causes npm to blow up when installing git dependencies (E2BIG exception). This
-# happens because the ca-file contents are passed as a cli argument to npm
-# install from npm/cli/lib/pack.js as --ca="contents of ca file" - "ca" is
-# populated automatically by npm when setting "--cafile" and passed through in
-# when spawning the cli to install git dependencies.
-cafile=/usr/local/share/ca-certificates/dbot-ca.crt
 # Because npm doesn't pass through all npm config when doing git installs in
 # npm/cli/lib/pack.js we also need to disable audit here to prevent npm from
 # auditing git dependencies, we do this to sped up installs


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Whilst working on adding the Bun package manager an issue was surfaced related to a custom cert used for NPM 6.

This PR removes the `calfile` from `.npmrc`.

<!-- What issues does this affect or fix? -->

See https://github.com/dependabot/dependabot-core/pull/11209

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

NPM 6 is no longer supported.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

No functional changes are observed.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
