### PR TITLE
install all .NET targeting packs specified by the installed SDKs

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -61,3 +61,6 @@ RUN mv bin/run bin/run-original
 COPY --chown=dependabot:dependabot nuget/script/* $DEPENDABOT_HOME/dependabot-updater/bin/
 COPY --chown=dependabot:dependabot nuget/updater/* $DEPENDABOT_HOME/dependabot-updater/bin/
 RUN chmod +x $DEPENDABOT_HOME/dependabot-updater/bin/run
+
+# .NET install targeting packs
+RUN pwsh $DEPENDABOT_HOME/dependabot-updater/bin/install-targeting-packs.ps1

--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -93,3 +93,39 @@ function Install-Sdks([string]$jobFilePath, [string]$repoContentsPath, [string]$
     # report the final set
     dotnet --list-sdks
 }
+
+function Get-RequiredTargetingPacks([string]$sdkInstallDir) {
+    $targetingPacksToInstall = @()
+    $sdkDirs = Get-ChildItem -Path "$sdkInstallDir/sdk" -Directory
+    foreach ($sdkDir in $sdkDirs) {
+        $versionsPropsFile = "$sdkDir/Microsoft.NETCoreSdk.BundledVersions.props"
+        $knownFrameworkReferences = Select-Xml -Path $versionsPropsFile -XPath "/Project/ItemGroup/KnownFrameworkReference"
+        foreach ($frameworkRef in $knownFrameworkReferences) {
+            $targetingPackName = $frameworkRef.Node.TargetingPackName
+            $targetingPackVersion = $frameworkRef.Node.TargetingPackVersion
+            $requiredTargetingPack = "$targetingPackName/$targetingPackVersion"
+            if (-not ($requiredTargetingPack -in $targetingPacksToInstall)) {
+                $targetingPacksToInstall += $requiredTargetingPack
+            }
+        }
+    }
+
+    return ,$targetingPacksToInstall
+}
+
+function Install-TargetingPacks([string]$sdkInstallDir, [string[]]$targetingPacks) {
+    foreach ($targetingPack in $targetingPacks) {
+        $parts = $targetingPack -Split "/"
+        $packName = $parts[0]
+        $packVersion = $parts[1]
+        $targetingPackUrl = "https://www.nuget.org/api/v2/package/$packName/$packVersion"
+        $destinationDirectory = "$sdkInstallDir/packs/$packName/$packVersion"
+        $archiveName = "$destinationDirectory/$packName.$packVersion.zip"
+        New-Item $destinationDirectory -ItemType Directory -Force | Out-Null
+        Write-Host "Downloading targeting pack [$packName/$packVersion]"
+        Invoke-WebRequest -Uri $targetingPackUrl -OutFile $archiveName
+        Write-Host "Extracting targeting pack [$packName/$packVersion] to $destinationDirectory"
+        Expand-Archive -Path $archiveName -DestinationPath $destinationDirectory -Force
+        Remove-Item -Path $archiveName
+    }
+}

--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -103,9 +103,14 @@ function Get-RequiredTargetingPacks([string]$sdkInstallDir) {
         foreach ($frameworkRef in $knownFrameworkReferences) {
             $targetingPackName = $frameworkRef.Node.TargetingPackName
             $targetingPackVersion = $frameworkRef.Node.TargetingPackVersion
-            $requiredTargetingPack = "$targetingPackName/$targetingPackVersion"
-            if (-not ($requiredTargetingPack -in $targetingPacksToInstall)) {
-                $targetingPacksToInstall += $requiredTargetingPack
+            $requiredTargetingPackName = "$targetingPackName/$targetingPackVersion"
+            $requiredTargetingPackDirectory = Join-Path $sdkInstallDir "packs/$requiredTargetingPackName"
+            if (Test-Path -Path $requiredTargetingPackDirectory) {
+                continue
+            }
+
+            if (-not ($requiredTargetingPackName -in $targetingPacksToInstall)) {
+                $targetingPacksToInstall += $requiredTargetingPackName
             }
         }
     }

--- a/nuget/updater/install-targeting-packs.ps1
+++ b/nuget/updater/install-targeting-packs.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+. $PSScriptRoot\common.ps1
+
+try {
+    $targetingPacksToInstall = Get-RequiredTargetingPacks -sdkInstallDir $env:DOTNET_INSTALL_DIR
+    Install-TargetingPacks -sdkInstallDir $env:DOTNET_INSTALL_DIR -targetingPacks $targetingPacksToInstall
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}

--- a/nuget/updater/test-data/targeting-packs/packs/Existing.Targeting.Pack.Ref/7.8.9/.gitignore
+++ b/nuget/updater/test-data/targeting-packs/packs/Existing.Targeting.Pack.Ref/7.8.9/.gitignore
@@ -1,0 +1,1 @@
+# empty file to force directory creation

--- a/nuget/updater/test-data/targeting-packs/sdk/1.2.3/Microsoft.NETCoreSdk.BundledVersions.props
+++ b/nuget/updater/test-data/targeting-packs/sdk/1.2.3/Microsoft.NETCoreSdk.BundledVersions.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <KnownFrameworkReference Include="Some.Targeting.Pack"
+                             TargetingPackName="Some.Targeting.Pack.Ref"
+                             TargetingPackVersion="1.0.1" />
+    <KnownFrameworkReference Include="Some.Other.Targeting.Pack"
+                             TargetingPackName="Some.Other.Targeting.Pack.Ref"
+                             TargetingPackVersion="1.0.2" />
+  </ItemGroup>
+</Project>

--- a/nuget/updater/test-data/targeting-packs/sdk/1.2.3/Microsoft.NETCoreSdk.BundledVersions.props
+++ b/nuget/updater/test-data/targeting-packs/sdk/1.2.3/Microsoft.NETCoreSdk.BundledVersions.props
@@ -6,5 +6,8 @@
     <KnownFrameworkReference Include="Some.Other.Targeting.Pack"
                              TargetingPackName="Some.Other.Targeting.Pack.Ref"
                              TargetingPackVersion="1.0.2" />
+    <KnownFrameworkReference Include="Existing.Targeting.Pack"
+                             TargetingPackName="Existing.Targeting.Pack.Ref"
+                             TargetingPackVersion="7.8.9" />
   </ItemGroup>
 </Project>

--- a/nuget/updater/test-data/targeting-packs/sdk/4.5.6/Microsoft.NETCoreSdk.BundledVersions.props
+++ b/nuget/updater/test-data/targeting-packs/sdk/4.5.6/Microsoft.NETCoreSdk.BundledVersions.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <KnownFrameworkReference Include="Some.Targeting.Pack"
+                             TargetingPackName="Some.Targeting.Pack.Ref"
+                             TargetingPackVersion="4.0.1" />
+    <KnownFrameworkReference Include="Some.Other.Targeting.Pack"
+                             TargetingPackName="Some.Other.Targeting.Pack.Ref"
+                             TargetingPackVersion="4.0.2" />
+  </ItemGroup>
+</Project>

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -19,6 +19,14 @@ function Test-GlobalJsonVersions([string] $testDirectory, [string[]] $directorie
     Write-Host "OK"
 }
 
+function Test-RequiredTargetingPacks([string] $testDirectory, [string[]] $expectedTargetingPacks) {
+    Write-Host "Test-RequiredTargetingPacks in $testDirectory ... " -NoNewLine
+    $testDirectoryFull = "$PSScriptRoot/test-data/$testDirectory"
+    $actualTargetingPacks = Get-RequiredTargetingPacks -sdkInstallDir $testDirectoryFull
+    Assert-ArraysEqual -expected $expectedTargetingPacks -actual $actualTargetingPacks
+    Write-Host "OK"
+}
+
 try {
     Test-GlobalJsonVersions `
         -testDirectory "global-json-discovery-root-no-file" `
@@ -67,6 +75,10 @@ try {
         -directories @("/dir-that-does-not-exist") `
         -installedSdks @("8.0.404", "9.0.101") `
         -expectedSdksToInstall @()
+
+    Test-RequiredTargetingPacks `
+        -testDirectory "targeting-packs" `
+        -expectedTargetingPacks @("Some.Targeting.Pack.Ref/1.0.1", "Some.Other.Targeting.Pack.Ref/1.0.2", "Some.Targeting.Pack.Ref/4.0.1", "Some.Other.Targeting.Pack.Ref/4.0.2")
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
The NuGet updater Docker image currently installs the .NET 8 and 9 SDKs, but an intereseting scenario was encountered.

Consider a repo with:
- a project targeting `net7.0`
- a `NuGet.Config` file that explicitly calls the `<clear />` directive **AND** where the remaining NuGet package feeds don't contain any `Microsoft.NETCore.App.Ref` packages
- **NO** `global.json` file forcing the installation of a 7.0 SDK

If dependency discovery is run on that project it will fail because the current 9.0.x SDK will require the `Microsoft.NETCore.App.Ref` targeting pack version `7.0.20` but since that package isn't on the remaining private feeds, the operation will fail.

This PR scans the currently installed SDKs and downloads and extracts all required targeting packs.

The result is the following lines reported during a build of the NuGet updater Docker image:

<details>
<summary>log snippet</summary>

```
#22 [16/16] RUN pwsh /home/dependabot/dependabot-updater/bin/install-targeting-packs.ps1
#22 0.977 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/8.0.11]
#22 2.051 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/8.0.11] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/8.0.11
#22 2.471 Downloading targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.17763.53]
#22 2.985 Extracting targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.17763.53] to /usr/local/dotnet/current/packs/Microsoft.Windows.SDK.NET.Ref/10.0.17763.53
#22 3.170 Downloading targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.18362.53]
#22 3.709 Extracting targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.18362.53] to /usr/local/dotnet/current/packs/Microsoft.Windows.SDK.NET.Ref/10.0.18362.53
#22 3.974 Downloading targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.19041.53]
#22 4.565 Extracting targeting pack [Microsoft.Windows.SDK.NET.Ref/10.0.19041.53] to /usr/local/dotnet/current/packs/Microsoft.Windows.SDK.NET.Ref/10.0.19041.53
#22 4.817 Downloading targeting pack [Microsoft.NETCore.App.Ref/7.0.20]
#22 5.237 Extracting targeting pack [Microsoft.NETCore.App.Ref/7.0.20] to /usr/local/dotnet/current/packs/Microsoft.NETCore.App.Ref/7.0.20
#22 5.831 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/7.0.20]
#22 6.245 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/7.0.20] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/7.0.20
#22 6.477 Downloading targeting pack [Microsoft.AspNetCore.App.Ref/7.0.20]
#22 6.921 Extracting targeting pack [Microsoft.AspNetCore.App.Ref/7.0.20] to /usr/local/dotnet/current/packs/Microsoft.AspNetCore.App.Ref/7.0.20
#22 7.258 Downloading targeting pack [Microsoft.NETCore.App.Ref/6.0.36]
#22 7.747 Extracting targeting pack [Microsoft.NETCore.App.Ref/6.0.36] to /usr/local/dotnet/current/packs/Microsoft.NETCore.App.Ref/6.0.36
#22 8.013 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/6.0.36]
#22 8.398 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/6.0.36] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/6.0.36
#22 8.550 Downloading targeting pack [Microsoft.AspNetCore.App.Ref/6.0.36]
#22 9.160 Extracting targeting pack [Microsoft.AspNetCore.App.Ref/6.0.36] to /usr/local/dotnet/current/packs/Microsoft.AspNetCore.App.Ref/6.0.36
#22 9.360 Downloading targeting pack [Microsoft.NETCore.App.Ref/5.0.0]
#22 9.791 Extracting targeting pack [Microsoft.NETCore.App.Ref/5.0.0] to /usr/local/dotnet/current/packs/Microsoft.NETCore.App.Ref/5.0.0
#22 10.01 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/5.0.0]
#22 10.62 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/5.0.0] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/5.0.0
#22 10.76 Downloading targeting pack [Microsoft.AspNetCore.App.Ref/5.0.0]
#22 11.24 Extracting targeting pack [Microsoft.AspNetCore.App.Ref/5.0.0] to /usr/local/dotnet/current/packs/Microsoft.AspNetCore.App.Ref/5.0.0
#22 11.43 Downloading targeting pack [Microsoft.NETCore.App.Ref/3.1.0]
#22 12.00 Extracting targeting pack [Microsoft.NETCore.App.Ref/3.1.0] to /usr/local/dotnet/current/packs/Microsoft.NETCore.App.Ref/3.1.0
#22 12.21 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/3.1.0]
#22 12.57 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/3.1.0] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/3.1.0
#22 12.70 Downloading targeting pack [Microsoft.AspNetCore.App.Ref/3.1.10]
#22 13.04 Extracting targeting pack [Microsoft.AspNetCore.App.Ref/3.1.10] to /usr/local/dotnet/current/packs/Microsoft.AspNetCore.App.Ref/3.1.10
#22 13.22 Downloading targeting pack [Microsoft.NETCore.App.Ref/3.0.0]
#22 13.58 Extracting targeting pack [Microsoft.NETCore.App.Ref/3.0.0] to /usr/local/dotnet/current/packs/Microsoft.NETCore.App.Ref/3.0.0
#22 13.79 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/3.0.0]
#22 14.15 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/3.0.0] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/3.0.0
#22 14.30 Downloading targeting pack [Microsoft.AspNetCore.App.Ref/3.0.1]
#22 14.60 Extracting targeting pack [Microsoft.AspNetCore.App.Ref/3.0.1] to /usr/local/dotnet/current/packs/Microsoft.AspNetCore.App.Ref/3.0.1
#22 14.79 Downloading targeting pack [Microsoft.WindowsDesktop.App.Ref/9.0.0]
#22 15.17 Extracting targeting pack [Microsoft.WindowsDesktop.App.Ref/9.0.0] to /usr/local/dotnet/current/packs/Microsoft.WindowsDesktop.App.Ref/9.0.0
#22 DONE 15.8s
```
</details>