### PR TITLE
Do not rename the javascript image to bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - { path: swift, name: swift, ecosystem: swift }
           - { path: devcontainers, name: devcontainers, ecosystem: devcontainers }
           - { path: terraform, name: terraform, ecosystem: terraform }
-          - { path: javascript, name: javascript, ecosystem: bun }
+          - { path: javascript, name: javascript, ecosystem: javascript }
 
     steps:
       - name: Checkout code

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -76,7 +76,7 @@ jobs:
           - { name: swift, ecosystem: swift }
           - { name: devcontainers, ecosystem: devcontainers }
           - { name: terraform, ecosystem: terraform }
-          - { name: javascript, ecosystem: bun }
+          - { name: javascript, ecosystem: javascript }
     permissions:
       contents: read
       id-token: write

--- a/script/_common
+++ b/script/_common
@@ -14,9 +14,6 @@ function set_tag() {
       npm_and_yarn)
         TAG=npm
         ;;
-      javascript)
-        TAG=bun
-        ;;
       python)
         TAG=pip
         ;;


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
We have a bug where the `javascript` docker image is being renamed to `bun`. This PR fixes that issue.

This was discovered after the gem release https://github.com/dependabot/dependabot-core/pull/11547

<!-- ### Anything you want to highlight for special attention from reviewers? -->

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

We should see a [`javascript`](https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater-javascript) docker image instead of [`bun`](https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater-bun).

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
