### PR TITLE
Handle `NoChangeError` for Transitive Dependency Updates in `pnpm` Package Manager Behind Feature Flag

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -33,6 +33,15 @@ module Dependabot
           "supported-versions": error.supported_versions
         }
       }
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::BranchNotFound
       {
         "error-type": "branch_not_found",
@@ -103,6 +112,15 @@ module Dependabot
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.parser_error_details(error)
     case error
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::DependencyFileNotEvaluatable
       {
         "error-type": "dependency_file_not_evaluatable",
@@ -170,6 +188,15 @@ module Dependabot
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.updater_error_details(error)
     case error
+    when Dependabot::ToolFeatureNotSupported
+      {
+        "error-type": "tool_feature_not_supported",
+        "error-detail": {
+          "tool-name": error.tool_name,
+          "tool-type": error.tool_type,
+          feature: error.feature
+        }
+      }
     when Dependabot::DependencyFileNotResolvable
       {
         "error-type": "dependency_file_not_resolvable",
@@ -300,6 +327,7 @@ module Dependabot
       }
     end
   end
+
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Lint/RedundantCopDisableDirective
@@ -487,6 +515,35 @@ module Dependabot
       msg = "Dependabot detected the following #{tool_name} requirement for your project: '#{detected_version}'." \
             "\n\nCurrently, the following #{tool_name} versions are supported in Dependabot: #{supported_versions}."
       super(msg)
+    end
+  end
+
+  class ToolFeatureNotSupported < DependabotError
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :tool_name, :tool_type, :feature
+
+    sig do
+      params(
+        tool_name: String,
+        tool_type: String,
+        feature: String
+      ).void
+    end
+    def initialize(tool_name:, tool_type:, feature:)
+      @tool_name = tool_name
+      @tool_type = tool_type
+      @feature = feature
+      super(build_message)
+    end
+
+    private
+
+    sig { returns(String) }
+    def build_message
+      "Dependabot doesn't support the feature '#{feature}' for #{tool_name} (#{tool_type}). " \
+        "Please refer to the documentation for supported features."
     end
   end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -48,6 +48,7 @@ module Dependabot
         ]
       end
 
+      # rubocop:disable Metrics/PerceivedComplexity
       sig { override.returns(T::Array[DependencyFile]) }
       def updated_dependency_files
         updated_files = T.let([], T::Array[DependencyFile])
@@ -88,6 +89,7 @@ module Dependabot
 
         vendor_updated_files(updated_files)
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       private
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -63,10 +63,10 @@ module Dependabot
             # when there is no update in package.json
             no_package_json_update = package_files.empty?
             # handle the no change error for transitive dependency updates
-            if dependencies.length.positive? && all_transitive && no_package_json_update
+            if pnpm_locks.any? && dependencies.length.positive? && all_transitive && no_package_json_update
               raise ToolFeatureNotSupported.new(
-                tool_name: "npm_and_yarn",
-                tool_type: "ecosystem",
+                tool_name: "pnpm",
+                tool_type: "package_manager",
                 feature: "updating transitive dependencies"
               )
             end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::BunLockfileUpdater do
     FileUtils.mkdir_p(tmp_path)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do


### PR DESCRIPTION
### What are you trying to accomplish?

This change introduces handling for the `NoChangeError` that occurs during transitive dependency updates specifically in the `pnpm` package manager. 

When certain conditions are met, the code raises a new error, `ToolFeatureNotSupported`, indicating that updating transitive dependencies is not supported in `pnpm`. 

This logic is gated behind the `enable_fix_for_pnpm_no_change_error` feature flag to allow for controlled testing and adoption.

This change ensures improved error feedback for unsupported scenarios in `pnpm`, reducing unknown failures.

---

### Conditions for Triggering the `ToolFeatureNotSupported` Error

The error is raised **only for `pnpm`** when **all** of the following conditions are true:
1. The `enable_fix_for_pnpm_no_change_error` feature flag is enabled.
2. The project includes a `pnpm-lock.yaml` file.
3. The `dependencies` array is not empty.
4. All dependencies are transitive (none are explicitly declared as top-level dependencies in `package.json`).
5. There are no updates in the `package.json` file.

---

### Anything you want to highlight for special attention from reviewers?

- This change applies **only to `pnpm`** and is controlled by the `enable_fix_for_pnpm_no_change_error` feature flag to avoid unintended impacts on other ecosystems.
- The error is raised specifically when `pnpm` is used, and the above conditions are met.
- Feedback is requested on:
  - The appropriateness of the error message (`ToolFeatureNotSupported`).
  - Any additional edge cases or scenarios that should be considered for `pnpm`.

---

### How will you know you've accomplished your goal?

- When reproducing the `NoChangeError` scenario in `pnpm`, the `ToolFeatureNotSupported` error is raised under the specified conditions when the feature flag is enabled.
- When the feature flag is disabled, the behavior remains unchanged.
- All tests pass successfully, including those for this new functionality.

---

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.