### PR TITLE
Don't use corepack for bun

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -323,6 +323,19 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         expect(result).to eq("10.8.2")
       end
     end
+
+    context "when corepack is not used for bun" do
+      it "falls back to the local version of the package manager" do
+        # Mock for `local_package_manager_version("bun")`
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "bun -v",
+          fingerprint: "bun -v"
+        ).and_return("1.1.39")
+
+        result = described_class.install("bun", "1.1.39")
+        expect(result).to eq("1.1.39")
+      end
+    end
   end
 
   describe "::npm8?" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
`corepack` [does not](https://github.com/nodejs/corepack/issues/295) support the `bun` package manager. We will use the `fallback_to_local_version` by default for `bun`.

<!-- What issues does this affect or fix? -->

GitHub actions are failing due to the use of `corepack` for `bun`.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

This wasn't surfaced by the dry-run as the `package_manager_install` and `package_manager_activate` are not invoked by the `dry-run`.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
We should be able to create PRs in https://github.com/dsp-testing/dependabot-bun-public for bun.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
