### PR TITLE
report pr status messages as appropriate

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -58,7 +58,7 @@ public class MiscellaneousTests
     public void GetUpdateOperations(WorkspaceDiscoveryResult discovery, (string ProjectPath, string DependencyName)[] expectedUpdateOperations)
     {
         var updateOperations = RunWorker.GetUpdateOperations(discovery).ToArray();
-        var actualUpdateOperations = updateOperations.Select(uo => (uo.FilePath, uo.Dependency.Name)).ToArray();
+        var actualUpdateOperations = updateOperations.Select(uo => (uo.ProjectPath, uo.Dependency.Name)).ToArray();
         Assert.Equal(expectedUpdateOperations, actualUpdateOperations);
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
@@ -1,0 +1,252 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class PullRequestMessageTests
+{
+    [Theory]
+    [MemberData(nameof(GetPullRequestApiMessageData))]
+    public void GetPullRequestApiMessage(Job job, DependencyFile[] updatedFiles, ReportedDependency[] updatedDependencies, MessageBase expectedMessage)
+    {
+        var actualMessage = RunWorker.GetPullRequestApiMessage(job, updatedFiles, updatedDependencies, "TEST-COMMIT-SHA");
+        Assert.NotNull(actualMessage);
+        actualMessage = actualMessage switch
+        {
+            // this isn't the place to verify the generated text
+            CreatePullRequest create => create with { CommitMessage = "test commit message", PrTitle = "test pr title", PrBody = "test pr body" },
+            UpdatePullRequest update => update with { CommitMessage = "test commit message", PrTitle = "test pr title", PrBody = "test pr body" },
+            _ => actualMessage,
+        };
+        Assert.Equal(expectedMessage.GetType(), actualMessage.GetType());
+        var actualMessageJson = HttpApiHandler.Serialize(actualMessage);
+        var expectedMessageJson = HttpApiHandler.Serialize(expectedMessage);
+        Assert.Equal(expectedMessageJson, actualMessageJson);
+    }
+
+    public static IEnumerable<object[]> GetPullRequestApiMessageData()
+    {
+        // candidate pull request does not match existing, no matching security advisory => create
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                }
+            },
+            // updatedFiles
+            new[]
+            {
+                new DependencyFile()
+                {
+                    Directory = "/src/",
+                    Name = "project.csproj",
+                    Content = "project contents irrelevant",
+                }
+            },
+            // updatedDependencies
+            new[]
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    Version = "1.0.1",
+                    Requirements = [],
+                }
+            },
+            // expectedMessage
+            new CreatePullRequest()
+            {
+                Dependencies = [new ReportedDependency() { Name = "Some.Dependency", Version = "1.0.1", Requirements = [] }],
+                UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+                CommitMessage = "test commit message",
+                PrTitle = "test pr title",
+                PrBody = "test pr body",
+            }
+        ];
+
+        // candidate pull request matches existing, no matching security advisory found => close
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                },
+                SecurityUpdatesOnly = true,
+                SecurityAdvisories = [], // no matching advisory
+                ExistingPullRequests = [
+                    new PullRequest()
+                    {
+                        Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("1.0.1") }]
+                    }
+                ]
+            },
+            // updatedFiles
+            Array.Empty<DependencyFile>(), // not used
+            // updatedDependencies
+            new[]
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    Version = "1.0.1",
+                    Requirements = [], // not used
+                }
+            },
+            // expectedMessage
+            new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "up_to_date" },
+        ];
+
+        // broken
+        // started a security job, but no changes were made => find matching existing PR and close
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                },
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [
+                    new PullRequest()
+                    {
+                        Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("1.0.1") }]
+                    }
+                ],
+                SecurityAdvisories = [
+                    new Advisory()
+                    {
+                        DependencyName = "Some.Dependency",
+                    }
+                ]
+            },
+            // updatedFiles
+            Array.Empty<DependencyFile>(),
+            // updatedDependencies
+            Array.Empty<ReportedDependency>(),
+            // expectedMessage
+            new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependency_removed" },
+        ];
+
+        // candidate pull request matches existing and updating is true => update
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                },
+                ExistingPullRequests = [
+                    new PullRequest()
+                    {
+                        Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("1.0.1") }]
+                    }
+                ],
+                UpdatingAPullRequest = true,
+            },
+            // updatedFiles
+            new[]
+            {
+                new DependencyFile()
+                {
+                    Directory = "/src/",
+                    Name = "project.csproj",
+                    Content = "project contents irrelevant",
+                }
+            },
+            // updatedDependencies
+            new[]
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    Version = "1.0.1",
+                    Requirements = [],
+                }
+            },
+            // expectedMessage
+            new UpdatePullRequest()
+            {
+                DependencyGroup = null,
+                DependencyNames = ["Some.Dependency"],
+                UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+                CommitMessage = "test commit message",
+                PrTitle = "test pr title",
+                PrBody = "test pr body",
+            }
+        ];
+
+        // candidate pull request matches existing group and updating is true => update
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                },
+                ExistingGroupPullRequests = [
+                    new GroupPullRequest()
+                    {
+                        DependencyGroupName = "test-group",
+                        Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("1.0.1") }]
+                    }
+                ],
+                UpdatingAPullRequest = true,
+            },
+            // updatedFiles
+            new[]
+            {
+                new DependencyFile()
+                {
+                    Directory = "/src/",
+                    Name = "project.csproj",
+                    Content = "project contents irrelevant",
+                }
+            },
+            // updatedDependencies
+            new[]
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    Version = "1.0.1",
+                    Requirements = [],
+                }
+            },
+            // expectedMessage
+            new UpdatePullRequest()
+            {
+                DependencyGroup = "test-group",
+                DependencyNames = ["Some.Dependency"],
+                UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+                CommitMessage = "test commit message",
+                PrTitle = "test pr title",
+                PrBody = "test pr body",
+            }
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -417,11 +417,11 @@ public class SerializationTests
             """;
         var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
         Assert.Single(jobWrapper.Job.ExistingPullRequests);
-        Assert.Single(jobWrapper.Job.ExistingPullRequests[0]);
-        Assert.Equal("Some.Package", jobWrapper.Job.ExistingPullRequests[0][0].DependencyName);
-        Assert.Equal(NuGetVersion.Parse("1.2.3"), jobWrapper.Job.ExistingPullRequests[0][0].DependencyVersion);
-        Assert.False(jobWrapper.Job.ExistingPullRequests[0][0].DependencyRemoved);
-        Assert.Null(jobWrapper.Job.ExistingPullRequests[0][0].Directory);
+        Assert.Single(jobWrapper.Job.ExistingPullRequests[0].Dependencies);
+        Assert.Equal("Some.Package", jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyName);
+        Assert.Equal(NuGetVersion.Parse("1.2.3"), jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyVersion);
+        Assert.False(jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyRemoved);
+        Assert.Null(jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].Directory);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
@@ -33,6 +33,12 @@ internal class TestApiHandler : IApiHandler
         return Task.CompletedTask;
     }
 
+    public Task ClosePullRequest(ClosePullRequest closePullRequest)
+    {
+        _receivedMessages.Add((closePullRequest.GetType(), closePullRequest));
+        return Task.CompletedTask;
+    }
+
     public Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
     {
         _receivedMessages.Add((updatePullRequest.GetType(), updatePullRequest));

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatePermittedAndMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatePermittedAndMessageTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGet.Versioning;
+
 using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
@@ -10,17 +12,30 @@ using DepType = NuGetUpdater.Core.Run.ApiModel.DependencyType;
 
 namespace NuGetUpdater.Core.Test.Run;
 
-public class UpdateAllowedTests
+public class UpdatePermittedAndMessageTests
 {
     [Theory]
-    [MemberData(nameof(IsUpdateAllowedTestData))]
-    public void IsUpdateAllowed(Job job, Dependency dependency, bool expectedResult)
+    [MemberData(nameof(UpdatePermittedAndMessageTestData))]
+    public void UpdatePermittedAndMessage(Job job, Dependency dependency, bool expectedResult, MessageBase? expectedMessage)
     {
-        var actualResult = RunWorker.IsUpdateAllowed(job, dependency);
+        var (actualResult, actualMessage) = RunWorker.UpdatePermittedAndMessage(job, dependency);
         Assert.Equal(expectedResult, actualResult);
+
+        if (expectedMessage is null)
+        {
+            Assert.Null(actualMessage);
+        }
+        else
+        {
+            Assert.True(actualMessage is not null, $"Expected message of type {expectedMessage.GetType().Name} but got null");
+            Assert.Equal(expectedMessage.GetType(), actualMessage.GetType());
+            var actualMessageJson = HttpApiHandler.Serialize(actualMessage);
+            var expectedMessageJson = HttpApiHandler.Serialize(expectedMessage);
+            Assert.Equal(expectedMessageJson, actualMessageJson);
+        }
     }
 
-    public static IEnumerable<object[]> IsUpdateAllowedTestData()
+    public static IEnumerable<object?[]> UpdatePermittedAndMessageTestData()
     {
         // with default allowed updates on a transitive dependency
         yield return
@@ -29,6 +44,7 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [], PatchedVersions = [Requirement.Parse(">= 1.11.0")], UnaffectedVersions = [] }
                 ],
@@ -36,6 +52,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: true),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when dealing with a security update
@@ -45,6 +63,7 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [], PatchedVersions = [Requirement.Parse(">= 1.11.0")], UnaffectedVersions = [] }
                 ],
@@ -52,6 +71,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: true),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // with a top-level dependency
@@ -62,11 +83,14 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // with a sub-dependency
@@ -77,11 +101,14 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: true),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when insecure
@@ -92,6 +119,7 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [], PatchedVersions = [Requirement.Parse(">= 1.11.0")], UnaffectedVersions = [] }
                 ],
@@ -99,6 +127,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: true),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // when only security fixes are allowed
@@ -109,11 +139,14 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: true),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when dealing with a security fix
@@ -124,6 +157,7 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [], PatchedVersions = [Requirement.Parse(">= 1.11.0")], UnaffectedVersions = [] }
                 ],
@@ -131,6 +165,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // when dealing with a security fix that doesn't apply
@@ -141,6 +177,7 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [Requirement.Parse("> 1.8.0")], PatchedVersions = [], UnaffectedVersions = [] }
                 ],
@@ -148,6 +185,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            new SecurityUpdateNotNeeded("Some.Package"),
         ];
 
         // when dealing with a security fix that doesn't apply to some versions
@@ -158,6 +197,7 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyType = DepType.Direct, UpdateType = UpdateType.All },
                     new AllowedUpdate() { DependencyType = DepType.Indirect, UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [Requirement.Parse("< 1.8.0"), Requirement.Parse("> 1.8.0")], PatchedVersions = [], UnaffectedVersions = [] }
                 ],
@@ -165,6 +205,8 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.1", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // when a dependency allow list that includes the dependency
@@ -174,11 +216,14 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Some.Package" }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // with a dependency allow list that uses a wildcard
@@ -188,11 +233,14 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Some.*" }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
         ];
 
         // when dependency allow list that excludes the dependency
@@ -202,11 +250,14 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Unrelated.Package" }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when matching with an incomplete dependency name
@@ -216,11 +267,14 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Some" }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // with a dependency allow list that uses a wildcard
@@ -230,11 +284,14 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Unrelated.*" }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when security fixes are also allowed
@@ -245,11 +302,14 @@ public class UpdateAllowedTests
                     new AllowedUpdate() { DependencyName = "Unrelated.Package" },
                     new AllowedUpdate() { UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [],
                 securityUpdatesOnly: false),
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             false,
+            // expectedMessage
+            null,
         ];
 
         // when dealing with a security fix
@@ -259,6 +319,7 @@ public class UpdateAllowedTests
                 allowedUpdates: [
                     new AllowedUpdate() { DependencyName = "Unrelated.Package"}, new AllowedUpdate(){ UpdateType = UpdateType.Security }
                 ],
+                existingPrs: [],
                 securityAdvisories: [
                     new Advisory() { DependencyName = "Some.Package", AffectedVersions = [], PatchedVersions = [Requirement.Parse(">= 1.11.0")], UnaffectedVersions = [] }
                 ],
@@ -266,14 +327,57 @@ public class UpdateAllowedTests
             new Dependency("Some.Package", "1.8.0", DependencyType.PackageReference, IsTransitive: false),
             // expectedResult
             true,
+            // expectedMessage
+            null,
+        ];
+
+        // security job, not vulnerable => security update not needed
+        yield return
+        [
+            CreateJob(
+                allowedUpdates: [
+                    new AllowedUpdate() { UpdateType = UpdateType.Security }
+                ],
+                existingPrs: [],
+                securityAdvisories: [
+                    new Advisory() { DependencyName = "Some.Package", AffectedVersions = [Requirement.Parse("1.0.0")], PatchedVersions = [Requirement.Parse("1.1.0")] }
+                ],
+                securityUpdatesOnly: true),
+            new Dependency("Some.Package", "1.1.0", DependencyType.PackageReference),
+            // expectedResult
+            false,
+            // expectedMessage
+            new SecurityUpdateNotNeeded("Some.Package")
+        ];
+
+        // security job, not updating existing => pr already exists
+        yield return
+        [
+            CreateJob(
+                allowedUpdates: [
+                    new AllowedUpdate() { UpdateType = UpdateType.Security }
+                ],
+                existingPrs: [
+                    new PullRequest() { Dependencies = [new PullRequestDependency() { DependencyName = "Some.Package", DependencyVersion = NuGetVersion.Parse("1.2.0") }] }
+                ],
+                securityAdvisories: [
+                    new Advisory() { DependencyName = "Some.Package", AffectedVersions = [Requirement.Parse("1.1.0")] }
+                ],
+                securityUpdatesOnly: true),
+            new Dependency("Some.Package", "1.1.0", DependencyType.PackageReference),
+            // expectedResult
+            false,
+            // expectedMessage
+            new PullRequestExistsForLatestVersion("Some.Package", "1.2.0")
         ];
     }
 
-    private static Job CreateJob(AllowedUpdate[] allowedUpdates, Advisory[] securityAdvisories, bool securityUpdatesOnly)
+    private static Job CreateJob(AllowedUpdate[] allowedUpdates, PullRequest[] existingPrs, Advisory[] securityAdvisories, bool securityUpdatesOnly)
     {
         return new Job()
         {
             AllowedUpdates = allowedUpdates.ToImmutableArray(),
+            ExistingPullRequests = existingPrs.ToImmutableArray(),
             SecurityAdvisories = securityAdvisories.ToImmutableArray(),
             SecurityUpdatesOnly = securityUpdatesOnly,
             Source = new()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public sealed record ClosePullRequest
+public sealed record ClosePullRequest : MessageBase
 {
     [JsonPropertyName("dependency-names")]
     public required ImmutableArray<string> DependencyNames { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public sealed record CreatePullRequest
+public sealed record CreatePullRequest : MessageBase
 {
     public required ReportedDependency[] Dependencies { get; init; }
     [JsonPropertyName("updated-dependency-files")]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/GroupPullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/GroupPullRequest.cs
@@ -5,5 +5,5 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 public record GroupPullRequest
 {
     public required string DependencyGroupName { get; init; }
-    public required ImmutableArray<PullRequest> Dependencies { get; init; }
+    public required ImmutableArray<PullRequestDependency> Dependencies { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -7,7 +7,7 @@ using NuGetUpdater.Core.Analyze;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public abstract record JobErrorBase
+public abstract record JobErrorBase : MessageBase
 {
     public JobErrorBase(string type)
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/MessageBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/MessageBase.cs
@@ -1,0 +1,5 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public abstract record MessageBase
+{
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
@@ -1,11 +1,8 @@
-using NuGet.Versioning;
+using System.Collections.Immutable;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record PullRequest
 {
-    public required string DependencyName { get; init; }
-    public required NuGetVersion DependencyVersion { get; init; }
-    public bool DependencyRemoved { get; init; } = false;
-    public string? Directory { get; init; } = null;
+    public ImmutableArray<PullRequestDependency> Dependencies { get; init; } = [];
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestDependency.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestDependency.cs
@@ -1,0 +1,11 @@
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PullRequestDependency
+{
+    public required string DependencyName { get; init; }
+    public required NuGetVersion DependencyVersion { get; init; }
+    public bool DependencyRemoved { get; init; } = false;
+    public string? Directory { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public sealed record UpdatePullRequest
+public sealed record UpdatePullRequest : MessageBase
 {
     [JsonPropertyName("base-commit-sha")]
     public required string BaseCommitSha { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -45,6 +45,11 @@ public class HttpApiHandler : IApiHandler
         await PostAsJson("create_pull_request", createPullRequest);
     }
 
+    public async Task ClosePullRequest(ClosePullRequest closePullRequest)
+    {
+        await PostAsJson("close_pull_request", closePullRequest);
+    }
+
     public async Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
     {
         await PostAsJson("update_pull_request", updatePullRequest);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -8,6 +8,7 @@ public interface IApiHandler
     Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList);
     Task IncrementMetric(IncrementMetric incrementMetric);
     Task CreatePullRequest(CreatePullRequest createPullRequest);
+    Task ClosePullRequest(ClosePullRequest closePullRequest);
     Task UpdatePullRequest(UpdatePullRequest updatePullRequest);
     Task MarkAsProcessed(MarkAsProcessed markAsProcessed);
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestConverter.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using NuGetUpdater.Core.Run.ApiModel;
+
+namespace NuGetUpdater.Core.Analyze;
+
+public class PullRequestConverter : JsonConverter<PullRequest>
+{
+    public override PullRequest? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("expected array of pull request dependencies");
+        }
+
+        var dependencies = JsonSerializer.Deserialize<ImmutableArray<PullRequestDependency>>(ref reader, options);
+        return new PullRequest()
+        {
+            Dependencies = dependencies
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, PullRequest value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var dependency in value.Dependencies)
+        {
+            JsonSerializer.Serialize(writer, dependency, options);
+        }
+
+        writer.WriteEndArray();
+    }
+}


### PR DESCRIPTION
## Changes are for the new end-to-end updater and are not live.

This PR adds the final bits of PR handling messages and will report things like `update_pull_request`, `pull_request_exists_for_latest_version`, `security_update_not_needed`, etc.

The bulk of the tests were copied from the existing Ruby implementation and slightly tweaked to better represent the NuGet ecosystem.

This also required more strongly typed values for existing pull requests.  In the JSON they're represented as an array of array of dependencies and that's what the old model represented, but now they're more strongly typed.  Consider the following example that better shows the structure:

``` jsonc
{
  "job": {
    // ...
    "existing-pull-requests": [
      // pull request 1
      [
        {
          "dependency-name": "Some.Dependency",
          "dependency-version": "1.2.3"
        }
      ],
      // pull request 2
      [
        {
          "dependency-name": "Some.Other.Dependency",
          "dependency-version": "4.5.6",
        }
      ]
    ]
    // ...
  }
}
```