### PR TITLE
go_modules: replace deprecated ioutil library

### DIFF
--- a/go_modules/helpers/importresolver/main.go
+++ b/go_modules/helpers/importresolver/main.go
@@ -1,7 +1,7 @@
 package importresolver
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/Masterminds/vcs"
@@ -20,7 +20,7 @@ func VCSRemoteForImport(args *Args) (interface{}, error) {
 		remote = "https://" + remote
 	}
 
-	local, err := ioutil.TempDir("", "unused-vcs-local-dir")
+	local, err := os.MkdirTemp("", "unused-vcs-local-dir")
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +29,8 @@ func VCSRemoteForImport(args *Args) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	defer func() {
+		os.RemoveAll(repo.LocalPath())
+	}()
 	return repo.Remote(), nil
 }

--- a/go_modules/helpers/importresolver/main_test.go
+++ b/go_modules/helpers/importresolver/main_test.go
@@ -1,0 +1,15 @@
+package importresolver
+
+import (
+	"testing"
+)
+
+func TestVCSRemoteForImport(t *testing.T) {
+	args := &Args{
+		Import: "https://github.com/dependabot/dependabot-core",
+	}
+	_, err := VCSRemoteForImport(args)
+	if err != nil {
+		t.Fatalf("failed to get VCS remote for import %s: %v", args.Import, err)
+	}
+}


### PR DESCRIPTION
### What are you trying to accomplish?
Per https://github.com/golang/go/issues/42026, the [io/ioutil](https://pkg.go.dev/io/ioutil) package has been deprecated since go1.16. Replace them with the standard invocation of os.MkdirTemp https://pkg.go.dev/os#MkdirTemp.

### Anything you want to highlight for special attention from reviewers?
a trivial change in the native helper - Go importresolver

in [importresolver/main.go:L32-L34](https://github.com/dependabot/dependabot-core/pull/11541/files#diff-ee661abcf6e1525d05ec5fbc6813717b564cd4688395b852ed11c489b5b3e332R32-R34), added the removal of the local file on function exit (to prevent "pollution" of the local filesystem) since `TestVCSRemoteForImport` returns only the `repo.Remote()` "portion" of `repo` and the local directory is not used.

### How will you know you've accomplished your goal?
added a unit test `go_modules/helpers/importresolver/main_test.go` to test the function `VCSRemoteForImport` (to check for syntax errors etc.)

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
