### PR TITLE
improve TFM discovery when targeting Windows

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -1131,7 +1131,7 @@ public partial class DiscoveryWorkerTests
                     ("src/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
+                            <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;net8.0-windows</TargetFrameworks>
                           </PropertyGroup>
                           <ItemGroup>
                             <PackageReference Include="Some.Package" Version="1.2.3" />
@@ -1151,11 +1151,12 @@ public partial class DiscoveryWorkerTests
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-ios"], IsDirect: true),
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-maccatalyst"], IsDirect: true),
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-macos"], IsDirect: true),
+                                new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-windows"], IsDirect: true),
                             ],
                             Properties = [
-                                new("TargetFrameworks", "net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst", @"src/project.csproj"),
+                                new("TargetFrameworks", "net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;net8.0-windows", @"src/project.csproj"),
                             ],
-                            TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos"],
+                            TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos", "net8.0-windows"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
                             AdditionalFiles = [],
@@ -1310,6 +1311,8 @@ public partial class DiscoveryWorkerTests
 
                           <PropertyGroup>
                             <TargetFramework>net8.0</TargetFramework>
+                            <!-- the SDK turns `<TargetFramework>net8.0</TargetFramework>` into the following -->
+                            <TargetFrameworkMoniker>.NETCoreApp,Version=8.0</TargetFrameworkMoniker>
                           </PropertyGroup>
 
                           <ItemGroup>
@@ -1360,7 +1363,8 @@ public partial class DiscoveryWorkerTests
                                 new("Test.Only.Package", "1.0.99", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true)
                             ],
                             Properties = [
-                                new("TargetFramework", "net8.0", "project.csproj")
+                                new("TargetFramework", "net8.0", "project.csproj"),
+                                new("TargetFrameworkMoniker", ".NETCoreApp,Version=8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
@@ -2,6 +2,7 @@
   <!-- The following properties enable target framework and dependency discovery when OS-specific workloads are required -->
   <PropertyGroup>
     <DesignTimeBuild>true</DesignTimeBuild>
-    <TargetPlatformVersion Condition=" $(TargetFramework.Contains('-')) ">1.0</TargetPlatformVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">1.0</TargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/TargetFrameworkReporter.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/TargetFrameworkReporter.targets
@@ -2,12 +2,7 @@
   <Import Project="DependencyDiscovery.props" />
 
   <Target Name="ReportTargetFramework">
-    <!-- this property is for non-SDK projects, commonly with `packages.config -->
-    <!-- e.g., returns ".NETFramework,Version=v4.5" -->
-    <Message Text="ProjectData::TargetFrameworkVersion=$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)" Importance="High" Condition="'$(TargetFrameworkIdentifier)' != '' AND '' != '$(TargetFrameworkVersion)'" />
-
-    <!-- these properties are for SDK projects -->
-    <Message Text="ProjectData::TargetFramework=$(TargetFramework)" Importance="High" Condition="'$(TargetFramework)' != ''" />
+    <Message Text="ProjectData::TargetFrameworkMoniker=$(TargetFrameworkMoniker);ProjectData::TargetPlatformMoniker=$(TargetPlatformMoniker)" Importance="High" Condition="'$(TargetFrameworkMoniker)' != ''" />
     <Message Text="ProjectData::TargetFrameworks=$(TargetFrameworks)" Importance="High" Condition="'$(TargetFrameworks)' != ''" />
   </Target>
 </Project>


### PR DESCRIPTION
Dependabot runs in a Linux container so a TFM like `net8.0-windows` needs some special handling.

The core of the fix was adding `<EnableWindowsTargeting>true</EnableWindowsTargeting>` when doing direct TFM detection and the rest is a big cleanup and simplification as well as more testing.

Fixes #11506