### PR TITLE
Use `dependabot-common` gem if available

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -26,7 +26,7 @@
     - '(go|gomod)'
 
 "L: javascript":
-    - '(javascript|npm|pnpm|yarn)'
+    - '(javascript|npm|pnpm|yarn|bun)'
 
 "L: java:gradle":
     - '(gradle)'

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -26,7 +26,7 @@
     - '(go|gomod)'
 
 "L: javascript":
-    - '(javascript|npm|pnpm|yarn|bun)'
+    - '(javascript|npm|pnpm|yarn)'
 
 "L: java:gradle":
     - '(gradle)'

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -111,7 +111,7 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
   done
 
 # Special cases: 
-#  - Bun ecosystem under Javascript
+#  - Bun ecosystem is a special case that is under the javascript folder
 RUN mkdir -p javascript/lib/dependabot && touch javascript/lib/dependabot/bun.rb
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -110,7 +110,8 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
     touch $ecosystem/lib/dependabot/$ecosystem.rb; \
   done
 
-# Special case: Bun under Javascript
+# Special cases: 
+#  - Bun ecosystem under Javascript
 RUN mkdir -p javascript/lib/dependabot && touch javascript/lib/dependabot/bun.rb
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -105,10 +105,13 @@ COPY --chown=dependabot:dependabot swift/.bundle swift/dependabot-swift.gemspec 
 COPY --chown=dependabot:dependabot terraform/.bundle terraform/dependabot-terraform.gemspec terraform/
 
 # prevent having all the source in every ecosystem image
-RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler silent swift devcontainers dotnet_sdk javascript; do \
+RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler silent swift devcontainers dotnet_sdk; do \
     mkdir -p $ecosystem/lib/dependabot; \
     touch $ecosystem/lib/dependabot/$ecosystem.rb; \
   done
+
+# Special case: Bun under Javascript
+RUN mkdir -p javascript/lib/dependabot && touch javascript/lib/dependabot/bun.rb
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -191,7 +191,7 @@ docker run --rm -ti \
   -v "$(pwd)/hex/script:$CODE_DIR/hex/script" \
   -v "$(pwd)/hex/spec:$CODE_DIR/hex/spec" \
   -v "$(pwd)/javascript/.rubocop.yml:$CODE_DIR/javascript/.rubocop.yml" \
-  -v "$(pwd)/javascript/dependabot-javascript.gemspec:$CODE_DIR/javascript/dependabot-javascript.gemspec" \
+  -v "$(pwd)/javascript/dependabot-bun.gemspec:$CODE_DIR/javascript/dependabot-bun.gemspec" \
   -v "$(pwd)/javascript/helpers:$CODE_DIR/javascript/helpers" \
   -v "$(pwd)/javascript/lib:$CODE_DIR/javascript/lib" \
   -v "$(pwd)/javascript/script:$CODE_DIR/javascript/script" \

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -1,10 +1,10 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
-ARG COREPACK_VERSION=0.30.0
+ARG COREPACK_VERSION=0.31.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=9.15.3
+ARG PNPM_VERSION=9.15.5
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
 ARG YARN_VERSION=4.5.3
@@ -44,8 +44,8 @@ RUN corepack install yarn@$YARN_VERSION --global
 RUN corepack install npm@$NPM_VERSION --global
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers
-RUN bash /opt/npm_and_yarn/helpers/build
+COPY --chown=dependabot:dependabot javascript/helpers /opt/javascript/helpers
+RUN bash /opt/javascript/helpers/build
 
 # START: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -43,9 +43,7 @@ RUN corepack install yarn@$YARN_VERSION --global
 # Install npm and set it to a stable version
 RUN corepack install npm@$NPM_VERSION --global
 
-ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-COPY --chown=dependabot:dependabot javascript/helpers /opt/javascript/helpers
-RUN bash /opt/javascript/helpers/build
+# TODO: Removed helpers as they are not used by bun. But we should add back when we use npm, pnpm, or yarn.
 
 # START: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 

--- a/javascript/lib/dependabot/bun.rb
+++ b/javascript/lib/dependabot/bun.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "zeitwerk"
@@ -6,11 +6,21 @@ require "zeitwerk"
 loader = Zeitwerk::Loader.new
 
 # Set autoload paths for common/lib, excluding files whose content does not match the filename
-loader.push_dir(File.join(__dir__, "../../../common/lib"))
-loader.ignore(File.join(__dir__, "../../../common/lib/dependabot/errors.rb"))
-loader.ignore(File.join(__dir__, "../../../common/lib/dependabot/logger.rb"))
-loader.ignore(File.join(__dir__, "../../../common/lib/dependabot/notices.rb"))
-loader.ignore(File.join(__dir__, "../../../common/lib/dependabot/clients/codecommit.rb"))
+common_lib_path = File.join(__dir__, "../../../common/lib")
+base_lib_path = if File.directory?(common_lib_path)
+                  common_lib_path
+                else
+                  common_spec = Gem::Specification.find_by_name("dependabot-common")
+                  File.join(common_spec.gem_dir, "lib")
+                end
+
+loader.push_dir(base_lib_path)
+
+# Ignore specific files that don't match their filename's content
+loader.ignore(File.join(base_lib_path, "dependabot/errors.rb"))
+loader.ignore(File.join(base_lib_path, "dependabot/logger.rb"))
+loader.ignore(File.join(base_lib_path, "dependabot/notices.rb"))
+loader.ignore(File.join(base_lib_path, "dependabot/clients/codecommit.rb"))
 
 loader.push_dir(File.join(__dir__, ".."))
 loader.ignore("#{__dir__}/../script", "#{__dir__}/../spec", "#{__dir__}/../dependabot-bun.gemspec")


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

We should try to load the `common/lib` path and fallback to the gem. This should cover running in the dry-run, api and now `dependabot-omnibus` gem.

<!-- What issues does this affect or fix? -->

The files could not be located when running in the `dependabot-omnibus` gem.

```
An error occurred while loading ./spec/actions/activate_account_spec.rb.
Failure/Error: require File.expand_path("../config/environment", __dir__)

Zeitwerk::Error:
  the root directory /home/dependabot/.local/share/gem/ruby/gems/common/lib does not exist
# /home/dependabot/.local/share/gem/ruby/gems/zeitwerk-2.7.1/lib/zeitwerk/loader/config.rb:125:in `push_dir'
# /home/dependabot/.local/share/gem/ruby/gems/dependabot-bun-0.296.2/lib/dependabot/bun.rb:9:in `<main>'
# /home/dependabot/.local/share/gem/ruby/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# /home/dependabot/.local/share/gem/ruby/gems/dependabot-bun-0.296.2/lib/dependabot/javascript.rb:4:in `<main>'
# /home/dependabot/.local/share/gem/ruby/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# /home/dependabot/.local/share/gem/ruby/gems/dependabot-omnibus-0.296.2/lib/dependabot/omnibus.rb:23:in `<main>'
# ./config/application.rb:47:in `<top (required)>'
# ./config/environment.rb:4:in `require_relative'
# ./config/environment.rb:4:in `<top (required)>'
# ./spec/rails_helper.rb:4:in `<top (required)>'
# ./spec/actions/activate_account_spec.rb:3:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- dependabot-omnibus
#   ./config/application.rb:47:in `<top (required)>'

An error occurred while loading ./spec/actions/azure_blob_storage_spec.rb.
Failure/Error: require File.expand_path("../config/environment", __dir__)
```

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
Ideally we could test building the `dependabot-omnibus` gem without going through the whole release process.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

`dependabot-omnibus` should build successfully.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
