### PR TITLE
Bump Hex Erlang to 25

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -2,25 +2,21 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-    gnupg2
+    gnupg2 sudo wget
 
-# Install Erlang
-# Note: Currently we install from Ubuntu PPA to unblock upgrading to Ubuntu 22.04, but we'd be happy to accept a PR
-# switching to a more up to date PPA. See also:
-#  * https://github.com/esl/packages/issues/15
-#  * https://github.com/dependabot/dependabot-core/pull/7865
-#  * https://erlangforums.com/t/erlang-solutions-apt-package-for-otp-25/1552/1
-#  * https://erlangforums.com/t/the-eef-is-looking-for-volunteers-to-take-over-esls-build-packages/2238/1
-ARG ERLANG_MAJOR_VERSION=24
-ARG ERLANG_VERSION=1:${ERLANG_MAJOR_VERSION}.2.1+dfsg-1ubuntu0.1
+ARG ERLANG_MAJOR_VERSION=25
+
+RUN echo "deb http://binaries2.erlang-solutions.com/ubuntu/ jammy-esl-erlang-25 contrib" >> /etc/apt/sources.list
+RUN wget https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc \
+  && sudo apt-key add GPG-KEY-pmanager.asc
+
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    erlang=${ERLANG_VERSION}
+  && apt-get install -y --no-install-recommends esl-erlang
 
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.14.4
-ARG ELIXIR_CHECKSUM=b5705275d62ce3dae172d25d7ea567fffdabb45458abeb29c0189923b907367c
+ARG ELIXIR_VERSION=v1.14.5
+ARG ELIXIR_CHECKSUM=f3b35d9fa61da7e93c9979cb8a08f64a9ce7074aeda66fae994f2a4ea2e4f82e
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "elixir"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "1.14.4"
+        expect(language.version.to_s).to eq "1.14.5"
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This is a baby step on the way to Elixir 1.18 (https://github.com/dependabot/dependabot-core/pull/11295). I've found that the jump of 4 minor versions and a handful of erlang versions is a lot of debugging. I also think that handling the upgrade in smaller steps will lead to a better git history anyways.

Currently we are using 24 from apt, and there are notes that we should not use ESL for this version of Ubuntu, but times have changed and ESL seems to have caught up.

I think ESL is the best way forward outside of using the RabbitMQ erlang solutions (which I'm fine with doing if desired, I'm just more familiar with ESL).

This also bumps Elixir by a patch version (1.14.4 -> 1.14.5)

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
