### PR TITLE
Update use of the `enable_beta_ecosystems` experiment

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -276,7 +276,7 @@ option_parse = OptionParser.new do |opts|
   end
 
   opts.on("--enable-beta-ecosystems", "Enable beta ecosystems") do |_value|
-    $options[:updater_options] = { enable_beta_ecosystems: true }
+    Dependabot::Experiments.register(:enable_beta_ecosystems, true)
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -130,7 +130,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def allow_beta_ecosystems?
-        !!options["enable_beta_ecosystems"]
+        Experiments.enabled?(:enable_beta_ecosystems)
       end
 
       sig { returns(T::Array[DependencyFile]) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -213,7 +213,7 @@ module Dependabot
 
       sig { returns(T.nilable(T.any(Integer, String))) }
       def bun_version
-        return @bun_version = nil unless allow_beta_ecosystems? || Experiments.enabled?(:bun_updates)
+        return @bun_version = nil unless allow_beta_ecosystems?
 
         @bun_version ||= T.let(
           package_manager_helper.setup(BunPackageManager::NAME),

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -526,11 +526,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     describe "fetching and parsing the bun.lock" do
       before do
         allow(Dependabot::Experiments).to receive(:enabled?)
-        allow(Dependabot::Experiments).to receive(:enabled?).with(:bun_updates).and_return(enable_bun_updates)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:enable_beta_ecosystems).and_return(enable_beta_ecosystems)
       end
 
-      context "when the experiment :bun_updates is inactive" do
-        let(:enable_bun_updates) { false }
+      context "when the experiment :enable_beta_ecosystems is inactive" do
+        let(:enable_beta_ecosystems) { false }
 
         it "does not fetch or parse the the bun.lock" do
           expect(file_fetcher_instance.files.map(&:name))
@@ -540,8 +541,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         end
       end
 
-      context "when the experiment :bun_updates is active" do
-        let(:enable_bun_updates) { true }
+      context "when the experiment :enable_beta_ecosystems is active" do
+        let(:enable_beta_ecosystems) { true }
 
         it "fetches and parses the bun.lock" do
           expect(file_fetcher_instance.files.map(&:name))


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

The previous implementation was incorrect. This PR correctly sets the `:enable_beta_ecosystems` experiment state. We are also removing the more specific `:bun_updates` feature as it is now redundant.

<!-- What issues does this affect or fix? -->

This is a follow-up/fix for [Handle enable_beta_ecosystems boolean setting #11334](https://github.com/dependabot/dependabot-core/pull/11334)

<!-- ### Anything you want to highlight for special attention from reviewers? -->

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

```bash
./bin/docker-dev-shell npm_and_yarn --rebuild
./bin/dry-run.rb npm_and_yarn dsp-testing/dependabot-bun-public --enable-beta-ecosystems
```

<details>

<summary>Expected output</summary>

```
 => bump @types/bun from 1.1.16 to 1.1.18

    ± bun.lock
    ~~~
    --- /tmp/original20250122-2574-6rmd3r       2025-01-22 11:34:43.796832648 +0000
    +++ /tmp/updated20250122-2574-1wx5kf        2025-01-22 11:34:43.796832648 +0000
    @@ -2,10 +2,9 @@
       "lockfileVersion": 0,
       "workspaces": {
         "": {
    -      "name": "minimal-dependabot-bun",
           "dependencies": {
             "express": "^4.21.2",
    -        "lodash": "4.17.20",
    +        "lodash": "^4.17.21",
           },
           "devDependencies": {
             "@types/bun": "latest",
    @@ -16,7 +15,7 @@
         },
       },
       "packages": {
    -    "@types/bun": ["@types/bun@1.1.16", "", { "dependencies": { "bun-types": "1.1.43" } }, "sha512-E+ue6NMcn4FXC5bDRE1W/BXUVs01h5Mt02qH8/8HGCox9akuh8KNOFdwvaQS9TDgT2RmUyJYFRRqA60WtTnm2g=="],
    +    "@types/bun": ["@types/bun@1.1.18", "", { "dependencies": { "bun-types": "1.1.44" } }, "sha512-gtw6cIv/8Q530D0BmoYnjEzR65SjVq2SaUE0NeU6tbm7QBMsTZ61/NBNERtK/FUJaoi7PiteUohK7JcrXBCkvw=="],
     
         "@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
     
    @@ -28,7 +27,7 @@
     
         "body-parser": ["body-parser@1.20.3", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.13.0", "raw-body": "2.5.2", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="],
     
    -    "bun-types": ["bun-types@1.1.43", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-W0wCtVH+bwFp7p3Zgs03CqxEDmXxEvmmUM/FBKgWIv9T8gyeotvIjIbHzuDScc2DphhRNtr7hJLCR5PspYL5qw=="],
    +    "bun-types": ["bun-types@1.1.44", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-jtcekoZeSINgEcHSISzhR13w/cyE+Fankw2Cpl4c0fN3lRmKVAX0i9ay4FyK4lOxUK1HG4HkuIlrPvXKz4Y7sw=="],
     
         "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
     
    @@ -94,7 +93,7 @@
     
         "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
     
    -    "lodash": ["lodash@4.17.20", "", {}, "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="],
    +    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
     
         "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
     
    ~~~
    5 insertions (+), 6 deletions (-)
```
</details>

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
