### PR TITLE
Add Support for `latest` Constraint in Version Detection

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
@@ -213,7 +213,7 @@ module Dependabot
       def self.to_ruby_constraints_with_versions(constraints, dependabot_versions = [])
         constraints.filter_map do |constraint|
           parsed = to_ruby_constraint_with_version(constraint, dependabot_versions)
-          parsed if parsed && parsed[:constraint] # Only include valid constraints
+          parsed if parsed
         end.uniq
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
@@ -309,8 +309,10 @@ module Dependabot
             version < Version.new(constraint_version)
           end
           { constraint: "<#{Regexp.last_match(1)}", version: found_version&.to_s }
-        when WILDCARD_REGEX # Wildcard
-          { constraint: nil, version: dependabot_versions&.max&.to_s } # Explicitly valid but no specific constraint
+        when WILDCARD_REGEX # No specific constraint, resolves to the highest available version
+          { constraint: nil, version: dependabot_versions&.max&.to_s }
+        when LATEST_REGEX
+          { constraint: nil, version: dependabot_versions&.max&.to_s } # Resolves to the latest available version
         end
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/constraint_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/constraint_helper_spec.rb
@@ -7,6 +7,9 @@ require "dependabot/npm_and_yarn/constraint_helper"
 RSpec.describe Dependabot::NpmAndYarn::ConstraintHelper do
   let(:helper) { described_class }
   let(:version_regex) { /^#{helper::VERSION}$/o }
+  let(:dependabot_versions) do
+    []
+  end
 
   describe "Regex Constants" do
     describe "VERSION" do
@@ -146,6 +149,16 @@ RSpec.describe Dependabot::NpmAndYarn::ConstraintHelper do
         end
       end
     end
+
+    describe "LATEST_REGEX" do
+      it "matches valid wildcard constraints" do
+        expect(helper::LATEST_REGEX.match?("latest")).to be(true)
+      end
+
+      it "does not match invalid keyword constraints" do
+        expect(helper::LATEST_REGEX.match?("invalid")).to be(false), "Expected invalid to not match"
+      end
+    end
   end
 
   describe ".extract_ruby_constraints" do
@@ -174,22 +187,70 @@ RSpec.describe Dependabot::NpmAndYarn::ConstraintHelper do
   end
 
   describe ".find_highest_version_from_constraint_expression" do
-    it "finds the highest version from valid constraints" do
-      constraints = ">=1.2.3 <2.0.0 || ~2.3.4 || ^3.0.0"
-      result = helper.find_highest_version_from_constraint_expression(constraints)
-      expect(result).to eq("3.0.0")
+    let(:dependabot_versions) do
+      ["1.2.3", "2.0.0", "3.4.5", "3.5.1", "4.0.0"].map do |v|
+        Dependabot::Version.new(v)
+      end
     end
 
-    it "returns nil if no versions are present" do
-      constraints = "* || invalid"
-      result = helper.find_highest_version_from_constraint_expression(constraints)
+    it "finds the highest version from valid constraints" do
+      constraints = ">=1.2.3 <2.0.0 || ~2.3.4 || ^3.0.0"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("4.0.0")
+    end
+
+    it "handles exact versions correctly" do
+      constraints = "3.4.5"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("3.4.5")
+    end
+
+    it "handles greater than or equal constraints" do
+      constraints = ">=2.0.0"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("4.0.0")
+    end
+
+    it "handles less than constraints" do
+      constraints = "<3.5.1"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("3.4.5")
+    end
+
+    it "handles caret (^) constraints correctly" do
+      constraints = "^3.4.5"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("3.4.5") # Matches highest within 3.x.x range
+    end
+
+    it "handles tilde (~) constraints correctly" do
+      constraints = "~3.4.5"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("3.4.5") # Matches within minor range 3.4.x
+    end
+
+    it "handles wildcard (*) constraints correctly" do
+      constraints = "*"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("4.0.0") # Highest available version
+    end
+
+    it "handles 'latest' constraint correctly" do
+      constraints = "latest"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to eq("4.0.0") # Explicit latest resolution
+    end
+
+    it "returns nil if no versions match" do
+      constraints = ">5.0.0"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
       expect(result).to be_nil
     end
 
-    it "handles constraints with spaces and commas" do
-      constraints = ">= 1.2.3 , <= 2.0.0 , ~ 3.4.5"
-      result = helper.find_highest_version_from_constraint_expression(constraints)
-      expect(result).to eq("3.4.5")
+    it "returns nil for invalid constraints" do
+      constraints = "invalid || >=x.y.z"
+      result = helper.find_highest_version_from_constraint_expression(constraints, dependabot_versions)
+      expect(result).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR improves version constraint handling by adding explicit support for `latest`. While we previously handled the wildcard (`*`), `latest` was not recognized separately. This update ensures `latest` correctly resolves to the newest available version.

#### **What issues does this affect or fix?**  
- Adds explicit handling for the `latest` constraint.  
- Ensures `latest` resolves to the newest available version.  
- Improves consistency in version resolution logic.

#### **Anything you want to highlight for special attention from reviewers?**  
- This change introduces `LATEST_REGEX` to distinguish `latest` from other constraints.  
- Please verify that the behavior aligns with expected package manager resolution.

#### **How will you know you've accomplished your goal?**  
- Tests confirm `latest` resolves correctly to the newest available version.  
- No regressions in existing wildcard (`*`) or constraint handling.  

---

### **Checklist**
- [x] I have run the complete test suite to ensure all tests and linters pass.  
- [x] I have thoroughly tested my code changes, including adding tests for new functionality.  
- [x] I have written clear and descriptive commit messages.  
- [x] I have provided a detailed description of the changes in the pull request.  
- [x] I have ensured that the code is well-documented and easy to understand.  