### PR TITLE
ensure regex matched before pulling out values

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -143,7 +143,10 @@ module Dependabot
         repo = img_hash.fetch("repository", nil)
         return [] unless repo
 
-        tag_details = T.must(tag_value.to_s.match(TAG_WITH_DIGEST)).named_captures
+        match = tag_value.to_s.match(TAG_WITH_DIGEST)
+        return [] unless match
+
+        tag_details = match.named_captures
         tag = tag_details["tag"]
         return [repo] unless tag
 

--- a/docker/spec/fixtures/helm/yaml/multi-image-with-bad-version.yaml
+++ b/docker/spec/fixtures/helm/yaml/multi-image-with-bad-version.yaml
@@ -10,3 +10,8 @@ item2:
   image:
     repository: some.repository
     tag: 3.2025.123.4567-123abc-20250305t1309
+
+item3:
+  image:
+    repository: some.repository
+    tag: ""


### PR DESCRIPTION
The docker tag parser matched against a regular expression but didn't verify that the match worked before trying to pull out the values.

An internal investigation found a helm chart with an empty tag that caused the parser to fail.