### PR TITLE
report `private_source_authentication_failure` during fetch

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -85,6 +85,11 @@ module Dependabot
         "error-type": "path_dependencies_not_reachable",
         "error-detail": { dependencies: error.dependencies }
       }
+    when Dependabot::PrivateSourceAuthenticationFailure
+      {
+        "error-type": "private_source_authentication_failure",
+        "error-detail": { source: error.source }
+      }
     when Octokit::Unauthorized
       { "error-type": "octokit_unauthorized" }
     when Octokit::ServerError


### PR DESCRIPTION
The NuGet updater can raise a `PrivateSourceAuthentication` error during a fetch operation.  This PR adds that error to the list of known errors in the `fetcher_error_details` function.