### PR TITLE
Document why `bundler-cache: true` isn't needed

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -38,6 +38,7 @@ jobs:
           # `updater/Gemfile.lock`, which in prod will silently change the
           # version of bundler used by the bundler native helper.
           working-directory: updater
+          # bundler-cache: true # not needed since we don't `bundle install` anything
 
       - name: Bump the version
         # Cron runs with no inputs, so version_type will default to 'minor'


### PR DESCRIPTION
I was about to add `bundler-cache: true` when I realized that we don't actually `bundle install` anything. So the cache is not only superfluous, it's probably slower.

Since I spent a little bit of time digging into this and it's easy to miss if someone is in a hurry, I thought best to document for the next person.

Hopefully this way if someone changes to `bundle install` a gem, they'll realize this should get flipped on.
