### PR TITLE
expand error patterns for missing packages

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -97,6 +97,11 @@ module Dependabot
         "error-type": "private_source_bad_response",
         "error-detail": { source: error.source }
       }
+    when Dependabot::DependencyNotFound
+      {
+        "error-type": "dependency_not_found",
+        "error-detail": { source: error.source }
+      }
     when Octokit::Unauthorized
       { "error-type": "octokit_unauthorized" }
     when Octokit::ServerError

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -622,6 +622,14 @@ public class SerializationTests
 
         yield return
         [
+            new DependencyNotFound("some source"),
+            """
+            {"data":{"error-type":"dependency_not_found","error-details":{"source":"some source"}}}
+            """
+        ];
+
+        yield return
+        [
             new JobRepoNotFound("some message"),
             """
             {"data":{"error-type":"job_repo_not_found","error-details":{"message":"some message"}}}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -2632,7 +2632,7 @@ public partial class UpdateWorkerTests
                     """,
                 expectedResult: new()
                 {
-                    Error = new UpdateNotPossible(["Unrelated.Package.1.0.0"]),
+                    Error = new DependencyNotFound("Unrelated.Package.1.0.0"),
                 }
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1521,9 +1521,25 @@ public class MSBuildHelperTests : TestBase
         yield return
         [
             // output
-            "Package 'Some.Package' is not found on source",
+            "Package 'Some.Package' is not found on source 'some-source'.",
             // expectedError
-            new UpdateNotPossible(["Some.Package"]),
+            new DependencyNotFound("Some.Package"),
+        ];
+
+        yield return
+        [
+            // output
+            "error NU1101: Unable to find package Some.Package. No packages exist with this id in source(s): some-source",
+            // expectedError
+            new DependencyNotFound("Some.Package"),
+        ];
+
+        yield return
+        [
+            // output
+            "Unable to find package Some.Package with version (= 1.2.3)",
+            // expectedError
+            new DependencyNotFound("Some.Package"),
         ];
 
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyNotFoundException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyNotFoundException.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core;
+
+internal class DependencyNotFoundException : Exception
+{
+    public string[] Dependencies { get; }
+
+    public DependencyNotFoundException(string[] dependencies)
+    {
+        Dependencies = dependencies;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyNotFound.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record DependencyNotFound : JobErrorBase
+{
+    public DependencyNotFound(string dependency)
+        : base("dependency_not_found")
+    {
+        // the corresponding error type in Ruby calls this `source` but it's treated like a dependency name
+        Details["source"] = dependency;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -25,6 +25,7 @@ public abstract record JobErrorBase
         return ex switch
         {
             BadRequirementException badRequirement => new BadRequirement(badRequirement.Message),
+            DependencyNotFoundException dependencyNotFound => new DependencyNotFound(string.Join(", ", dependencyNotFound.Dependencies)),
             HttpRequestException httpRequest => httpRequest.StatusCode switch
             {
                 HttpStatusCode.Unauthorized or

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -970,12 +970,17 @@ internal static partial class MSBuildHelper
 
     private static void ThrowOnMissingPackages(string output)
     {
-        var missingPackagesPattern = new Regex(@"Package '(?<PackageName>[^']*)' is not found on source");
-        var matchCollection = missingPackagesPattern.Matches(output);
-        var missingPackages = matchCollection.Select(m => m.Groups["PackageName"].Value).Distinct().ToArray();
-        if (missingPackages.Length > 0)
+        var patterns = new[]
         {
-            throw new UpdateNotPossibleException(missingPackages);
+            new Regex(@"Package '(?<PackageName>[^']*)' is not found on source '(?<PackageSource>[^$\r\n]*)'\."),
+            new Regex(@"Unable to find package (?<PackageName>[^ ]+)\. No packages exist with this id in source\(s\): (?<PackageSource>.*)$", RegexOptions.Multiline),
+            new Regex(@"Unable to find package (?<PackageName>[^ ]+) with version \((?<PackageVersion>[^)]+)\)"),
+        };
+        var matches = patterns.Select(p => p.Match(output)).Where(m => m.Success);
+        if (matches.Any())
+        {
+            var packages = matches.Select(m => m.Groups["PackageName"].Value).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            throw new DependencyNotFoundException(packages);
         }
     }
 

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -325,6 +325,9 @@ module Dependabot
           file_path = T.let(error_details.fetch("file-path"), String)
           message = T.let(error_details.fetch("message", nil), T.nilable(String))
           raise DependencyFileNotParseable.new(file_path, message)
+        when "dependency_not_found"
+          source = T.let(error_details.fetch("source"), String)
+          raise DependencyNotFound, source
         when "illformed_requirement"
           raise BadRequirementError, T.let(error_details.fetch("message"), String)
         when "private_source_authentication_failure"


### PR DESCRIPTION
Include more error message patterns for missing packages.

The `dependency_not_found` error can happen during NuGet fetch so a corresponding entry was added to `fetcher_error_details` to match the entry in `updater_error_details` in `errors.rb`.