### PR TITLE
Simplify the "version already exists" check by using RubyGems v2 API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,12 +127,8 @@ def guard_tag_match
 end
 
 def rubygems_release_exists?(name, version)
-  uri = URI.parse("https://rubygems.org/api/v1/versions/#{name}.json")
+  uri = URI.parse("https://rubygems.org/api/v2/rubygems/#{name}/versions/#{version}.json")
   response = Net::HTTP.get_response(uri)
-  return false if response.code != "200"
-
-  body = JSON.parse(response.body)
-  existing_versions = body.map { |b| b["number"] }
-  existing_versions.include?(version)
+  response.code == "200"
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The v2 API added endpoints specific for a specific version of a gem: https://guides.rubygems.org/rubygems-org-api-v2/

Benefits:

1. Less data gets returned over the wire.
    Compare:
    * https://rubygems.org/api/v1/versions/dependabot-omnibus.json 
    * https://rubygems.org/api/v2/rubygems/dependabot-omnibus/versions/0.299.1.json
3. Less brittle since we no longer parse the `response.body`
4. Faster since we only check `response.code`

I verified that sending a non-existent version returns a `404`: https://rubygems.org/api/v2/rubygems/dependabot-omnibus/versions/0.7.1.json