### PR TITLE
Skip catalog protocol when using directory configuration in monorepos

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -212,7 +212,7 @@ module Dependabot
             next unless requirement.is_a?(String)
 
             # Skip dependencies using Yarn workspace cross-references as requirements
-            next if requirement.start_with?("workspace:")
+            next if requirement.start_with?("workspace:", "catalog:")
 
             requirement = "*" if requirement == ""
             dep = build_dependency(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
         its(:length) { is_expected.to eq(0) }
       end
 
+      context "with pnpm `catalog:` requirements and no lockfile" do
+        let(:files) { project_dependency_files("yarn/workspace_requirements_catalog") }
+
+        its(:length) { is_expected.to eq(0) }
+      end
+
       context "with a package-lock.json" do
         let(:npm_fallback_version_above_v6_enabled) { false }
 

--- a/npm_and_yarn/spec/fixtures/projects/yarn/workspace_requirements_catalog/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/yarn/workspace_requirements_catalog/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "workspace_requirements_catalog",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "ember-simple-charts": "catalog:",
+    "react": "catalog:react18"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

When updating individual repositories within a monorepo using the `directory` configuration, we want to skip the `catalog:` protocol. This change improves the handling of monorepo dependency updates by ensuring Dependabot correctly processes directory-specific updates without being affected by the catalog protocol.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The main change focuses on the protocol handling logic. I chose to skip the catalog protocol specifically for directory updates since these are meant to operate on isolated parts of the repository, and the catalog protocol isn't necessary in this context. This approach ensures clean, targeted updates for individual packages within monorepos.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Users can successfully process updates for specific directories in their monorepo. The "no change" errors previously triggered by catalog versions no longer block these updates

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
