### PR TITLE
report specific missing file during discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1355,4 +1355,30 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
+
+    [Fact]
+    public async Task MissingFileIsReported()
+    {
+        await TestDiscoveryAsync(
+            packages: [],
+            experimentsManager: new ExperimentsManager() { UseDirectDiscovery = true, InstallDotnetSdks = true },
+            workspacePath: "",
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <Import Project="file-that-does-not-exist.props" />
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "",
+                Projects = [],
+                ErrorRegex = @"file-that-does-not-exist\.props",
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -795,7 +795,7 @@ internal static partial class MSBuildHelper
             );
             return (exitCode, stdOut, stdErr);
         });
-        ThrowOnUnauthenticatedFeed(stdOut);
+        ThrowOnError(stdOut);
         if (exitCode != 0)
         {
             logger.Warn($"Error determining target frameworks.\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");


### PR DESCRIPTION
If a required project, props, or targets file is missing **_or if the casing doesn't match and MSBuild on Linux can't resolve it_**, report the specific file.

Previously a missing file would cause an error in discovery and nothing would be returned and the empty dependency file set turned into a `dependency_file_not_found` reporting that no `.csproj` files were found.

That's not entirely correct so now that specific file is captured and reported.  The end result for the user is the same, but this will make log classification easier.