### PR TITLE
nuget: allow for empty dependencies in project

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -70,6 +70,8 @@ module Dependabot
 
       sig { override.void }
       def check_required_files
+        return if dependencies.empty?
+
         requirement_files = dependencies.flat_map do |dep|
           dep.requirements.map { |r| T.let(r.fetch(:file), String) }
         end.uniq

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -179,6 +179,40 @@ RSpec.describe Dependabot::Nuget::FileParser do
           }])
         end
       end
+
+      context "with no dependencies" do
+        before do
+          intercept_native_tools(
+            discovery_content_hash: {
+              Path: "",
+              IsSuccess: true,
+              Projects: [{
+                FilePath: "my.csproj",
+                Dependencies: [],
+                IsSuccess: true,
+                Properties: [{
+                  Name: "TargetFrameworks",
+                  Value: "net462",
+                  SourceFilePath: "my.csproj"
+                }],
+                TargetFrameworks: ["net462"],
+                ReferencedProjectPaths: [],
+                ImportedFiles: [],
+                AdditionalFiles: []
+              }],
+              GlobalJson: nil,
+              DotNetToolsJson: nil
+            }
+          )
+        end
+
+        it "is returns the expected set of dependencies" do
+          run_parser_test do |parser|
+            dependencies = parser.parse
+            expect(dependencies.length).to eq(0)
+          end
+        end
+      end
     end
 
     context "with a csproj and a vbproj" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Trying to fix some issues where `DependencyFileNotFound/dependency_file_not_found` is being raised as a job error when a project file doesn't reference any dependencies.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I'm not sure at all this is a good change 😆 .  Even moreso because there's a test that explicitly checks for a failure when a project file doesn't contain dependencies which is the exact opposite of what this change is aiming to implement 😅 .

My understanding for `check_required_files` was that it should be checking for the existence of the dependency file (e.g. a csproj file), and answer the question "can this file_parser attempt to find dependencies for a project".  

In https://github.com/dependabot/dependabot-core/pull/11026 the nuget ecoystem was updated to check for the existence of a dependency file for each dependency in the project. If a project doesn't have any dependencies then that would raise an error similar to a dependency not having a findable file source.  

cc @brettfo as the author of that PR - do you have any context to judge "correct" behavior?

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Dependabot stops raising errors for projects that don't have any dependencies.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
