### PR TITLE
Hex: handle base64 decoding error

### DIFF
--- a/hex/helpers/lib/run.exs
+++ b/hex/helpers/lib/run.exs
@@ -23,7 +23,7 @@ defmodule DependencyHelper do
       {:ok, result} ->
         result
 
-      {:error, _error} ->
+      :error ->
         result
     end
   end


### PR DESCRIPTION
On error, Base.decode64 returns :error, not {:error, _}. Let's change the case pattern to avoid this error:

    ** (CaseClauseError) no case clause matching: :error
        /opt/hex/lib/run.exs:22: DependencyHelper.try_decode/1
        /opt/hex/lib/run.exs:8: DependencyHelper.main/0
        /opt/hex/lib/run.exs:157: (file)

### What are you trying to accomplish?

I noticed the error above, and I'm hoping that fixing this brings us closer to seeing the actual error messages for Hex update failures.

This improves on #11661 , aiming to fix #11569 .

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

To be honest, I'm not sure. I don't have a good test case for this - it's just something I noticed in the logs, and I don't know why base64 decoding failed in the first place.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
