### PR TITLE
add error for missing sdk

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1545,6 +1545,14 @@ public class MSBuildHelperTests : TestBase
         yield return
         [
             // output
+            """error : Could not resolve SDK "missing-sdk".""",
+            // expectedError
+            new DependencyNotFound("missing-sdk"),
+        ];
+
+        yield return
+        [
+            // output
             "Unable to resolve dependencies. 'Some.Package 1.2.3' is not compatible with",
             // expectedError
             new UpdateNotPossible(["Some.Package.1.2.3"]),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -975,6 +975,7 @@ internal static partial class MSBuildHelper
             new Regex(@"Package '(?<PackageName>[^']*)' is not found on source '(?<PackageSource>[^$\r\n]*)'\."),
             new Regex(@"Unable to find package (?<PackageName>[^ ]+)\. No packages exist with this id in source\(s\): (?<PackageSource>.*)$", RegexOptions.Multiline),
             new Regex(@"Unable to find package (?<PackageName>[^ ]+) with version \((?<PackageVersion>[^)]+)\)"),
+            new Regex(@"Could not resolve SDK ""(?<PackageName>[^ ]+)""\."),
         };
         var matches = patterns.Select(p => p.Match(output)).Where(m => m.Success);
         if (matches.Any())


### PR DESCRIPTION
This is a less common error, but something that appeared during a manual audit of the logs.  This will turn the missing SDK message into a `dependency_not_found` error.