### PR TITLE
Downgrade Rust Docker image from 1.85.0-bookworm to 1.84.0-bookworm to restore missing dependencies

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.85.0-bookworm AS rust
+FROM docker.io/library/rust:1.84.0-bookworm AS rust
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 


### PR DESCRIPTION
### What are you trying to accomplish?

Downgrading the Rust base image from `rust:1.85.0-bookworm` to `rust:1.84.0-bookworm` to fix missing dependencies in the Cargo ecosystem.  

#### Why?  
The `rust:1.85.0-bookworm` Docker image is missing required layers, leading to issues where `cargo` is not found in the container environment. This has been confirmed by reverting locally and testing `cargo` commands successfully.  

Issue Link: [dependabot-core/issues/11737](https://github.com/dependabot/dependabot-core/issues/11737)  
Sentry Issue: [DELTAFORCE-12XK](https://github.sentry.io/issues/6352804694/?referrer=github_integration)  

### Anything you want to highlight for special attention from reviewers?

- This downgrade is a temporary fix to restore functionality.  
- Further investigation may be needed to determine why `rust:1.85.0-bookworm` is missing essential dependencies.  
- If a better long-term solution is found, we may consider upgrading in the future.  

### How will you know you've accomplished your goal?

- Running `cargo` commands inside the container should work as expected.  
- CI/CD tests should pass without any dependency-related failures.  
- The error reported in the linked issue should no longer occur.  

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.  
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.  
- [x] I have written clear and descriptive commit messages.  
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.  
- [x] I have ensured that the code is well-documented and easy to understand.  
