### PR TITLE
Filtering out support files update.

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -145,9 +145,12 @@ module Dependabot
 
     sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(Dependabot::FileUpdaters::Base) }
     def file_updater_for(dependencies)
+      if dependencies.all? { |dep| dep.package_manager == "pub" }
+        filtered_files = dependency_files.reject { |file| file.support_file }
+      end
       Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
         dependencies: dependencies,
-        dependency_files: dependency_files,
+        dependency_files: filtered_files,
         repo_contents_path: job.repo_contents_path,
         credentials: job.credentials,
         options: job.experiments


### PR DESCRIPTION
### What are you trying to accomplish?

Following our discussion with @jakecoffman, we've decided to exclude support files from the file updater before generating the PR.

Before implementing this change, there were 543 support files:
![image](https://github.com/user-attachments/assets/862bb9e8-f5d5-4b28-9c9f-43eacaf5a544)

After the change, there are now 0 support files:
![image](https://github.com/user-attachments/assets/a3a0e341-068c-4257-a8ac-3e834e7e66aa)

### Anything you want to highlight for special attention from reviewers?

Here's a comparison of the out.yml file before and after the changes, highlighting the difference in the number of lines between both versions:
![image](https://github.com/user-attachments/assets/9b132020-2f7f-42d5-baa1-1f01735c84f1)


### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
