### PR TITLE
skip clone operation if git repo already exists

### DIFF
--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -15,12 +15,20 @@ $operationExitCode = 0
 function Get-Files {
     $job = Get-Job -jobFilePath $env:DEPENDABOT_JOB_PATH
     Write-Host "Job: $($job | ConvertTo-Json -Depth 99)"
-    & $updaterTool clone `
-        --job-path $env:DEPENDABOT_JOB_PATH `
-        --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `
-        --api-url $env:DEPENDABOT_API_URL `
-        --job-id $env:DEPENDABOT_JOB_ID
-    $script:operationExitCode = $LASTEXITCODE
+    if (Test-Path (Join-Path $env:DEPENDABOT_REPO_CONTENTS_PATH ".git")) {
+        # this can happen if the CLI specified the `--local` option
+        Write-Host "Git repository already exists, skipping clone."
+        $script:operationExitCode = 0
+    }
+    else {
+        & $updaterTool clone `
+            --job-path $env:DEPENDABOT_JOB_PATH `
+            --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `
+            --api-url $env:DEPENDABOT_API_URL `
+            --job-id $env:DEPENDABOT_JOB_ID
+        $script:operationExitCode = $LASTEXITCODE
+    }
+
     if ($script:operationExitCode -eq 0) {
         # this only makes sense if the native clone operation succeeded
         Repair-FileCasing


### PR DESCRIPTION
## End-to-end updater only, code not live

If an update job is started from the CLI with the `--local` option, a local directory is copied into the updater container and initialized as a git repository.  This PR allows the end-to-end updater to skip the clone step if this is the case.  This mimics the behavior used by the [common code](https://github.com/dependabot/dependabot-core/blob/b2b563118078b2bd16b18081a09f29957007020c/common/lib/dependabot/file_fetchers/base.rb#L786).