### PR TITLE
[Sorbet] Add strict typing for logger formats

### DIFF
--- a/updater/lib/dependabot/logger/formats.rb
+++ b/updater/lib/dependabot/logger/formats.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
 require "logger"
@@ -10,19 +10,31 @@ module Dependabot
     TIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
     class BasicFormatter < ::Logger::Formatter
+      extend T::Sig
+
+      sig do
+        params(severity: String, _datetime: T.nilable(Time), _progname: T.nilable(String), msg: T.nilable(String))
+          .returns(String)
+      end
       def call(severity, _datetime, _progname, msg)
         "#{Time.now.strftime(TIME_FORMAT)} #{severity} #{msg2str(msg)}\n"
       end
     end
 
     class JobFormatter < ::Logger::Formatter
+      extend T::Sig
       CLI_ID = "cli"
       UNKNOWN_ID = "unknown_id"
 
+      sig { params(job_id: T.nilable(String)).void }
       def initialize(job_id)
         @job_id = job_id
       end
 
+      sig do
+        params(severity: String, _datetime: T.nilable(Time), _progname: T.nilable(String), msg: T.nilable(String))
+          .returns(String)
+      end
       def call(severity, _datetime, _progname, msg)
         [
           Time.now.strftime(TIME_FORMAT),
@@ -34,15 +46,13 @@ module Dependabot
 
       private
 
+      sig { returns(T.nilable(String)) }
       def job_prefix
-        return @job_prefix if defined? @job_prefix
-        # The dependabot/cli tool uses a placeholder value since it does not
-        # have an actual Job ID issued by the service.
-        #
-        # Let's just omit the prefix if this is the case.
-        return @job_prefix = nil if @job_id == CLI_ID
+        @job_prefix ||= T.let(begin
+          return nil if @job_id == CLI_ID
 
-        @job_prefix = "<job_#{@job_id || UNKNOWN_ID}>"
+          "<job_#{@job_id || UNKNOWN_ID}>"
+        end, T.nilable(String))
       end
     end
   end

--- a/updater/spec/dependabot/logger/basic_formatter_spec.rb
+++ b/updater/spec/dependabot/logger/basic_formatter_spec.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/logger/formats"
+
+RSpec.describe Dependabot::Logger::BasicFormatter do
+  describe "#call" do
+    it "returns a formatted log line" do
+      formatter = described_class.new
+      log_line = formatter.call("INFO", Time.now, "progname", "msg")
+
+      expect(log_line).to match(%r{\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} INFO msg\n})
+    end
+
+    it "returns a formatted log line with only a severity" do
+      formatter = described_class.new
+      log_line = formatter.call("ERROR", nil, nil, nil)
+
+      expect(log_line).to match(%r{\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} ERROR nil\n})
+    end
+  end
+end

--- a/updater/spec/dependabot/logger/job_formatter_spec.rb
+++ b/updater/spec/dependabot/logger/job_formatter_spec.rb
@@ -1,0 +1,50 @@
+# typed: true
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/logger/formats"
+
+RSpec.describe Dependabot::Logger::JobFormatter do
+  describe "#new" do
+    it "returns a formatter when provided a job_id" do
+      formatter = described_class.new("job_id")
+      expect(formatter).to be_a(described_class)
+    end
+
+    it "returns a formatter when provided a nil job_id" do
+      formatter = described_class.new(nil)
+      expect(formatter).to be_a(described_class)
+    end
+  end
+
+  describe "#call" do
+    let(:job_id) { "job_id" }
+    let(:formatter) { described_class.new(job_id) }
+
+    it "returns a formatted log line with a job_id" do
+      log_line = formatter.call("INFO", Time.now, "progname", "msg")
+
+      expect(log_line).to match(%r{\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} INFO <job_job_id> msg\n})
+    end
+
+    it "returns a formatted log line with a nil job_id" do
+      formatter = described_class.new(nil)
+      log_line = formatter.call("INFO", Time.now, "progname", "msg")
+
+      expect(log_line).to match(%r{\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} INFO <job_unknown_id> msg\n})
+    end
+
+    it "returns a formatted log line with only a severity" do
+      log_line = formatter.call("ERROR", nil, nil, nil)
+
+      expect(log_line).to match(%r{\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} ERROR <job_job_id> nil\n})
+    end
+
+    it "returns a formatted log line when using the CLI" do
+      formatter = described_class.new("cli")
+      log_line = formatter.call("ERROR", nil, nil, nil)
+
+      expect(log_line).to match(%r{\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} ERROR nil\n})
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

This PR adds strict typing to the logger formats `Dependabot::Logger::BasicFormatter` and `Dependabot::Logger::JobFormatter`.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
In production we saw errors due to `nil` being passed to `_progname`. We have allowed `nil` values for all the unused params in the `call` method and added missing specs.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

- The code has been refactored to be type-safe with Sorbet, eliminating reliance on unsafe casts.
- The functionality should remain unchanged.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
