### PR TITLE
report full shape of job file

### DIFF
--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -14,7 +14,7 @@ $operationExitCode = 0
 
 function Get-Files {
     $job = Get-Job -jobFilePath $env:DEPENDABOT_JOB_PATH
-    Write-Host "Job: $($job | ConvertTo-Json)"
+    Write-Host "Job: $($job | ConvertTo-Json -Depth 99)"
     & $updaterTool clone `
         --job-path $env:DEPENDABOT_JOB_PATH `
         --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `


### PR DESCRIPTION
The end-to-end NuGet updater reports the job file, but due to an oddity with PowerShell, only 2 levels of JSON are reported.  While this isn't a necessary functional change, this does make reading the log easier.