### PR TITLE
consider a successfully evaluated project with no dependencies to be valid

### DIFF
--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -1133,5 +1133,39 @@ RSpec.describe Dependabot::Nuget::FileParser do
         end
       end
     end
+
+    context "with a project file that has no dependencies" do
+      before do
+        intercept_native_tools(
+          discovery_content_hash: {
+            Path: "",
+            IsSuccess: true,
+            Projects: [{
+              FilePath: "my.csproj",
+              Dependencies: [],
+              IsSuccess: true,
+              Properties: [{
+                Name: "TargetFramework",
+                Value: "net9.0",
+                SourceFilePath: "my.csproj"
+              }],
+              TargetFrameworks: ["net9.0"],
+              ReferencedProjectPaths: [],
+              ImportedFiles: [],
+              AdditionalFiles: []
+            }],
+            GlobalJson: nil,
+            DotNetToolsJson: nil
+          }
+        )
+      end
+
+      it "is returns an empty set of dependencies" do
+        run_parser_test do |parser|
+          dependencies = parser.parse
+          expect(dependencies).to be_empty
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When the NuGet updater determines if it was able to resolve any files, it only considered reportable dependencies and pulled file information out of that.  That scenario missed a situation where the project evaluation was successful, but there was nothing that could be used as the basis of an update.

This PR fixes that.

The function `DiscoveryJsonReader.run_discovery_in_directory` was called twice and I'd have had to add a third, so it was lifted to a common function to reduce duplication.