### PR TITLE
Private registry error handling.

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -86,6 +86,10 @@ module Dependabot
                 headers: auth_header_for(details["token"])
               )
               response.status < 400 && JSON.parse(response.body)
+              if response.status >= 400
+                raise DependencyFileNotResolvable,
+                      "Response status from the `#{details["registry"]}` registry: #{response.status}"
+              end
             rescue Excon::Error::Timeout,
                    Excon::Error::Socket,
                    JSON::ParserError


### PR DESCRIPTION
### What are you trying to accomplish?

Currently, if the private registry returns an error, Dependabot falls back to the global registry to fetch dependencies. Based on the discussion with the team, in this PR, I am now throwing an error and informing the customer that there was an issue accessing the configured registry.

### Anything you want to highlight for special attention from reviewers?

The PR is not yet complete.
1. I still need to discuss with the team regarding which error should be thrown.
2. RSpec tests have not been implemented yet.
3. I need to have a discussion with @jakecoffman since he has implemented the fallback logic.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
