### PR TITLE
Handle import error when a package is referenced incorrectly

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -51,7 +51,9 @@ module Dependabot
           # auth problems with either git or the go proxy
           /go(?: get)?: .*: unknown revision/m,
           # Package pointing to a proxy that 404s
-          /go(?: get)?: .*: unrecognized import path/m
+          /go(?: get)?: .*: unrecognized import path/m,
+          # Package not being referenced correctly
+          /go:.*imports.*package.+is not in std/m
         ].freeze, T::Array[Regexp])
 
         MODULE_PATH_MISMATCH_REGEXES = T.let([


### PR DESCRIPTION
### What are you trying to accomplish?
Fix the following type of Sentry error:

```
go: governor imports
	governor/app/bootstrap imports
	governor/app/providers/pub_sub imports
	governor/rpc/governor/v1: package governor/rpc/governor/v1 is not in std (/home/dependabot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/governor/rpc/governor/v1)
```

### Anything you want to highlight for special attention from reviewers?
This is a user error that occurs when a package is not being referenced correctly. We can't resolve it on our end so we just need to raise the appropriate error so that it stops appearing in Sentry as an unknown error.

### How will you know you've accomplished your goal?
There shouldn't be any new occurrences of this issue in Sentry once this fix has been deployed.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
