### PR TITLE
Adds error handler for Ruby version not found class error

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -9,11 +9,11 @@ module Dependabot
   module Bundler
     class FileUpdater
       class RubyRequirementSetter
-        class RubyVersionNotFound < StandardError; end
-
         RUBY_VERSIONS = %w(
           1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.9 2.7.6 3.0.6 3.1.6 3.2.4 3.3.6
         ).freeze
+
+        LANGUAGE = "ruby"
 
         attr_reader :gemspec
 
@@ -62,7 +62,13 @@ module Dependabot
             .map { |v| Gem::Version.new(v) }.sort
             .find { |v| requirement.satisfied_by?(v) }
 
-          raise RubyVersionNotFound unless ruby_version
+          unless ruby_version
+            raise ToolVersionNotSupported.new(
+              LANGUAGE,
+              requirement.to_s,
+              RUBY_VERSIONS.join(", ")
+            )
+          end
 
           ruby_version
         end

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
           bundler_project_dependency_file("gemfile_impossible_ruby", filename: "example.gemspec")
         end
 
-        specify { expect { rewrite }.to raise_error(described_class::RubyVersionNotFound) }
+        specify { expect { rewrite }.to raise_error(Dependabot::ToolVersionNotSupported) }
       end
 
       context "when requiring ruby 3" do


### PR DESCRIPTION
### What are you trying to accomplish?


Adds error handler for Ruby version not found class so that they don't end up being in Sentry.

```
Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound: Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound
  bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:65:in `ruby_version'
  bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:33:in `rewrite'
  bundler/lib/dependabot/bundler/update_checker/file_preparer.rb:262:in `block in lock_ruby_version'
  bundler/lib/dependabot/bundler/update_checker/file_preparer.rb:260:in `each'
  bundler/lib/dependabot/bundler/update_checker/file_preparer.rb:260:in `lock_ruby_version'
```
...
(50 additional frame(s) were not displayed)

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
