### PR TITLE
Enforce proper minimum Windows version for OS-specific TFM

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -1117,6 +1117,50 @@ public partial class DiscoveryWorkerTests
         }
 
         [Fact]
+        public async Task WindowsSpecificProjectAndWindowsSpecificDependency()
+        {
+            await TestDiscoveryAsync(
+                experimentsManager: new ExperimentsManager() { UseDirectDiscovery = true },
+                packages: [
+                    MockNuGetPackage.CreateSimplePackage("Some.Os.Package", "1.2.3", "net6.0-windows7.0")
+                ],
+                workspacePath: "",
+                files: [
+                    ("project.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net9.0-windows</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Os.Package" Version="1.2.3" />
+                          </ItemGroup>
+                        </Project>
+                        """)
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Os.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net9.0-windows"], IsDirect: true)
+                            ],
+                            Properties = [
+                                new("TargetFramework", "net9.0-windows", "project.csproj")
+                            ],
+                            TargetFrameworks = ["net9.0-windows"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = []
+                        }
+                    ]
+                }
+            );
+        }
+
+        [Fact]
         public async Task DiscoveryWithTargetPlaformVersion_DirectDiscovery()
         {
             await TestDiscoveryAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
@@ -102,7 +102,7 @@ public class FrameworkCompatibilityServiceFacts
     }
 
     [Theory]
-    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0")]
+    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0", "net8.0-windows", "net8.0-windows7.0", "net9.0-windows", "net9.0-windows7.0")]
     public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[] windowsProjectFrameworks)
     {
         var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.props
@@ -14,6 +14,6 @@
     <NuGetInteractive>false</NuGetInteractive>
     <RunAnalyzers>false</RunAnalyzers>
     <EnableWindowsTargeting Condition="$(TargetFramework.Contains('-windows'))">true</EnableWindowsTargeting>
-    <TargetPlatformVersion Condition="$(TargetPlatformVersion) == '' AND $(TargetFramework.Contains('-'))">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework.Contains('-')) AND '$(TargetPlatformVersion)' == ''">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscovery.targets
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
-    <!-- Dependency discovery requires a non-zero value for $(TargetPlatformVersion) -->
+    <!-- Dependency discovery requires a custom value for $(TargetPlatformVersion).  Minimum version of unspecified Windows targeting is 7.0. -->
     <_DefaultTargetPlatformVersion>1.0</_DefaultTargetPlatformVersion>
+    <_DefaultTargetPlatformVersion Condition="$(TargetFramework.ToLowerInvariant().EndsWith('-windows'))">7.0</_DefaultTargetPlatformVersion>
     <_DiscoverDependenciesDependsOn>ResolveAssemblyReferences</_DiscoverDependenciesDependsOn>
 
     <!-- only SDK-style projects set `$(NETCoreSdkVersion)`; legacy projects don't have it -->

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -72,6 +72,8 @@ namespace NuGetGallery.Frameworks
 
         public static readonly NuGetFramework Net60Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", Version7);
         public static readonly NuGetFramework Net70Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", Version7);
+        public static readonly NuGetFramework Net80Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", Version7);
+        public static readonly NuGetFramework Net90Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "windows", Version7);
 
         public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
 
@@ -83,10 +85,10 @@ namespace NuGetGallery.Frameworks
                 Native,
                 Net11, Net2, Net35, Net4, Net403, Net45, Net451, Net452, Net46, Net461, Net462, Net463, Net47, Net471, Net472, Net48, Net481,
                 Net50, Net50Windows,
-                Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows,
-                Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows,
-                Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows,
-                Net90, Net90Android, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows,
+                Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows, Net60Windows7,
+                Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows, Net70Windows7,
+                Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
+                Net90, Net90Android, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,


### PR DESCRIPTION
If no `$(TargetPlatformVersion)` is specified for a `-windows` TFM, manually set the default of `7.0`.

The MSBuild interactions here are complicated and the dependency discovery entry point targets we're using have bypassed target platform resolution so we have to do some manual intervention.  We may end up needing custom values for other OS-specific TFMs, but that work will be trivial.

The test case that was missed before is a project target framework of `net9.0-windows` _AND_ a dependency framework requirement of `*-windows7.0`.

Fixes #11719.