### PR TITLE
ensure proper casing for `NuGet.Config` prior to any operations being performed

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -26,6 +26,7 @@ module Dependabot
 
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files
+        NativeHelpers.normalize_file_names
         NativeHelpers.install_dotnet_sdks
         discovery_json_reader = DiscoveryJsonReader.run_discovery_in_directory(
           repo_contents_path: T.must(repo_contents_path),

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -287,6 +287,22 @@ module Dependabot
       end
 
       sig { void }
+      def self.normalize_file_names
+        # environment variables are required and the following will generate an actionable error message if they're not
+        _dependabot_repo_contents_path = ENV.fetch("DEPENDABOT_REPO_CONTENTS_PATH")
+
+        # this environment variable is directly used
+        dependabot_home = ENV.fetch("DEPENDABOT_HOME")
+
+        command = [
+          "pwsh",
+          "#{dependabot_home}/dependabot-updater/bin/normalize-file-names.ps1"
+        ].join(" ")
+        output = SharedHelpers.run_shell_command(command)
+        puts output
+      end
+
+      sig { void }
       def self.install_dotnet_sdks
         return unless Dependabot::Experiments.enabled?(:nuget_install_dotnet_sdks)
 

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
           discovery_json_content = discovery_content_hash.to_json
           File.write(discovery_json_path, discovery_json_content)
         end
+      allow(Dependabot::Nuget::NativeHelpers)
+        .to receive(:normalize_file_names)
       # stub call to `fetch_file_from_host` because it expects an empty directory and other things that make the test
       # more difficult than it needs to be
       allow(file_fetcher_instance)

--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -134,3 +134,20 @@ function Install-TargetingPacks([string]$sdkInstallDir, [string[]]$targetingPack
         Remove-Item -Path $archiveName
     }
 }
+
+function Repair-FileCasingForName([string]$fileName) {
+    # Get-ChildItem is case-insensitive
+    $discoveredFiles = Get-ChildItem $env:DEPENDABOT_REPO_CONTENTS_PATH -r -inc $fileName
+    foreach ($file in $discoveredFiles) {
+        # `-cne` = Case-sensitive Not Equal
+        if ($file.Name -cne $fileName) {
+            $newName = "$($file.Directory)/$fileName"
+            Write-Host "Renaming '$file' to '$newName'"
+            Rename-Item -Path $file -NewName $newName
+        }
+    }
+}
+
+function Repair-FileCasing() {
+    Repair-FileCasingForName -fileName "NuGet.Config"
+}

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -21,6 +21,7 @@ function Get-Files {
         --api-url $env:DEPENDABOT_API_URL `
         --job-id $env:DEPENDABOT_JOB_ID
     $script:operationExitCode = $LASTEXITCODE
+    Repair-FileCasing
 }
 
 function Update-Files {

--- a/nuget/updater/normalize-file-names.ps1
+++ b/nuget/updater/normalize-file-names.ps1
@@ -1,0 +1,14 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+. $PSScriptRoot\common.ps1
+
+try {
+    Repair-FileCasing
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    Write-Host $_.ScriptStackTrace
+    exit 1
+}


### PR DESCRIPTION
NuGet only allows [three options](https://github.com/NuGet/NuGet.Client/blob/68db83a99814547864e09170f6c3179b33933a27/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L24-L37) for the config file naming:

- `nuget.config`
- `NuGet.config`
- `NuGet.Config`

If a code base is primarily developed on a case-insensitive file system like Windows, a config file named `Nuget.config` is fine, but dependabot runs in a Linux container with a case-sensitive file system and in that instance the config file won't be picked up by the NuGet tooling resulting in the default package feed of `api.nuget.org`.

This PR addresses that by running a script to rename the files prior to any operation being performed.

Fixes #11525.