### PR TITLE
Increase timeout for getting tags from 5 seconds to 60 seconds

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -379,7 +379,7 @@ module Dependabot
 
       # Defaults from https://github.com/deitch/docker_registry2/blob/bfde04144f0b7fd63c156a1aca83efe19ee78ffd/lib/registry/registry.rb#L26-L27
       DEFAULT_DOCKER_OPEN_TIMEOUT_IN_SECONDS = 2
-      DEFAULT_DOCKER_READ_TIMEOUT_IN_SECONDS = 5
+      DEFAULT_DOCKER_READ_TIMEOUT_IN_SECONDS = 60
 
       sig { returns(DockerRegistry2::Registry) }
       def docker_registry_client


### PR DESCRIPTION
### What are you trying to accomplish?

Increasing timeouts for fetching tags from 5 seconds to 60 seconds
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
### How will you know you've accomplished your goal?

Images with a lot of tags will be fetched successfully

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
