### PR TITLE
Make `setup-go` inherit `go` version from the `go.mod` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+
       - name: Build ecosystem image
         run: script/build silent
+
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: 1.22
+          go-version-file: 'silent/tests/go.mod'
+
       - name: Download Dependabot CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -122,6 +125,7 @@ jobs:
           gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
           tar xzvf *.tar.gz >/dev/null 2>&1
           ./dependabot --version
+
       - name: Run integration tests
         env:
           PATH: ${{ github.workspace }}:$PATH

--- a/silent/tests/go.mod
+++ b/silent/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/dependabot-core/example
 
-go 1.21.6
+go 1.22
 
 require (
 	golang.org/x/tools v0.14.0 // indirect


### PR DESCRIPTION
This way it's one less place we have to keep things in-sync.

I realize the version in `go.mod` is intended as a minimum bound and not a hardcoded version, for example, the underlying file is already using a slightly different version:
https://github.com/dependabot/dependabot-core/blob/d0b3517a63291220cbdb7b04f1f6859474fcd375/silent/tests/go.mod

But practically speaking my experience is this way is simpler to reason about.

