### PR TITLE
Add missing `dist_tags` attribute reader to PackageDetails

### DIFF
--- a/common/lib/dependabot/package/package_details.rb
+++ b/common/lib/dependabot/package/package_details.rb
@@ -33,6 +33,9 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::Package::PackageRelease]) }
       attr_reader :releases
+
+      sig { returns(T.nilable(T::Hash[String, String])) }
+      attr_reader :dist_tags
     end
   end
 end

--- a/common/spec/dependabot/package/package_details_spec.rb
+++ b/common/spec/dependabot/package/package_details_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe Dependabot::Package::PackageDetails do
       expect(details.dependency).to eq(dependency)
       expect(details.releases).to contain_exactly(release1)
     end
+
+    it "exposes dist_tags when provided" do
+      dist_tags = { "latest" => "6.1.4", "beta" => "6.2.0-beta1" }
+
+      details = described_class.new(
+        dependency: dependency,
+        releases: [release1, release2],
+        dist_tags: dist_tags
+      )
+
+      expect(details.dist_tags).to eq(dist_tags)
+      expect(details.dist_tags["latest"]).to eq("6.1.4")
+    end
   end
 
   describe "#releases" do


### PR DESCRIPTION
### What are you trying to accomplish?

Make the `dist_tags` attribute publicly accessible in `PackageDetails`.  
Although the `dist_tags` parameter has been initialized in the constructor, it was previously missing an `attr_reader`, making it unreachable externally.

This change enables consumers of `PackageDetails` to access distribution tags (e.g., `latest`, `beta`), which are useful for version resolution logic, especially in ecosystems like NPM and Yarn.

### Anything you want to highlight for special attention from reviewers?

This is a minimal and targeted change — no logic is altered, only a missing attribute reader is added.  
This ensures consistency with the initialized state of the object and avoids silent confusion when attempting to read `dist_tags`.

### How will you know you've accomplished your goal?

- Consumers of `PackageDetails` will now be able to call `.dist_tags` without encountering a `NoMethodError`.
- Existing test suites should continue passing, and we may optionally add a test that verifies the value is retrievable.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
