### PR TITLE
Bump Yarn to 4.7.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -7,7 +7,7 @@ ARG COREPACK_VERSION=0.31.0
 ARG PNPM_VERSION=9.15.5
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
-ARG YARN_VERSION=4.6.0
+ARG YARN_VERSION=4.7.0
 
 # Check for updates at https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=1.2.1

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -7,7 +7,7 @@ ARG COREPACK_VERSION=0.31.0
 ARG PNPM_VERSION=9.15.5
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
-ARG YARN_VERSION=4.5.3
+ARG YARN_VERSION=4.6.0
 
 # Check for updates at https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=1.2.1


### PR DESCRIPTION
Release notes: [4.6.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.6.0)

What's Changed

> 
>     fix(pnp): support require(esm) by @merceyz in https://github.com/yarnpkg/berry/pull/6639
>     feat: add yarnpkg/core sub exports by @ChALkeR in https://github.com/yarnpkg/berry/pull/6614
>     add a config option to disallow the cache clean command by @elbywan in https://github.com/yarnpkg/berry/pull/6610
>     Small typo in yarn workspaces foreach: include -> exclude by @miorel in https://github.com/yarnpkg/berry/pull/6561