### PR TITLE
condition out multiple file patterns

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -1,0 +1,99 @@
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Update;
+
+public class SpecialFilePatcherTests
+{
+    [Theory]
+    [MemberData(nameof(SpecialImportsConditionPatcherTestData))]
+    public async Task SpecialImportsConditionPatcher(string fileContent, string expectedPatchedContent)
+    {
+        // arrange
+        var projectFileName = "project.csproj";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((projectFileName, fileContent));
+        var projectPath = Path.Join(tempDir.DirectoryPath, projectFileName);
+
+        // act
+        using (var patcher = new SpecialImportsConditionPatcher(projectPath))
+        {
+            var actualPatchedContent = await File.ReadAllTextAsync(projectPath);
+
+            // assert
+            Assert.Equal(expectedPatchedContent.Replace("\r", ""), actualPatchedContent.Replace("\r", ""));
+        }
+
+        // assert again
+        var restoredContent = await File.ReadAllTextAsync(projectPath);
+        Assert.Equal(restoredContent.Replace("\r", ""), fileContent.Replace("\r", ""));
+    }
+
+    public static IEnumerable<object[]> SpecialImportsConditionPatcherTestData()
+    {
+        // one-off test to verify namespaces don't interfere
+        yield return
+        [
+            // fileContent
+            """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+
+        // one-off test to verify existing conditions are restored
+        yield return
+        [
+            // fileContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="existing condition" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+
+        // all file variations - by its nature, also verifies that multiple replacements can occur
+        yield return
+        [
+            // fileContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.TextTemplating.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.TextTemplating.targets" Condition="false" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -325,7 +325,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
 
                 _processedProjectPaths.Add(actualProjectPath);
 
-                using (new WebApplicationTargetsConditionPatcher(actualProjectPath))
+                using (new SpecialImportsConditionPatcher(actualProjectPath))
                 {
                     var relativeProjectPath = Path.GetRelativePath(workspacePath, actualProjectPath).NormalizePathToUnix();
                     var packagesConfigResult = await PackagesConfigDiscovery.Discover(repoRootPath, workspacePath, actualProjectPath, _experimentsManager, _logger);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -86,7 +86,7 @@ internal static partial class PackagesConfigUpdater
             }
         }
 
-        using (new WebApplicationTargetsConditionPatcher(projectPath))
+        using (new SpecialImportsConditionPatcher(projectPath))
         {
             RunNugetUpdate(updateArgs, restoreArgs, projectDirectory ?? packagesDirectory, logger);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
@@ -2,43 +2,50 @@ using Microsoft.Language.Xml;
 
 namespace NuGetUpdater.Core.Updater
 {
-    internal class WebApplicationTargetsConditionPatcher : IDisposable
+    internal class SpecialImportsConditionPatcher : IDisposable
     {
-        private string? _capturedCondition;
+        private readonly List<string?> _capturedConditions = new List<string?>();
         private readonly XmlFilePreAndPostProcessor _processor;
 
-        public WebApplicationTargetsConditionPatcher(string projectFilePath)
+        private readonly HashSet<string> ImportedFilesToIgnore = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Microsoft.TextTemplating.targets",
+            "Microsoft.WebApplication.targets"
+        };
+
+        public SpecialImportsConditionPatcher(string projectFilePath)
         {
             _processor = new XmlFilePreAndPostProcessor(
                 getContent: () => File.ReadAllText(projectFilePath),
                 setContent: s => File.WriteAllText(projectFilePath, s),
                 nodeFinder: doc => doc.Descendants()
                     .Where(e => e.Name == "Import")
-                    .FirstOrDefault(e =>
+                    .Where(e =>
                     {
                         var projectPath = e.GetAttributeValue("Project");
                         if (projectPath is not null)
                         {
                             var projectFileName = Path.GetFileName(projectPath.NormalizePathToUnix());
-                            return projectFileName.Equals("Microsoft.WebApplication.targets", StringComparison.OrdinalIgnoreCase);
+                            return ImportedFilesToIgnore.Contains(projectFileName);
                         }
 
                         return false;
                     })
-                    as XmlNodeSyntax,
-                preProcessor: n =>
+                    .Cast<XmlNodeSyntax>(),
+                preProcessor: (i, n) =>
                 {
                     var element = (IXmlElementSyntax)n;
-                    _capturedCondition = element.GetAttributeValue("Condition");
+                    _capturedConditions.Add(element.GetAttributeValue("Condition"));
                     return (XmlNodeSyntax)element.RemoveAttributeByName("Condition").WithAttribute("Condition", "false");
                 },
-                postProcessor: n =>
+                postProcessor: (i, n) =>
                 {
                     var element = (IXmlElementSyntax)n;
                     var newElement = element.RemoveAttributeByName("Condition");
-                    if (_capturedCondition is not null)
+                    var capturedCondition = _capturedConditions[i];
+                    if (capturedCondition is not null)
                     {
-                        newElement = newElement.WithAttribute("Condition", _capturedCondition);
+                        newElement = newElement.WithAttribute("Condition", capturedCondition);
                     }
 
                     return (XmlNodeSyntax)newElement;


### PR DESCRIPTION
Project files might contain VS-only imports like `Microsoft.WebApplication.targets`.  Previously we only conditioned out that import and only the first instance of it to allow subsequent calls to `dotnet` and `MSBuild` to succeed.

This PR expands the patcher to condition out _all_ instances of matching files and it expands the match pattern to also include `Microsoft.TextTemplating.targets`; another common VS-only import.

Fixes #11782