### PR TITLE
Remove python 3.8 deprecation / unsupported FFs and cleanup tests

### DIFF
--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -52,7 +52,6 @@ module Dependabot
       def deprecated?
         return false unless detected_version
         return false if unsupported?
-        return false unless Dependabot::Experiments.enabled?(:python_3_8_deprecation_warning)
 
         deprecated_versions.include?(detected_version)
       end
@@ -60,7 +59,6 @@ module Dependabot
       sig { override.returns(T::Boolean) }
       def unsupported?
         return false unless detected_version
-        return false unless Dependabot::Experiments.enabled?(:python_3_8_unsupported_error)
 
         supported_versions.all? { |supported| supported > detected_version }
       end

--- a/python/spec/dependabot/python/language_spec.rb
+++ b/python/spec/dependabot/python/language_spec.rb
@@ -13,56 +13,27 @@ RSpec.describe Dependabot::Python::Language do
     )
   end
 
-  let(:detected_version) { "3.8.20" }
+  let(:detected_version) { "3.11" }
   let(:raw_version) { "3.13.1" }
 
   describe "#deprecated?" do
-    let(:detected_version) { "3.8.20" }
-    let(:raw_version) { "3.13.1" }
-
-    before do
-      allow(::Dependabot::Experiments).to receive(:enabled?)
-        .with(:python_3_8_deprecation_warning)
-        .and_return(deprecation_enabled)
-      allow(::Dependabot::Experiments).to receive(:enabled?)
-        .with(:python_3_8_unsupported_error)
-        .and_return(unsupported_enabled)
+    it "returns false" do
+      expect(language.deprecated?).to be false
     end
 
-    context "when python_3_8_deprecation_warning is enabled and detected version is deprecated" do
-      let(:deprecation_enabled) { true }
-      let(:unsupported_enabled) { false }
+    context "when detected version is deprecated but not unsupported" do
+      let(:detected_version) { "3.8.1" }
+
+      before do
+        allow(language).to receive(:unsupported?).and_return(false)
+      end
 
       it "returns true" do
         expect(language.deprecated?).to be true
       end
     end
 
-    context "when python_3_8_deprecation_warning is enabled but detected version is not deprecated" do
-      let(:detected_version) { "3.13" }
-      let(:raw_version) { "3.13.1" }
-
-      let(:deprecation_enabled) { true }
-      let(:unsupported_enabled) { false }
-
-      it "returns false" do
-        expect(language.deprecated?).to be false
-      end
-    end
-
-    context "when python_3_8_deprecation_warning is disabled" do
-      let(:deprecation_enabled) { false }
-      let(:unsupported_enabled) { false }
-
-      it "returns false" do
-        expect(language.deprecated?).to be false
-      end
-    end
-
     context "when detected version is unsupported" do
-      let(:deprecation_enabled) { true }
-      let(:unsupported_enabled) { true }
-
       it "returns false, as unsupported takes precedence" do
         expect(language.deprecated?).to be false
       end
@@ -70,65 +41,29 @@ RSpec.describe Dependabot::Python::Language do
   end
 
   describe "#unsupported?" do
-    let(:detected_version) { "3.8" }
-    let(:raw_version) { "3.13.1" }
-
-    before do
-      allow(::Dependabot::Experiments).to receive(:enabled?)
-        .with(:python_3_8_unsupported_error)
-        .and_return(unsupported_enabled)
+    it "returns false" do
+      expect(language.unsupported?).to be false
     end
 
-    context "when python_3_8_unsupported_error is enabled and detected version is unsupported" do
-      let(:unsupported_enabled) { true }
+    context "when detected version is unsupported" do
+      let(:detected_version) { "3.8" }
 
       it "returns true" do
         expect(language.unsupported?).to be true
       end
     end
-
-    context "when python_3_8_unsupported_error is enabled but detected version is supported" do
-      let(:detected_version) { "3.13" }
-      let(:raw_version) { "3.13.1" }
-
-      let(:unsupported_enabled) { true }
-
-      it "returns false" do
-        expect(language.unsupported?).to be false
-      end
-    end
-
-    context "when python_3_8_unsupported_error is disabled" do
-      let(:unsupported_enabled) { false }
-
-      it "returns false" do
-        expect(language.unsupported?).to be false
-      end
-    end
   end
 
   describe "#raise_if_unsupported!" do
-    let(:version) { "3.8" }
-
-    before do
-      allow(Dependabot::Experiments).to receive(:enabled?)
-        .with(:python_3_8_unsupported_error)
-        .and_return(unsupported_enabled)
+    it "does not raise an error" do
+      expect { language.raise_if_unsupported! }.not_to raise_error
     end
 
-    context "when python_3_8_unsupported_error is enabled and detected version is unsupported" do
-      let(:unsupported_enabled) { true }
+    context "when detected version is unsupported" do
+      let(:detected_version) { "3.8" }
 
       it "raises a ToolVersionNotSupported error" do
         expect { language.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)
-      end
-    end
-
-    context "when python_3_8_unsupported_error is disabled" do
-      let(:unsupported_enabled) { false }
-
-      it "does not raise an error" do
-        expect { language.raise_if_unsupported! }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

In order to support the smooth deprecation of python 3.8 we added two feature flags: `python_3_8_deprecation_warning ` and `python_3_8_unsupported_error`. As we stopped supporting python 3.8 on 5th February 2025, these feature flags are no longer required and this PR removes them to make the code easier to maintain.

### How will you know you've accomplished your goal?
After this PR is merged, the feature flags `python_3_8_deprecation_warning ` and `python_3_8_unsupported_error` will be removed from the codebase and tests should continue to pass.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfils the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
