### PR TITLE
Revert "mount the SSH_AUTH_SOCK socket for ssh-agent"

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -109,13 +109,6 @@ if [ "$#" -gt "1" ]; then
   CONTAINER_ARGS=("${@:2}")
 fi
 
-# for Mac with Docker Desktop or Rancher Desktop, use:
-# SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock ./bin/docker-dev-shell go_modules -r
-if [ -n "$SSH_AUTH_SOCK" ]; then
-  DOCKER_OPTS+=("-v" "$SSH_AUTH_SOCK:/tmp/ssh-auth.sock")
-  DOCKER_OPTS+=("-e" "SSH_AUTH_SOCK=/tmp/ssh-auth.sock")
-fi
-
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot"
 touch .core-bash_history


### PR DESCRIPTION
Reverts dependabot/dependabot-core#11683

As @robaiken has raised an issue with this config.

```
docker: Error response from daemon: error while creating mount source path '/host_mnt/private/tmp/com.apple.launchd.Q3NRTvcke4/Listeners': mkdir /host_mnt/private/tmp/com.apple.launchd.Q3NRTvcke4/Listeners: operation not supported```
```
@dmitris Need your thoughts on this pls

FYI @abdulapopoola 