### PR TITLE
allow alternate experiment names

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -227,6 +227,36 @@ public class SerializationTests
         Assert.False(experimentsManager.UseDirectDiscovery);
     }
 
+    [Fact]
+    public void DeserializeExperimentsManager_AlternateNames()
+    {
+        // experiment names can be either snake case or kebab case
+        var jobWrapper = RunWorker.Deserialize("""
+            {
+              "job": {
+                "package-manager": "nuget",
+                "allowed-updates": [
+                  {
+                    "update-type": "all"
+                  }
+                ],
+                "source": {
+                  "provider": "github",
+                  "repo": "some-org/some-repo",
+                  "directory": "some-dir"
+                },
+                "experiments": {
+                  "nuget-legacy-dependency-solver": true,
+                  "nuget-use-direct-discovery": true
+                }
+              }
+            }
+            """);
+        var experimentsManager = ExperimentsManager.GetExperimentsManager(jobWrapper.Job.Experiments);
+        Assert.True(experimentsManager.UseLegacyDependencySolver);
+        Assert.True(experimentsManager.UseDirectDiscovery);
+    }
+
     [Theory]
     [MemberData(nameof(DeserializeErrorTypesData))]
     public void SerializeError(JobErrorBase error, string expectedSerialization)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -62,9 +62,13 @@ public record ExperimentsManager
             return false;
         }
 
-        if (experiments.TryGetValue(experimentName, out var value))
+        // prefer experiments named with underscores, but hyphens are also allowed as an alternate
+        object? experimentValue;
+        var experimentNameAlternate = experimentName.Replace("_", "-");
+        if (experiments.TryGetValue(experimentName, out experimentValue) ||
+            experiments.TryGetValue(experimentNameAlternate, out experimentValue))
         {
-            if ((value?.ToString() ?? "").Equals("true", StringComparison.OrdinalIgnoreCase))
+            if ((experimentValue?.ToString() ?? "").Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }


### PR DESCRIPTION
Experiment names in `job.json` can be either snake case or kebab case.  Previously only snake case was supported, but this PR supports the alternate, too.

Inspiration taken from [here](https://github.com/dependabot/dependabot-core/blob/fa20d494ab21ac1ace2ab1b4be01b3a251e544b1/updater/lib/dependabot/job.rb#L127).