### PR TITLE
NuGet test for job file containing invalid JSON throws 

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/ExperimentsManagerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/ExperimentsManagerTests.cs
@@ -1,0 +1,78 @@
+using Xunit;
+
+namespace NuGetUpdater.Core.Test;
+
+public class ExperimentsManagerTests
+{
+    [Fact]
+    public async Task FromJobFileAsync_WithJobFileContainingInvalidJson_ShouldNotThrowExceptions()
+    {
+        var jobId = Guid.NewGuid().ToString();
+        var jobPath = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        File.WriteAllText(jobPath, """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "allowed-updates": [
+                  {
+                    "update-type": "all"
+                  }
+                ],
+                "source": {
+                  "provider": "github",
+                  "repo": "some-org/some-repo",
+                  "directory": "specific-sdk",
+                  "hostname": null,
+                  "api-endpoint": null
+                },
+                "commit-message-options": {
+                  "include-scope": "true"
+                }
+              }
+            }
+            """
+        );
+
+        try
+        {
+            var (manager, error) = await ExperimentsManager.FromJobFileAsync(jobId, jobPath);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail("Expected no exception, but got: " + ex.Message);
+        }
+    }
+
+    [Fact]
+    public async Task FromJobFileAsync_WithJobFileContainingInvalidJson_ShouldReturnError()
+    {
+        var jobId = Guid.NewGuid().ToString();
+        var jobPath = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        File.WriteAllText(jobPath, """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "allowed-updates": [
+                  {
+                    "update-type": "all"
+                  }
+                ],
+                "source": {
+                  "provider": "github",
+                  "repo": "some-org/some-repo",
+                  "directory": "specific-sdk",
+                  "hostname": null,
+                  "api-endpoint": null
+                },
+                "commit-message-options": {
+                  "include-scope": "true"
+                }
+              }
+            }
+            """
+        );
+
+        var (manager, error) = await ExperimentsManager.FromJobFileAsync(jobId, jobPath);
+        Assert.NotNull(error);
+    }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

@brettfo, if the job file contains invalid JSON (e.g. see https://github.com/dependabot/cli/pull/408), the NuGet updater will throw an exception instead of gracefully returning a `JobErrorBase` object.

The exception thrown is:

```log
updater | Unhandled exception: System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
updater |
updater | File name: 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
updater |    at NuGetUpdater.Core.Run.ApiModel.JobErrorBase.ErrorFromException(Exception ex, String jobId, String currentDirectory)
updater |    at NuGetUpdater.Core.ExperimentsManager.FromJobFileAsync(String jobId, String jobFilePath) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs:line 53
updater |    at NuGetUpdater.Cli.Commands.DiscoverCommand.<>c.<<GetCommand>b__5_0>d.MoveNext() in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/DiscoverCommand.cs:line 31
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
updater |    at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<<UseHelp>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass19_0.<<UseTypoCorrections>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__18_0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseParseDirective>b__0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__5_0>d.MoveNext()
updater | --- End of stack trace from previous location ---
updater |    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()
```

![image](https://github.com/user-attachments/assets/7e26edab-2c07-4ae3-a088-96932f693cbc)

This PR adds unit tests that reproduce the issue, but I don't know how to fix it as it seems that `Microsoft.Build` is already referenced in the project given that it compiles without errors.

Do you have any suggestions?

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
