### PR TITLE
Update `PackageManagerDetector` for bun

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/bun_package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/bun_package_manager.rb
@@ -39,7 +39,7 @@ module Dependabot
 
       sig { override.returns(T::Boolean) }
       def unsupported?
-        supported_versions.all? { |supported| supported > version }
+        false
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -59,14 +59,16 @@ module Dependabot
       T.any(
         T.class_of(Dependabot::NpmAndYarn::NpmPackageManager),
         T.class_of(Dependabot::NpmAndYarn::YarnPackageManager),
-        T.class_of(Dependabot::NpmAndYarn::PNPMPackageManager)
+        T.class_of(Dependabot::NpmAndYarn::PNPMPackageManager),
+        T.class_of(Dependabot::NpmAndYarn::BunPackageManager)
       )
     end
 
     PACKAGE_MANAGER_CLASSES = T.let({
       NpmPackageManager::NAME => NpmPackageManager,
       YarnPackageManager::NAME => YarnPackageManager,
-      PNPMPackageManager::NAME => PNPMPackageManager
+      PNPMPackageManager::NAME => PNPMPackageManager,
+      BunPackageManager::NAME => BunPackageManager
     }.freeze, T::Hash[String, NpmAndYarnPackageManagerClassType])
 
     # Error malformed version number string

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/bun_package_manager_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/bun_package_manager_spec.rb
@@ -46,20 +46,8 @@ RSpec.describe Dependabot::NpmAndYarn::BunPackageManager do
   end
 
   describe "#unsupported?" do
-    context "when version is the minimum supported version" do
-      let(:detected_version) { Dependabot::NpmAndYarn::BunPackageManager::MIN_SUPPORTED_VERSION.to_s }
-
-      it "returns false" do
-        expect(package_manager.unsupported?).to be false
-      end
-    end
-
-    context "when version is unsupported" do
-      let(:raw_version) { "1.1.38" }
-
-      it "returns true" do
-        expect(package_manager.unsupported?).to be true
-      end
+    it "returns false" do
+      expect(package_manager.unsupported?).to be false
     end
   end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_detector_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_detector_spec.rb
@@ -61,6 +61,24 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerDetector do
     )
   end
 
+  let(:bun_lockfile) do
+    instance_double(
+      Dependabot::DependencyFile,
+      name: "bun.lock",
+      content: <<~LOCKFILE
+        lockfileVersion: 1.1.39
+
+        dependencies:
+          lodash:
+            specifier: ^4.17.20
+            version: 4.17.21
+            resolution:
+              integrity: sha512-abc123
+              tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz
+      LOCKFILE
+    )
+  end
+
   let(:lockfiles) { { npm: npm_lockfile, yarn: yarn_lockfile, pnpm: pnpm_lockfile } }
   let(:package_json) { { "packageManager" => "npm@7" } }
   let(:detector) { described_class.new(lockfiles, package_json) }
@@ -85,6 +103,14 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerDetector do
 
       it "returns pnpm as the package manager" do
         expect(detector.detect_package_manager).to eq("pnpm")
+      end
+    end
+
+    context "when bun lock file exists and npm lockfile is absent" do
+      let(:lockfiles) { { bun: bun_lockfile } }
+
+      it "returns bun as the package manager" do
+        expect(detector.detect_package_manager).to eq("bun")
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
Package manager detector was defaulting to the [DEFAULT_PACKAGE_MANAGER](https://github.com/dependabot/dependabot-core/blob/535799dd68a47cd686e8205e59f9754e4b4730c3/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb#L105) of `npm` when we using the `bun` package manager.

<!-- What issues does this affect or fix? -->

We encounter a `tool_version_not_supported ` error in the dependabot workflow [run](https://github.com/dsp-testing/dependabot-bun-public/actions/runs/12927975464/job/36054271621).

<!-- ### Anything you want to highlight for special attention from reviewers? -->

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
We can test with https://github.com/dsp-testing/dependabot-bun-public

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
