### PR TITLE
align version checking code with the parse method

### DIFF
--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -47,7 +47,9 @@ module Dependabot
         return false if parsed_version.nil?
 
         release_part, = T.must(parsed_version[:version]).split("_", 2)
-        release_part = Tag.new(T.must(release_part).chomp(".").chomp("-").chomp("_")).numeric_version || parsed_version
+        release_part = Tag.new(T.must(release_part).chomp(".").chomp("-").chomp("_")).numeric_version
+        return false unless release_part
+
         super(release_part.to_s)
       rescue ArgumentError
         # if we can't instantiate a version, it can't be correct

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -1262,5 +1262,13 @@ RSpec.describe Dependabot::Docker::FileParser do
         end
       end
     end
+
+    context "with images with unparseable versions" do
+      let(:helmfile_fixture_name) { "multi-image-with-bad-version.yaml" }
+
+      it "omits the images with unparseable version numbers" do
+        expect(dependencies.map(&:version)).to eq(["some-name_123"])
+      end
+    end
   end
 end

--- a/docker/spec/fixtures/helm/yaml/multi-image-with-bad-version.yaml
+++ b/docker/spec/fixtures/helm/yaml/multi-image-with-bad-version.yaml
@@ -1,0 +1,12 @@
+# this bug requires that multiple images exist on the same repository with different tags where at least one fo them
+# can't be parsed
+
+item1:
+  image:
+    repository: some.repository
+    tag: some-name_123
+
+item2:
+  image:
+    repository: some.repository
+    tag: 3.2025.123.4567-123abc-20250305t1309


### PR DESCRIPTION
The docker updater version class has slightly different code between the `initialize` method and the `correct?` method.  This PR aligns the two by removing the fallback to `parsed_version` and explicitly checking a return value before proceeding.

Fixes #11739.