### PR TITLE
Remove sha256 from the source's digest

### DIFF
--- a/docker_compose/lib/dependabot/docker_compose/file_parser.rb
+++ b/docker_compose/lib/dependabot/docker_compose/file_parser.rb
@@ -10,7 +10,9 @@ module Dependabot
     class FileParser < Dependabot::Shared::SharedFileParser
       extend T::Sig
 
-      IMAGE_REGEX = %r{^(?:#{REGISTRY}/)?#{IMAGE}(?:#{TAG})?(?:#{DIGEST})?(?:#{NAME})?}
+      DIGEST = /(?<digest>[0-9a-f]{64})/
+      IMAGE_REGEX = %r{^(#{REGISTRY}/)?#{IMAGE}#{TAG}?(?:@sha256:#{DIGEST})?#{NAME}?}x
+
       FROM = /FROM/i
       PLATFORM = /--platform\=(?<platform>\S+)/
 

--- a/docker_compose/lib/dependabot/docker_compose/file_updater.rb
+++ b/docker_compose/lib/dependabot/docker_compose/file_updater.rb
@@ -54,48 +54,6 @@ module Dependabot
 
         updated_files
       end
-
-      sig do
-        override.params(previous_content: String, old_source: T::Hash[Symbol, T.nilable(String)],
-                        new_source: T::Hash[Symbol, T.nilable(String)]).returns(String)
-      end
-      def update_digest_and_tag(previous_content, old_source, new_source)
-        old_digest = old_source[:digest]
-        new_digest = new_source[:digest]
-
-        old_tag = old_source[:tag]
-        new_tag = new_source[:tag]
-
-        old_declaration =
-          if private_registry_url(old_source)
-            "#{private_registry_url(old_source)}/"
-          else
-            ""
-          end
-        old_declaration += T.must(dependency).name
-        old_declaration +=
-          if specified_with_tag?(old_source)
-            ":#{old_tag}"
-          else
-            ""
-          end
-        old_declaration +=
-          if old_digest&.start_with?("sha256:")
-            "@#{old_digest}"
-          else
-            ""
-          end
-
-        escaped_declaration = Regexp.escape(old_declaration)
-
-        old_declaration_regex = build_old_declaration_regex(escaped_declaration)
-
-        previous_content.gsub(old_declaration_regex) do |old_dec|
-          old_dec
-            .gsub(":#{old_tag}", ":#{new_tag}")
-            .gsub(old_digest.to_s, new_digest.to_s)
-        end
-      end
     end
   end
 end

--- a/docker_compose/lib/dependabot/docker_compose/tag.rb
+++ b/docker_compose/lib/dependabot/docker_compose/tag.rb
@@ -1,6 +1,8 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "dependabot/docker_compose/file_parser"
+
 require "sorbet-runtime"
 
 module Dependabot
@@ -18,7 +20,6 @@ module Dependabot
           #{VERSION_WITH_SFX}|
           #{VERSION_WITH_PFX_AND_SFX}
       /x
-      DIGEST = /@(?<digest>[^\s]+)/
 
       sig { returns(String) }
       attr_reader :name
@@ -35,7 +36,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def digest?
-        name.match?(DIGEST)
+        name.match?(FileParser::DIGEST)
       end
 
       sig { returns(T.nilable(T::Boolean)) }

--- a/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
               groups: [],
               file: "docker-compose.yml",
               source: {
-                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -164,7 +164,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -202,7 +202,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
                   file: "docker-compose.yml",
                   source: {
                     registry: "registry-host.io:5000",
-                    digest: "sha256:18305429afa14ea462f810146ba44d4363ae76" \
+                    digest: "18305429afa14ea462f810146ba44d4363ae76" \
                             "e4c8dfc38288cf73aa07485005"
                   }
                 }]
@@ -211,9 +211,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("myreg/ubuntu")
-                expect(dependency.version).to eq(
-                  "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
-                )
+                expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
             end

--- a/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }],
@@ -318,7 +318,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }],
@@ -352,7 +352,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
                 groups: [],
                 file: "docker-compose.yml",
                 source: {
-                  digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                  digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                           "ca97eba880ebf600d68608",
                   tag: "17.10"
                 }
@@ -362,7 +362,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
                 groups: [],
                 file: "docker-compose.yml",
                 source: {
-                  digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                  digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                           "dfc38288cf73aa07485005",
                   tag: "12.04.5"
                 }
@@ -396,7 +396,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               file: "docker-compose.yml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }],
@@ -406,7 +406,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               file: "docker-compose.yml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005"
               }
             }],
@@ -457,7 +457,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }, {
@@ -465,7 +465,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608",
               tag: "17.10"
             }
@@ -475,7 +475,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }, {
@@ -483,7 +483,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005",
               tag: "12.04.5"
             }
@@ -523,7 +523,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608",
                 tag: "17.10"
               }
@@ -533,7 +533,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005",
                 tag: "12.04.5"
               }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing how Dependabot handles Docker image digest updates in Docker Compose by:
1. Modifying the regex pattern to properly parse sha256: prefixed digests
2. Storing only the digest hash (without sha256: prefix) in the dependency's source hash
3. Reusing Dependabot's existing Docker version updater logic for Docker Compose updates
4. Updated the digest parser in the `Tag` class to use the `FileParser` constant

Thanks to @gegoune https://github.com/dependabot/dependabot-core/issues/390#issuecomment-2672326569 and @DigitallyRefined https://github.com/dependabot/dependabot-core/issues/390#issuecomment-2673761870 for raising this issue

### Anything you want to highlight for special attention from reviewers?

Removed custom update_digest_and_tag implementation to reuse the base Docker version updater

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The changes will be verified when:
1. Digest updates preserve the sha256: prefix in the final output
2. Version updates work correctly using Dependabot's Docker version updater
3. PR titles and descriptions show proper version information

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
