### PR TITLE
group update operations by dependency name

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1147,7 +1147,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.0",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1161,7 +1161,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1175,7 +1175,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.0",
-                                    File = "/some-dir/ProjectA/ProjectA.csproj",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1189,7 +1189,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectA/ProjectA.csproj",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ]
@@ -1218,7 +1218,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.1",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                     Source = new()
                                     {
@@ -1233,36 +1233,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.0",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
-                                    Groups = ["dependencies"],
-                                }
-                            ],
-                        },
-                        new ReportedDependency()
-                        {
-                            Name = "Some.Package2",
-                            Version = "2.0.1",
-                            Requirements =
-                            [
-                                new ReportedRequirement()
-                                {
-                                    Requirement = "2.0.1",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
-                                    Groups = ["dependencies"],
-                                    Source = new()
-                                    {
-                                        SourceUrl = "https://nuget.example.com/some-package2",
-                                        Type = "nuget_repo",
-                                    }
-                                }
-                            ],
-                            PreviousVersion = "2.0.0",
-                            PreviousRequirements =
-                            [
-                                new ReportedRequirement()
-                                {
-                                    Requirement = "2.0.0",
-                                    File = "/some-dir/ProjectB/ProjectB.csproj",
+                                    File = "/some-dir/ProjectA/ProjectA.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],
@@ -1276,7 +1247,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.1",
-                                    File = "/some-dir/ProjectA/ProjectA.csproj",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                     Source = new()
                                     {
@@ -1291,7 +1262,7 @@ public class RunWorkerTests
                                 new ReportedRequirement()
                                 {
                                     Requirement = "1.0.0",
-                                    File = "/some-dir/ProjectA/ProjectA.csproj",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],
@@ -1321,6 +1292,35 @@ public class RunWorkerTests
                                 {
                                     Requirement = "2.0.0",
                                     File = "/some-dir/ProjectA/ProjectA.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                        new ReportedDependency()
+                        {
+                            Name = "Some.Package2",
+                            Version = "2.0.1",
+                            Requirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "2.0.1",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = "https://nuget.example.com/some-package2",
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "2.0.0",
+                            PreviousRequirements =
+                            [
+                                new ReportedRequirement()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/some-dir/ProjectB/ProjectB.csproj",
                                     Groups = ["dependencies"],
                                 }
                             ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -92,20 +92,6 @@ public class UpdatedDependencyListTests
                 },
                 new ReportedDependency()
                 {
-                    Name = "System.Text.Json",
-                    Version = "6.0.0",
-                    Requirements =
-                    [
-                        new ReportedRequirement()
-                        {
-                            Requirement = "6.0.0",
-                            File = "/src/c/project.csproj",
-                            Groups = ["dependencies"],
-                        }
-                    ],
-                },
-                new ReportedDependency()
-                {
                     Name = "Newtonsoft.Json",
                     Version = "13.0.1",
                     Requirements =
@@ -117,6 +103,20 @@ public class UpdatedDependencyListTests
                             Groups = ["dependencies"],
                         },
                     ]
+                },
+                new ReportedDependency()
+                {
+                    Name = "System.Text.Json",
+                    Version = "6.0.0",
+                    Requirements =
+                    [
+                        new ReportedRequirement()
+                        {
+                            Requirement = "6.0.0",
+                            File = "/src/c/project.csproj",
+                            Groups = ["dependencies"],
+                        }
+                    ],
                 },
             ],
             DependencyFiles = ["/src/a/packages.config", "/src/a/project.csproj", "/src/b/packages.config", "/src/b/project.csproj", "/src/c/packages.config", "/src/c/project.csproj"],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -11,6 +11,7 @@ using NuGet.Versioning;
 using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Run;
 
@@ -145,59 +146,51 @@ public class RunWorker
         }
 
         // do update
-        _logger.Info($"Running update in directory {repoDirectory}");
-        foreach (var project in discoveryResult.Projects)
+        var updateOperations = GetUpdateOperations(discoveryResult).ToArray();
+        foreach (var updateOperation in updateOperations)
         {
-            foreach (var dependency in project.Dependencies)
+            var dependency = updateOperation.Dependency;
+            if (!IsUpdateAllowed(job, dependency))
             {
-                if (!IsUpdateAllowed(job, dependency))
+                continue;
+            }
+
+            _logger.Info($"Updating [{dependency.Name}] in [{updateOperation.ProjectPath}]");
+
+            var dependencyInfo = GetDependencyInfo(job, dependency);
+            var analysisResult = await _analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+            // TODO: log analysisResult
+            if (analysisResult.CanUpdate)
+            {
+                // TODO: this is inefficient, but not likely causing a bottleneck
+                var previousDependency = discoveredUpdatedDependencies.Dependencies
+                    .Single(d => d.Name == dependency.Name && d.Requirements.Single().File == updateOperation.ProjectPath);
+                var updatedDependency = new ReportedDependency()
                 {
-                    continue;
-                }
-
-                var dependencyInfo = GetDependencyInfo(job, dependency);
-                var analysisResult = await _analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
-                // TODO: log analysisResult
-                if (analysisResult.CanUpdate)
-                {
-                    var dependencyLocation = Path.Join(discoveryResult.Path, project.FilePath).FullyNormalizedRootedPath();
-
-                    // TODO: this is inefficient, but not likely causing a bottleneck
-                    var previousDependency = discoveredUpdatedDependencies.Dependencies
-                        .Single(d => d.Name == dependency.Name && d.Requirements.Single().File == dependencyLocation);
-                    var updatedDependency = new ReportedDependency()
-                    {
-                        Name = dependency.Name,
-                        Version = analysisResult.UpdatedVersion,
-                        Requirements =
-                        [
-                            new ReportedRequirement()
-                            {
-                                File = dependencyLocation,
-                                Requirement = analysisResult.UpdatedVersion,
-                                Groups = previousDependency.Requirements.Single().Groups,
-                                Source = new RequirementSource()
-                                {
-                                    SourceUrl = analysisResult.UpdatedDependencies.FirstOrDefault(d => d.Name == dependency.Name)?.InfoUrl,
-                                },
-                            }
-                        ],
-                        PreviousVersion = dependency.Version,
-                        PreviousRequirements = previousDependency.Requirements,
-                    };
-
-                    var dependencyFilePath = Path.Join(discoveryResult.Path, project.FilePath).FullyNormalizedRootedPath();
-                    var updateResult = await _updaterWorker.RunAsync(repoContentsPath.FullName, dependencyFilePath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, isTransitive: dependency.IsTransitive);
-                    // TODO: need to report if anything was actually updated
-                    if (updateResult.Error is null)
-                    {
-                        if (dependencyLocation != dependencyFilePath)
+                    Name = dependency.Name,
+                    Version = analysisResult.UpdatedVersion,
+                    Requirements =
+                    [
+                        new ReportedRequirement()
                         {
-                            updatedDependency.Requirements.All(r => r.File == dependencyFilePath);
+                            File = updateOperation.ProjectPath,
+                            Requirement = analysisResult.UpdatedVersion,
+                            Groups = previousDependency.Requirements.Single().Groups,
+                            Source = new RequirementSource()
+                            {
+                                SourceUrl = analysisResult.UpdatedDependencies.FirstOrDefault(d => d.Name == dependency.Name)?.InfoUrl,
+                            },
                         }
+                    ],
+                    PreviousVersion = dependency.Version,
+                    PreviousRequirements = previousDependency.Requirements,
+                };
 
-                        actualUpdatedDependencies.Add(updatedDependency);
-                    }
+                var updateResult = await _updaterWorker.RunAsync(repoContentsPath.FullName, updateOperation.ProjectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, isTransitive: dependency.IsTransitive);
+                // TODO: need to report if anything was actually updated
+                if (updateResult.Error is null)
+                {
+                    actualUpdatedDependencies.Add(updatedDependency);
                 }
             }
         }
@@ -271,6 +264,38 @@ public class RunWorker
             BaseCommitSha = baseCommitSha,
         };
         return result;
+    }
+
+    internal static IEnumerable<(string ProjectPath, Dependency Dependency)> GetUpdateOperations(WorkspaceDiscoveryResult discovery)
+    {
+        // discovery is grouped by project then dependency, but we want to pivot and return a list of update operations sorted by dependency name then project path
+
+        var updateOrder = new Dictionary<string, Dictionary<string, Dictionary<string, Dependency>>>(StringComparer.OrdinalIgnoreCase);
+        //                     <dependency name,     <project path, specific dependencies>>
+
+        // collect
+        foreach (var project in discovery.Projects)
+        {
+            var projectPath = Path.Join(discovery.Path, project.FilePath).FullyNormalizedRootedPath();
+            foreach (var dependency in project.Dependencies)
+            {
+                var dependencyGroup = updateOrder.GetOrAdd(dependency.Name, () => new Dictionary<string, Dictionary<string, Dependency>>(PathComparer.Instance));
+                var dependenciesForProject = dependencyGroup.GetOrAdd(projectPath, () => new Dictionary<string, Dependency>(StringComparer.OrdinalIgnoreCase));
+                dependenciesForProject[dependency.Name] = dependency;
+            }
+        }
+
+        // return
+        foreach (var dependencyName in updateOrder.Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+        {
+            var projectDependencies = updateOrder[dependencyName];
+            foreach (var projectPath in projectDependencies.Keys.OrderBy(p => p, PathComparer.Instance))
+            {
+                var dependencies = projectDependencies[projectPath];
+                var dependency = dependencies[dependencyName];
+                yield return (projectPath, dependency);
+            }
+        }
     }
 
     internal static IncrementMetric GetIncrementMetric(Job job)
@@ -421,23 +446,28 @@ public class RunWorker
             .Distinct()
             .OrderBy(p => p)
             .ToArray();
+        var orderedProjects = discoveryResult.Projects
+            .OrderBy(p => Path.Join(discoveryResult.Path, p.FilePath).FullyNormalizedRootedPath(), PathComparer.Instance)
+            .ToArray();
         var updatedDependencyList = new UpdatedDependencyList()
         {
-            Dependencies = discoveryResult.Projects.SelectMany(p =>
+            Dependencies = orderedProjects.SelectMany(p =>
             {
-                return p.Dependencies.Where(d => d.Version is not null).Select(d =>
-                    new ReportedDependency()
-                    {
-                        Name = d.Name,
-                        Requirements = [new ReportedRequirement()
+                return p.Dependencies
+                    .Where(d => d.Version is not null)
+                    .OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(d =>
+                        new ReportedDependency()
                         {
-                            File = GetFullRepoPath(p.FilePath),
-                            Requirement = d.Version!,
-                            Groups = ["dependencies"],
-                        }],
-                        Version = d.Version,
-                    }
-                );
+                            Name = d.Name,
+                            Requirements = [new ReportedRequirement()
+                            {
+                                File = GetFullRepoPath(p.FilePath),
+                                Requirement = d.Version!,
+                                Groups = ["dependencies"],
+                            }],
+                            Version = d.Version,
+                        });
             }).ToArray(),
             DependencyFiles = dependencyFiles,
         };

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathComparer.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathComparer.cs
@@ -2,27 +2,34 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace NuGetUpdater.Core.Utilities;
 
-public class PathComparer : IEqualityComparer<string>
+public class PathComparer : IComparer<string>, IEqualityComparer<string>
 {
     public static PathComparer Instance { get; } = new PathComparer();
 
-    public bool Equals(string? x, string? y)
+    public int Compare(string? x, string? y)
     {
         x = x?.NormalizePathToUnix();
         y = y?.NormalizePathToUnix();
 
         if (x is null && y is null)
         {
-            return true;
+            return 0;
         }
 
-        if (x is null || y is null)
+        if (x is null)
         {
-            return false;
+            return -1;
         }
 
-        return x.Equals(y, StringComparison.OrdinalIgnoreCase);
+        if (y is null)
+        {
+            return 1;
+        }
+
+        return x.CompareTo(y);
     }
+
+    public bool Equals(string? x, string? y) => Compare(x, y) == 0;
 
     public int GetHashCode([DisallowNull] string obj)
     {


### PR DESCRIPTION
Update is for the non-yet-running end-to-end updater.

Instead of performing updates by project then by dependency, invert that to update by dependency then by project.  This is more in line with the current updater and makes the future work of generating a PR description easier.

This includes sorting the reported dependencies where before it was discover order.  This will make all future reporting more deterministic.