### PR TITLE
Revert "Downgrade Rust Docker image from 1.85.0-bookworm to 1.84.0-bookworm to restore missing dependencies"

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.84.0-bookworm AS rust
+FROM docker.io/library/rust:1.85.0-bookworm AS rust
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 


### PR DESCRIPTION
Reverts dependabot/dependabot-core#11738

This PR reverts our previous downgrade from Rust 1.85.0-bookworm to 1.84.0-bookworm. The Docker image has been [republished](https://hub.docker.com/layers/library/rust/1.85.0-bookworm/images/sha256-56248c7a926f4202b184d07269ba61295b21955b745e4b2b18dc869aec128575) with fixes for the issues we encountered earlier.

The cargo unit tests are now passing successfully with the 1.85.0 image. Note that some cargo e2e tests are still experiencing issues, but these appear to be unrelated to the Docker image version.

This PR can be merged if all unit cargo tests continue to pass in CI.

closes: https://github.com/dependabot/dependabot-core/issues/11745