### PR TITLE
Handle `Content did not change!` in poetry_file_updater.rb 

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -251,6 +251,11 @@ module Dependabot
           "file-path": error.file_path
         }
       }
+    when Dependabot::DependencyFileContentNotChanged
+      {
+        "error-type": "dependency_file_content_not_changed",
+        "error-detail": { message: error.message }
+      }
     when Dependabot::ToolVersionNotSupported
       {
         "error-type": "tool_version_not_supported",
@@ -640,6 +645,8 @@ module Dependabot
   class DependencyFileNotResolvable < DependabotError; end
 
   class DependencyFileNotSupported < DependabotError; end
+
+  class DependencyFileContentNotChanged < DependabotError; end
 
   class BadRequirementError < Gem::Requirement::BadRequirementError; end
 

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -73,7 +73,7 @@ module Dependabot
             updated_content = replace_dep(dependency, updated_content, new_r, old_r)
           end
 
-          raise "Content did not change!" if content == updated_content
+          raise DependencyFileContentNotChanged, "Content did not change!" if content == updated_content
 
           updated_content
         end

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -729,6 +729,36 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
           end
         end
       end
+
+      context "when the requirement has not changed" do
+        let(:pyproject_fixture_name) { "caret_version.toml" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "2.19.1",
+            previous_version: nil,
+            package_manager: "pip",
+            requirements: [{
+              requirement: "^2.19.1",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }],
+            previous_requirements: [{
+              requirement: ">=2.19.1",
+              file: "pyproject.toml",
+              source: nil,
+              groups: ["dependencies"]
+            }]
+          )
+        end
+
+        it "raises the correct error" do
+          expect do
+            updated_files.map(&:name)
+          end.to raise_error(Dependabot::DependencyFileContentNotChanged, "Content did not change!")
+        end
+      end
     end
 
     context "with a poetry.lock" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the Sentry error below:

**RuntimeError**: python/lib/dependabot/python/file_updater/poetry_file_updater.rb in updated_pyproject_content
Content did not change!

### Anything you want to highlight for special attention from reviewers?

I have added a new error type: DependencyFileContentNotChanged to the errors.rb file. This will replace the current runtime error that is polluting Sentry. I'll be adding this error on the API repo as well.

### How will you know you've accomplished your goal?
This error won't appear in Sentry anymore.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
