### PR TITLE
Update `DEPENDENCIES_LABEL_REGEX`

### DIFF
--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -12,7 +12,7 @@ module Dependabot
     class Labeler
       extend T::Sig
 
-      DEPENDENCIES_LABEL_REGEX = %r{^[^/]*dependenc[^/]+$}i
+      DEPENDENCIES_LABEL_REGEX = %r{^dependenc(y|ies)$}i
       DEFAULT_DEPENDENCIES_LABEL = "dependencies"
       DEFAULT_SECURITY_LABEL = "security"
 


### PR DESCRIPTION
### What are you trying to accomplish?

This regex is used to find and apply dependency labels to Dependabot pull requests. This feature is undocumented and sometimes results in unexpected and unwanted labels being applied to Dependabot pull requests.

Updating the regex to only match `depenency` or `dependencies` instead of the substring `dependenc` should fix this in most cases.

- Fixes https://github.com/dependabot/dependabot-core/issues/6753
- Partially fixes https://github.com/dependabot/dependabot-core/issues/8232

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I picked this approach to balance minimizing potentially breaking changes while maximizing the desired impact of the fix. Alternatively, we could remove this undocumented feature altogether so that any non-default label must be configured.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
