### PR TITLE
Add Bun image strategy to push the Bun updater image

### DIFF
--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
+          - { name: bun, ecosystem: bun }
           - { name: bundler, ecosystem: bundler }
           - { name: cargo, ecosystem: cargo }
           - { name: composer, ecosystem: composer }

--- a/bun/lib/dependabot/bun.rb
+++ b/bun/lib/dependabot/bun.rb
@@ -26,13 +26,6 @@ Dependabot::Dependency.register_production_check(
   end
 )
 
-## A type used for defining a proc that creates a new error object
-ErrorHandler = T.type_alias do
-  T.proc
-   .params(message: String, error: Dependabot::DependabotError, params: T::Hash[Symbol, T.untyped])
-   .returns(Dependabot::DependabotError)
-end
-
 module Dependabot
   module Bun
     NODE_VERSION_NOT_SATISFY_REGEX = /The current Node version (?<current_version>v?\d+\.\d+\.\d+) does not satisfy the required version (?<required_version>v?\d+\.\d+\.\d+)\./ # rubocop:disable Layout/LineLength
@@ -129,6 +122,13 @@ module Dependabot
 
     # registry returns malformed response
     REGISTRY_NOT_REACHABLE = /Received malformed response from registry for "(?<ver>.*)". The registry may be down./
+
+    ## A type used for defining a proc that creates a new error object
+    ErrorHandler = T.type_alias do
+      T.proc
+       .params(message: String, error: Dependabot::DependabotError, params: T::Hash[Symbol, T.untyped])
+       .returns(Dependabot::DependabotError)
+    end
 
     class Utils
       extend T::Sig


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
When running the Bun updater, it is matching to the "bundler" image as the Bun image has not been registered correctly.

<!-- What issues does this affect or fix? -->
Part of https://github.com/github/dependabot-updates/issues/7990

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
We should start to see the Bun image being pushed to the registry and used.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
