### PR TITLE
Bump Hex OTP to 26, Elixir to 1.18.1

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -4,9 +4,9 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     gnupg2 sudo wget
 
-ARG ERLANG_MAJOR_VERSION=25
+ARG ERLANG_MAJOR_VERSION=26
 
-RUN echo "deb http://binaries2.erlang-solutions.com/ubuntu/ jammy-esl-erlang-25 contrib" >> /etc/apt/sources.list
+RUN echo "deb http://binaries2.erlang-solutions.com/ubuntu/ jammy-esl-erlang-26 contrib" >> /etc/apt/sources.list
 RUN wget https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc \
   && sudo apt-key add GPG-KEY-pmanager.asc
 
@@ -15,8 +15,8 @@ RUN apt-get update \
 
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.17.3
-ARG ELIXIR_CHECKSUM=3fd0f58730f848b5650be2ef7c892b76c74324b8537181778117c43306a6e5f7
+ARG ELIXIR_VERSION=v1.18.1
+ARG ELIXIR_CHECKSUM=aae4625102ba7020887918d1c0ac7c8ad972b65fe8103476765cc6b00ab16b5f
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -396,13 +396,13 @@ RSpec.describe Dependabot::Hex::FileParser do
             name: "plug",
             version: "1.3.6",
             requirements: [{
-              requirement: "1.3.6",
-              file: "apps/dependabot_web/mix.exs",
+              requirement: "~> 1.3.0",
+              file: "apps/dependabot_business/mix.exs",
               groups: [],
               source: nil
             }, {
-              requirement: "~> 1.3.0",
-              file: "apps/dependabot_business/mix.exs",
+              requirement: "1.3.6",
+              file: "apps/dependabot_web/mix.exs",
               groups: [],
               source: nil
             }],
@@ -476,7 +476,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "elixir"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "1.17.3"
+        expect(language.version.to_s).to eq "1.18.1"
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

This makes Elixir current.

I included the OTP bump because it had no alterations besides version numbers.

This enables the #11295 changes.

Only minor change required for 1.18.1 was re-ordering within the Dependabot::Dependency.requirements inside of a test. Hope that's fine.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
