### PR TITLE
Register the bun package manager

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -99,6 +99,7 @@ require "dependabot/pull_request_creator"
 require "dependabot/config/file_fetcher"
 require "dependabot/simple_instrumentor"
 
+require "dependabot/bun"
 require "dependabot/bundler"
 require "dependabot/cargo"
 require "dependabot/composer"

--- a/javascript/lib/dependabot/bun.rb
+++ b/javascript/lib/dependabot/bun.rb
@@ -41,3 +41,4 @@ end
 Dependabot::FileFetchers.register("bun", Dependabot::Bun::FileFetcher)
 Dependabot::FileParsers.register("bun", Dependabot::Bun::FileParser)
 Dependabot::FileUpdaters.register("bun", Dependabot::Bun::FileUpdater)
+Dependabot::UpdateCheckers.register("bun", Dependabot::Bun::UpdateChecker)

--- a/javascript/lib/dependabot/bun/file_parser/bun_lock.rb
+++ b/javascript/lib/dependabot/bun/file_parser/bun_lock.rb
@@ -56,7 +56,7 @@ module Dependabot
             dependency_set << Dependency.new(
               name: name,
               version: semver.to_s,
-              package_manager: "npm_and_yarn",
+              package_manager: "bun",
               requirements: []
             )
           end

--- a/javascript/lib/dependabot/bun/update_checker.rb
+++ b/javascript/lib/dependabot/bun/update_checker.rb
@@ -1,0 +1,438 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Bun
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
+      def up_to_date?
+        return false if security_update? &&
+                        dependency.version &&
+                        version_class.correct?(dependency.version) &&
+                        vulnerable_versions.any? &&
+                        !vulnerable_versions.include?(current_version)
+
+        super
+      end
+
+      def vulnerable?
+        super || vulnerable_versions.any?
+      end
+
+      def latest_version
+        @latest_version ||=
+          if git_dependency?
+            latest_version_for_git_dependency
+          else
+            latest_version_details&.fetch(:version)
+          end
+      end
+
+      def latest_resolvable_version
+        return unless latest_version
+
+        @latest_resolvable_version ||=
+          if dependency.top_level?
+            version_resolver.latest_resolvable_version
+          else
+            # If the dependency is indirect its version is constrained  by the
+            # requirements placed on it by dependencies lower down the tree
+            subdependency_version_resolver.latest_resolvable_version
+          end
+      end
+
+      def lowest_security_fix_version
+        # This will require a full unlock to update multiple top level ancestors.
+        return if vulnerability_audit["fix_available"] && vulnerability_audit["top_level_ancestors"].count > 1
+
+        latest_version_finder.lowest_security_fix_version
+      end
+
+      def lowest_resolvable_security_fix_version
+        raise "Dependency not vulnerable!" unless vulnerable?
+
+        # NOTE: Currently, we don't resolve transitive/sub-dependencies as
+        # npm/yarn don't provide any control over updating to a specific
+        # sub-dependency version.
+
+        # Return nil for vulnerable transitive dependencies if there are conflicting dependencies.
+        # This helps catch errors in such cases.
+        return nil if !dependency.top_level? && conflicting_dependencies.any?
+
+        # For transitive dependencies without conflicts, return the latest resolvable transitive
+        # security fix version that does not require unlocking other dependencies.
+        return latest_resolvable_transitive_security_fix_version_with_no_unlock unless dependency.top_level?
+
+        # For top-level dependencies, return the lowest security fix version.
+        # TODO: Consider checking resolvability here in the future.
+        lowest_security_fix_version
+      end
+
+      def latest_resolvable_version_with_no_unlock
+        return latest_resolvable_version unless dependency.top_level?
+
+        return latest_resolvable_version_with_no_unlock_for_git_dependency if git_dependency?
+
+        latest_version_finder.latest_version_with_no_unlock
+      end
+
+      def latest_resolvable_previous_version(updated_version)
+        version_resolver.latest_resolvable_previous_version(updated_version)
+      end
+
+      def updated_requirements
+        resolvable_version =
+          if preferred_resolvable_version.is_a?(version_class)
+            preferred_resolvable_version.to_s
+          elsif preferred_resolvable_version.nil?
+            nil
+          else
+            # If the preferred_resolvable_version came back as anything other
+            # than a version class or `nil` it must be because this is a git
+            # dependency, for which we don't check resolvability.
+            latest_version_details&.fetch(:version, nil)&.to_s
+          end
+
+        @updated_requirements ||=
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            updated_source: updated_source,
+            latest_resolvable_version: resolvable_version,
+            update_strategy: requirements_update_strategy
+          ).updated_requirements
+      end
+
+      def requirements_unlocked_or_can_be?
+        !requirements_update_strategy.lockfile_only?
+      end
+
+      def requirements_update_strategy
+        # If passed in as an option (in the base class) honour that option
+        return @requirements_update_strategy if @requirements_update_strategy
+
+        # Otherwise, widen ranges for libraries and bump versions for apps
+        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
+      end
+
+      def conflicting_dependencies
+        conflicts = ConflictingDependencyResolver.new(
+          dependency_files: dependency_files,
+          credentials: credentials
+        ).conflicting_dependencies(
+          dependency: dependency,
+          target_version: lowest_security_fix_version
+        )
+        return conflicts unless vulnerability_audit_performed?
+
+        vulnerable = [vulnerability_audit].select do |hash|
+          !hash["fix_available"] && hash["explanation"]
+        end
+
+        conflicts + vulnerable
+      end
+
+      private
+
+      def vulnerability_audit_performed?
+        defined?(@vulnerability_audit)
+      end
+
+      def vulnerability_audit
+        @vulnerability_audit ||=
+          VulnerabilityAuditor.new(
+            dependency_files: dependency_files,
+            credentials: credentials
+          ).audit(
+            dependency: dependency,
+            security_advisories: security_advisories
+          )
+      end
+
+      def vulnerable_versions
+        @vulnerable_versions ||=
+          begin
+            all_versions = dependency.all_versions
+                                     .filter_map { |v| version_class.new(v) if version_class.correct?(v) }
+
+            all_versions.select do |v|
+              security_advisories.any? { |advisory| advisory.vulnerable?(v) }
+            end
+          end
+      end
+
+      def latest_version_resolvable_with_full_unlock?
+        return false unless latest_version
+
+        return version_resolver.latest_version_resolvable_with_full_unlock? if dependency.top_level?
+
+        return false unless security_advisories.any?
+
+        vulnerability_audit["fix_available"]
+      end
+
+      def updated_dependencies_after_full_unlock
+        return conflicting_updated_dependencies if security_advisories.any? && vulnerability_audit["fix_available"]
+
+        version_resolver.dependency_updates_from_full_unlock
+                        .map { |update_details| build_updated_dependency(update_details) }
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def conflicting_updated_dependencies
+        top_level_dependencies = top_level_dependency_lookup
+
+        updated_deps = []
+        vulnerability_audit["fix_updates"].each do |update|
+          dependency_name = update["dependency_name"]
+          requirements = top_level_dependencies[dependency_name]&.requirements || []
+
+          updated_deps << build_updated_dependency(
+            dependency: Dependency.new(
+              name: dependency_name,
+              package_manager: "npm_and_yarn",
+              requirements: requirements
+            ),
+            version: update["target_version"],
+            previous_version: update["current_version"]
+          )
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        # We don't need to directly update the target dependency if it will
+        # be updated as a side effect of updating the parent. However, we need
+        # to include it so it's described in the PR and we'll pass validation
+        # that this dependency is at a non-vulnerable version.
+        if updated_deps.none? { |dep| dep.name == dependency.name }
+          target_version = vulnerability_audit["target_version"]
+          updated_deps << build_updated_dependency(
+            dependency: dependency,
+            version: target_version,
+            previous_version: dependency.version,
+            removed: target_version.nil?,
+            metadata: { information_only: true } # Instruct updater to not directly update this dependency
+          )
+        end
+
+        # Target dependency should be first in the result to support rebases
+        updated_deps.select { |dep| dep.name == dependency.name } +
+          updated_deps.reject { |dep| dep.name == dependency.name }
+      end
+
+      def top_level_dependency_lookup
+        top_level_dependencies = FileParser.new(
+          dependency_files: dependency_files,
+          credentials: credentials,
+          source: nil
+        ).parse.select(&:top_level?)
+
+        top_level_dependencies.to_h { |dep| [dep.name, dep] }
+      end
+
+      def build_updated_dependency(update_details)
+        original_dep = update_details.fetch(:dependency)
+        removed = update_details.fetch(:removed, false)
+        version = update_details.fetch(:version).to_s unless removed
+        previous_version = update_details.fetch(:previous_version)&.to_s
+        metadata = update_details.fetch(:metadata, {})
+
+        Dependency.new(
+          name: original_dep.name,
+          version: version,
+          requirements: RequirementsUpdater.new(
+            requirements: original_dep.requirements,
+            updated_source: original_dep == dependency ? updated_source : original_source(original_dep),
+            latest_resolvable_version: version,
+            update_strategy: requirements_update_strategy
+          ).updated_requirements,
+          previous_version: previous_version,
+          previous_requirements: original_dep.requirements,
+          package_manager: original_dep.package_manager,
+          removed: removed,
+          metadata: metadata
+        )
+      end
+
+      def latest_resolvable_transitive_security_fix_version_with_no_unlock
+        fix_possible = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
+          [latest_resolvable_version].compact,
+          security_advisories
+        ).any?
+        return nil unless fix_possible
+
+        latest_resolvable_version
+      end
+
+      def latest_resolvable_version_with_no_unlock_for_git_dependency
+        reqs = dependency.requirements.filter_map do |r|
+          next if r.fetch(:requirement).nil?
+
+          requirement_class.requirements_array(r.fetch(:requirement))
+        end
+
+        current_version =
+          if existing_version_is_sha? ||
+             !version_class.correct?(dependency.version)
+            dependency.version
+          else
+            version_class.new(dependency.version)
+          end
+
+        return current_version if git_commit_checker.pinned?
+
+        # TODO: Really we should get a tag that satisfies the semver req
+        return current_version if reqs.any?
+
+        git_commit_checker.head_commit_for_current_branch
+      end
+
+      def latest_version_for_git_dependency
+        @latest_version_for_git_dependency ||=
+          if version_class.correct?(dependency.version)
+            latest_git_version_details[:version] &&
+              version_class.new(latest_git_version_details[:version])
+          else
+            latest_git_version_details[:sha]
+          end
+      end
+
+      def latest_released_version
+        @latest_released_version ||=
+          latest_version_finder.latest_version_from_registry
+      end
+
+      def latest_version_details
+        @latest_version_details ||=
+          if git_dependency?
+            latest_git_version_details
+          else
+            { version: latest_released_version }
+          end
+      end
+
+      def latest_version_finder
+        @latest_version_finder ||=
+          LatestVersionFinder.new(
+            dependency: dependency,
+            credentials: credentials,
+            dependency_files: dependency_files,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
+            security_advisories: security_advisories
+          )
+      end
+
+      def version_resolver
+        @version_resolver ||=
+          VersionResolver.new(
+            dependency: dependency,
+            credentials: credentials,
+            dependency_files: dependency_files,
+            latest_allowable_version: latest_version,
+            latest_version_finder: latest_version_finder,
+            repo_contents_path: repo_contents_path,
+            dependency_group: dependency_group
+          )
+      end
+
+      def subdependency_version_resolver
+        @subdependency_version_resolver ||=
+          SubdependencyVersionResolver.new(
+            dependency: dependency,
+            credentials: credentials,
+            dependency_files: dependency_files,
+            ignored_versions: ignored_versions,
+            latest_allowable_version: latest_version,
+            repo_contents_path: repo_contents_path
+          )
+      end
+
+      def git_dependency?
+        git_commit_checker.git_dependency?
+      end
+
+      def latest_git_version_details
+        semver_req =
+          dependency.requirements
+                    .find { |req| req.dig(:source, :type) == "git" }
+                    &.fetch(:requirement)
+
+        # If there was a semver requirement provided or the dependency was
+        # pinned to a version, look for the latest tag
+        if semver_req || git_commit_checker.pinned_ref_looks_like_version?
+          latest_tag = git_commit_checker.local_tag_for_latest_version
+          return {
+            sha: latest_tag&.fetch(:commit_sha),
+            version: latest_tag&.fetch(:tag)&.gsub(/^[^\d]*/, "")
+          }
+        end
+
+        # Otherwise, if the gem isn't pinned, the latest version is just the
+        # latest commit for the specified branch.
+        return { sha: git_commit_checker.head_commit_for_current_branch } unless git_commit_checker.pinned?
+
+        # If the dependency is pinned to a tag that doesn't look like a
+        # version then there's nothing we can do.
+        { sha: dependency.version }
+      end
+
+      def updated_source
+        # Never need to update source, unless a git_dependency
+        return dependency_source_details unless git_dependency?
+
+        # Update the git tag if updating a pinned version
+        if git_commit_checker.pinned_ref_looks_like_version? &&
+           !git_commit_checker.local_tag_for_latest_version.nil?
+          new_tag = git_commit_checker.local_tag_for_latest_version
+          return dependency_source_details.merge(ref: new_tag.fetch(:tag))
+        end
+
+        # Otherwise return the original source
+        dependency_source_details
+      end
+
+      def library?
+        return true unless dependency.version
+        return true if dependency_files.any? { |f| f.name == "lerna.json" }
+
+        @library =
+          LibraryDetector.new(
+            package_json_file: package_json,
+            credentials: credentials,
+            dependency_files: dependency_files
+          ).library?
+      end
+
+      def security_update?
+        security_advisories.any?
+      end
+
+      def dependency_source_details
+        original_source(dependency)
+      end
+
+      def original_source(updated_dependency)
+        sources =
+          updated_dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact
+                            .sort_by do |source|
+            Javascript::UpdateChecker::RegistryFinder.central_registry?(source[:url]) ? 1 : 0
+          end
+
+        sources.first
+      end
+
+      def package_json
+        @package_json ||=
+          dependency_files.find { |f| f.name == "package.json" }
+      end
+
+      def git_commit_checker
+        @git_commit_checker ||=
+          GitCommitChecker.new(
+            dependency: dependency,
+            credentials: credentials,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored
+          )
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/conflicting_dependency_resolver.rb
+++ b/javascript/lib/dependabot/bun/update_checker/conflicting_dependency_resolver.rb
@@ -1,0 +1,62 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Bun
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
+      class ConflictingDependencyResolver
+        def initialize(dependency_files:, credentials:)
+          @dependency_files = dependency_files
+          @credentials = credentials
+        end
+
+        # Finds any dependencies in the `yarn.lock` or `package-lock.json` that
+        # have a subdependency on the given dependency that does not satisfly
+        # the target_version.
+        #
+        # @param dependency [Dependabot::Dependency] the dependency to check
+        # @param target_version [String] the version to check
+        # @return [Array<Hash{String => String}]
+        #   * name [String] the blocking dependencies name
+        #   * version [String] the version of the blocking dependency
+        #   * requirement [String] the requirement on the target_dependency
+        def conflicting_dependencies(dependency:, target_version:)
+          SharedHelpers.in_a_temporary_directory do
+            dependency_files_builder = DependencyFilesBuilder.new(
+              dependency: dependency,
+              dependency_files: dependency_files,
+              credentials: credentials
+            )
+            dependency_files_builder.write_temporary_dependency_files
+
+            # TODO: Look into using npm/arborist for parsing yarn lockfiles (there's currently partial yarn support)
+            #
+            # Prefer the npm conflicting dependency parser if there's both a npm lockfile and a yarn.lock file as the
+            # npm parser handles edge cases where the package.json is out of sync with the lockfile, something the yarn
+            # parser doesn't deal with at the moment.
+            if dependency_files_builder.lockfiles.any?
+              SharedHelpers.run_helper_subprocess(
+                command: Javascript::NativeHelpers.helper_path,
+                function: "npm:findConflictingDependencies",
+                args: [Dir.pwd, dependency.name, target_version.to_s]
+              )
+            else
+              SharedHelpers.run_helper_subprocess(
+                command: Javascript::NativeHelpers.helper_path,
+                function: "yarn:findConflictingDependencies",
+                args: [Dir.pwd, dependency.name, target_version.to_s]
+              )
+            end
+          end
+        rescue SharedHelpers::HelperSubprocessFailed
+          []
+        end
+
+        private
+
+        attr_reader :dependency_files
+        attr_reader :credentials
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/javascript/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -1,0 +1,448 @@
+# typed: true
+# frozen_string_literal: true
+
+require "excon"
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class LatestVersionFinder
+        extend T::Sig
+
+        def initialize(dependency:, credentials:, dependency_files:,
+                       ignored_versions:, security_advisories:,
+                       raise_on_ignored: false)
+          @dependency          = dependency
+          @credentials         = credentials
+          @dependency_files    = dependency_files
+          @ignored_versions    = ignored_versions
+          @raise_on_ignored    = raise_on_ignored
+          @security_advisories = security_advisories
+        end
+
+        def latest_version_from_registry
+          return unless valid_npm_details?
+          return version_from_dist_tags if version_from_dist_tags
+          return if specified_dist_tag_requirement?
+
+          possible_versions.find { |v| !yanked?(v) }
+        rescue Excon::Error::Socket, Excon::Error::Timeout, RegistryError
+          raise if dependency_registry == "registry.npmjs.org"
+          # Custom registries can be flaky. We don't want to make that
+          # our problem, so we quietly return `nil` here.
+        end
+
+        def latest_version_with_no_unlock
+          return unless valid_npm_details?
+          return version_from_dist_tags if specified_dist_tag_requirement?
+
+          in_range_versions = filter_out_of_range_versions(possible_versions)
+          in_range_versions.find { |version| !yanked?(version) }
+        rescue Excon::Error::Socket, Excon::Error::Timeout
+          raise if dependency_registry == "registry.npmjs.org"
+          # Sometimes custom registries are flaky. We don't want to make that
+          # our problem, so we quietly return `nil` here.
+        end
+
+        def lowest_security_fix_version
+          return unless valid_npm_details?
+
+          secure_versions =
+            if specified_dist_tag_requirement?
+              [version_from_dist_tags].compact
+            else
+              possible_versions(filter_ignored: false)
+            end
+
+          secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions,
+                                                                                                  security_advisories)
+          secure_versions = filter_ignored_versions(secure_versions)
+          secure_versions = filter_lower_versions(secure_versions)
+
+          secure_versions.reverse.find { |version| !yanked?(version) }
+        rescue Excon::Error::Socket, Excon::Error::Timeout
+          raise if dependency_registry == "registry.npmjs.org"
+          # Sometimes custom registries are flaky. We don't want to make that
+          # our problem, so we quietly return `nil` here.
+        end
+
+        def possible_previous_versions_with_details
+          @possible_previous_versions_with_details ||= npm_details.fetch("versions", {})
+                                                                  .transform_keys { |k| version_class.new(k) }
+                                                                  .reject do |v, _|
+                                                                    v.prerelease? && !related_to_current_pre?(v)
+                                                                  end
+                                                                  .sort_by(&:first).reverse
+        end
+
+        def possible_versions_with_details(filter_ignored: true)
+          versions = possible_previous_versions_with_details
+                     .reject { |_, details| details["deprecated"] }
+
+          return filter_ignored_versions(versions) if filter_ignored
+
+          versions
+        end
+
+        def possible_versions(filter_ignored: true)
+          possible_versions_with_details(filter_ignored: filter_ignored)
+            .map(&:first)
+        end
+
+        private
+
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :ignored_versions
+        attr_reader :security_advisories
+
+        def valid_npm_details?
+          !npm_details&.fetch("dist-tags", nil).nil?
+        end
+
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+        def filter_ignored_versions(versions_array)
+          filtered = versions_array.reject do |v, _|
+            ignore_requirements.any? { |r| r.satisfied_by?(v) }
+          end
+
+          if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
+            raise AllVersionsIgnored
+          end
+
+          if versions_array.count > filtered.count
+            diff = versions_array.count - filtered.count
+            Dependabot.logger.info("Filtered out #{diff} ignored versions")
+          end
+
+          filtered
+        end
+
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+        def filter_out_of_range_versions(versions_array)
+          reqs = dependency.requirements.filter_map do |r|
+            NpmAndYarn::Requirement.requirements_array(r.fetch(:requirement))
+          end
+
+          versions_array
+            .select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }
+        end
+
+        sig { params(versions_array: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+        def filter_lower_versions(versions_array)
+          return versions_array unless dependency.numeric_version
+
+          versions_array
+            .select { |version, _| version > dependency.numeric_version }
+        end
+
+        def version_from_dist_tags
+          dist_tags = npm_details["dist-tags"].keys
+
+          # Check if a dist tag was specified as a requirement. If it was, and
+          # it exists, use it.
+          dist_tag_req = dependency.requirements
+                                   .find { |r| dist_tags.include?(r[:requirement]) }
+                                   &.fetch(:requirement)
+
+          if dist_tag_req
+            tag_vers =
+              version_class.new(npm_details["dist-tags"][dist_tag_req])
+            return tag_vers unless yanked?(tag_vers)
+          end
+
+          # Use the latest dist tag unless there's a reason not to
+          return nil unless npm_details["dist-tags"]["latest"]
+
+          latest = version_class.new(npm_details["dist-tags"]["latest"])
+
+          wants_latest_dist_tag?(latest) ? latest : nil
+        end
+
+        def related_to_current_pre?(version)
+          current_version = dependency.numeric_version
+          if current_version&.prerelease? &&
+             current_version&.release == version.release
+            return true
+          end
+
+          dependency.requirements.any? do |req|
+            next unless req[:requirement]&.match?(/\d-[A-Za-z]/)
+
+            NpmAndYarn::Requirement
+              .requirements_array(req.fetch(:requirement))
+              .any? do |r|
+                r.requirements.any? { |a| a.last.release == version.release }
+              end
+          rescue Gem::Requirement::BadRequirementError
+            false
+          end
+        end
+
+        def specified_dist_tag_requirement?
+          dependency.requirements.any? do |req|
+            next false if req[:requirement].nil?
+            next false unless req[:requirement].match?(/^[A-Za-z]/)
+
+            !req[:requirement].match?(/^v\d/i)
+          end
+        end
+
+        def wants_latest_dist_tag?(latest_version)
+          ver = latest_version
+          return false if related_to_current_pre?(ver) ^ ver.prerelease?
+          return false if current_version_greater_than?(ver)
+          return false if current_requirement_greater_than?(ver)
+          return false if ignore_requirements.any? { |r| r.satisfied_by?(ver) }
+          return false if yanked?(ver)
+
+          true
+        end
+
+        def current_version_greater_than?(version)
+          return false unless dependency.numeric_version
+
+          dependency.numeric_version > version
+        end
+
+        def current_requirement_greater_than?(version)
+          dependency.requirements.any? do |req|
+            next false unless req[:requirement]
+
+            req_version = req[:requirement].sub(/^\^|~|>=?/, "")
+            next false unless version_class.correct?(req_version)
+
+            version_class.new(req_version) > version
+          end
+        end
+
+        def yanked?(version)
+          @yanked ||= {}
+          return @yanked[version] if @yanked.key?(version)
+
+          @yanked[version] =
+            begin
+              if dependency_registry == "registry.npmjs.org"
+                status = Dependabot::RegistryClient.head(
+                  url: registry_finder.tarball_url(version),
+                  headers: registry_auth_headers
+                ).status
+              else
+                status = Dependabot::RegistryClient.get(
+                  url: dependency_url + "/#{version}",
+                  headers: registry_auth_headers
+                ).status
+
+                if status == 404
+                  # Some registries don't handle escaped package names properly
+                  status = Dependabot::RegistryClient.get(
+                    url: dependency_url.gsub("%2F", "/") + "/#{version}",
+                    headers: registry_auth_headers
+                  ).status
+                end
+              end
+
+              version_not_found = status == 404
+              version_not_found && version_endpoint_working?
+            rescue Excon::Error::Timeout, Excon::Error::Socket
+              # Give the benefit of the doubt if the registry is playing up
+              false
+            end
+        end
+
+        def version_endpoint_working?
+          return true if dependency_registry == "registry.npmjs.org"
+
+          return @version_endpoint_working if defined?(@version_endpoint_working)
+
+          @version_endpoint_working =
+            begin
+              Dependabot::RegistryClient.get(
+                url: dependency_url + "/latest",
+                headers: registry_auth_headers
+              ).status < 400
+            rescue Excon::Error::Timeout, Excon::Error::Socket
+              # Give the benefit of the doubt if the registry is playing up
+              true
+            end
+        end
+
+        def npm_details
+          return @npm_details if defined?(@npm_details)
+
+          @npm_details = fetch_npm_details
+        end
+
+        def fetch_npm_details
+          npm_response = fetch_npm_response
+
+          check_npm_response(npm_response)
+          JSON.parse(npm_response.body)
+        rescue JSON::ParserError,
+               Excon::Error::Timeout,
+               Excon::Error::Socket,
+               RegistryError => e
+          if git_dependency?
+            nil
+          else
+            raise_npm_details_error(e)
+          end
+        end
+
+        def fetch_npm_response
+          response = Dependabot::RegistryClient.get(
+            url: dependency_url,
+            headers: registry_auth_headers
+          )
+          return response unless response.status == 500
+          return response unless registry_auth_headers["Authorization"]
+
+          auth = registry_auth_headers["Authorization"]
+          return response unless auth.start_with?("Basic")
+
+          decoded_token = Base64.decode64(auth.gsub("Basic ", ""))
+          return unless decoded_token.include?(":")
+
+          username, password = decoded_token.split(":")
+          Dependabot::RegistryClient.get(
+            url: dependency_url,
+            options: {
+              user: username,
+              password: password
+            }
+          )
+        rescue URI::InvalidURIError => e
+          raise DependencyFileNotResolvable, e.message
+        end
+
+        def check_npm_response(npm_response)
+          return if git_dependency?
+
+          if private_dependency_not_reachable?(npm_response)
+            raise PrivateSourceAuthenticationFailure, dependency_registry
+          end
+
+          # handles scenario when private registry returns a server error 5xx
+          if private_dependency_server_error?(npm_response)
+            msg = "Server error #{npm_response.status} returned while accessing registry" \
+                  " #{dependency_registry}."
+            raise DependencyFileNotResolvable, msg
+          end
+
+          status = npm_response.status
+
+          # handles issue when status 200 is returned from registry but with an invalid JSON object
+          if status.to_s.start_with?("2") && response_invalid_json?(npm_response)
+            msg = "Invalid JSON object returned from registry #{dependency_registry}."
+            Dependabot.logger.warn("#{msg} Response body (truncated) : #{npm_response.body[0..500]}...")
+            raise DependencyFileNotResolvable, msg
+          end
+
+          return if status.to_s.start_with?("2")
+
+          # Ignore 404s from the registry for updates where a lockfile doesn't
+          # need to be generated. The 404 won't cause problems later.
+          return if status == 404 && dependency.version.nil?
+
+          msg = "Got #{status} response with body #{npm_response.body}"
+          raise RegistryError.new(status, msg)
+        end
+
+        def raise_npm_details_error(error)
+          raise if dependency_registry == "registry.npmjs.org"
+          raise unless error.is_a?(Excon::Error::Timeout)
+
+          raise PrivateSourceTimedOut, dependency_registry
+        end
+
+        def private_dependency_not_reachable?(npm_response)
+          return true if npm_response.body.start_with?(/user ".*?" is not a /)
+          return false unless [401, 402, 403, 404].include?(npm_response.status)
+
+          # Check whether this dependency is (likely to be) private
+          if dependency_registry == "registry.npmjs.org"
+            return false unless dependency.name.start_with?("@")
+
+            web_response = Dependabot::RegistryClient.get(url: "https://www.npmjs.com/package/#{dependency.name}")
+            # NOTE: returns 429 when the login page is rate limited
+            return web_response.body.include?("Forgot password?") ||
+                   web_response.status == 429
+          end
+
+          true
+        end
+
+        def private_dependency_server_error?(npm_response)
+          if [500, 501, 502, 503].include?(npm_response.status)
+            Dependabot.logger.warn("#{dependency_registry} returned code #{npm_response.status} with " \
+                                   "body #{npm_response.body}.")
+            return true
+          end
+          false
+        end
+
+        def response_invalid_json?(npm_response)
+          result = JSON.parse(npm_response.body)
+          result.is_a?(Hash) || result.is_a?(Array)
+          false
+        rescue JSON::ParserError, TypeError
+          true
+        end
+
+        def dependency_url
+          registry_finder.dependency_url
+        end
+
+        def dependency_registry
+          registry_finder.registry
+        end
+
+        def registry_auth_headers
+          registry_finder.auth_headers
+        end
+
+        def registry_finder
+          @registry_finder ||= Javascript::UpdateChecker::RegistryFinder.new(
+            dependency: dependency,
+            credentials: credentials,
+            rc_file: npmrc_file
+          )
+        end
+
+        def ignore_requirements
+          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
+        end
+
+        def version_class
+          dependency.version_class
+        end
+
+        def requirement_class
+          dependency.requirement_class
+        end
+
+        def npmrc_file
+          dependency_files.find { |f| f.name.end_with?(".npmrc") }
+        end
+
+        def yarnrc_file
+          dependency_files.find { |f| f.name.end_with?(".yarnrc") }
+        end
+
+        def yarnrc_yml_file
+          dependency_files.find { |f| f.name.end_with?(".yarnrc.yml") }
+        end
+
+        # TODO: Remove need for me
+        def git_dependency?
+          # ignored_version/raise_on_ignored are irrelevant.
+          GitCommitChecker.new(
+            dependency: dependency,
+            credentials: credentials
+          ).git_dependency?
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/library_detector.rb
+++ b/javascript/lib/dependabot/bun/update_checker/library_detector.rb
@@ -1,0 +1,74 @@
+# typed: true
+# frozen_string_literal: true
+
+require "excon"
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class LibraryDetector
+        def initialize(package_json_file:, credentials:, dependency_files:)
+          @package_json_file = package_json_file
+          @credentials = credentials
+          @dependency_files = dependency_files
+        end
+
+        def library?
+          return false unless package_json_may_be_for_library?
+
+          npm_response_matches_package_json?
+        end
+
+        private
+
+        attr_reader :package_json_file
+        attr_reader :credentials
+        attr_reader :dependency_files
+
+        def package_json_may_be_for_library?
+          return false unless project_name
+          return false if project_name.match?(/\{\{.*\}\}/)
+          return false unless parsed_package_json["version"]
+          return false if parsed_package_json["private"]
+
+          true
+        end
+
+        def npm_response_matches_package_json?
+          project_description = parsed_package_json["description"]
+          return false unless project_description
+
+          # Check if the project is listed on npm. If it is, it's a library
+          url = "#{registry.chomp('/')}/#{escaped_project_name}"
+          @project_npm_response ||= Dependabot::RegistryClient.get(url: url)
+          return false unless @project_npm_response.status == 200
+
+          @project_npm_response.body.dup.force_encoding("UTF-8").encode
+                               .include?(project_description)
+        rescue Excon::Error::Socket, Excon::Error::Timeout, URI::InvalidURIError
+          false
+        end
+
+        def project_name
+          parsed_package_json.fetch("name", nil)
+        end
+
+        def escaped_project_name
+          project_name&.gsub("/", "%2F")
+        end
+
+        def parsed_package_json
+          @parsed_package_json ||= JSON.parse(package_json_file.content)
+        end
+
+        def registry
+          Javascript::UpdateChecker::RegistryFinder.new(
+            dependency: nil,
+            credentials: credentials,
+            rc_file: dependency_files.find { |f| f.name.end_with?(".npmrc") }
+          ).registry_from_rc(project_name)
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/requirements_updater.rb
+++ b/javascript/lib/dependabot/bun/update_checker/requirements_updater.rb
@@ -1,0 +1,201 @@
+# typed: true
+# frozen_string_literal: true
+
+################################################################################
+# For more details on npm version constraints, see:                            #
+# https://docs.npmjs.com/misc/semver                                           #
+################################################################################
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class RequirementsUpdater
+        VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
+        SEPARATOR = /(?<=[a-zA-Z0-9*])[\s|]+(?![\s|-])/
+        ALLOWED_UPDATE_STRATEGIES = T.let(
+          [
+            RequirementsUpdateStrategy::LockfileOnly,
+            RequirementsUpdateStrategy::WidenRanges,
+            RequirementsUpdateStrategy::BumpVersions,
+            RequirementsUpdateStrategy::BumpVersionsIfNecessary
+          ].freeze,
+          T::Array[Dependabot::RequirementsUpdateStrategy]
+        )
+
+        def initialize(requirements:, updated_source:, update_strategy:,
+                       latest_resolvable_version:)
+          @requirements = requirements
+          @updated_source = updated_source
+          @update_strategy = update_strategy
+
+          check_update_strategy
+
+          return unless latest_resolvable_version
+
+          @latest_resolvable_version =
+            version_class.new(latest_resolvable_version)
+        end
+
+        def updated_requirements
+          return requirements if update_strategy.lockfile_only?
+
+          requirements.map do |req|
+            req = req.merge(source: updated_source)
+            next req unless latest_resolvable_version
+            next initial_req_after_source_change(req) unless req[:requirement]
+            next req if req[:requirement].match?(/^([A-Za-uw-z]|v[^\d])/)
+
+            case update_strategy
+            when RequirementsUpdateStrategy::WidenRanges then widen_requirement(req)
+            when RequirementsUpdateStrategy::BumpVersions then update_version_requirement(req)
+            when RequirementsUpdateStrategy::BumpVersionsIfNecessary
+              update_version_requirement_if_needed(req)
+            else raise "Unexpected update strategy: #{update_strategy}"
+            end
+          end
+        end
+
+        private
+
+        attr_reader :requirements
+        attr_reader :updated_source
+        attr_reader :update_strategy
+        attr_reader :latest_resolvable_version
+
+        def check_update_strategy
+          return if ALLOWED_UPDATE_STRATEGIES.include?(update_strategy)
+
+          raise "Unknown update strategy: #{update_strategy}"
+        end
+
+        def updating_from_git_to_npm?
+          return false unless updated_source.nil?
+
+          original_source = requirements.filter_map { |r| r[:source] }.first
+          original_source&.fetch(:type) == "git"
+        end
+
+        def initial_req_after_source_change(req)
+          return req unless updating_from_git_to_npm?
+          return req unless req[:requirement].nil?
+
+          req.merge(requirement: "^#{latest_resolvable_version}")
+        end
+
+        def update_version_requirement(req)
+          current_requirement = req[:requirement]
+
+          if current_requirement.match?(/(<|-\s)/i)
+            ruby_req = ruby_requirements(current_requirement).first
+            return req if ruby_req.satisfied_by?(latest_resolvable_version)
+
+            updated_req = update_range_requirement(current_requirement)
+            return req.merge(requirement: updated_req)
+          end
+
+          reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
+          req.merge(requirement: update_version_string(reqs.first))
+        end
+
+        def update_version_requirement_if_needed(req)
+          current_requirement = req[:requirement]
+          version = latest_resolvable_version
+          return req if current_requirement.strip == ""
+
+          ruby_reqs = ruby_requirements(current_requirement)
+          return req if ruby_reqs.any? { |r| r.satisfied_by?(version) }
+
+          update_version_requirement(req)
+        end
+
+        def widen_requirement(req)
+          current_requirement = req[:requirement]
+          version = latest_resolvable_version
+          return req if current_requirement.strip == ""
+
+          ruby_reqs = ruby_requirements(current_requirement)
+          return req if ruby_reqs.any? { |r| r.satisfied_by?(version) }
+
+          reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
+
+          updated_requirement =
+            if reqs.any? { |r| r.match?(/(<|-\s)/i) }
+              update_range_requirement(current_requirement)
+            elsif current_requirement.strip.split(SEPARATOR).count == 1
+              update_version_string(current_requirement)
+            else
+              current_requirement
+            end
+
+          req.merge(requirement: updated_requirement)
+        end
+
+        def ruby_requirements(requirement_string)
+          Javascript::Requirement
+            .requirements_array(requirement_string)
+        end
+
+        def update_range_requirement(req_string)
+          range_requirements =
+            req_string.split(SEPARATOR).select { |r| r.match?(/<|(\s+-\s+)/) }
+
+          if range_requirements.count == 1
+            range_requirement = range_requirements.first
+            versions = range_requirement.scan(VERSION_REGEX)
+            upper_bound = versions.map { |v| version_class.new(v) }.max
+            new_upper_bound = update_greatest_version(
+              upper_bound,
+              latest_resolvable_version
+            )
+
+            req_string.sub(
+              upper_bound.to_s,
+              new_upper_bound.to_s
+            )
+          else
+            req_string + " || ^#{latest_resolvable_version}"
+          end
+        end
+
+        def update_version_string(req_string)
+          req_string
+            .sub(VERSION_REGEX) do |old_version|
+              if old_version.match?(/\d-/) ||
+                 latest_resolvable_version.to_s.match?(/\d-/)
+                latest_resolvable_version.to_s
+              else
+                old_parts = old_version.split(".")
+                new_parts = latest_resolvable_version.to_s.split(".")
+                                                     .first(old_parts.count)
+                new_parts.map.with_index do |part, i|
+                  old_parts[i].match?(/^x\b/) ? "x" : part
+                end.join(".")
+              end
+            end
+        end
+
+        def update_greatest_version(old_version, version_to_be_permitted)
+          version = version_class.new(old_version)
+          version = version.release if version.prerelease?
+
+          index_to_update =
+            version.segments.map.with_index { |seg, i| seg.zero? ? 0 : i }.max
+
+          version.segments.map.with_index do |_, index|
+            if index < index_to_update
+              version_to_be_permitted.segments[index]
+            elsif index == index_to_update
+              version_to_be_permitted.segments[index] + 1
+            else
+              0
+            end
+          end.join(".")
+        end
+
+        def version_class
+          Javascript::Version
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/subdependency_version_resolver.rb
+++ b/javascript/lib/dependabot/bun/update_checker/subdependency_version_resolver.rb
@@ -1,0 +1,142 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class SubdependencyVersionResolver
+        def initialize(dependency:, credentials:, dependency_files:,
+                       ignored_versions:, latest_allowable_version:, repo_contents_path:)
+          @dependency = dependency
+          @credentials = credentials
+          @dependency_files = dependency_files
+          @ignored_versions = ignored_versions
+          @latest_allowable_version = latest_allowable_version
+          @repo_contents_path = repo_contents_path
+        end
+
+        def latest_resolvable_version
+          raise "Not a subdependency!" if dependency.requirements.any?
+          return if bundled_dependency?
+
+          base_dir = dependency_files.first.directory
+          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+            dependency_files_builder.write_temporary_dependency_files
+
+            updated_lockfiles = filtered_lockfiles.map do |lockfile|
+              updated_content = update_subdependency_in_lockfile(lockfile)
+              updated_lockfile = lockfile.dup
+              updated_lockfile.content = updated_content
+              updated_lockfile
+            end
+
+            version_from_updated_lockfiles(updated_lockfiles)
+          end
+        rescue SharedHelpers::HelperSubprocessFailed
+          # TODO: Move error handling logic from the FileUpdater to this class
+
+          # Return nil (no update possible) if an unknown error occurred
+          nil
+        end
+
+        private
+
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :ignored_versions
+        attr_reader :latest_allowable_version
+        attr_reader :repo_contents_path
+
+        def update_subdependency_in_lockfile(lockfile)
+          lockfile_name = Pathname.new(lockfile.name).basename.to_s
+          path = Pathname.new(lockfile.name).dirname.to_s
+
+          updated_files = run_bun_updater(path, lockfile_name) if lockfile.name.end_with?("bun.lock")
+
+          updated_files.fetch(lockfile_name)
+        end
+
+        def version_from_updated_lockfiles(updated_lockfiles)
+          updated_files = dependency_files -
+                          dependency_files_builder.lockfiles +
+                          updated_lockfiles
+
+          updated_version = NpmAndYarn::FileParser.new(
+            dependency_files: updated_files,
+            source: nil,
+            credentials: credentials
+          ).parse.find { |d| d.name == dependency.name }&.version
+          return unless updated_version
+
+          version_class.new(updated_version)
+        end
+
+        def run_bun_updater(path, lockfile_name)
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            Dir.chdir(path) do
+              Helpers.run_bun_command(
+                "update #{dependency.name} --save-text-lockfile",
+                fingerprint: "update <dependency_name> --save-text-lockfile"
+              )
+              { lockfile_name => File.read(lockfile_name) }
+            end
+          end
+        end
+
+        def version_class
+          dependency.version_class
+        end
+
+        def updated_dependency
+          Dependabot::Dependency.new(
+            name: dependency.name,
+            version: latest_allowable_version,
+            previous_version: dependency.version,
+            requirements: [],
+            package_manager: dependency.package_manager
+          )
+        end
+
+        def filtered_lockfiles
+          @filtered_lockfiles ||=
+            Javascript::SubDependencyFilesFilterer.new(
+              dependency_files: dependency_files,
+              updated_dependencies: [updated_dependency]
+            ).files_requiring_update
+        end
+
+        def dependency_files_builder
+          @dependency_files_builder ||=
+            DependencyFilesBuilder.new(
+              dependency: dependency,
+              dependency_files: dependency_files,
+              credentials: credentials
+            )
+        end
+
+        # TODO: We should try and fix this by updating the parent that's not
+        # bundled. For this case: `chokidar > fsevents > node-pre-gyp > tar` we
+        # would need to update `fsevents`
+        #
+        # We shouldn't update bundled sub-dependencies as they have been bundled
+        # into the release at an exact version by a parent using
+        # `bundledDependencies`.
+        #
+        # For example, fsevents < 2 bundles node-pre-gyp meaning all it's
+        # sub-dependencies get bundled into the release tarball at publish time
+        # so you always get the same sub-dependency versions if you re-install a
+        # specific version of fsevents.
+        #
+        # Updating the sub-dependency by deleting the entry works but it gets
+        # removed from the bundled set of dependencies and moved top level
+        # resulting in a bunch of package duplication which is pretty confusing.
+        def bundled_dependency?
+          dependency.subdependency_metadata
+                    &.any? { |h| h.fetch(:npm_bundled, false) } ||
+            false
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/version_resolver.rb
+++ b/javascript/lib/dependabot/bun/update_checker/version_resolver.rb
@@ -1,0 +1,522 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class VersionResolver # rubocop:disable Metrics/ClassLength
+        extend T::Sig
+
+        require_relative "latest_version_finder"
+
+        TIGHTLY_COUPLED_MONOREPOS = {
+          "vue" => %w(vue vue-template-compiler)
+        }.freeze
+
+        def initialize(dependency:, credentials:, dependency_files:,
+                       latest_allowable_version:, latest_version_finder:, repo_contents_path:, dependency_group: nil)
+          @dependency               = dependency
+          @credentials              = credentials
+          @dependency_files         = dependency_files
+          @latest_allowable_version = latest_allowable_version
+          @dependency_group = dependency_group
+
+          @latest_version_finder = {}
+          @latest_version_finder[dependency] = latest_version_finder
+          @repo_contents_path = repo_contents_path
+        end
+
+        def latest_resolvable_version
+          return latest_allowable_version if git_dependency?(dependency)
+          return if part_of_tightly_locked_monorepo?
+          return if types_update_available?
+          return if original_package_update_available?
+
+          return latest_allowable_version unless relevant_unmet_peer_dependencies.any?
+
+          satisfying_versions.first
+        end
+
+        def latest_version_resolvable_with_full_unlock?
+          return false if dependency_updates_from_full_unlock.nil?
+
+          true
+        end
+
+        def latest_resolvable_previous_version(updated_version)
+          resolve_latest_previous_version(dependency, updated_version)
+        end
+
+        # rubocop:disable Metrics/PerceivedComplexity
+        def dependency_updates_from_full_unlock
+          return if git_dependency?(dependency)
+          return updated_monorepo_dependencies if part_of_tightly_locked_monorepo?
+          return if newly_broken_peer_reqs_from_dep.any?
+          return if original_package_update_available?
+
+          updates = [{
+            dependency: dependency,
+            version: latest_allowable_version,
+            previous_version: latest_resolvable_previous_version(
+              latest_allowable_version
+            )
+          }]
+          newly_broken_peer_reqs_on_dep.each do |peer_req|
+            dep_name = peer_req.fetch(:requiring_dep_name)
+            dep = top_level_dependencies.find { |d| d.name == dep_name }
+
+            # Can't handle reqs from sub-deps or git source deps (yet)
+            return nil if dep.nil?
+            return nil if git_dependency?(dep)
+
+            updated_version =
+              latest_version_of_dep_with_satisfied_peer_reqs(dep)
+            return nil unless updated_version
+
+            updates << {
+              dependency: dep,
+              version: updated_version,
+              previous_version: resolve_latest_previous_version(
+                dep, updated_version
+              )
+            }
+          end
+          updates += updated_types_dependencies if types_update_available?
+          updates.uniq
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        private
+
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+        attr_reader :credentials
+        attr_reader :dependency_files
+        attr_reader :latest_allowable_version
+        attr_reader :repo_contents_path
+        attr_reader :dependency_group
+
+        def latest_version_finder(dep)
+          @latest_version_finder[dep] ||=
+            LatestVersionFinder.new(
+              dependency: dep,
+              credentials: credentials,
+              dependency_files: dependency_files,
+              ignored_versions: [],
+              security_advisories: []
+            )
+        end
+
+        # rubocop:disable Metrics/PerceivedComplexity
+        def resolve_latest_previous_version(dep, updated_version)
+          return dep.version if dep.version
+
+          @resolve_latest_previous_version ||= {}
+          @resolve_latest_previous_version[dep] ||= begin
+            relevant_versions = latest_version_finder(dependency)
+                                .possible_previous_versions_with_details
+                                .map(&:first)
+            reqs = dep.requirements.filter_map { |r| r[:requirement] }
+                      .map { |r| requirement_class.requirements_array(r) }
+
+            # Pick the lowest version from the max possible version from all
+            # requirements. This matches the logic when combining the same
+            # dependency in DependencySet from multiple manifest files where we
+            # pick the lowest version from the duplicates.
+            latest_previous_version = reqs.flat_map do |req|
+              relevant_versions.select do |version|
+                req.any? { |r| r.satisfied_by?(version) }
+              end.max
+            end.min&.to_s
+
+            # Handle cases where the latest resolvable previous version is the
+            # latest version. This often happens if you don't have lockfiles and
+            # have requirements update strategy set to bump_versions, where an
+            # update might go from ^1.1.1 to ^1.1.2 (both resolve to 1.1.2).
+            if updated_version.to_s == latest_previous_version
+              nil
+            else
+              latest_previous_version
+            end
+          end
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def part_of_tightly_locked_monorepo?
+          monorepo_dep_names =
+            TIGHTLY_COUPLED_MONOREPOS.values
+                                     .find { |deps| deps.include?(dependency.name) }
+          return false unless monorepo_dep_names
+
+          deps_to_update =
+            top_level_dependencies
+            .select { |d| monorepo_dep_names.include?(d.name) }
+
+          deps_to_update.count > 1
+        end
+
+        def updated_monorepo_dependencies
+          monorepo_dep_names =
+            TIGHTLY_COUPLED_MONOREPOS.values
+                                     .find { |deps| deps.include?(dependency.name) }
+
+          deps_to_update =
+            top_level_dependencies
+            .select { |d| monorepo_dep_names.include?(d.name) }
+
+          updates = []
+          deps_to_update.each do |dep|
+            next if git_dependency?(dep)
+            next if dep.version &&
+                    version_class.new(dep.version) >= latest_allowable_version
+
+            updated_version =
+              latest_version_finder(dep)
+              .possible_versions
+              .find { |v| v == latest_allowable_version }
+            next unless updated_version
+
+            updates << {
+              dependency: dep,
+              version: updated_version,
+              previous_version: resolve_latest_previous_version(
+                dep, updated_version
+              )
+            }
+          end
+
+          updates
+        end
+
+        def types_package
+          @types_package ||= begin
+            types_package_name = Javascript::PackageName.new(dependency.name).types_package_name
+            top_level_dependencies.find { |d| types_package_name.to_s == d.name } if types_package_name
+          end
+        end
+
+        def original_package
+          @original_package ||= begin
+            original_package_name = Javascript::PackageName.new(dependency.name).library_name
+            top_level_dependencies.find { |d| original_package_name.to_s == d.name } if original_package_name
+          end
+        end
+
+        def latest_types_package_version
+          @latest_types_package_version ||= latest_version_finder(types_package).latest_version_from_registry
+        end
+
+        def types_update_available?
+          return false if types_package.nil?
+
+          return false if latest_types_package_version.nil?
+
+          return false unless latest_allowable_version.backwards_compatible_with?(latest_types_package_version)
+
+          return false unless version_class.correct?(types_package.version)
+
+          current_types_package_version = version_class.new(types_package.version)
+
+          return false unless current_types_package_version < latest_types_package_version
+
+          true
+        end
+
+        def original_package_update_available?
+          return false if original_package.nil?
+
+          return false unless version_class.correct?(original_package.version)
+
+          original_package_version = version_class.new(original_package.version)
+
+          latest_version = latest_version_finder(original_package).latest_version_from_registry
+
+          # If the latest version is within the scope of the current requirements,
+          # latest_version will be nil. In such cases, there is no update available.
+          return false if latest_version.nil?
+
+          original_package_version < latest_version
+        end
+
+        def updated_types_dependencies
+          [{
+            dependency: types_package,
+            version: latest_types_package_version,
+            previous_version: resolve_latest_previous_version(
+              types_package, latest_types_package_version
+            )
+          }]
+        end
+
+        def peer_dependency_errors
+          return @peer_dependency_errors if @peer_dependency_errors_checked
+
+          @peer_dependency_errors_checked = true
+
+          @peer_dependency_errors =
+            fetch_peer_dependency_errors(version: latest_allowable_version)
+        end
+
+        def old_peer_dependency_errors
+          return @old_peer_dependency_errors if @old_peer_dependency_errors_checked
+
+          @old_peer_dependency_errors_checked = true
+
+          version = version_for_dependency(dependency)
+
+          @old_peer_dependency_errors =
+            fetch_peer_dependency_errors(version: version)
+        end
+
+        def fetch_peer_dependency_errors(version:)
+          # TODO: Add all of the error handling that the FileUpdater does
+          # here (since problematic repos will be resolved here before they're
+          # seen by the FileUpdater)
+          base_dir = dependency_files.first.directory
+          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+            dependency_files_builder.write_temporary_dependency_files
+
+            paths_requiring_update_check.flat_map do |path|
+              run_checker(path: path, version: version)
+            end.compact
+          end
+        rescue SharedHelpers::HelperSubprocessFailed
+          # Fall back to allowing the version through. Whatever error
+          # occurred should be properly handled by the FileUpdater. We
+          # can slowly migrate error handling to this class over time.
+          []
+        end
+
+        def unmet_peer_dependencies
+          peer_dependency_errors
+            .map { |captures| error_details_from_captures(captures) }
+        end
+
+        def old_unmet_peer_dependencies
+          old_peer_dependency_errors
+            .map { |captures| error_details_from_captures(captures) }
+        end
+
+        def error_details_from_captures(captures)
+          return {} unless captures.is_a?(Hash)
+
+          required_dep_captures  = captures.fetch("required_dep")
+          requiring_dep_captures = captures.fetch("requiring_dep")
+          return {} unless required_dep_captures && requiring_dep_captures
+
+          {
+            requirement_name: required_dep_captures.sub(/@[^@]+$/, ""),
+            requirement_version: required_dep_captures.split("@").last.delete('"'),
+            requiring_dep_name: requiring_dep_captures.sub(/@[^@]+$/, "")
+          }
+        end
+
+        def relevant_unmet_peer_dependencies
+          relevant_unmet_peer_dependencies =
+            unmet_peer_dependencies.select do |dep|
+              dep[:requirement_name] == dependency.name ||
+                dep[:requiring_dep_name] == dependency.name
+            end
+
+          unless dependency_group.nil?
+            # Ignore unmet peer dependencies that are in the dependency group because
+            # the update is also updating those dependencies.
+            relevant_unmet_peer_dependencies.reject! do |dep|
+              dependency_group.dependencies.any? do |group_dep|
+                dep[:requirement_name] == group_dep.name ||
+                  dep[:requiring_dep_name] == group_dep.name
+              end
+            end
+          end
+
+          return [] if relevant_unmet_peer_dependencies.empty?
+
+          # Prune out any pre-existing warnings
+          relevant_unmet_peer_dependencies.reject do |issue|
+            old_unmet_peer_dependencies.any? do |old_issue|
+              old_issue.slice(:requirement_name, :requiring_dep_name) ==
+                issue.slice(:requirement_name, :requiring_dep_name)
+            end
+          end
+        end
+
+        # rubocop:disable Metrics/PerceivedComplexity
+        def satisfying_versions
+          latest_version_finder(dependency)
+            .possible_versions_with_details
+            .select do |version, details|
+              next false unless satisfies_peer_reqs_on_dep?(version)
+              next true unless details["peerDependencies"]
+              next true if version == version_for_dependency(dependency)
+
+              details["peerDependencies"].all? do |dep, req|
+                dep = top_level_dependencies.find { |d| d.name == dep }
+                next false unless dep
+                next git_dependency?(dep) if req.include?("/")
+
+                reqs = requirement_class.requirements_array(req)
+                next false unless version_for_dependency(dep)
+
+                reqs.any? { |r| r.satisfied_by?(version_for_dependency(dep)) }
+              rescue Gem::Requirement::BadRequirementError
+                false
+              end
+            end
+            .map(&:first)
+        end
+
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def satisfies_peer_reqs_on_dep?(version)
+          newly_broken_peer_reqs_on_dep.all? do |peer_req|
+            req = peer_req.fetch(:requirement_version)
+
+            # Git requirements can't be satisfied by a version
+            next false if req.include?("/")
+
+            reqs = requirement_class.requirements_array(req)
+            reqs.any? { |r| r.satisfied_by?(version) }
+          rescue Gem::Requirement::BadRequirementError
+            false
+          end
+        end
+
+        def latest_version_of_dep_with_satisfied_peer_reqs(dep)
+          latest_version_finder(dep)
+            .possible_versions_with_details
+            .find do |version, details|
+              next false unless version > version_for_dependency(dep)
+              next true unless details["peerDependencies"]
+
+              details["peerDependencies"].all? do |peer_dep_name, req|
+                # Can't handle multiple peer dependencies
+                next false unless peer_dep_name == dependency.name
+                next git_dependency?(dependency) if req.include?("/")
+
+                reqs = requirement_class.requirements_array(req)
+
+                reqs.any? { |r| r.satisfied_by?(latest_allowable_version) }
+              rescue Gem::Requirement::BadRequirementError
+                false
+              end
+            end
+            &.first
+        end
+
+        def git_dependency?(dep)
+          # ignored_version/raise_on_ignored are irrelevant.
+          GitCommitChecker
+            .new(dependency: dep, credentials: credentials)
+            .git_dependency?
+        end
+
+        def newly_broken_peer_reqs_on_dep
+          relevant_unmet_peer_dependencies
+            .select { |dep| dep[:requirement_name] == dependency.name }
+        end
+
+        def newly_broken_peer_reqs_from_dep
+          relevant_unmet_peer_dependencies
+            .select { |dep| dep[:requiring_dep_name] == dependency.name }
+        end
+
+        def lockfiles_for_path(lockfiles:, path:)
+          lockfiles.select do |lockfile|
+            File.dirname(lockfile.name) == File.dirname(path)
+          end
+        end
+
+        def run_checker(path:, version:)
+          bun_lockfiles = lockfiles_for_path(lockfiles: dependency_files_builder.bun_locks, path: path)
+          return run_bun_checker(path: path, version: version) if bun_lockfiles.any?
+
+          root_bun_lock = dependency_files_builder.root_bun_lock
+          run_bun_checker(path: path, version: version) if root_bun_lock
+        end
+
+        def run_bun_checker(path:, version:)
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            Dir.chdir(path) do
+              Helpers.run_bun_command(
+                "update #{dependency.name}@#{version} --save-text-lockfile",
+                fingerprint: "update <dependency_name>@<version> --save-text-lockfile"
+              )
+            end
+          end
+        end
+
+        def version_install_arg(version:)
+          git_source = dependency.requirements.find { |req| req[:source] && req[:source][:type] == "git" }
+
+          if git_source
+            "#{dependency.name}@#{git_source[:source][:url]}##{version}"
+          else
+            "#{dependency.name}@#{version}"
+          end
+        end
+
+        def requirements_for_path(requirements, path)
+          return requirements if path.to_s == "."
+
+          requirements.filter_map do |r|
+            next unless r[:file].start_with?("#{path}/")
+
+            r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
+          end
+        end
+
+        # Top level dependencies are required in the peer dep checker
+        # to fetch the manifests for all top level deps which may contain
+        # "peerDependency" requirements
+        def top_level_dependencies
+          @top_level_dependencies ||= Bun::FileParser.new(
+            dependency_files: dependency_files,
+            source: nil,
+            credentials: credentials
+          ).parse.select(&:top_level?)
+        end
+
+        def paths_requiring_update_check
+          @paths_requiring_update_check ||=
+            Javascript::DependencyFilesFilterer.new(
+              dependency_files: dependency_files,
+              updated_dependencies: [dependency]
+            ).paths_requiring_update_check
+        end
+
+        def dependency_files_builder
+          @dependency_files_builder ||=
+            DependencyFilesBuilder.new(
+              dependency: dependency,
+              dependency_files: dependency_files,
+              credentials: credentials
+            )
+        end
+
+        def version_for_dependency(dep)
+          return version_class.new(dep.version) if dep.version && version_class.correct?(dep.version)
+
+          dep.requirements.filter_map { |r| r[:requirement] }
+             .reject { |req_string| req_string.start_with?("<") }
+             .select { |req_string| req_string.match?(version_regex) }
+             .map { |req_string| req_string.match(version_regex) }
+             .select { |version| version_class.correct?(version.to_s) }
+             .map { |version| version_class.new(version.to_s) }
+             .max
+        end
+
+        def version_class
+          dependency.version_class
+        end
+
+        def requirement_class
+          dependency.requirement_class
+        end
+
+        def version_regex
+          Dependabot::Javascript::Version::VERSION_PATTERN
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
+++ b/javascript/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
@@ -1,0 +1,163 @@
+# typed: true
+# frozen_string_literal: true
+
+require "stringio"
+
+module Dependabot
+  module Bun
+    class UpdateChecker
+      class VulnerabilityAuditor
+        def initialize(dependency_files:, credentials:)
+          @dependency_files = dependency_files
+          @credentials = credentials
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        # Finds any dependencies in the `package-lock.json` or `npm-shrinkwrap.json` that have
+        # a subdependency on the given dependency that is locked to a vuln version range.
+        #
+        # NOTE: yarn is currently not supported.
+        #
+        # @param dependency [Dependabot::Dependency] the dependency to check
+        # @param security_advisories [Array<Dependabot::SecurityAdvisory>] advisories for the dependency
+        # @return [Hash<String, [String, Array<Hash<String, String>>]>] the audit results
+        #   * :dependency_name [String] the name of the dependency
+        #   * :fix_available [Boolean] whether a fix is available
+        #   * :current_version [String] the version of the dependency
+        #   * :target_version [String] the version of the dependency after the fix
+        #   * :fix_updates [Array<Hash<String, String>>] a list of dependencies to update in order to fix
+        #     * :dependency_name [String] the name of the blocking dependency
+        #     * :current_version [String] the current version of the blocking dependency
+        #     * :target_version [String] the target version of the blocking dependency
+        #     * :top_level_ancestors [Array<String>] the names of top-level dependencies with a transitive
+        #       dependency on the blocking dependency
+        #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
+        #     dependency on the dependency
+        #   * :explanation [String] an explanation for why the project failed the vulnerability auditor run
+        def audit(dependency:, security_advisories:)
+          Dependabot.logger.info("VulnerabilityAuditor: starting audit")
+
+          fix_unavailable = {
+            "dependency_name" => dependency.name,
+            "fix_available" => false,
+            "fix_updates" => [],
+            "top_level_ancestors" => []
+          }
+
+          SharedHelpers.in_a_temporary_directory do
+            dependency_files_builder = DependencyFilesBuilder.new(
+              dependency: dependency,
+              dependency_files: dependency_files,
+              credentials: credentials
+            )
+            dependency_files_builder.write_temporary_dependency_files
+
+            # `npm-shrinkwrap.js`, if present, takes precedence over `package-lock.js`.
+            # Both files use the same format. See https://bit.ly/3lDIAJV for more.
+            lockfile = dependency_files_builder.lockfiles.first
+            unless lockfile
+              Dependabot.logger.info("VulnerabilityAuditor: missing lockfile")
+              return fix_unavailable
+            end
+
+            vuln_versions = security_advisories.map do |a|
+              {
+                dependency_name: a.dependency_name,
+                affected_versions: a.vulnerable_version_strings
+              }
+            end
+
+            audit_result = SharedHelpers.run_helper_subprocess(
+              command: Javascript::NativeHelpers.helper_path,
+              function: "npm:vulnerabilityAuditor",
+              args: [Dir.pwd, vuln_versions]
+            )
+
+            validation_result = validate_audit_result(audit_result, security_advisories)
+            if validation_result != :viable
+              Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")
+              fix_unavailable["explanation"] = explain_fix_unavailable(validation_result, dependency)
+              return fix_unavailable
+            end
+
+            Dependabot.logger.info("VulnerabilityAuditor: audit result viable")
+            audit_result
+          end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          log_helper_subprocess_failure(dependency, e)
+          fix_unavailable
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        private
+
+        attr_reader :dependency_files
+        attr_reader :credentials
+
+        def explain_fix_unavailable(validation_result, dependency)
+          case validation_result
+          when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
+            "No patched version available for #{dependency.name}"
+          when :fix_incomplete
+            "The lockfile might be out of sync?"
+          end
+        end
+
+        def validate_audit_result(audit_result, security_advisories)
+          return :fix_unavailable unless audit_result["fix_available"]
+          return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
+          return :downgrades_dependencies if downgrades_dependencies?(audit_result)
+          return :fix_incomplete if fix_incomplete?(audit_result)
+
+          :viable
+        end
+
+        def dependency_still_vulnerable?(audit_result, security_advisories)
+          # vulnerable dependency is removed if the target version is nil
+          return false unless audit_result["target_version"]
+
+          version = Version.new(audit_result["target_version"])
+          security_advisories.any? { |a| a.vulnerable?(version) }
+        end
+
+        def downgrades_dependencies?(audit_result)
+          return true if downgrades_version?(audit_result["current_version"], audit_result["target_version"])
+
+          audit_result["fix_updates"].any? do |update|
+            downgrades_version?(update["current_version"], update["target_version"])
+          end
+        end
+
+        def downgrades_version?(current_version, target_version)
+          return false unless target_version
+
+          current = Version.new(current_version)
+          target = Version.new(target_version)
+          current > target
+        end
+
+        def fix_incomplete?(audit_result)
+          audit_result["fix_updates"].any? { |update| !update.key?("target_version") } ||
+            audit_result["fix_updates"].empty?
+        end
+
+        def log_helper_subprocess_failure(dependency, error)
+          # See `Dependabot::SharedHelpers.run_helper_subprocess` for details on error context
+          context = error.error_context || {}
+
+          builder = ::StringIO.new
+          builder << "VulnerabilityAuditor: "
+          builder << "#{context[:function]} " if context[:function]
+          builder << "failed"
+          builder << " after #{context[:time_taken].truncate(2)}s" if context[:time_taken]
+          builder << " while auditing #{dependency.name}: "
+          builder << error.message
+          builder << "\n" << context[:trace]
+
+          msg = builder.string
+          Dependabot.logger.info(msg) # TODO: is this the right log level?
+        end
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/javascript/file_fetcher.rb
+++ b/javascript/lib/dependabot/javascript/file_fetcher.rb
@@ -1,0 +1,246 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Dependabot
+  module Javascript
+    class FileFetcher < Dependabot::FileFetchers::Base
+      extend T::Sig
+
+      abstract!
+
+      PATH_DEPENDENCY_STARTS = T.let(%w(file: / ./ ../ ~/).freeze, [String, String, String, String, String])
+      PATH_DEPENDENCY_CLEAN_REGEX = /^file:|^link:/
+      DEPENDENCY_TYPES = T.let(%w(dependencies devDependencies optionalDependencies).freeze, T::Array[String])
+
+      sig { params(instance: Dependabot::Bun::FileFetcher).returns(T::Array[DependencyFile]) }
+      def workspace_package_jsons(instance)
+        @workspace_package_jsons ||= T.let(fetch_workspace_package_jsons(instance), T.nilable(T::Array[DependencyFile]))
+      end
+
+      sig do
+        params(instance: Dependabot::Bun::FileFetcher, fetched_files: T::Array[DependencyFile])
+          .returns(T::Array[DependencyFile])
+      end
+      def path_dependencies(instance, fetched_files)
+        package_json_files = T.let([], T::Array[DependencyFile])
+
+        path_dependency_details(instance, fetched_files).each do |name, path|
+          # This happens with relative paths in the package-lock. Skipping it since it results
+          # in /package.json which is outside of the project directory.
+          next if path == "file:"
+
+          path = path.gsub(PATH_DEPENDENCY_CLEAN_REGEX, "")
+          raise PathDependenciesNotReachable, "#{name} at #{path}" if path.start_with?("/")
+
+          filename = path
+          filename = File.join(filename, MANIFEST_FILENAME)
+          cleaned_name = Pathname.new(filename).cleanpath.to_path
+          next if fetched_files.map(&:name).include?(cleaned_name)
+
+          file = instance.fetch_file(filename, fetch_submodules: true)
+          package_json_files << file
+        end
+
+        if package_json_files.any?
+          package_json_files +=
+            path_dependencies(instance, fetched_files + package_json_files)
+        end
+
+        package_json_files.tap { |fs| fs.each { |f| f.support_file = true } }
+      end
+
+      sig do
+        params(instance: Dependabot::Bun::FileFetcher, fetched_files: T::Array[DependencyFile])
+          .returns(T::Array[[String, String]])
+      end
+      def path_dependency_details(instance, fetched_files)
+        package_json_path_deps = T.let([], T::Array[[String, String]])
+
+        fetched_files.each do |file|
+          package_json_path_deps +=
+            path_dependency_details_from_manifest(instance, file)
+        end
+
+        [
+          *package_json_path_deps
+        ].uniq
+      end
+
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
+      sig { params(instance: Dependabot::Bun::FileFetcher, file: DependencyFile).returns(T::Array[[String, String]]) }
+      def path_dependency_details_from_manifest(instance, file)
+        return [] unless file.name.end_with?(MANIFEST_FILENAME)
+
+        current_dir = file.name.rpartition("/").first
+        current_dir = nil if current_dir == ""
+
+        current_depth = File.join(instance.directory, file.name).split("/").count { |path| !path.empty? }
+        path_to_directory = "../" * current_depth
+
+        dep_types = DEPENDENCY_TYPES # TODO: Is this needed?
+        parsed_manifest = JSON.parse(T.must(file.content))
+        dependency_objects = parsed_manifest.values_at(*dep_types).compact
+        # Fetch yarn "file:" path "resolutions" so the lockfile can be resolved
+        resolution_objects = parsed_manifest.values_at("resolutions").compact
+        manifest_objects = dependency_objects + resolution_objects
+
+        raise Dependabot::DependencyFileNotParseable, file.path unless manifest_objects.all?(Hash)
+
+        resolution_deps = resolution_objects.flat_map(&:to_a)
+                                            .map do |path, value|
+          # skip dependencies that contain invalid values such as inline comments, null, etc.
+
+          unless value.is_a?(String)
+            Dependabot.logger.warn("File fetcher: Skipping dependency \"#{path}\" " \
+                                   "with value: \"#{value}\"")
+
+            next
+          end
+
+          convert_dependency_path_to_name(path, value)
+        end
+
+        path_starts = PATH_DEPENDENCY_STARTS
+        (dependency_objects.flat_map(&:to_a) + resolution_deps)
+          .select { |_, v| v.is_a?(String) && v.start_with?(*path_starts) }
+          .map do |name, path|
+            path = path.gsub(PATH_DEPENDENCY_CLEAN_REGEX, "")
+            raise PathDependenciesNotReachable, "#{name} at #{path}" if path.start_with?("/", "#{path_to_directory}..")
+
+            path = File.join(current_dir, path) unless current_dir.nil?
+            [name, Pathname.new(path).cleanpath.to_path]
+          end
+      rescue JSON::ParserError
+        raise Dependabot::DependencyFileNotParseable, file.path
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # Re-write the glob name to the targeted dependency name (which is used
+      # in the lockfile), for example "parent-package/**/sub-dep/target-dep" >
+      # "target-dep"
+      sig { params(path: String, value: String).returns([String, String]) }
+      def convert_dependency_path_to_name(path, value)
+        # Picking the last two parts that might include a scope
+        parts = path.split("/").last(2)
+        parts.shift if parts.count == 2 && !T.must(parts.first).start_with?("@")
+        [parts.join("/"), value]
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher).returns(T::Array[DependencyFile]) }
+      def fetch_workspace_package_jsons(instance)
+        parsed_manifest = parsed_package_json(instance)
+        return [] unless parsed_manifest["workspaces"]
+
+        workspace_paths(instance, parsed_manifest["workspaces"]).filter_map do |workspace|
+          fetch_package_json_if_present(instance, workspace)
+        end
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, workspace_object: T.untyped).returns(T::Array[String]) }
+      def workspace_paths(instance, workspace_object)
+        paths_array =
+          if workspace_object.is_a?(Hash)
+            workspace_object.values_at("packages", "nohoist").flatten.compact
+          elsif workspace_object.is_a?(Array) then workspace_object
+          else
+            [] # Invalid lerna.json, which must not be in use
+          end
+
+        paths_array.flat_map { |path| recursive_find_directories(instance, path) }
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, glob: String).returns(T::Array[String]) }
+      def find_directories(instance, glob)
+        return [glob] unless glob.include?("*")
+
+        unglobbed_path =
+          glob.gsub(%r{^\./}, "").gsub(/!\(.*?\)/, "*")
+              .split("*")
+              .first&.gsub(%r{(?<=/)[^/]*$}, "") || "."
+
+        dir = instance.directory.gsub(%r{(^/|/$)}, "")
+
+        paths =
+          instance.fetch_repo_contents(dir: unglobbed_path, raise_errors: false)
+                  .select { |file| file.type == "dir" }
+                  .map { |f| f.path.gsub(%r{^/?#{Regexp.escape(dir)}/?}, "") }
+
+        matching_paths(glob, paths)
+      end
+
+      sig { params(glob: String, paths: T::Array[String]).returns(T::Array[String]) }
+      def matching_paths(glob, paths)
+        glob = glob.gsub(%r{^\./}, "").gsub(/!\(.*?\)/, "*")
+        glob = "#{glob}/*" if glob.end_with?("**")
+
+        paths.select { |filename| File.fnmatch?(glob, filename, File::FNM_PATHNAME) }
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, glob: String, prefix: String).returns(T::Array[String]) }
+      def recursive_find_directories(instance, glob, prefix = "")
+        return [prefix + glob] unless glob.include?("*")
+
+        glob = glob.gsub(%r{^\./}, "")
+        glob_parts = glob.split("/")
+
+        current_glob = glob_parts.first
+        paths = find_directories(instance, prefix + T.must(current_glob))
+        next_parts = current_glob == "**" ? glob_parts : glob_parts.drop(1)
+        return paths if next_parts.empty?
+
+        paths += paths.flat_map do |expanded_path|
+          recursive_find_directories(instance, next_parts.join("/"), "#{expanded_path}/")
+        end
+
+        matching_paths(prefix + glob, paths)
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, workspace: String).returns(T.nilable(DependencyFile)) }
+      def fetch_package_json_if_present(instance, workspace)
+        file = File.join(workspace, MANIFEST_FILENAME)
+
+        begin
+          instance.fetch_file(file)
+        rescue Dependabot::DependencyFileNotFound
+          # Not all paths matched by a workspace glob may contain a package.json
+          # file. Ignore if that's the case
+          nil
+        end
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher).returns(DependencyFile) }
+      def package_json(instance)
+        @package_json ||= T.let(instance.fetch_file(Javascript::MANIFEST_FILENAME), T.nilable(DependencyFile))
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher).returns(T.untyped) }
+      def parsed_package_json(instance)
+        manifest_file = package_json(instance)
+        parsed = JSON.parse(T.must(manifest_file.content))
+        raise Dependabot::DependencyFileNotParseable, manifest_file.path unless parsed.is_a?(Hash)
+
+        parsed
+      rescue JSON::ParserError
+        raise Dependabot::DependencyFileNotParseable, T.must(manifest_file).path
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, filename: String).returns(T.nilable(DependencyFile)) }
+      def fetch_file_with_support(instance, filename)
+        instance.fetch_file(filename).tap { |f| f.support_file = true }
+      rescue Dependabot::DependencyFileNotFound
+        nil
+      end
+
+      sig { params(instance: Dependabot::Bun::FileFetcher, filename: String).returns(T.nilable(DependencyFile)) }
+      def fetch_file_from_parent_directories(instance, filename)
+        (1..instance.directory.split("/").count).each do |i|
+          file = fetch_file_with_support(instance, ("../" * i) + filename)
+          return file if file
+        end
+        nil
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/javascript/native_helpers.rb
+++ b/javascript/lib/dependabot/javascript/native_helpers.rb
@@ -1,0 +1,19 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dependabot
+  module Javascript
+    module NativeHelpers
+      def self.helper_path
+        "node #{File.join(native_helpers_root, 'run.js')}"
+      end
+
+      def self.native_helpers_root
+        helpers_root = ENV.fetch("DEPENDABOT_NATIVE_HELPERS_PATH", nil)
+        return File.join(helpers_root, "npm_and_yarn") unless helpers_root.nil?
+
+        File.join(__dir__, "../../../helpers")
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/javascript/package_name.rb
+++ b/javascript/lib/dependabot/javascript/package_name.rb
@@ -1,0 +1,116 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Dependabot
+  module Javascript
+    class PackageName
+      extend T::Sig
+
+      # NPM package naming rules are defined by the following projects:
+      # - https://github.com/npm/npm-user-validate
+      # - https://github.com/npm/validate-npm-package-name
+      PACKAGE_NAME_REGEX = %r{
+        \A                                          # beginning of string
+        (?=.{1,214}\z)                              # enforce length (1 - 214)
+        (@(?<scope>                                 # capture 'scope' if present
+          [a-z0-9\-\_\.\!\~\*\'\(\)]+               # URL-safe characters in scope
+        )\/)?                                       # scope must be followed by slash
+        (?<name>                                    # capture package name
+          (?(<scope>)                               # if scope is present
+            [a-z0-9\-\_\.\!\~\*\'\(\)]+             # scoped names can start with any URL-safe character
+          |                                         # if no scope
+            [a-z0-9\-\!\~\*\'\(\)]                  # non-scoped names cannot start with . or _
+            [a-z0-9\-\_\.\!\~\*\'\(\)]*             # subsequent characters can be any URL-safe character
+          )
+        )
+        \z                                          # end of string
+      }xi # multi-line/case-insensitive
+
+      TYPES_PACKAGE_NAME_REGEX = %r{
+          \A                                          # beginning of string
+          @types\/                                    # starts with @types/
+          ((?<scope>.+)__)?                           # capture scope
+          (?<name>.+)                                 # capture name
+          \z                                          # end of string
+      }xi # multi-line/case-insensitive
+
+      class InvalidPackageName < StandardError; end
+
+      sig { params(string: String).void }
+      def initialize(string)
+        match = PACKAGE_NAME_REGEX.match(string.to_s)
+        raise InvalidPackageName unless match
+
+        @scope = T.let(match[:scope], T.nilable(String))
+        @name = T.let(match[:name], T.nilable(String))
+      end
+
+      sig { returns(String) }
+      def to_s
+        if scoped?
+          "@#{@scope}/#{@name}"
+        else
+          @name.to_s
+        end
+      end
+
+      sig { params(other: PackageName).returns(T::Boolean) }
+      def eql?(other)
+        self.class == other.class && to_s == other.to_s
+      end
+
+      sig { returns(Integer) }
+      def hash
+        to_s.downcase.hash
+      end
+
+      sig { params(other: PackageName).returns(T.nilable(Integer)) }
+      def <=>(other)
+        to_s.casecmp(other.to_s)
+      end
+
+      sig { returns(T.nilable(PackageName)) }
+      def library_name
+        return unless types_package?
+        return @library_name if defined?(@library_name)
+
+        lib_name =
+          begin
+            match = T.must(TYPES_PACKAGE_NAME_REGEX.match(to_s))
+            if match[:scope]
+              self.class.new("@#{match[:scope]}/#{match[:name]}")
+            else
+              self.class.new(match[:name].to_s)
+            end
+          end
+
+        @library_name ||= T.let(lib_name, T.nilable(PackageName))
+      end
+
+      sig { returns(T.nilable(PackageName)) }
+      def types_package_name
+        return if types_package?
+
+        @types_package_name ||= T.let(
+          if scoped?
+            self.class.new("@types/#{@scope}__#{@name}")
+          else
+            self.class.new("@types/#{@name}")
+          end, T.nilable(PackageName)
+        )
+      end
+
+      private
+
+      sig { returns(T::Boolean) }
+      def scoped?
+        !@scope.nil?
+      end
+
+      sig { returns(T.nilable(T::Boolean)) }
+      def types_package?
+        "types".casecmp?(@scope)
+      end
+    end
+  end
+end

--- a/javascript/lib/dependabot/javascript/update_checker/dependency_files_builder.rb
+++ b/javascript/lib/dependabot/javascript/update_checker/dependency_files_builder.rb
@@ -3,7 +3,7 @@
 
 module Dependabot
   module Javascript
-    class UpdateChecker
+    module UpdateChecker
       class DependencyFilesBuilder
         extend T::Helpers
         extend T::Sig


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
The final step in enabling the bun ecosystem is to register the bun package manager.

<!-- What issues does this affect or fix? -->

Follows https://github.com/dependabot/dependabot-core/pull/11445, https://github.com/dependabot/dependabot-core/pull/11446, https://github.com/dependabot/dependabot-core/pull/11508, and https://github.com/dependabot/dependabot-core/pull/11521

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
This approach is quite coarse and will be revisited. To facilitate the expedient release of the bun ecosystem we have moved required files directly under the `Dependabot::Bun` namespace. Later when more other `javascript` ecosystems move we can properly organise the shared code.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

We can test with `dry-run`:

`./bin/dry-run.rb bun dsp-testing/dependabot-bun-public  --updater-options=enable_bun_ecosystem --enable-beta-ecosystems`

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.


<details>
  <summary>Click to expand example output</summary>

```bash
 => bump @types/bun from 1.1.16 to 1.2.2

    ± bun.lock
    ~~~
    --- /tmp/original20250207-2479-vcrhtn       2025-02-07 19:31:47.565628858 +0000
    +++ /tmp/updated20250207-2479-6asz4a        2025-02-07 19:31:47.565628858 +0000
    @@ -6,7 +6,7 @@
           "dependencies": {
             "bun-types": "^1.2.0",
             "express": "^4.21.2",
    -        "lodash": "4.17.20",
    +        "lodash": "^4.17.21",
           },
           "devDependencies": {
             "@types/bun": "latest",
    @@ -17,7 +17,7 @@
         },
       },
       "packages": {
    -    "@types/bun": ["@types/bun@1.1.16", "", { "dependencies": { "bun-types": "1.1.43" } }, "sha512-E+ue6NMcn4FXC5bDRE1W/BXUVs01h5Mt02qH8/8HGCox9akuh8KNOFdwvaQS9TDgT2RmUyJYFRRqA60WtTnm2g=="],
    +    "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
     
         "@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg=="],
     
    @@ -95,7 +95,7 @@
     
         "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
     
    -    "lodash": ["lodash@4.17.20", "", {}, "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="],
    +    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
     
         "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
     
    @@ -165,7 +165,7 @@
     
         "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
     
    -    "@types/bun/bun-types": ["bun-types@1.1.43", "", { "dependencies": { "@types/node": "~20.12.8", "@types/ws": "~8.5.10" } }, "sha512-W0wCtVH+bwFp7p3Zgs03CqxEDmXxEvmmUM/FBKgWIv9T8gyeotvIjIbHzuDScc2DphhRNtr7hJLCR5PspYL5qw=="],
    +    "@types/bun/bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
     
         "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
     
    ~~~
    5 insertions (+), 5 deletions (-)
🌍 Total requests made: '17'
```

</details>
