### PR TITLE
build(deps): bump terraform from 1.11.0 to 1.11.2

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -2,13 +2,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/
-ARG TERRAFORM_VERSION=1.11.0
+ARG TERRAFORM_VERSION=1.11.2
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ARG TERRAFORM_AMD64_CHECKSUM=069e531fd4651b9b510adbd7e27dd648b88d66d5f369a2059aadbb4baaead1c1
+ARG TERRAFORM_AMD64_CHECKSUM=b94f7c5080196081ea5180e8512edd3c2037f28445ce3562cfb0adfd0aab64ca
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_arm64.zip"
-ARG TERRAFORM_ARM64_CHECKSUM=0a7e88cbb431044a16335369f850359def93b2898adc1778063784760db69093
+ARG TERRAFORM_ARM64_CHECKSUM=1f162f947e346f75ac3f6ccfdf5e6910924839f688f0773de9a79bc2e0b4ca94
 
 RUN cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \


### PR DESCRIPTION
### What are you trying to accomplish?

Making Dependabot work with Terraform 1.11.2.

https://github.com/hashicorp/terraform/releases/tag/v1.11.2
https://releases.hashicorp.com/terraform/1.11.2/

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The build output will show if the image will build successfully.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
