### PR TITLE
use different values for `$(TargetPlatformVersion)` for TFM and dependency discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -606,6 +606,18 @@ public class MSBuildHelperTests : TestBase
             new[] { "net8.0-windows7.0" }
         ];
 
+        yield return
+        [
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net9.0-windows</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """,
+            new[] { "net9.0-windows" }
+        ];
+
         // legacy projects
         yield return
         [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
@@ -1,8 +1,16 @@
 <Project>
   <!-- The following properties enable target framework and dependency discovery when OS-specific workloads are required -->
   <PropertyGroup>
+    <!--
+
+    $(TargetPlatformVersion) should default to '0.0' as per https://github.com/dotnet/sdk/blob/v9.0.100/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.TargetFrameworkInference.targets#L69
+
+    HOWEVER, this will need to be set differently (e.g., '1.0') to do dependency discovery
+
+    -->
+    <_DefaultTargetPlatformVersion Condition="'$(_DefaultTargetPlatformVersion)' == ''">0.0</_DefaultTargetPlatformVersion>
     <DesignTimeBuild>true</DesignTimeBuild>
     <EnableWindowsTargeting Condition="$(TargetFramework.Contains('-windows'))">true</EnableWindowsTargeting>
-    <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">1.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <!-- Dependency discovery requires a non-zero value for $(TargetPlatformVersion) -->
+    <_DefaultTargetPlatformVersion>1.0</_DefaultTargetPlatformVersion>
+  </PropertyGroup>
+
   <Import Project="DependencyDiscovery.props" />
 
   <Target Name="_DiscoverDependencies" DependsOnTargets="ResolveAssemblyReferences;GenerateBuildDependencyFile;ResolvePackageAssets">


### PR DESCRIPTION
Dependency discovery is a two step process:

1. Discover a project's TFMs.
2. For each TFM, discover dependencies.

Several MSBuild properties are set to enable this to work properly for OS-specific situations, but if a value for `$(TargetPlatformVersion)` is not set, there are two separate values that need to be used as a default.  For scenario (1) a default value of `0.0` is required, but for scenario (2) a default value of `1.0` is required.  This PR allows each stage of dependency discovery to set the appropriate value.

Fixes #11719.