### PR TITLE
allow multiple forms for `$.job.commit-message-options.include-scope` property

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -517,10 +517,15 @@ public class SerializationTests
         Assert.Null(jobWrapper.Job.SecurityAdvisories[0].PatchedVersions);
     }
 
-    [Fact]
-    public void DeserializeCommitOptions()
+    [Theory]
+    [InlineData("true", true)] // bool
+    [InlineData("false", false)]
+    [InlineData("\"true\"", true)] // stringified bool
+    [InlineData("\"false\"", false)]
+    [InlineData("null", false)]
+    public void DeserializeCommitOptions(string includeScopeJsonValue, bool expectedIncludeScopeValue)
     {
-        var jsonWrapperJson = """
+        var jsonWrapperJson = $$"""
             {
                 "job": {
                     "source": {
@@ -530,7 +535,7 @@ public class SerializationTests
                     "commit-message-options": {
                         "prefix": "[SECURITY] ",
                         "prefix-development": null,
-                        "include-scope": true
+                        "include-scope": {{includeScopeJsonValue}}
                     }
                 }
             }
@@ -538,7 +543,7 @@ public class SerializationTests
         var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
         Assert.Equal("[SECURITY] ", jobWrapper.Job.CommitMessageOptions!.Prefix);
         Assert.Null(jobWrapper.Job.CommitMessageOptions!.PrefixDevelopment);
-        Assert.True(jobWrapper.Job.CommitMessageOptions!.IncludeScope);
+        Assert.Equal(expectedIncludeScopeValue, jobWrapper.Job.CommitMessageOptions!.IncludeScope);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CommitOptions.cs
@@ -1,8 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record CommitOptions
 {
     public string? Prefix { get; init; } = null;
     public string? PrefixDevelopment { get; init; } = null;
-    public bool? IncludeScope { get; init; } = null;
+
+    [JsonConverter(typeof(CommitOptions_IncludeScopeConverter))]
+    public bool IncludeScope { get; init; } = false;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/CommitOptions_IncludeScopeConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/CommitOptions_IncludeScopeConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run;
+
+public class CommitOptions_IncludeScopeConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+            case JsonTokenType.Null:
+                return false;
+            case JsonTokenType.String:
+                var stringValue = reader.GetString();
+                return bool.Parse(stringValue!);
+            default:
+                throw new JsonException($"Unexpected token type {reader.TokenType}");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}


### PR DESCRIPTION
To help with https://github.com/dependabot/cli/pull/408 this PR allows the following values for the `include-scope` property:

- `true` bool
- `false`
- `"true"` stringified bool
- `"false"`
- `null` null - false

The old values are still supported to allow for older CLI versions to still work.