### PR TITLE
install .NET SDK from channel if necessary

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -86,8 +86,16 @@ function Install-Sdks([string]$jobFilePath, [string]$repoContentsPath, [string]$
 
     $sdksToInstall = Get-SdkVersionsToInstall -repoRoot $rootDir -updateDirectories $candidateDirectories -installedSdks $installedSdks
     foreach ($sdkVersion in $sdksToInstall) {
-        Write-Host "Installing SDK $sdkVersion"
-        & $dotnetInstallScriptPath --version $sdkVersion --install-dir $dotnetInstallDir
+        $versionParts = $sdkVersion.Split(".")
+        if ($versionParts.Length -eq 3 -and $versionParts[2] -eq "0") {
+            $channelVersion = "$($versionParts[0]).$($versionParts[1])"
+            Write-Host "Installing SDK from channel $channelVersion"
+            & $dotnetInstallScriptPath --channel $channelVersion --install-dir $dotnetInstallDir
+        }
+        else {
+            Write-Host "Installing SDK $sdkVersion"
+            & $dotnetInstallScriptPath --version $sdkVersion --install-dir $dotnetInstallDir
+        }
     }
 
     # report the final set


### PR DESCRIPTION
A common practice is for a repo to have a `global.json` that looks like this:

``` json
{
  "sdk": {
    "version": "8.0.0",
    "rollForward": "latestMinor"
  }
}
```

where the SDK version listed isn't actually a proper SDK version like `8.0.100`.  The `global.json` can be used at runtime, however, so we should still try to install what we can.

To accomplish this we see if the SDK version consists of three parts and if the last part is `0` then we can do an alternate installation mechanism where we treat the first two version parts (e.g., `8.0`) as an installation channel.  We then pass this with a separate switch to the installer script which will install the latest from that channel (e.g., `8.0.404` or whatever is current).

Fixes #11752.

With this change the log looks like this:

```
updater | Currently installed SDKs: 8.0.404 9.0.101
updater | Installing SDK from channel 9.0
updater | dotnet-install: Attempting to download using primary link https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.201/dotnet-sdk-9.0.201-linux-x64.tar.gz
updater | dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.201/dotnet-sdk-9.0.201-linux-x64.tar.gz size is 216930685 bytes.
updater | dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.201/dotnet-sdk-9.0.201-linux-x64.tar.gz
updater | dotnet-install: Downloaded file size is 216930685 bytes.
updater | dotnet-install: The remote and local file sizes are equal.
updater | dotnet-install: Installed version is 9.0.201
updater | dotnet-install: Adding to current process PATH: `/usr/local/dotnet/current`. Note: This change will be visible only when sourcing script.
updater | dotnet-install: Note that the script does not resolve dependencies during installation.
updater | dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
updater | dotnet-install: Installation finished successfully.
updater | 8.0.404 [/usr/local/dotnet/current/sdk]
updater | 9.0.101 [/usr/local/dotnet/current/sdk]
updater | 9.0.201 [/usr/local/dotnet/current/sdk]
```