### PR TITLE
Remove cooldown parameter from update checker for security updates

### DIFF
--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -238,7 +238,7 @@ module Dependabot
             security_advisories: job.security_advisories_for(dependency),
             raise_on_ignored: true, # always true for security updates
             requirements_update_strategy: job.requirements_update_strategy,
-            update_cooldown: job.cooldown,
+            # update_cooldown: job.cooldown, Currently not supported for security updates
             options: job.experiments
           )
         end

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -245,7 +245,7 @@ module Dependabot
             security_advisories: job.security_advisories_for(dependency),
             raise_on_ignored: true,
             requirements_update_strategy: job.requirements_update_strategy,
-            update_cooldown: job.cooldown,
+            # update_cooldown: job.cooldown, Currently not supported for security updates
             options: job.experiments
           )
         end


### PR DESCRIPTION
### What are you trying to accomplish?

Currently, we do not support cooldown for security updates. This change removes the cooldown parameter from the update checker for security updates to align with this decision.

<!-- What issues does this affect or fix? -->

This prevents unnecessary parameter passing and ensures security updates are handled correctly without cooldown delays.

### Anything you want to highlight for special attention from reviewers?

- This change affects only security updates, general update logic remains unchanged.
- No functional impact on non-security updates.

### How will you know you've accomplished your goal?

- Security updates will no longer receive a cooldown parameter.
- The behavior of security updates remains consistent with the intended functionality.
- Tests confirm that security updates continue to be processed correctly.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
