### PR TITLE
Don't update the required python version in pyproject.toml for uv projects

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -152,7 +152,6 @@ module Dependabot
               content = updated_pyproject_content
               content = sanitize(content)
               content = freeze_other_dependencies(content)
-              content = update_python_requirement(content)
               content
             end
         end
@@ -161,12 +160,6 @@ module Dependabot
           PyprojectPreparer
             .new(pyproject_content: pyproject_content, lockfile: lockfile)
             .freeze_top_level_dependencies_except(dependencies)
-        end
-
-        def update_python_requirement(pyproject_content)
-          PyprojectPreparer
-            .new(pyproject_content: pyproject_content)
-            .update_python_requirement(language_version_manager.python_version)
         end
 
         def sanitize(pyproject_content)


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
Following discussions on the dependabot [issue](https://github.com/astral-sh/uv/issues/2512) on the `uv` repo we are removing the code that updates the required python version in the `pyproject.toml` file for `uv` projects.

<!-- What issues does this affect or fix? -->
Part of https://github.com/dependabot/dependabot-core/issues/10478
Relates to https://github.com/astral-sh/uv/issues/2512#issuecomment-2736991441

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
This behaviour was carried over from the `python` ecosystem implementation, but is not necessary for `uv`.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

`./bin/dry-run.rb uv dsp-testing/dependabot-uv` completes successfully with the expected changes.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
