### PR TITLE
ensure `$TEMP` and `$TMP` environment variables exist

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -64,6 +64,12 @@ COPY --chown=dependabot:dependabot nuget $DEPENDABOT_HOME/nuget
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
+# ensure windows-style environment variables are set
+ARG TEMP_DIR=/tmp/dependabot
+RUN mkdir -p $TEMP_DIR
+ENV TEMP=$TEMP_DIR
+ENV TMP=$TEMP_DIR
+
 # redirect entrypoint
 RUN mv bin/run bin/run-original
 COPY --chown=dependabot:dependabot nuget/script/* $DEPENDABOT_HOME/dependabot-updater/bin/


### PR DESCRIPTION
Windows exposes two environment variables, `%TEMP%` and `%TMP%` and those are commonly used in `.targets` files, but since those variables don't exist in the docker image, those steps can fail.

This PR simply creates a directory `/tmp/dependabot` and sets both environment variables to that location.  I've manually verified that those locations are writable by the `dependabot` user.

Fixes #11595.