### PR TITLE
explicitly override `TreatWarningsAsErrors` to `false` during discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1464,6 +1464,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                       <PropertyGroup>
                         <TargetFramework>net9.0</TargetFramework>
                         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
                       </PropertyGroup>
                       <ItemGroup>
                         <PackageReference Include="Package1" />
@@ -1496,6 +1497,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                             new("Package2", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true),
                         ],
                         Properties = [
+                            new("MSBuildTreatWarningsAsErrors", "false", "src/project.csproj"), // this was specifically overridden by discovery
                             new("TargetFramework", "net9.0", "src/project.csproj"),
                             new("TreatWarningsAsErrors", "false", "src/project.csproj"), // this was specifically overridden by discovery
                         ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -3649,6 +3649,7 @@ public partial class UpdateWorkerTests
                       <PropertyGroup>
                         <TargetFramework>net9.0</TargetFramework>
                         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
                       </PropertyGroup>
                       <ItemGroup>
                         <PackageReference Include="Package1" />
@@ -3683,6 +3684,7 @@ public partial class UpdateWorkerTests
                       <PropertyGroup>
                         <TargetFramework>net9.0</TargetFramework>
                         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+                        <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
                       </PropertyGroup>
                       <ItemGroup>
                         <PackageReference Include="Package1" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -110,6 +110,7 @@ internal static class SdkProjectDiscovery
                         $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={dependencyDiscoveryTargetsPath}",
                         $"/p:CustomAfterMicrosoftCommonTargets={dependencyDiscoveryTargetsPath}",
                         "/p:TreatWarningsAsErrors=false", // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause discovery to fail; explicitly don't allow that
+                        "/p:MSBuildTreatWarningsAsErrors=false",
                         $"/bl:{binLogPath}"
                     };
                     var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, startingProjectDirectory, experimentsManager);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -109,6 +109,7 @@ internal static class SdkProjectDiscovery
                         $"/p:TargetFramework={tfm}",
                         $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={dependencyDiscoveryTargetsPath}",
                         $"/p:CustomAfterMicrosoftCommonTargets={dependencyDiscoveryTargetsPath}",
+                        "/p:TreatWarningsAsErrors=false", // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause discovery to fail; explicitly don't allow that
                         $"/bl:{binLogPath}"
                     };
                     var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, startingProjectDirectory, experimentsManager);


### PR DESCRIPTION
If all of the following are true:

- The repo doesn't have a `NuGet.Config` file (or it does but doesn't specify the `<clear />` directive)
- The repo is using Central Package Management (i.e., `Directory.Packages.props`)
- The project sets `$(TreatWarningsAsErrors)` to `true`
- The `dependabot.yml` file lists custom NuGet feeds

...then dependency discovery can fail because the updater generates a `NuGet.Config` file before the updater is run that contains all of the feeds listed in `dependabot.yml` as well as `api.nuget.org` and if there are multiple remote feeds used with CPM, a warning `NU1507` is generated indicating that no `packageSourceMapping` elements were specified in `NuGet.Config`.  `$(TreatWarningsAsErrors)` then kicks in and prevents dependency discovery from happening.

Dependency discovery needs to succeed so we inject the command line argument `/p:TreatWarningsAsErrors=false` to override any property that might be set in the project file or imported `.props` or `.targets` so the `NU1507` warning doesn't cause a failure.  Note, properties specified on the command line always override even explicitly set properties in the project or imported files.

### Side note on why `api.nuget.org` is added to the generated `NuGet.Config` that leads to this issue:
The default feed of `api.nuget.org` is explicitly added because if the repo doesn't contain a `NuGet.Config` file (or if it does and it doesn't specify the `<clear />` directive) then they're already opting in to the default feed behavior which means `api.nuget.org`.  It's possible that a developer's local machine manually removed `api.nuget.org` from the user-level file, but there is no way dependabot can know about that scenario and having the fallback to `api.nuget.org` is the default.

