### PR TITLE
Enabling alias parsing in pnpm_workspace_yaml

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -645,7 +645,7 @@ module Dependabot
       def parsed_pnpm_workspace_yaml
         return {} unless pnpm_workspace_yaml
 
-        YAML.safe_load(T.must(T.must(pnpm_workspace_yaml).content))
+        YAML.safe_load(T.must(T.must(pnpm_workspace_yaml).content), aliases: true)
       rescue Psych::SyntaxError
         raise Dependabot::DependencyFileNotParseable, T.must(pnpm_workspace_yaml).path
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -646,7 +646,7 @@ module Dependabot
         return {} unless pnpm_workspace_yaml
 
         YAML.safe_load(T.must(T.must(pnpm_workspace_yaml).content), aliases: true)
-      rescue Psych::SyntaxError
+      rescue Psych::SyntaxError, Psych::BadAlias
         raise Dependabot::DependencyFileNotParseable, T.must(pnpm_workspace_yaml).path
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2021,7 +2021,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
-  context "with an unparseable package.json file" do
+  context "with an pnpm_workspace_yaml" do
     let(:source) do
       Dependabot::Source.new(
         provider: "github",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2021,7 +2021,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
-  context "with an pnpm_workspace_yaml" do
+  context "with a pnpm_workspace_yaml" do
     let(:source) do
       Dependabot::Source.new(
         provider: "github",
@@ -2036,7 +2036,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       allow(file_fetcher).to receive(:pnpm_workspace_yaml).and_return(pnpm_workspace_yaml)
     end
 
-    context "when pnpm_workspace_yaml is nil" do
+    context "when the content is nil" do
       let(:pnpm_workspace_yaml) { nil }
 
       it "returns an empty hash" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2036,7 +2036,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       allow(file_fetcher).to receive(:pnpm_workspace_yaml).and_return(pnpm_workspace_yaml)
     end
 
-    context "when the content is nil" do
+    context "when it's content is nil" do
       let(:pnpm_workspace_yaml) { nil }
 
       it "returns an empty hash" do
@@ -2044,7 +2044,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       end
     end
 
-    context "when the content is valid YAML" do
+    context "when it's content is valid YAML" do
       let(:content) { "---\npackages:\n  - 'packages/*'\n" }
 
       it "parses the YAML content" do
@@ -2052,7 +2052,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       end
     end
 
-    context "when the content contains valid alias" do
+    context "when it's content contains valid alias" do
       let(:content) { "---\npackages:\n  - &default 'packages/*'\n  - *default\n" }
       let(:pnpm_workspace_yaml) { Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: content) }
 
@@ -2061,7 +2061,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       end
     end
 
-    context "when the content contains invalid alias (BadAlias)" do
+    context "when it's content contains invalid alias (BadAlias)" do
       let(:content) { "---\npackages:\n  - &id 'packages/*'\n  - *id" } # Invalid alias reference
 
       before do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing the Bug related to [this workflow](https://github.com/dsp-testing/pnpm-monorepo-7659)

Error:

```
updater | 2025/01/20 14:45:53 ERROR <job_950629041> Error during file fetching; aborting: Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
updater | 2025/01/20 14:45:53 ERROR <job_950629041> Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`.
updater | 2025/01/20 14:45:53 ERROR <job_950629041> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:432:in `visit_Psych_Nodes_Alias'
```

### Anything you want to highlight for special attention from reviewers?

Wrote new rspec to test pnpm-workspace-yaml 
`rspec ./spec/dependabot/npm_and_yarn/file_fetcher_spec.rb:2024`

nil scenario `rspec ./spec/dependabot/npm_and_yarn/file_fetcher_spec.rb:2039`
valid scenario `rspec ./spec/dependabot/npm_and_yarn/file_fetcher_spec.rb:2047`
Recreated this error scenario `rspec ./spec/dependabot/npm_and_yarn/file_fetcher_spec.rb:2057`

And provided the fix

### How will you know you've accomplished your goal?

Recreated the same error with RSpec and provided fixes for that

`rspec ./spec/dependabot/npm_and_yarn/file_fetcher_spec.rb:2061`
![image](https://github.com/user-attachments/assets/8a6f642d-1bb4-438f-8dba-2c10253b0e8f)


Ran CLI , Wrote 3 Rspec tests, and ensured specs are passing

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
