### PR TITLE
Hex: Encode exceptions

### DIFF
--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -1,11 +1,25 @@
 defmodule Parser do
+  @allowed_scms [Hex.SCM, Mix.SCM.Git, Mix.SCM.Path]
+
   def run do
     # This is necessary because we can't specify :extra_applications to have :hex in other mixfiles.
     Mix.ensure_application!(:hex)
 
-    Mix.Dep.Converger.converge()
-    |> Enum.flat_map(&parse_dep/1)
-    |> Enum.map(&build_dependency(&1.opts[:lock], &1))
+    with {:ok, deps} <- converge_deps() do
+      result =
+        for %Mix.Dep{scm: scm} = dep <- deps, scm in @allowed_scms,
+            expanded_dep <- expand_deps(dep) do
+          build_dependency(expanded_dep.opts[:lock], expanded_dep)
+        end
+
+      {:ok, result}
+    end
+  end
+
+  defp converge_deps do
+    {:ok, Mix.Dep.Converger.converge()}
+  rescue e ->
+    {:error, Exception.format_banner(:error, e, __STACKTRACE__)}
   end
 
   defp build_dependency(nil, dep) do
@@ -39,7 +53,7 @@ defmodule Parser do
   defp parse_groups(only), do: [only]
 
   # path dependency
-  defp parse_dep(%{scm: Mix.SCM.Path, opts: opts} = dep) do
+  defp expand_deps(%{scm: Mix.SCM.Path, opts: opts} = dep) do
     cond do
       # umbrella dependency - ignore
       opts[:in_umbrella] ->
@@ -55,10 +69,7 @@ defmodule Parser do
   end
 
   # hex, git dependency
-  defp parse_dep(%{scm: scm} = dep) when scm in [Hex.SCM, Mix.SCM.Git], do: [dep]
-
-  # unsupported
-  defp parse_dep(_dep), do: []
+  defp expand_deps(%{scm: scm} = dep) when scm in [Hex.SCM, Mix.SCM.Git], do: [dep]
 
   defp umbrella_top_level_dep?(dep) do
     if Mix.Project.umbrella?() do
@@ -85,7 +96,9 @@ defmodule Parser do
     |> empty_str_to_nil()
   end
 
-  defp maybe_regex_to_str(s), do: if(Regex.regex?(s), do: Regex.source(s), else: s)
+  defp maybe_regex_to_str(%Regex{} = s), do: Regex.source(s)
+  defp maybe_regex_to_str(s), do: s
+
   defp empty_str_to_nil(""), do: nil
   defp empty_str_to_nil(s), do: s
 
@@ -102,7 +115,7 @@ defmodule Parser do
   end
 end
 
-{:ok, Parser.run()}
+Parser.run()
 |> :erlang.term_to_binary()
 |> Base.encode64()
 |> IO.write()

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Dependabot::Hex::FileParser do
         )
       end
 
-      it "parses the dependencies correctly", skip: "Hex upgrade work is in progress" do
+      it "parses the dependencies correctly" do
         expect(dependencies.length).to eq(3)
         expect(dependencies).to include(
           Dependabot::Dependency.new(

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -391,24 +391,31 @@ RSpec.describe Dependabot::Hex::FileParser do
             package_manager: "hex"
           )
         )
-        expect(dependencies).to include(
-          Dependabot::Dependency.new(
-            name: "plug",
-            version: "1.3.6",
-            requirements: [{
-              requirement: "~> 1.3.0",
-              file: "apps/dependabot_business/mix.exs",
-              groups: [],
-              source: nil
-            }, {
-              requirement: "1.3.6",
-              file: "apps/dependabot_web/mix.exs",
-              groups: [],
-              source: nil
-            }],
-            package_manager: "hex"
-          )
+
+        plug_expectation = Dependabot::Dependency.new(
+          name: "plug",
+          version: "1.3.6",
+          requirements: [{
+            requirement: "~> 1.3.0",
+            file: "apps/dependabot_business/mix.exs",
+            groups: [],
+            source: nil
+          }, {
+            requirement: "1.3.6",
+            file: "apps/dependabot_web/mix.exs",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "hex"
         )
+
+        plug_dep = dependencies.find { |d| d.name == "plug" }
+
+        expect(plug_dep.name).to eq(plug_expectation.name)
+        expect(plug_dep.version).to eq(plug_expectation.version)
+        expect(plug_dep.requirements).to match_array(plug_expectation.requirements)
+        expect(plug_dep.package_manager).to eq(plug_expectation.package_manager)
+
         expect(dependencies).to include(
           Dependabot::Dependency.new(
             name: "distillery",


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Mix.Dep.Converger.converge can raise exceptions, which then leak the exception into IO as non-encoded binary.

Basically, since we now encode/decode base64, anything non base64 is going to fail.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I unskipped the skipped test. It was failed in CI due to the `requirements` array being sorted inconsistently, but I ran it ~45 times locally and it passed every time.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
