### PR TITLE
Change DefaultRequirement in go_modules

### DIFF
--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -39,7 +39,7 @@ module Dependabot
           raise BadRequirementError, msg
         end
 
-        return DefaultRequirement if matches[1] == ">=" && matches[2] == "0"
+        return DefaultPrereleaseRequirement if matches[1] == ">=" && matches[2] == "0"
 
         [matches[1] || "=", Version.new(matches[2])]
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #11420 by changing [DefaultRequirement](https://docs.ruby-lang.org/en/3.0/Gem/Requirement.html) to [DefaultPrereleaseRequirement](https://docs.ruby-lang.org/en/3.0/Gem/Requirement.html). 

### Anything you want to highlight for special attention from reviewers?

This seems like the most straightforward way to fix the problem where security updates incorrectly states that updates for versions v0.0.0 are not needed.

### How will you know you've accomplished your goal?

Security updates should start succeed for go modules where vulnerable packages are versioned like v0.0.0-xxxx.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
