### PR TITLE
suppress red herring warning from legacy project dependency discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscoveryTargetingPacks.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscoveryTargetingPacks.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <!--
+    Suppress errors like:
+      error MSB3644: The reference assemblies for .NETFramework,Version=v4.7.2 were not found.
+    because that's irrelevant to dependency discovery.
+    -->
+    <NoWarn>$(NoWarn);MSB3644</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -108,6 +108,7 @@ internal static class SdkProjectDiscovery
                 var (exitCode, stdOut, stdErr) = await MSBuildHelper.HandleGlobalJsonAsync(startingProjectDirectory, repoRootPath, experimentsManager, async () =>
                 {
                     // the built-in target `GenerateBuildDependencyFile` forces resolution of all NuGet packages, but doesn't invoke a full build
+                    var dependencyDiscoveryTargetingPacksPropsPath = MSBuildHelper.GetFileFromRuntimeDirectory("DependencyDiscoveryTargetingPacks.props");
                     var dependencyDiscoveryTargetsPath = MSBuildHelper.GetFileFromRuntimeDirectory("DependencyDiscovery.targets");
                     var args = new List<string>()
                     {
@@ -115,6 +116,7 @@ internal static class SdkProjectDiscovery
                         startingProjectPath,
                         "/t:_DiscoverDependencies",
                         $"/p:TargetFramework={tfm}",
+                        $"/p:CustomBeforeMicrosoftCommonProps={dependencyDiscoveryTargetingPacksPropsPath}",
                         $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={dependencyDiscoveryTargetsPath}",
                         $"/p:CustomAfterMicrosoftCommonTargets={dependencyDiscoveryTargetsPath}",
                         "/p:TreatWarningsAsErrors=false", // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause discovery to fail; explicitly don't allow that

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <None Include="DependencyDiscovery.props" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="DependencyDiscoveryTargetingPacks.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DependencyDiscovery.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="TargetFrameworkReporter.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
When attempting dependency discovery for legacy C# projects, it's common to see a warning `The reference assemblies for .NETFramework.Version=v4.7.2 were not found.`  This isn't necessary or relevant for dependency discovery and can be safely ignored.  It's being explicitly removed because it's a red herring and makes it difficult to discover any real failures.  No functional change, but it makes the logs easier to understand.

Due to the order of imports, etc., we need to update the `$(NoWarn)` property earlier in the build process so we need a separate file to do the work.