### PR TITLE
Bump Hex Elixir to 1.17.3

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update \
 
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.16.3
-ARG ELIXIR_CHECKSUM=e8e81771bc6acd62a2c1bf1b31c3aa3d0a469415de3b243b99f3e2e2d639f5ea
+ARG ELIXIR_VERSION=v1.17.3
+ARG ELIXIR_CHECKSUM=3fd0f58730f848b5650be2ef7c892b76c74324b8537181778117c43306a6e5f7
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \

--- a/hex/helpers/lib/run.exs
+++ b/hex/helpers/lib/run.exs
@@ -1,6 +1,6 @@
 defmodule DependencyHelper do
   def main() do
-    IO.read(:stdio, :all)
+    IO.read(:stdio, :eof)
     |> Jason.decode!()
     |> run()
     |> case do

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "elixir"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "1.16.3"
+        expect(language.version.to_s).to eq "1.17.3"
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

This bumps Elixir to 1.17.3

There's only one required change here to switch the IO.read mode.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
