### PR TITLE
Refactor pnpm updater to handle devDependencies and optimize update logic

### DIFF
--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -53,7 +53,8 @@ module Dependabot
           name: dependency.name,
           version: version,
           requirements: dependency.requirements,
-          package_manager: dependency.package_manager
+          package_manager: dependency.package_manager,
+          workspace: dependency.workspace
         )
       end
 

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -88,6 +88,9 @@ module Dependabot
     sig { returns(T::Hash[Symbol, T.untyped]) }
     attr_reader :metadata
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :workspace
+
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/PerceivedComplexity
     sig do
@@ -100,6 +103,7 @@ module Dependabot
         previous_version: T.nilable(String),
         previous_requirements: T.nilable(T::Array[T::Hash[T.any(Symbol, String), T.untyped]]),
         directory: T.nilable(String),
+        workspace: T.nilable(String),
         subdependency_metadata: T.nilable(T::Array[T::Hash[T.any(Symbol, String), String]]),
         removed: T::Boolean,
         metadata: T.nilable(T::Hash[T.any(Symbol, String), String])
@@ -107,7 +111,7 @@ module Dependabot
     end
     def initialize(name:, requirements:, package_manager:, version: nil,
                    previous_version: nil, previous_requirements: nil, directory: nil,
-                   subdependency_metadata: [], removed: false, metadata: {})
+                   workspace: nil, subdependency_metadata: [], removed: false, metadata: {})
       @name = name
       @version = T.let(
         case version
@@ -126,6 +130,8 @@ module Dependabot
       )
       @package_manager = package_manager
       @directory = directory
+      @workspace = workspace
+
       unless top_level? || subdependency_metadata == []
         @subdependency_metadata = T.let(
           subdependency_metadata&.map { |h| symbolize_keys(h) },
@@ -166,6 +172,7 @@ module Dependabot
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,
         "directory" => directory,
+        "workspace" => workspace,
         "package_manager" => package_manager,
         "subdependency_metadata" => subdependency_metadata,
         "removed" => removed? ? true : nil

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -33,6 +33,15 @@ module Dependabot
           "supported-versions": error.supported_versions
         }
       }
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::BranchNotFound
       {
         "error-type": "branch_not_found",
@@ -103,6 +112,15 @@ module Dependabot
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.parser_error_details(error)
     case error
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::DependencyFileNotEvaluatable
       {
         "error-type": "dependency_file_not_evaluatable",
@@ -170,6 +188,15 @@ module Dependabot
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.updater_error_details(error)
     case error
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::DependencyFileNotResolvable
       {
         "error-type": "dependency_file_not_resolvable",
@@ -300,6 +327,7 @@ module Dependabot
       }
     end
   end
+
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Lint/RedundantCopDisableDirective
@@ -487,6 +515,35 @@ module Dependabot
       msg = "Dependabot detected the following #{tool_name} requirement for your project: '#{detected_version}'." \
             "\n\nCurrently, the following #{tool_name} versions are supported in Dependabot: #{supported_versions}."
       super(msg)
+    end
+  end
+
+  class ToolFeatureNotSupported < DependabotError
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :tool_name, :tool_type, :feature
+
+    sig do
+      params(
+        tool_name: String,
+        tool_type: String,
+        feature: String
+      ).void
+    end
+    def initialize(tool_name:, tool_type:, feature:)
+      @tool_name = tool_name
+      @tool_type = tool_type
+      @feature = feature
+      super(build_message)
+    end
+
+    private
+
+    sig { returns(String) }
+    def build_message
+      "Dependabot doesn't support the feature '#{feature}' for #{tool_name} (#{tool_type}). " \
+        "Please refer to the documentation for supported features."
     end
   end
 

--- a/common/lib/dependabot/file_parsers/base/dependency_set.rb
+++ b/common/lib/dependabot/file_parsers/base/dependency_set.rb
@@ -156,6 +156,7 @@ module Dependabot
               version: version,
               requirements: requirements,
               package_manager: old_dep.package_manager,
+              workspace: old_dep.workspace,
               metadata: old_dep.metadata,
               subdependency_metadata: subdependency_metadata
             )

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -478,6 +478,7 @@ module Dependabot
           candidate_dep = Dependency.new(
             name: dependency.name,
             version: dependency.version,
+            workspace: dependency.workspace,
             requirements: [],
             package_manager: dependency.package_manager
           )

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -233,6 +233,7 @@ module Dependabot
           previous_version: previous_version,
           previous_requirements: dependency.requirements,
           package_manager: dependency.package_manager,
+          workspace: dependency.workspace,
           metadata: dependency.metadata,
           subdependency_metadata: dependency.subdependency_metadata
         )
@@ -250,6 +251,7 @@ module Dependabot
           previous_version: previous_version,
           previous_requirements: dependency.requirements,
           package_manager: dependency.package_manager,
+          workspace: dependency.workspace,
           metadata: dependency.metadata,
           subdependency_metadata: dependency.subdependency_metadata
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -237,6 +237,8 @@ module Dependabot
         lockfile_parser.parse_set
       end
 
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/PerceivedComplexity
       sig do
         params(file: DependencyFile, type: T.untyped, name: String, requirement: String)
           .returns(T.nilable(Dependency))
@@ -292,6 +294,8 @@ module Dependabot
           }]
         )
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/PerceivedComplexity
 
       sig { override.void }
       def check_required_files

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -50,6 +50,8 @@ module Dependabot
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       sig { override.returns(T::Array[DependencyFile]) }
       def updated_dependency_files
         updated_files = T.let([], T::Array[DependencyFile])
@@ -100,6 +102,8 @@ module Dependabot
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::BunLockfileUpdater do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do


### PR DESCRIPTION
### What are you trying to accomplish?

This PR refactors the `pnpm updater` logic to improve how it handles `devDependencies` and other dependencies. The changes include:
- Raising a `ToolFeatureNotSupported` error for dependencies that are part of `workspaces-devDependencies` since we currently do not support `devDependencies` in workspaces.
- Separating `devDependencies` and other dependencies for updates.
- Using the `--save-dev` flag specifically for `devDependencies`.
- Avoiding unnecessary resets of changes by skipping `pnpm install` when an experimental flag is enabled.

This resolves potential issues where unsupported dependencies in workspaces caused unclear errors and optimizes dependency management.

### Anything you want to highlight for special attention from reviewers?

- The decision to raise a `ToolFeatureNotSupported` error for `workspaces-devDependencies` ensures better clarity for users and aligns with the current limitations of our tool.
- Feedback on the approach for handling unsupported dependencies and managing `devDependencies` with the `--save-dev` flag is welcome.
- If there are better alternatives to skipping `pnpm install` under the experimental flag, suggestions are appreciated.

### How will you know you've accomplished your goal?

- The updater raises a clear and descriptive `ToolFeatureNotSupported` error for unsupported `workspaces-devDependencies`.
- The new updater logic ensures that `devDependencies` and other dependencies are correctly updated with their respective flags.
- The changes are behind the feature flag, `enable_fix_for_pnpm_no_change_error`.
- Tests will confirm that the updates and `lockfile` changes behave as expected under different scenarios, including unsupported workspace dependencies.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.