### PR TITLE
properly report failure to deserialize job file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/DiscoverCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/DiscoverCommand.cs
@@ -28,6 +28,7 @@ internal static class DiscoverCommand
 
         command.SetHandler(async (jobId, jobPath, repoRoot, workspace, outputPath) =>
         {
+            MSBuildHelper.RegisterMSBuild(repoRoot.FullName, repoRoot.FullName);
             var (experimentsManager, error) = await ExperimentsManager.FromJobFileAsync(jobId, jobPath.FullName);
             if (error is not null)
             {

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -21,7 +21,10 @@ function Get-Files {
         --api-url $env:DEPENDABOT_API_URL `
         --job-id $env:DEPENDABOT_JOB_ID
     $script:operationExitCode = $LASTEXITCODE
-    Repair-FileCasing
+    if ($script:operationExitCode -eq 0) {
+        # this only makes sense if the native clone operation succeeded
+        Repair-FileCasing
+    }
 }
 
 function Update-Files {


### PR DESCRIPTION
If the C# NuGet updater fails to deserialize the `job.json` file, the error handler goes into a method that attempts to turn the exception into a dependabot-specific type.  One of the exception types listed, however, is from an MSBuild binary which means that MSBuild needs to have been resolved first.

This PR builds on the findings of @rhyskoedijk and forces MSBuild to have been loaded before the first time the job file is parsed.  This behavior is really complicated to unit-test because by definition, all unit test runs have _already_ loaded MSBuild.  Subsequent calls to the updater don't need MSBuild pre-loaded in this way because if we get that far we already know the file is formatted correctly.

This also contains a fix to the end-to-end updater (code not live) to not attempt any filesystem operations if the `clone` command failed, which can also happen if the job file failed to parse correctly.  The error reporting in the `clone` handler doesn't rely on MSBuild pre-loads.