### PR TITLE
prefer `SafeVersions` property when considering other versions

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -479,6 +479,61 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
     }
 
     [Fact]
+    public async Task SafeVersionsPropertyIsHonored()
+    {
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"), // initially this
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.1.0", "net8.0"), // should update to this due to `SafeVersions`
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.0", "net8.0"), // this should not be considered
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [
+                    new()
+                    {
+                        DependencyName = "Some.Package",
+                        PackageManager = "nuget",
+                        VulnerableVersions = [Requirement.Parse(">= 1.0.0, < 1.1.0")],
+                        SafeVersions = [Requirement.Parse("= 1.1.0")]
+                    }
+                ],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "1.1.0",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies = [
+                    new("Some.Package", "1.1.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
     public async Task VersionFinderCanHandle404FromPackageSource_V2()
     {
         static (int, byte[]) TestHttpHandler1(string uriString)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -116,29 +116,18 @@ internal static class VersionFinder
         var safeVersions = dependencyInfo.Vulnerabilities.SelectMany(v => v.SafeVersions).ToList();
         return version =>
         {
-            if (safeVersions.Any())
-            {
-                // only consider these
-                if (safeVersions.Any(s => s.IsSatisfiedBy(version)))
-                {
-                    return true;
-                }
-
-                return false;
-            }
-            else
-            {
-                var versionGreaterThanCurrent = currentVersion is null || version > currentVersion;
-                var rangeSatisfies = versionRange.Satisfies(version);
-                var prereleaseTypeMatches = currentVersion is null || !currentVersion.IsPrerelease || !version.IsPrerelease || version.Version == currentVersion.Version;
-                var isIgnoredVersion = dependencyInfo.IgnoredVersions.Any(i => i.IsSatisfiedBy(version));
-                var isVulnerableVersion = dependencyInfo.Vulnerabilities.Any(v => v.IsVulnerable(version));
-                return versionGreaterThanCurrent
-                    && rangeSatisfies
-                    && prereleaseTypeMatches
-                    && !isIgnoredVersion
-                    && !isVulnerableVersion;
-            }
+            var versionGreaterThanCurrent = currentVersion is null || version > currentVersion;
+            var rangeSatisfies = versionRange.Satisfies(version);
+            var prereleaseTypeMatches = currentVersion is null || !currentVersion.IsPrerelease || !version.IsPrerelease || version.Version == currentVersion.Version;
+            var isIgnoredVersion = dependencyInfo.IgnoredVersions.Any(i => i.IsSatisfiedBy(version));
+            var isVulnerableVersion = dependencyInfo.Vulnerabilities.Any(v => v.IsVulnerable(version));
+            var isSafeVersion = !safeVersions.Any() || safeVersions.Any(s => s.IsSatisfiedBy(version));
+            return versionGreaterThanCurrent
+                && rangeSatisfies
+                && prereleaseTypeMatches
+                && !isIgnoredVersion
+                && !isVulnerableVersion
+                && isSafeVersion;
         };
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Advisory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Advisory.cs
@@ -10,4 +10,6 @@ public record Advisory
     public ImmutableArray<Requirement>? AffectedVersions { get; init; } = null;
     public ImmutableArray<Requirement>? PatchedVersions { get; init; } = null;
     public ImmutableArray<Requirement>? UnaffectedVersions { get; init; } = null;
+
+    public IEnumerable<Requirement> SafeVersions => (PatchedVersions ?? []).Concat(UnaffectedVersions ?? []);
 }


### PR DESCRIPTION
Also consider a security advisory's explicit safe versions when evaluating package updates.

The lambda version filter was rewritten to make it easier to read and debug because there are several places to set a breakpoint.  The only functional change is the additional explicit check in the `SafeVersions` property at the end.

The run worker was also updated to generate the correct `DependencyInfo` object from the `SecurityAdvisory`s from the job file.

Fixes #11311.