### PR TITLE
Fix sorbet type in dependabot/python/file_parser.rb

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -315,8 +315,9 @@ module Dependabot
         else
           return true if dep["markers"].include?("<")
           return false if dep["markers"].include?(">")
+          return false if dep["requirement"].nil?
 
-          dep["requirement"]&.include?("<")
+          dep["requirement"].include?("<")
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix an incorrect sorbet type in dependabot/python/file_parser.rb that's causing the following error in Sentry:

```
Dependabot::Sorbet::Runtime::InformationalError
Return value: Expected type T::Boolean, got type NilClass
Caller: /home/dependabot/python/lib/dependabot/python/file_parser.rb:258
Definition: /home/dependabot/python/lib/dependabot/python/file_parser.rb:307 (Dependabot::Python::FileParser#blocking_marker?)
```

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
