### PR TITLE
add manual dependency resolution for VS-only PackageReference legacy projects

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -3707,5 +3707,43 @@ public partial class UpdateWorkerTests
                 ]
             );
         }
+
+        [Fact]
+        public async Task LegacyProjectWithPackageReferencesCanUpdate()
+        {
+            await TestUpdateForProject("Some.Dependency", "1.0.0", "1.0.1",
+                experimentsManager: new ExperimentsManager() { UseDirectDiscovery = true },
+                packages: [
+                    MockNuGetPackage.CreateSimplePackage("Some.Dependency", "1.0.0", "net48"),
+                    MockNuGetPackage.CreateSimplePackage("Some.Dependency", "1.0.1", "net48"),
+                ],
+                projectContents: """
+                    <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <OutputType>Library</OutputType>
+                        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """,
+                expectedProjectContents: """
+                    <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <OutputType>Library</OutputType>
+                        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" Version="1.0.1" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
@@ -10,6 +10,9 @@
     -->
     <_DefaultTargetPlatformVersion Condition="'$(_DefaultTargetPlatformVersion)' == ''">0.0</_DefaultTargetPlatformVersion>
     <DesignTimeBuild>true</DesignTimeBuild>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <NuGetInteractive>false</NuGetInteractive>
+    <RunAnalyzers>false</RunAnalyzers>
     <EnableWindowsTargeting Condition="$(TargetFramework.Contains('-windows'))">true</EnableWindowsTargeting>
     <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
   </PropertyGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
@@ -2,14 +2,28 @@
   <PropertyGroup>
     <!-- Dependency discovery requires a non-zero value for $(TargetPlatformVersion) -->
     <_DefaultTargetPlatformVersion>1.0</_DefaultTargetPlatformVersion>
+    <_DiscoverDependenciesDependsOn>ResolveAssemblyReferences</_DiscoverDependenciesDependsOn>
+
+    <!-- only SDK-style projects set `$(NETCoreSdkVersion)`; legacy projects don't have it -->
+    <_IsLegacyStyleProject Condition="'$(NETCoreSdkVersion)' == ''">true</_IsLegacyStyleProject>
+
+    <!-- These targets only exists for SDK-style projects -->
+    <_DiscoverDependenciesDependsOn Condition="'$(_IsLegacyStyleProject)' != 'true'">$(_DiscoverDependenciesDependsOn);GenerateBuildDependencyFile;ResolvePackageAssets</_DiscoverDependenciesDependsOn>
+
+    <!-- For non-SDK-style projects, use a different target defined below -->
+    <_DiscoverDependenciesDependsOn Condition="'$(_IsLegacyStyleProject)' == 'true'">$(_DiscoverDependenciesDependsOn);_DependencyDiscovery_LegacyProjects</_DiscoverDependenciesDependsOn>
   </PropertyGroup>
 
   <Import Project="DependencyDiscovery.props" />
 
-  <Target Name="_DiscoverDependencies" DependsOnTargets="ResolveAssemblyReferences;GenerateBuildDependencyFile;ResolvePackageAssets">
+  <Target Name="_DiscoverDependencies" DependsOnTargets="$(_DiscoverDependenciesDependsOn)">
     <!--
-    The targets ResolveAssemblyReferences and GenerateBuildDependencyFile are sufficient for projects targeting .NET Standard or .NET Core.
-    The target ResolvePackageAssets is necessary for projects targeting .NET Framework.
+    This is purely a place to collect the `DependsOnTargets` attribute.
     -->
+  </Target>
+
+  <Target Name="_DependencyDiscovery_LegacyProjects" Condition="'@(PackageReference)' != ''">
+    <!-- pseudo-sdk-style project; legacy, but with PackageReference elements - dependencies need to be resolved differently; output a sentinel value to notify the dependency discovery -->
+    <Message Text="_DependencyDiscovery_LegacyProjects::UseTemporaryProject" Importance="High" />
   </Target>
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -318,17 +318,10 @@ internal static class SdkProjectDiscovery
             // to do this we create a temporary project with all of the top-level project elements, resolve _again_, then rebuild the proper result
             packagesPerProject = await RebuildPackagesPerProject(
                 repoRootPath,
-                workspacePath,
                 startingProjectPath,
                 tfms,
                 packagesPerProject,
                 explicitPackageVersionsPerProject,
-                packagesReplacedBySdkPerProject,
-                topLevelPackagesPerProject,
-                resolvedProperties,
-                referencedProjects,
-                importedFiles,
-                additionalFiles,
                 experimentsManager,
                 logger
             );
@@ -458,17 +451,10 @@ internal static class SdkProjectDiscovery
 
     private static async Task<Dictionary<string, Dictionary<string, Dictionary<string, string>>>> RebuildPackagesPerProject(
         string repoRootPath,
-        string workspacePath,
         string projectPath,
         ImmutableArray<string> targetFrameworks,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesPerProject,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> explicitPackageVersionsPerProject,
-        Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesReplacedBySdkPerProject,
-        Dictionary<string, Dictionary<string, HashSet<string>>> topLevelPackagesPerProject,
-        Dictionary<string, Dictionary<string, string>> resolvedProperties,
-        Dictionary<string, HashSet<string>> referencedProjects,
-        Dictionary<string, HashSet<string>> importedFiles,
-        Dictionary<string, HashSet<string>> additionalFiles,
         ExperimentsManager experimentsManager,
         ILogger logger
     )


### PR DESCRIPTION
There are two types of project files: SDK-style projects, and legacy projects.

When determining dependencies, we essentially call `dotnet restore` on the project.

- If it was an SDK-style project, we'll get a list of dependencies.
- If it was a legacy project, we'll see the error `error MSB4057: The target "GenerateBuildDependencyFile" does not exist in the project.` If that error text is found, we know it's a legacy project and we just return an empty array because the newer SDK can't do anything with that.

There's a secret third type of project file: it looks like a legacy project, but it contains `<PackageReference>` elements.  The dotnet CLI can't resolve these packages and we have to do something special.  (Side note, this feature does work in Visual Studio, but we don't have that here.)

Something special:
1. Update the dependency discovery targets to not allow the `error MSB4057...` error from above and detect if we're in a legacy project with `<PackageReference>` elements.
   - SDK-style projects always set a property `$(NETCoreSdkVersion)` and we use that as a sentinel to know if we're in a SDK or legacy project.
 2. If we're in an SDK project, discovery is exactly the same as before.
 3. If we're in a legacy project, we'll quietly return nothing.
 4. If we're in a legacy project __with__ `<PackageReference>` elements, we'll do some more discovery.

More discovery:
1. MSBuild evaluation has completed so we at least have fully formed `<PackageReference>` elements, but we don't know anything about transitive dependencies.
2. We also don't necessarily know the package version because they may have been specified in a `<PackageVersion>` element that wasn't correlated with the package yet, because that only happens in SDK-style projects.
3. If we're in this extra special case, we take the top-level `<PackageReference>` elements, gather an appropriate version number for them, either directly through the `Version` attribute, or by manually checking the `<PackageVersion>` collection, then we go back to some older behavior of creating a temporary project on disk, populating a bunch of `<PackageReference>` elements, and running `dotnet restore`.
4. Once all of that is done, we recreate the original project discovery results by merging the original MSBuild evaluation with the newly resolved transitive dependencies.