### PR TITLE
don't unnecessarily require windows app ref package

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -23,12 +23,13 @@ public class DiscoveryWorkerTestBase : TestBase
         TestFile[] files,
         ExpectedWorkspaceDiscoveryResult expectedResult,
         MockNuGetPackage[]? packages = null,
+        bool includeCommonPackages = true,
         ExperimentsManager? experimentsManager = null)
     {
         experimentsManager ??= new ExperimentsManager();
         var actualResult = await RunDiscoveryAsync(files, async directoryPath =>
         {
-            await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath);
+            await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath, includeCommonPackages: includeCommonPackages);
 
             var worker = new DiscoveryWorker("TEST-JOB-ID", experimentsManager, new TestLogger());
             var result = await worker.RunWithErrorHandlingAsync(directoryPath, workspacePath);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1247,4 +1247,51 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
+
+    [LinuxOnlyFact]
+    public async Task DiscoverySucceedsWhenNoWindowsAppRefPackageCanBeFound()
+    {
+        // this test mimics a package feed that doesn't have the common Microsoft.Windows.App.Ref package; common in Azure DevOps
+        // Windows machines always have the package, so this test only makes sense on Linux
+        await TestDiscoveryAsync(
+            experimentsManager: new ExperimentsManager() { InstallDotnetSdks = true, UseDirectDiscovery = true },
+            includeCommonPackages: false,
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.2.3", "net8.0"),
+            ],
+            workspacePath: "",
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.2.3" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
+                        ],
+                        Properties = [
+                            new("TargetFramework", "net8.0", "project.csproj"),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    }
+                ]
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -298,13 +298,17 @@ public abstract class UpdateWorkerTestBase : TestBase
         await File.WriteAllTextAsync(Path.Join(temporaryDirectory, "job.json"), JsonSerializer.Serialize(jobFile, RunWorker.SerializerOptions));
     }
 
-    public static async Task MockNuGetPackagesInDirectory(MockNuGetPackage[]? packages, string temporaryDirectory)
+    public static async Task MockNuGetPackagesInDirectory(MockNuGetPackage[]? packages, string temporaryDirectory, bool includeCommonPackages = true)
     {
         if (packages is not null)
         {
             string localFeedPath = Path.Join(temporaryDirectory, "local-feed");
             Directory.CreateDirectory(localFeedPath);
-            MockNuGetPackage[] allPackages = packages.Concat(MockNuGetPackage.CommonPackages).ToArray();
+            var allPackages = packages;
+            if (includeCommonPackages)
+            {
+                allPackages = allPackages.Concat(MockNuGetPackage.CommonPackages).ToArray();
+            }
 
             // write all packages to disk
             foreach (MockNuGetPackage package in allPackages)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
@@ -2,7 +2,7 @@
   <!-- The following properties enable target framework and dependency discovery when OS-specific workloads are required -->
   <PropertyGroup>
     <DesignTimeBuild>true</DesignTimeBuild>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <EnableWindowsTargeting Condition="$(TargetFramework.Contains('-windows'))">true</EnableWindowsTargeting>
     <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">1.0</TargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -784,11 +784,11 @@ internal static partial class MSBuildHelper
             var targetsHelperPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "TargetFrameworkReporter.targets");
             var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(
                 [
-                    "build",
+                    "msbuild",
                     projectPath,
                     "/t:ReportTargetFramework",
                     $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={targetsHelperPath}",
-                    $"/p:CustomAfterMicrosoftCommonTargets={targetsHelperPath}"
+                    $"/p:CustomAfterMicrosoftCommonTargets={targetsHelperPath}",
                 ],
                 projectDirectory,
                 experimentsManager
@@ -833,6 +833,12 @@ internal static partial class MSBuildHelper
                     var framework = string.IsNullOrWhiteSpace(tfpm.Item2)
                         ? NuGetFramework.Parse(tfpm.Item1)
                         : NuGetFramework.ParseComponents(tfpm.Item1, tfpm.Item2);
+                    if (framework.Framework == "_")
+                    {
+                        // error/default value
+                        return null;
+                    }
+
                     return framework;
                 }
                 catch


### PR DESCRIPTION
A private package source might not contain the `Microsoft.Windows.App.Ref` package so only set `EnbleWindowsTargeting` when the TFM explicitly contains the string `-windows`.