### PR TITLE
add pr management message types to NuGet updater

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1945,7 +1945,7 @@ public class RunWorkerTests
                     Metric = "updater.started",
                     Tags = new()
                     {
-                        ["operation"] = "group_update_all_versions"
+                        ["operation"] = "create_security_pr"
                     }
                 },
                 new CreatePullRequest()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -560,6 +560,26 @@ public class SerializationTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact]
+    public void SerializeUpdatePullRequest()
+    {
+        var update = new UpdatePullRequest()
+        {
+            BaseCommitSha = "TEST-COMMIT-SHA",
+            DependencyNames = ["dep"],
+            UpdatedDependencyFiles = [new() { Name = "project.csproj", Directory = "/", Content = "updated content" }],
+            PrTitle = "pr title",
+            PrBody = "pr body",
+            CommitMessage = "commit message",
+            DependencyGroup = null,
+        };
+        var actual = HttpApiHandler.Serialize(update);
+        var expected = """
+            {"data":{"base-commit-sha":"TEST-COMMIT-SHA","dependency-names":["dep"],"updated-dependency-files":[{"name":"project.csproj","content":"updated content","directory":"/","type":"file","support_file":false,"content_encoding":"utf-8","deleted":false,"operation":"update","mode":null}],"pr-title":"pr title","pr-body":"pr body","commit-message":"commit message","dependency-group":null}}
+            """;
+        Assert.Equal(expected, actual);
+    }
+
     public static IEnumerable<object?[]> DeserializeErrorTypesData()
     {
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -585,6 +585,22 @@ public class SerializationTests
 
         yield return
         [
+            new PullRequestExistsForLatestVersion("dep", "ver"),
+            """
+            {"data":{"error-type":"pull_request_exists_for_latest_version","error-details":{"dependency-name":"dep","dependency-version":"ver"}}}
+            """
+        ];
+
+        yield return
+        [
+            new SecurityUpdateNotNeeded("dep"),
+            """
+            {"data":{"error-type":"security_update_not_needed","error-details":{"dependency-name":"dep"}}}
+            """
+        ];
+
+        yield return
+        [
             new UnknownError(new Exception("some message"), "JOB-ID"),
             """
             {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"some message","error-backtrace":"TEST-BACKTRACE","package-manager":"nuget","job-id":"JOB-ID"}}}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -541,6 +541,25 @@ public class SerializationTests
         Assert.True(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
     }
 
+    [Fact]
+    public void SerializeCreatePullRequest()
+    {
+        var create = new CreatePullRequest()
+        {
+            Dependencies = [new() { Name = "dep", Version = "ver2", PreviousVersion = "ver1", Requirements = [new() { Requirement = "ver2", File = "project.csproj" }], PreviousRequirements = [new() { Requirement = "ver1", File = "project.csproj" }] }],
+            UpdatedDependencyFiles = [new() { Name = "project.csproj", Directory = "/", Content = "updated content" }],
+            BaseCommitSha = "TEST-COMMIT-SHA",
+            CommitMessage = "commit message",
+            PrTitle = "pr title",
+            PrBody = "pr body"
+        };
+        var actual = HttpApiHandler.Serialize(create);
+        var expected = """
+            {"data":{"dependencies":[{"name":"dep","version":"ver2","requirements":[{"requirement":"ver2","file":"project.csproj","groups":[],"source":null}],"previous-version":"ver1","previous-requirements":[{"requirement":"ver1","file":"project.csproj","groups":[],"source":null}]}],"updated-dependency-files":[{"name":"project.csproj","content":"updated content","directory":"/","type":"file","support_file":false,"content_encoding":"utf-8","deleted":false,"operation":"update","mode":null}],"base-commit-sha":"TEST-COMMIT-SHA","commit-message":"commit message","pr-title":"pr title","pr-body":"pr body"}}
+            """;
+        Assert.Equal(expected, actual);
+    }
+
     public static IEnumerable<object?[]> DeserializeErrorTypesData()
     {
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -542,6 +542,20 @@ public class SerializationTests
     }
 
     [Fact]
+    public void SerializeClosePullRequest()
+    {
+        var close = new ClosePullRequest()
+        {
+            DependencyNames = ["dep"],
+        };
+        var actual = HttpApiHandler.Serialize(close);
+        var expected = """
+            {"data":{"dependency-names":["dep"],"reason":"up_to_date"}}
+            """;
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void SerializeCreatePullRequest()
     {
         var create = new CreatePullRequest()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
@@ -33,6 +33,12 @@ internal class TestApiHandler : IApiHandler
         return Task.CompletedTask;
     }
 
+    public Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
+    {
+        _receivedMessages.Add((updatePullRequest.GetType(), updatePullRequest));
+        return Task.CompletedTask;
+    }
+
     public Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
     {
         _receivedMessages.Add((markAsProcessed.GetType(), markAsProcessed));

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
@@ -1,0 +1,12 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public sealed record ClosePullRequest
+{
+    [JsonPropertyName("dependency-names")]
+    public required ImmutableArray<string> DependencyNames { get; init; }
+
+    public string Reason { get; init; } = "up_to_date";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestExistsForLatestVersion.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestExistsForLatestVersion.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PullRequestExistsForLatestVersion : JobErrorBase
+{
+    public PullRequestExistsForLatestVersion(string dependencyName, string dependencyVersion)
+        : base("pull_request_exists_for_latest_version")
+    {
+        Details["dependency-name"] = dependencyName;
+        Details["dependency-version"] = dependencyVersion;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotNeeded.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotNeeded.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record SecurityUpdateNotNeeded : JobErrorBase
+{
+    public SecurityUpdateNotNeeded(string dependencyName)
+        : base("security_update_not_needed")
+    {
+        Details["dependency-name"] = dependencyName;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
@@ -1,0 +1,28 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public sealed record UpdatePullRequest
+{
+    [JsonPropertyName("base-commit-sha")]
+    public required string BaseCommitSha { get; init; }
+
+    [JsonPropertyName("dependency-names")]
+    public required ImmutableArray<string> DependencyNames { get; init; }
+
+    [JsonPropertyName("updated-dependency-files")]
+    public required DependencyFile[] UpdatedDependencyFiles { get; init; }
+
+    [JsonPropertyName("pr-title")]
+    public required string PrTitle { get; init; }
+
+    [JsonPropertyName("pr-body")]
+    public required string PrBody { get; init; }
+
+    [JsonPropertyName("commit-message")]
+    public required string CommitMessage { get; init; }
+
+    [JsonPropertyName("dependency-group")]
+    public required string? DependencyGroup { get; init; }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -45,6 +45,11 @@ public class HttpApiHandler : IApiHandler
         await PostAsJson("create_pull_request", createPullRequest);
     }
 
+    public async Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
+    {
+        await PostAsJson("update_pull_request", updatePullRequest);
+    }
+
     public async Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
     {
         await PostAsJson("mark_as_processed", markAsProcessed);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -8,5 +8,6 @@ public interface IApiHandler
     Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList);
     Task IncrementMetric(IncrementMetric incrementMetric);
     Task CreatePullRequest(CreatePullRequest createPullRequest);
+    Task UpdatePullRequest(UpdatePullRequest updatePullRequest);
     Task MarkAsProcessed(MarkAsProcessed markAsProcessed);
 }

--- a/nuget/script/run
+++ b/nuget/script/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=all
 
-nuget_experiment_value=$(cat "$DEPENDABOT_JOB_PATH" | jq '.job.experiments.nuget_native_updater')
+nuget_experiment_value=$(cat "$DEPENDABOT_JOB_PATH" | sed -En "s/-/_/pg" | jq '.job.experiments.nuget_native_updater')
 echo "NuGet native updater experiment value: $nuget_experiment_value"
 
 if echo "$nuget_experiment_value" | grep -q 'true'; then


### PR DESCRIPTION
In preparation of future work, this adds some PR management message types to the end-to-end NuGet updater.  No functional change.