### PR TITLE
Fixes [weekly 1.3k] [docker] RestClient::ServerBrokeConnection and related errors

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 require "dependabot/utils"
 
+# rubocop:disable Metrics/ModuleLength
 module Dependabot
   extend T::Sig
 
@@ -21,6 +22,7 @@ module Dependabot
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.fetcher_error_details(error)
     case error
@@ -90,6 +92,11 @@ module Dependabot
         "error-type": "private_source_authentication_failure",
         "error-detail": { source: error.source }
       }
+    when Dependabot::PrivateSourceBadResponse
+      {
+        "error-type": "private_source_response_error",
+        "error-detail": { source: error.source }
+      }
     when Octokit::Unauthorized
       { "error-type": "octokit_unauthorized" }
     when Octokit::ServerError
@@ -113,6 +120,7 @@ module Dependabot
       }
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
   def self.parser_error_details(error)
@@ -165,6 +173,11 @@ module Dependabot
     when Dependabot::PrivateSourceAuthenticationFailure
       {
         "error-type": "private_source_authentication_failure",
+        "error-detail": { source: error.source }
+      }
+    when Dependabot::PrivateSourceBadResponse
+      {
+        "error-type": "private_source_response_error",
         "error-detail": { source: error.source }
       }
     when Dependabot::GitDependenciesNotReachable
@@ -260,6 +273,11 @@ module Dependabot
     when Dependabot::PrivateSourceAuthenticationFailure
       {
         "error-type": "private_source_authentication_failure",
+        "error-detail": { source: error.source }
+      }
+    when Dependabot::PrivateSourceBadResponse
+      {
+        "error-type": "private_source_response_error",
         "error-detail": { source: error.source }
       }
     when Dependabot::DependencyNotFound
@@ -645,6 +663,20 @@ module Dependabot
     end
   end
 
+  class PrivateSourceBadResponse < DependabotError
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :source
+
+    sig { params(source: T.nilable(String)).void }
+    def initialize(source)
+      @source = T.let(sanitize_source(T.must(source)), String)
+      msg = "Bad response error while accessing source: #{@source}"
+      super(msg)
+    end
+  end
+
   class PrivateSourceTimedOut < DependabotError
     extend T::Sig
 
@@ -846,3 +878,4 @@ module Dependabot
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -94,7 +94,7 @@ module Dependabot
       }
     when Dependabot::PrivateSourceBadResponse
       {
-        "error-type": "private_source_response_error",
+        "error-type": "private_source_bad_response",
         "error-detail": { source: error.source }
       }
     when Octokit::Unauthorized
@@ -177,7 +177,7 @@ module Dependabot
       }
     when Dependabot::PrivateSourceBadResponse
       {
-        "error-type": "private_source_response_error",
+        "error-type": "private_source_bad_response",
         "error-detail": { source: error.source }
       }
     when Dependabot::GitDependenciesNotReachable
@@ -277,7 +277,7 @@ module Dependabot
       }
     when Dependabot::PrivateSourceBadResponse
       {
-        "error-type": "private_source_response_error",
+        "error-type": "private_source_bad_response",
         "error-detail": { source: error.source }
       }
     when Dependabot::DependencyNotFound

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -232,7 +232,7 @@ module Dependabot
         attempt ||= 1
         attempt += 1
         return if attempt > 3 && e.is_a?(DockerRegistry2::NotFound)
-        raise if attempt > 3
+        raise PrivateSourceBadResponse, registry_hostname if attempt > 3
 
         retry
       rescue DockerRegistry2::RegistryAuthenticationException,


### PR DESCRIPTION
### What are you trying to accomplish?

Adds error handlers for bad response while accessing private registries

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
