### PR TITLE
fix tests - remove javascript/helpers and omnibus/Gemfile volume mapping in docker-dev-shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -196,6 +196,11 @@ docker run --rm -ti \
   -v "$(pwd)/hex/lib:$CODE_DIR/hex/lib" \
   -v "$(pwd)/hex/script:$CODE_DIR/hex/script" \
   -v "$(pwd)/hex/spec:$CODE_DIR/hex/spec" \
+  -v "$(pwd)/javascript/.rubocop.yml:$CODE_DIR/javascript/.rubocop.yml" \
+  -v "$(pwd)/javascript/dependabot-bun.gemspec:$CODE_DIR/javascript/dependabot-bun.gemspec" \
+  -v "$(pwd)/javascript/lib:$CODE_DIR/javascript/lib" \
+  -v "$(pwd)/javascript/script:$CODE_DIR/javascript/script" \
+  -v "$(pwd)/javascript/spec:$CODE_DIR/javascript/spec" \
   -v "$(pwd)/maven/.rubocop.yml:$CODE_DIR/maven/.rubocop.yml" \
   -v "$(pwd)/maven/dependabot-maven.gemspec:$CODE_DIR/maven/dependabot-maven.gemspec" \
   -v "$(pwd)/maven/lib:$CODE_DIR/maven/lib" \

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -196,11 +196,6 @@ docker run --rm -ti \
   -v "$(pwd)/hex/lib:$CODE_DIR/hex/lib" \
   -v "$(pwd)/hex/script:$CODE_DIR/hex/script" \
   -v "$(pwd)/hex/spec:$CODE_DIR/hex/spec" \
-  -v "$(pwd)/javascript/.rubocop.yml:$CODE_DIR/javascript/.rubocop.yml" \
-  -v "$(pwd)/javascript/dependabot-bun.gemspec:$CODE_DIR/javascript/dependabot-bun.gemspec" \
-  -v "$(pwd)/javascript/lib:$CODE_DIR/javascript/lib" \
-  -v "$(pwd)/javascript/script:$CODE_DIR/javascript/script" \
-  -v "$(pwd)/javascript/spec:$CODE_DIR/javascript/spec" \
   -v "$(pwd)/maven/.rubocop.yml:$CODE_DIR/maven/.rubocop.yml" \
   -v "$(pwd)/maven/dependabot-maven.gemspec:$CODE_DIR/maven/dependabot-maven.gemspec" \
   -v "$(pwd)/maven/lib:$CODE_DIR/maven/lib" \
@@ -219,7 +214,6 @@ docker run --rm -ti \
   -v "$(pwd)/nuget/script:$CODE_DIR/nuget/script" \
   -v "$(pwd)/nuget/spec:$CODE_DIR/nuget/spec" \
   -v "$(pwd)/omnibus/.rubocop.yml:$CODE_DIR/omnibus/.rubocop.yml" \
-  -v "$(pwd)/omnibus/Gemfile:$CODE_DIR/omnibus/Gemfile" \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/pub/.rubocop.yml:$CODE_DIR/pub/.rubocop.yml" \


### PR DESCRIPTION
### What are you trying to accomplish?
Removal of the directories mapping fixes the issue (possibly introduced in PR #11550, but still occurring after subsequent changes) and allows to run tests. Verified with:
```bash
bin/docker-dev-shell go_modules -r
=> running docker development shell
cd go_modules; rspec spec
```

Fix #11553.

### Anything you want to highlight for special attention from reviewers?
Please see the related [issue](https://github.com/dependabot/dependabot-core/issues/11553) for details.

It would be good to figure out why the regression is not caught by the CI tests and what needs to be done to be able to flag and catch such errors in the future.

### How will you know you've accomplished your goal?
Re-enabel running tests with the `docker-dev-shell`:
```bash
$ bin/docker-dev-shell go_modules
 > image dependabot/dependabot-core-development-go_modules already exists

=> running docker development shell
[dependabot-core-dev] ~ $ cd go_modules/; rspec spec

Randomized with seed 29822
..........................................................................
^C
````

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
