### PR TITLE
Match input EOLs when performing nuget updates

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Update.cs
@@ -13,8 +13,11 @@ public partial class EntryPointTests
 {
     public class Update : UpdateWorkerTestBase
     {
-        [Fact]
-        public async Task WithSolution()
+        [Theory]
+        [InlineData(["\r"])]
+        [InlineData(["\n"])]
+        [InlineData(["\r\n"])]
+        public async Task WithSolution(string EOL)
         {
             await Run(path =>
                 [
@@ -63,7 +66,7 @@ public partial class EntryPointTests
                             HideSolutionNode = FALSE
                             EndGlobalSection
                         EndGlobal
-                        """),
+                        """.Replace("\n", EOL)),
                     ("path/to/my.csproj", """
                         <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                           <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -81,12 +84,12 @@ public partial class EntryPointTests
                           </ItemGroup>
                           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("path/to/packages.config", """
                         <packages>
                           <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                         </packages>
-                        """)
+                        """.Replace("\n", EOL))
                       ],
                 expectedFiles:
                 [
@@ -107,19 +110,22 @@ public partial class EntryPointTests
                           </ItemGroup>
                           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("path/to/packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
                           <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
-                        """)
+                        """.Replace("\n", EOL))
                 ]
             );
         }
 
-        [Fact]
-        public async Task WithProject()
+        [Theory]
+        [InlineData(["\r"])]
+        [InlineData(["\n"])]
+        [InlineData(["\r\n"])]
+        public async Task WithProject(string EOL)
         {
             await Run(path =>
                 [
@@ -163,12 +169,12 @@ public partial class EntryPointTests
                           </ItemGroup>
                           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("path/to/packages.config", """
                         <packages>
                           <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                         </packages>
-                        """)
+                        """.Replace("\n", EOL))
                 ],
                 expectedFiles:
                 [
@@ -189,19 +195,22 @@ public partial class EntryPointTests
                           </ItemGroup>
                           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("path/to/packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
                           <package id="Some.Package" version="13.0.1" targetFramework="net45" />
                         </packages>
-                        """)
+                        """.Replace("\n", EOL))
                 ]
             );
         }
 
-        [Fact]
-        public async Task WithDirsProjAndDirectoryBuildPropsThatIsOutOfDirectoryButStillMatchingThePackage()
+        [Theory]
+        [InlineData(["\r"])]
+        [InlineData(["\n"])]
+        [InlineData(["\r\n"])]
+        public async Task WithDirsProjAndDirectoryBuildPropsThatIsOutOfDirectoryButStillMatchingThePackage(string EOL)
         {
             await Run(path =>
                 [
@@ -235,7 +244,7 @@ public partial class EntryPointTests
                             <ProjectReference Include="project2/project.csproj" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("some-dir/project1/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
@@ -248,7 +257,7 @@ public partial class EntryPointTests
                             <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("some-dir/project2/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
@@ -261,7 +270,7 @@ public partial class EntryPointTests
                             <PackageReference Include="Some.Package" Version="6.1.0" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("other-dir/Directory.Build.props", """
                         <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
@@ -270,7 +279,7 @@ public partial class EntryPointTests
                           </ItemGroup>
 
                         </Project>
-                        """)
+                        """.Replace("\n", EOL))
                 ],
                 expectedFiles:
                 [
@@ -281,7 +290,7 @@ public partial class EntryPointTests
                             <ProjectReference Include="project2/project.csproj" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("some-dir/project1/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
@@ -294,7 +303,7 @@ public partial class EntryPointTests
                             <PackageReference Include="Some.Package" Version="6.6.1" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("some-dir/project2/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
@@ -307,7 +316,7 @@ public partial class EntryPointTests
                             <PackageReference Include="Some.Package" Version="6.6.1" />
                           </ItemGroup>
                         </Project>
-                        """),
+                        """.Replace("\n", EOL)),
                     ("other-dir/Directory.Build.props", """
                         <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
@@ -316,7 +325,7 @@ public partial class EntryPointTests
                           </ItemGroup>
 
                         </Project>
-                        """)
+                        """.Replace("\n", EOL))
                 ]
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -357,7 +357,7 @@ public abstract class UpdateWorkerTestBase : TestBase
         {
             var actualContent = actualContents[expectedPair.Path];
             var expectedContent = expectedPair.Content;
-            Assert.Equal(expectedContent.Replace("\r", ""), actualContent.Replace("\r", "")); // normalize line endings
+            Assert.Equal(expectedContent, actualContent);
         }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/BasicBuildFile.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/BasicBuildFile.cs
@@ -1,0 +1,14 @@
+namespace NuGetUpdater.Core.Files
+{
+    internal class BasicBuildFile : BuildFile<string>
+    {
+        private BasicBuildFile(string repoRootPath, string path, string contents) : base(repoRootPath, path, contents)
+        {
+        }
+
+        public static BasicBuildFile Open(string repoRootPath, string path)
+            => new(repoRootPath, path, File.ReadAllText(path));
+
+        protected override string GetContentsString(string contents) => Contents;
+    }
+}


### PR DESCRIPTION
Currently, when using nuget to perform the updates the end-of-line characters get reset to uniformly be \n. This is typically fine, except for cases where project files are set to have \r\n line endings in the .gitattributes file of a repo, where this results in dependabot making a PR that breaks EOL normalization. To avoid this, we can simply cache the original line endings and re-apply those after performing the update.

### What are you trying to accomplish?

This change attempts to persist the original predominant line ending type of a file when performing nuget updates. Previously, this was not persisted, which resulted in some cases where dependabot would open PRs that break EOL normalization for a repo.

### Anything you want to highlight for special attention from reviewers?

The majority of the current updater tests were made into variadic tests that exercise all three major common line ending formats that might reasonably be encountered.

### How will you know you've accomplished your goal?

This was performed through TDD and the expanded tests now pass where they initially failed.

### Checklist

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
