### PR TITLE
add simple title, commit message, and body text generation

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
@@ -18,8 +18,8 @@ public class PullRequestMessageTests
         actualMessage = actualMessage switch
         {
             // this isn't the place to verify the generated text
-            CreatePullRequest create => create with { CommitMessage = "test commit message", PrTitle = "test pr title", PrBody = "test pr body" },
-            UpdatePullRequest update => update with { CommitMessage = "test commit message", PrTitle = "test pr title", PrBody = "test pr body" },
+            CreatePullRequest create => create with { CommitMessage = RunWorkerTests.TestPullRequestCommitMessage, PrTitle = RunWorkerTests.TestPullRequestTitle, PrBody = RunWorkerTests.TestPullRequestBody },
+            UpdatePullRequest update => update with { CommitMessage = RunWorkerTests.TestPullRequestCommitMessage, PrTitle = RunWorkerTests.TestPullRequestTitle, PrBody = RunWorkerTests.TestPullRequestBody },
             _ => actualMessage,
         };
         Assert.Equal(expectedMessage.GetType(), actualMessage.GetType());
@@ -68,9 +68,9 @@ public class PullRequestMessageTests
                 Dependencies = [new ReportedDependency() { Name = "Some.Dependency", Version = "1.0.1", Requirements = [] }],
                 UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
                 BaseCommitSha = "TEST-COMMIT-SHA",
-                CommitMessage = "test commit message",
-                PrTitle = "test pr title",
-                PrBody = "test pr body",
+                CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                PrTitle = RunWorkerTests.TestPullRequestTitle,
+                PrBody = RunWorkerTests.TestPullRequestBody,
             }
         ];
 
@@ -190,9 +190,9 @@ public class PullRequestMessageTests
                 DependencyNames = ["Some.Dependency"],
                 UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
                 BaseCommitSha = "TEST-COMMIT-SHA",
-                CommitMessage = "test commit message",
-                PrTitle = "test pr title",
-                PrBody = "test pr body",
+                CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                PrTitle = RunWorkerTests.TestPullRequestTitle,
+                PrBody = RunWorkerTests.TestPullRequestBody,
             }
         ];
 
@@ -243,9 +243,9 @@ public class PullRequestMessageTests
                 DependencyNames = ["Some.Dependency"],
                 UpdatedDependencyFiles = [new DependencyFile() { Directory = "/src/", Name = "project.csproj", Content = "project contents irrelevant" } ],
                 BaseCommitSha = "TEST-COMMIT-SHA",
-                CommitMessage = "test commit message",
-                PrTitle = "test pr title",
-                PrBody = "test pr body",
+                CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                PrTitle = RunWorkerTests.TestPullRequestTitle,
+                PrBody = RunWorkerTests.TestPullRequestBody,
             }
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -1,11 +1,136 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
 
 namespace NuGetUpdater.Core.Test.Run;
 
 public class PullRequestTextTests
 {
+    [Theory]
+    [MemberData(nameof(GetPullRequestTextTestData))]
+    public void PullRequestText(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName, string expectedTitle, string expectedCommitMessage, string expectedBody)
+    {
+        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        Assert.Equal(expectedTitle, actualTitle);
+        Assert.Equal(expectedCommitMessage, actualCommitMessage);
+        Assert.Equal(expectedBody, actualBody);
+    }
+
+    public static IEnumerable<object?[]> GetPullRequestTextTestData()
+    {
+        // single dependency, no optional values
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updatedDependencies
+            new []
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Package",
+                    Version = "1.2.3",
+                    Requirements = []
+                }
+            },
+            // updatedFiles
+            Array.Empty<DependencyFile>(),
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "Update Some.Package to 1.2.3",
+            // expectedCommitMessage
+            "Update Some.Package to 1.2.3",
+            // expectedBody
+            "Update Some.Package to 1.2.3"
+        ];
+
+        // single dependency, prefix given
+        yield return
+        [
+            // job
+            FromCommitOptions(new(){ Prefix = "[SECURITY] " }),
+            // updatedDependencies
+            new []
+            {
+                new ReportedDependency()
+                {
+                    Name = "Some.Package",
+                    Version = "1.2.3",
+                    Requirements = []
+                }
+            },
+            // updatedFiles
+            Array.Empty<DependencyFile>(),
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "[SECURITY] Update Some.Package to 1.2.3",
+            // expectedCommitMessage
+            "[SECURITY] Update Some.Package to 1.2.3",
+            // expectedBody
+            "[SECURITY] Update Some.Package to 1.2.3"
+        ];
+
+        // multiple dependencies, multiple versions
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updatedDependencies
+            new[]
+            {
+                new ReportedDependency()
+                {
+                    Name = "Package.A",
+                    Version = "1.0.0",
+                    Requirements = []
+                },
+                new ReportedDependency()
+                {
+                    Name = "Package.A",
+                    Version = "2.0.0",
+                    Requirements = []
+                },
+                new ReportedDependency()
+                {
+                    Name = "Package.B",
+                    Version = "3.0.0",
+                    Requirements = []
+                },
+                new ReportedDependency()
+                {
+                    Name = "Package.B",
+                    Version = "4.0.0",
+                    Requirements = []
+                },
+            },
+            // updatedFiles
+            Array.Empty<DependencyFile>(),
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
+            // expectedCommitMessage
+            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
+            // expectedBody
+            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0"
+        ];
+    }
+
+    private static Job FromCommitOptions(CommitOptions? commitOptions)
+    {
+        return new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "test/repo"
+            },
+            CommitMessageOptions = commitOptions,
+        };
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class PullRequestTextTests
+{
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -2601,6 +2601,7 @@ public class RunWorkerTests
             .Select(m =>
                 m.Object switch
                 {
+                    // this isn't the place to verify the generated text
                     CreatePullRequest create => (m.Type, create with { CommitMessage = TestPullRequestCommitMessage, PrTitle = TestPullRequestTitle, PrBody = TestPullRequestBody }),
                     UpdatePullRequest update => (m.Type, update with { CommitMessage = TestPullRequestCommitMessage, PrTitle = TestPullRequestTitle, PrBody = TestPullRequestBody }),
                     _ => m,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -22,6 +22,10 @@ using TestFile = (string Path, string Content);
 
 public class RunWorkerTests
 {
+    public const string TestPullRequestCommitMessage = "test-pull-request-commit-message";
+    public const string TestPullRequestTitle = "test-pull-request-title";
+    public const string TestPullRequestBody = "test-pull-request-body";
+
     [Theory]
     [InlineData(EOLType.CR)]
     [InlineData(EOLType.LF)]
@@ -210,9 +214,9 @@ public class RunWorkerTests
                         },
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -462,9 +466,9 @@ public class RunWorkerTests
 
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -856,9 +860,9 @@ public class RunWorkerTests
                         },
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -1416,9 +1420,9 @@ public class RunWorkerTests
                         },
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -1724,9 +1728,9 @@ public class RunWorkerTests
                         }
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -2065,9 +2069,9 @@ public class RunWorkerTests
                         }
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body"
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -2450,9 +2454,9 @@ public class RunWorkerTests
                         },
                     ],
                     BaseCommitSha = "TEST-COMMIT-SHA",
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
@@ -2593,7 +2597,15 @@ public class RunWorkerTests
         var worker = new RunWorker(jobId, testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
         var repoContentsPathDirectoryInfo = new DirectoryInfo(tempDirectory.DirectoryPath);
         var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA");
-        var actualApiMessages = testApiHandler.ReceivedMessages.ToArray();
+        var actualApiMessages = testApiHandler.ReceivedMessages
+            .Select(m =>
+                m.Object switch
+                {
+                    CreatePullRequest create => (m.Type, create with { CommitMessage = TestPullRequestCommitMessage, PrTitle = TestPullRequestTitle, PrBody = TestPullRequestBody }),
+                    UpdatePullRequest update => (m.Type, update with { CommitMessage = TestPullRequestCommitMessage, PrTitle = TestPullRequestTitle, PrBody = TestPullRequestBody }),
+                    _ => m,
+                }
+            ).ToArray();
 
         // assert
         var actualRunResultJson = JsonSerializer.Serialize(actualResult);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,3 +1,5 @@
+using NuGet.Versioning;
+
 using NuGetUpdater.Core.Run.ApiModel;
 
 namespace NuGetUpdater.Core.Run;
@@ -6,16 +8,37 @@ public class PullRequestTextGenerator
 {
     public static string GetPullRequestTitle(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
     {
-        return "TODO: title";
-    }
-
-    public static string GetPullRequestBody(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
-    {
-        return "TODO: body";
+        // simple version looks like
+        //   Update Some.Package to 1.2.3
+        // if multiple packages are updated to multiple versions, result looks like:
+        //   Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0
+        var dependencySets = updatedDependencies
+            .GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new
+            {
+                Name = g.Key,
+                Versions = g
+                    .Where(d => d.Version is not null)
+                    .Select(d => d.Version!)
+                    .OrderBy(d => NuGetVersion.Parse(d))
+                    .ToArray()
+            })
+            .ToArray();
+        var updatedPartTitles = dependencySets
+            .Select(d => $"{d.Name} to {string.Join(", ", d.Versions)}")
+            .ToArray();
+        var title = $"{job.CommitMessageOptions?.Prefix}Update {string.Join("; ", updatedPartTitles)}";
+        return title;
     }
 
     public static string GetPullRequestCommitMessage(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
     {
-        return "TODO: message";
+        return GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
+    }
+
+    public static string GetPullRequestBody(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    {
+        return GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,0 +1,21 @@
+using NuGetUpdater.Core.Run.ApiModel;
+
+namespace NuGetUpdater.Core.Run;
+
+public class PullRequestTextGenerator
+{
+    public static string GetPullRequestTitle(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    {
+        return "TODO: title";
+    }
+
+    public static string GetPullRequestBody(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    {
+        return "TODO: body";
+    }
+
+    public static string GetPullRequestCommitMessage(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    {
+        return "TODO: message";
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -385,9 +385,9 @@ public class RunWorker
                     DependencyNames = updatedDependencies.Select(d => d.Name).ToImmutableArray(),
                     UpdatedDependencyFiles = updatedFiles,
                     BaseCommitSha = baseCommitSha,
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updatedDependencies, updatedFiles, existingPullRequest.Item1),
+                    PrTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updatedDependencies, updatedFiles, existingPullRequest.Item1),
+                    PrBody = PullRequestTextGenerator.GetPullRequestBody(job, updatedDependencies, updatedFiles, existingPullRequest.Item1),
                 };
             }
             else
@@ -421,9 +421,9 @@ public class RunWorker
                     Dependencies = updatedDependencies,
                     UpdatedDependencyFiles = updatedFiles,
                     BaseCommitSha = baseCommitSha,
-                    CommitMessage = "TODO: message",
-                    PrTitle = "TODO: title",
-                    PrBody = "TODO: body",
+                    CommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updatedDependencies, updatedFiles),
+                    PrTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updatedDependencies, updatedFiles),
+                    PrBody = PullRequestTextGenerator.GetPullRequestBody(job, updatedDependencies, updatedFiles),
                 };
             }
         }


### PR DESCRIPTION
## These changes are for the end-to-end updater and this code is not live.

Adds simple PR title generation of the shape:

```
Update Some.Package to 1.2.3
```

In a more complicated scenario where multiple versions were updated for multiple packages the text will look like:

```
Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0
```

The same text is used for all three generated fields: PR title, body, and commit message.

The other tests were modified to always report static text for these fields so that changes to the new text generation won't cause a bunch of other tests to fail and require a lot of churn.