### PR TITLE
Return nil when fetching latest tag results in a JSON::ParserError

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -294,6 +294,10 @@ module Dependabot
       rescue RestClient::ServerBrokeConnection,
              RestClient::TooManyRequests
         raise PrivateSourceBadResponse, registry_hostname
+      rescue JSON::ParserError
+        Dependabot.logger.info \
+          "docker_registry_client.manifest_digest(#{docker_repo_name}, #{tag}) returned an empty string"
+        nil
       end
 
       sig { returns(T::Array[T.class_of(StandardError)]) }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -426,6 +426,28 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("17.04") }
     end
 
+    context "when fetching the latest tag results in a JSON parser error" do
+      let(:tags_fixture_name) { "ubuntu.json" }
+      let(:version) { "12.10" }
+
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+
+      before do
+        stub_request(:head, repo_url + "manifests/17.10")
+          .and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+
+        stub_request(:head, repo_url + "manifests/latest").to_raise(JSON::ParserError)
+      end
+
+      it { is_expected.to eq("17.10") }
+    end
+
     context "when the dependency's version has a prefix" do
       let(:version) { "artful-20170826" }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Resolve the Sentry error below:

```
JSON::ParserError
unexpected token at ''
```
The error occurs when fetching the latest tag results in a JSON::ParserError. However, the method where the result of this call is being used says the result is nilable; therefore it should be safe to return nil when the error occurs

### How will you know you've accomplished your goal?
The error will no longer appear in Sentry.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
