### PR TITLE
[Feature Flag] - Remove `enable_fix_for_pnpm_no_change_error` Feature Flag

### DIFF
--- a/bun/spec/dependabot/bun/file_updater_spec.rb
+++ b/bun/spec/dependabot/bun/file_updater_spec.rb
@@ -69,8 +69,6 @@ RSpec.describe Dependabot::Bun::FileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/javascript/spec/dependabot/javascript/bun/file_updater_spec.rb
+++ b/javascript/spec/dependabot/javascript/bun/file_updater_spec.rb
@@ -69,8 +69,6 @@ RSpec.describe Dependabot::Javascript::Bun::FileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
@@ -26,37 +26,6 @@ module Dependabot
         end
 
         def dependencies
-          if Dependabot::Experiments.enabled?(:enable_fix_for_pnpm_no_change_error)
-            return dependencies_with_prioritization
-          end
-
-          dependency_set = Dependabot::FileParsers::Base::DependencySet.new
-
-          parsed.each do |details|
-            next if details["aliased"]
-
-            name = details["name"]
-            version = details["version"]
-
-            dependency_args = {
-              name: name,
-              version: version,
-              package_manager: "npm_and_yarn",
-              requirements: []
-            }
-
-            if details["dev"]
-              dependency_args[:subdependency_metadata] =
-                [{ production: !details["dev"] }]
-            end
-
-            dependency_set << Dependency.new(**dependency_args)
-          end
-
-          dependency_set
-        end
-
-        def dependencies_with_prioritization
           dependency_set = Dependabot::FileParsers::Base::DependencySet.new
 
           # Separate dependencies into two categories: with specifiers and without specifiers.

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -62,8 +62,10 @@ module Dependabot
                          end
 
         if updated_files.none?
-          raise_tool_not_supported_for_pnpm_if_transitive
-          raise_miss_configured_tooling_if_pnpm_subdirectory
+          if original_pnpm_locks.any?
+            raise_tool_not_supported_for_pnpm_if_transitive
+            raise_miss_configured_tooling_if_pnpm_subdirectory
+          end
 
           raise NoChangeError.new(
             message: "No files were updated!",

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -62,10 +62,8 @@ module Dependabot
                          end
 
         if updated_files.none?
-          if Dependabot::Experiments.enabled?(:enable_fix_for_pnpm_no_change_error) && original_pnpm_locks.any?
-            raise_tool_not_supported_for_pnpm_if_transitive
-            raise_miss_configured_tooling_if_pnpm_subdirectory
-          end
+          raise_tool_not_supported_for_pnpm_if_transitive
+          raise_miss_configured_tooling_if_pnpm_subdirectory
 
           raise NoChangeError.new(
             message: "No files were updated!",

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -127,17 +127,10 @@ module Dependabot
             "#{d.name}@#{d.version}"
           end.join(" ")
 
-          if Dependabot::Experiments.enabled?(:enable_fix_for_pnpm_no_change_error)
-            Helpers.run_pnpm_command(
-              "update #{dependency_updates}  --lockfile-only --no-save -r",
-              fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r"
-            )
-          else
-            Helpers.run_pnpm_command(
-              "install #{dependency_updates} --lockfile-only --ignore-workspace-root-check",
-              fingerprint: "install <dependency_updates> --lockfile-only --ignore-workspace-root-check"
-            )
-          end
+          Helpers.run_pnpm_command(
+            "update #{dependency_updates}  --lockfile-only --no-save -r",
+            fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r"
+          )
         end
 
         def run_pnpm_install

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -46,8 +46,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::BunLockfileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -77,8 +77,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -81,11 +81,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
   end
 
   describe "errors" do
-    before do
-      allow(Dependabot::Experiments).to receive(:enabled?)
-        .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    end
-
     context "with a dependency version that can't be found" do
       let(:project_name) { "pnpm/yanked_version" }
 
@@ -692,11 +687,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
   end
 
   describe "lockfile updates" do
-    before do
-      allow(Dependabot::Experiments).to receive(:enabled?)
-        .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    end
-
     context "when updating a regular package dependency" do
       let(:project_name) { "pnpm/catalog_prettier" }
       let(:dependencies) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -73,8 +73,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:avoid_duplicate_updates_package_json).and_return(false)
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -45,8 +45,6 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -87,8 +87,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       .with(:enable_shared_helpers_command_timeout).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:npm_v6_deprecation_warning).and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_fix_for_pnpm_no_change_error).and_return(true)
   end
 
   after do


### PR DESCRIPTION
### What are you trying to accomplish?
This change removes the `enable_fix_for_pnpm_no_change_error` feature flag from **dependabot-core** and **dependabot-api**, making the logic always behave as if the flag were enabled. This simplifies the code and ensures the fix is always applied.

### What issues does this affect or fix?
The feature flag is no longer needed as the fix is stable, and removing it helps streamline the codebase.

### Anything you want to highlight for special attention from reviewers?
- The removal of the feature flag is straightforward, but please review to ensure no unintended dependencies remain.
- All conditional checks for this flag have been removed or modified to assume it is always `true`.

### How will you know you've accomplished your goal?
- All related tests should pass without issues.
- The expected behavior (previously gated by the feature flag) should now be the default behavior.
- Code should be simpler and easier to maintain without feature flag conditionals.

### Checklist
- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

