### PR TITLE
Fix sorbet tying error in bundler/file_updater/gemspec_sanitizer.rb

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
@@ -121,7 +121,7 @@ module Dependabot
             node.children.each { |child| replace_version_assignments(child) }
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).void }
+          sig { params(node: ParserNode).void }
           def replace_version_constant_references(node)
             return unless node.is_a?(Parser::AST::Node)
 
@@ -152,7 +152,7 @@ module Dependabot
             end
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_assigns_to_version_constant?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -165,7 +165,7 @@ module Dependabot
             node_interpolates_version_constant?(node.children.last)
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_assigns_files_to_var?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -175,7 +175,7 @@ module Dependabot
             node_dynamically_lists_files?(node.children[2])
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_dynamically_lists_files?(node)
             return false unless node.is_a?(Parser::AST::Node)
 
@@ -184,7 +184,7 @@ module Dependabot
             node.type == :block && node.children.first&.type == :send
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_assigns_require_paths?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -193,7 +193,7 @@ module Dependabot
             node.children[1] == :require_paths=
           end
 
-          sig { params(node: T.nilable(T.any(Parser::AST::Node, Symbol, String))).void }
+          sig { params(node: ParserNode).void }
           def replace_file_reads(node)
             return unless node.is_a?(Parser::AST::Node)
             return if node.children[1] == :version=
@@ -203,7 +203,7 @@ module Dependabot
             node.children.each { |child| replace_file_reads(child) }
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_reads_a_file?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -213,7 +213,7 @@ module Dependabot
             node.children[1] == :read
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_uses_readlines?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -223,7 +223,7 @@ module Dependabot
             node.children[1] == :readlines
           end
 
-          sig { params(node: T.nilable(T.any(Parser::AST::Node, Symbol, String))).void }
+          sig { params(node: ParserNode).void }
           def replace_json_parses(node)
             return unless node.is_a?(Parser::AST::Node)
             return if node.children[1] == :version=
@@ -232,7 +232,7 @@ module Dependabot
             node.children.each { |child| replace_json_parses(child) }
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_parses_json?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -242,7 +242,7 @@ module Dependabot
             node.children[1] == :parse
           end
 
-          sig { params(node: T.nilable(T.any(Parser::AST::Node, Symbol, String))).void }
+          sig { params(node: ParserNode).void }
           def remove_find_dot_find_args(node)
             return unless node.is_a?(Parser::AST::Node)
             return if node.children[1] == :version=
@@ -251,7 +251,7 @@ module Dependabot
             node.children.each { |child| remove_find_dot_find_args(child) }
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_calls_find_dot_find?(node)
             return false unless node.is_a?(Parser::AST::Node)
             return false unless node.children.first.is_a?(Parser::AST::Node)
@@ -277,7 +277,7 @@ module Dependabot
             end
           end
 
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T::Boolean) }
+          sig { params(node: ParserNode).returns(T::Boolean) }
           def node_includes_heredoc?(node)
             !!find_heredoc_end_range(node)
           end
@@ -287,7 +287,7 @@ module Dependabot
           #
           # Returns a Parser::Source::Range identifying the location of the end
           #   of the heredoc, or nil if no heredoc was found.
-          sig { params(node: T.nilable(Parser::AST::Node)).returns(T.nilable(Parser::Source::Range)) }
+          sig { params(node: ParserNode).returns(T.nilable(Parser::Source::Range)) }
           def find_heredoc_end_range(node)
             return unless node.is_a?(Parser::AST::Node)
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix the sorbet typing error below:

```
Dependabot::Sorbet::Runtime::InformationalError
Parameter 'node': Expected type T.nilable(T.any(Parser::AST::Node, String, Symbol)), got type Integer with value 3
Caller: /home/dependabot/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb:232
Definition: /home/dependabot/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb:227 (Dependabot::Bundler::FileUpdater::GemspecSanitizer::Rewriter#replace_json_parses)
```

Instead of typing a node as `T.nilable(T.any(Parser::AST::Node, String, Symbol))`, we'll use the previously defined ParserNode type which is an alias of `T.nilable(T.any(Parser::AST::Node, String, Symbol, String, Integer, Float))`. This will correctly handle parse tokens that are symbols, strings or integers.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
