### PR TITLE
sideline all special targets files before discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -176,13 +176,13 @@ public partial class DiscoveryWorkerTests
         public async Task DirectDiscoveryWorksEvenWithTargetsImportsOnlyProvidedByVisualStudio()
         {
             await TestDiscoveryAsync(
-                workspacePath: "",
+                workspacePath: "project1/",
                 experimentsManager: new ExperimentsManager() { UseDirectDiscovery = true },
                 packages: [
                     MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net48"),
                 ],
                 files: [
-                    ("project.csproj", """
+                    ("project1/project1.csproj", """
                         <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                           <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
                           <PropertyGroup>
@@ -192,24 +192,38 @@ public partial class DiscoveryWorkerTests
                           <ItemGroup>
                             <None Include="packages.config" />
                           </ItemGroup>
+                          <ItemGroup>
+                            <ProjectReference Include="..\project2\project2.csproj" />
+                          </ItemGroup>
                           <Import Project="$(VSToolsPath)\SomeSubPath\WebApplications\Microsoft.WebApplication.targets" />
                           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
                         </Project>
                         """),
-                    ("packages.config", """
+                    ("project1/packages.config", """
                         <?xml version="1.0" encoding="utf-8"?>
                         <packages>
                           <package id="Some.Package" version="1.0.0" targetFramework="net48" />
                         </packages>
+                        """),
+                    ("project2/project2.csproj", """
+                        <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <OutputType>Library</OutputType>
+                            <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <Import Project="$(VSToolsPath)\SomeSubPath\WebApplications\Microsoft.WebApplication.targets" />
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
                         """)
                 ],
                 expectedResult: new()
                 {
-                    Path = "",
+                    Path = "project1/",
                     Projects = [
                         new()
                         {
-                            FilePath = "project.csproj",
+                            FilePath = "project1.csproj",
                             Properties = [],
                             TargetFrameworks = ["net48"],
                             Dependencies = [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -1965,6 +1965,9 @@ public partial class UpdateWorkerTests
                       <ItemGroup>
                         <Compile Include="Properties\AssemblyInfo.cs" />
                       </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="other-project\other-project.csproj" />
+                      </ItemGroup>
                       <PropertyGroup>
                         <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->
                         <VSToolsPath Condition="'$(VSToolsPath)' == ''">C:\some\path\that\does\not\exist</VSToolsPath>
@@ -1985,6 +1988,20 @@ public partial class UpdateWorkerTests
                       <package id="Some.Package" version="7.0.1" targetFramework="net45" />
                     </packages>
                     """,
+                additionalFiles:
+                [
+                    ("other-project/other-project.csproj", """
+                        <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <OutputType>Library</OutputType>
+                            <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <Import Project="$(VSToolsPath)\SomeSubPath\WebApplications\Microsoft.WebApplication.targets" />
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """)
+                ],
                 expectedProjectContents: """
                     <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                       <PropertyGroup>
@@ -2045,6 +2062,9 @@ public partial class UpdateWorkerTests
                       </ItemGroup>
                       <ItemGroup>
                         <Compile Include="Properties\AssemblyInfo.cs" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <ProjectReference Include="other-project\other-project.csproj" />
                       </ItemGroup>
                       <PropertyGroup>
                         <!-- some project files set this property which makes the Microsoft.WebApplication.targets import a few lines down always fail -->


### PR DESCRIPTION
The NuGet updater needs to manually sideline special targets files imports that only come with a full install of Visual Studio.  Previously these files were sidelined as each project was inspected, but if there was a `<ProjectReference>` element and that project _also_ had one of these files, we'd still fail.

The fix is to apply the special transform to all relevant projects files before running any discovery.  Two existing unit tests were updated to contain the relevant project reference.

When reviewing `DiscoveryWorker.cs` I recommend turning off whitespace because indentation was changed, but the functional change is relatively small.