### PR TITLE
Fix `Sorbet/ObsoleteStrictMemoization` in `Dependabot::Composer::FileUpdater`

### DIFF
--- a/composer/lib/dependabot/composer/file_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater.rb
@@ -62,13 +62,14 @@ module Dependabot
 
       sig { returns(String) }
       def updated_lockfile_content
-        @updated_lockfile_content = T.let(@updated_lockfile_content, T.nilable(String))
-        @updated_lockfile_content ||=
+        @updated_lockfile_content ||= T.let(
           LockfileUpdater.new(
             dependencies: dependencies,
             dependency_files: dependency_files,
             credentials: credentials
-          ).updated_lockfile_content
+          ).updated_lockfile_content,
+          T.nilable(String)
+        )
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Fix the following RuboCop error

```
composer/lib/dependabot/composer/file_updater.rb:65:9: C: [Correctable] Sorbet/ObsoleteStrictMemoization: This two-stage workaround for memoization in #typed: strict files is no longer necessary. See https://sorbet.org/docs/type-assertions#put-type-assertions-behind-memoization.
@updated_lockfile_content = T.let(@updated_lockfile_content, T.nilable(String))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
