### PR TITLE
Fix erroring sorbet types in gemspec_dependency_name_finder.rb

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_dependency_name_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_dependency_name_finder.rb
@@ -10,7 +10,7 @@ module Dependabot
       class GemspecDependencyNameFinder
         extend T::Sig
 
-        ChildNode = T.type_alias { T.nilable(T.any(Parser::AST::Node, Symbol, String)) }
+        ChildNode = T.type_alias { T.nilable(T.any(Parser::AST::Node, Symbol, String, Integer, Float)) }
 
         sig { returns(String) }
         attr_reader :gemspec_content


### PR DESCRIPTION
### What are you trying to accomplish?
Fix the Sentry error below:

```
Dependabot::Sorbet::Runtime::InformationalError
Parameter 'node': Expected type T.nilable(T.any(Parser::AST::Node, String, Symbol)), got type Integer with value 2
Caller: bundler/lib/dependabot/bundler/file_updater/gemspec_dependency_name_finder.rb:46
Definition: bundler/lib/dependabot/bundler/file_updater/gemspec_dependency_name_finder.rb:41 (Dependabot::Bundler::FileUpdater::GemspecDependencyNameFinder#find_dependency_name_node)
```

### How will you know you've accomplished your goal?
There shouldn't be any Sentry errors related to the `GemspecDependencyNameFinder` class.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
