### PR TITLE
Handle Dependabot::DependabotError in pub/lib/dependabot/pub/helpers.rb

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -220,6 +220,14 @@ module Dependabot
         "error-type": "git_dependencies_not_reachable",
         "error-detail": { "dependency-urls": error.dependency_urls }
       }
+    when Dependabot::DependencyFileNotFound
+      {
+        "error-type": "dependency_file_not_found",
+        "error-detail": {
+          message: error.message,
+          "file-path": error.file_path
+        }
+      }
     when Dependabot::ToolVersionNotSupported
       {
         "error-type": "tool_version_not_supported",

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "node"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "18.20.5"
+        expect(language.version.to_s).to eq "18.20.6"
       end
     end
   end

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -32,7 +32,7 @@ module Dependabot
       attr_reader :options
 
       def self.pub_helpers_path
-        File.join(ENV.fetch("DEPENDABOT_NATIVE_HELPERS_PATH", "helpers/bin"), "pub")
+        File.join(ENV.fetch("DEPENDABOT_NATIVE_HELPERS_PATH", nil), "pub")
       end
 
       def self.run_infer_sdk_versions(dir, url: nil)
@@ -235,7 +235,6 @@ module Dependabot
               # TODO(sigurdm): Would be nice to have a better handle for fixing the dart sdk version.
               "_PUB_TEST_SDK_VERSION" => sdk_versions["dart"]
             }
-
             command_dir = File.join(temp_dir, dependency_files.first&.directory)
 
             stdout, stderr, status = Open3.capture3(
@@ -245,7 +244,6 @@ module Dependabot
               stdin_data: stdin_data,
               chdir: command_dir
             )
-
             raise_error(stderr) unless status.success?
             return stdout unless block_given?
 

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -716,6 +716,67 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     end
   end
 
+  context "when there is an error while running a subshell command" do
+    let(:status) { instance_double(Process::Status, success?: false) }
+
+    before do
+      allow(Open3).to receive(:capture3).with({}, "/tmp/flutter/bin/flutter", "--version", "--machine",
+                                              Hash).and_call_original
+      allow(Open3).to receive(:capture3).with({}, "/tmp/flutter/bin/flutter", "doctor", Hash).and_call_original
+      allow(Open3).to receive(:capture3).with({}, "git", "fetch", "origin", "refs/tags/3.24.1",
+                                              Hash).and_call_original
+      allow(Open3).to receive(:capture3).with({}, "git", "checkout", "refs/tags/3.24.1", Hash).and_call_original
+      allow(Open3).to receive(:capture3).with({}, "/opt/pub/infer_sdk_versions", String, Hash).and_call_original
+      allow(Open3).to receive(:capture3).with(Hash, String, "report", Hash).and_return(["", stderr, status])
+    end
+
+    context "with a git error" do
+      let(:stderr) { "Git error. Command: `git clone --mirror https://github.com/***`" }
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::InvalidGitAuthToken)
+      end
+    end
+
+    context "when parsing the lockfile fails" do
+      let(:stderr) { "Failed parsing lock file" }
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
+
+    context "when version resolution fails" do
+      let(:stderr) do
+        "Because care_share_nepal depends on both freezed ^3.0.0-0.0.dev and freezed ^2.3.5, version solving failed."
+      end
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
+    context "when pubspec.yaml is missing" do
+      let(:stderr) do
+        "Could not find a file named \"pubspec.yaml\" in https://github.com/Iconica-Development"
+      end
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotFound)
+      end
+    end
+
+    context "when dependency file has unsupported syntax" do
+      let(:stderr) do
+        "Unsupported operation: Encountered an alias node along [dependencies, isar, version]!"
+      end
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
+  end
+
   context "with a git dependency" do
     include_context "with temp dir"
 

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -720,13 +720,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
     let(:status) { instance_double(Process::Status, success?: false) }
 
     before do
-      allow(Open3).to receive(:capture3).with({}, "/tmp/flutter/bin/flutter", "--version", "--machine",
-                                              Hash).and_call_original
-      allow(Open3).to receive(:capture3).with({}, "/tmp/flutter/bin/flutter", "doctor", Hash).and_call_original
-      allow(Open3).to receive(:capture3).with({}, "git", "fetch", "origin", "refs/tags/3.24.1",
-                                              Hash).and_call_original
-      allow(Open3).to receive(:capture3).with({}, "git", "checkout", "refs/tags/3.24.1", Hash).and_call_original
-      allow(Open3).to receive(:capture3).with({}, "/opt/pub/infer_sdk_versions", String, Hash).and_call_original
+      allow(Open3).to receive(:capture3).and_call_original
       allow(Open3).to receive(:capture3).with(Hash, String, "report", Hash).and_return(["", stderr, status])
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Replace Dependabot::DependabotError in pub/lib/dependabot/pub/helpers.rb with more meaningful error so that errors that don't need to be in Sentry don't end up there.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
