### PR TITLE
track and report all update operations performed

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -106,7 +106,10 @@ public class RunWorkerTests
                       </ItemGroup>
                     </Project>
                     """.SetEOL(EOL));
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new RunResult()
             {
@@ -314,7 +317,10 @@ public class RunWorkerTests
                       </ItemGroup>
                     </Project>
                     """.SetEOL(EOL));
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new RunResult()
             {
@@ -681,7 +687,10 @@ public class RunWorkerTests
                         throw new NotSupportedException();
                 }
 
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new RunResult()
             {
@@ -1091,7 +1100,10 @@ public class RunWorkerTests
                         throw new NotSupportedException();
                 }
 
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new RunResult()
             {
@@ -1553,7 +1565,10 @@ public class RunWorkerTests
                       </PropertyGroup>
                     </Project>
                     """.SetEOL(EOL));
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new RunResult()
             {
@@ -2316,7 +2331,10 @@ public class RunWorkerTests
                     _ => throw new NotImplementedException("unreachable")
                 };
                 await File.WriteAllTextAsync(dependencyFilePath, updatedContent);
-                return new UpdateOperationResult();
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
             }),
             expectedResult: new()
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Immutable;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Test.Utilities;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Update;
+
+public class PackageReferenceUpdaterTests
+{
+    [Theory]
+    [MemberData(nameof(ComputeUpdateOperationsTestData))]
+    public async Task ComputeUpdateOperations
+    (
+        ImmutableArray<Dependency> topLevelDependencies,
+        ImmutableArray<Dependency> requestedUpdates,
+        ImmutableArray<Dependency> resolvedDependencies,
+        ImmutableArray<UpdateOperationBase> expectedUpdateOperations
+    )
+    {
+        // arrange
+        using var repoRoot = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"));
+        var projectPath = Path.Combine(repoRoot.DirectoryPath, "project.csproj");
+        var experimentsManager = new ExperimentsManager() { UseDirectDiscovery = true };
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory([
+            MockNuGetPackage.CreateSimplePackage("Parent.Package", "1.0.0", "net9.0", [(null, [("Transitive.Package", "1.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Parent.Package", "2.0.0", "net9.0", [(null, [("Transitive.Package", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net9.0", [(null, [("Super.Transitive.Package", "1.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0", [(null, [("Super.Transitive.Package", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "1.0.0", "net9.0"),
+            MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "2.0.0", "net9.0")
+        ], repoRoot.DirectoryPath);
+
+        // act
+        var actualUpdateOperations = await PackageReferenceUpdater.ComputeUpdateOperations(
+            repoRoot.DirectoryPath,
+            projectPath,
+            "net9.0",
+            topLevelDependencies,
+            requestedUpdates,
+            resolvedDependencies,
+            experimentsManager,
+            new TestLogger());
+
+        // assert
+        AssertEx.Equal(expectedUpdateOperations, actualUpdateOperations);
+    }
+
+    public static IEnumerable<object[]> ComputeUpdateOperationsTestData()
+    {
+        // single dependency update
+        yield return
+        [
+            // topLevelDependencies
+            ImmutableArray.Create(
+                new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference),
+                new Dependency("Unrelated.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // requestedUpdates
+            ImmutableArray.Create(
+                new Dependency("Some.Package", "1.0.1", DependencyType.PackageReference)
+            ),
+
+            // resolvedDependencies
+            ImmutableArray.Create(
+                new Dependency("Some.Package", "1.0.1", DependencyType.PackageReference),
+                new Dependency("Unrelated.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // expectedUpdateOperations
+            ImmutableArray.Create<UpdateOperationBase>(
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    NewVersion = NuGetVersion.Parse("1.0.1"),
+                    UpdatedFiles = [],
+                }
+            )
+        ];
+
+        // dependency was updated by pinning
+        yield return
+        [
+            // topLevelDependencies
+            ImmutableArray.Create(
+                new Dependency("Top.Level.Package", "1.0.0", DependencyType.PackageReference)
+            ),
+
+            // requestedUpdates
+            ImmutableArray.Create(
+                new Dependency("Transitive.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // resolvedDependencies
+            ImmutableArray.Create(
+                new Dependency("Top.Level.Package", "1.0.0", DependencyType.PackageReference),
+                new Dependency("Transitive.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // expectedUpdateOperations
+            ImmutableArray.Create<UpdateOperationBase>(
+                new PinnedUpdate()
+                {
+                    DependencyName = "Transitive.Package",
+                    NewVersion = NuGetVersion.Parse("2.0.0"),
+                    UpdatedFiles = [],
+                }
+            )
+        ];
+
+        // dependency was updated by updating parent 1 level up
+        yield return
+        [
+            // topLevelDependencies
+            ImmutableArray.Create(
+                new Dependency("Parent.Package", "1.0.0", DependencyType.PackageReference)
+            ),
+
+            // requestedUpdates
+            ImmutableArray.Create(
+                new Dependency("Transitive.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // resolvedDependencies
+            ImmutableArray.Create(
+                new Dependency("Parent.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // expectedUpdateOperations
+            ImmutableArray.Create<UpdateOperationBase>(
+                new ParentUpdate()
+                {
+                    DependencyName = "Transitive.Package",
+                    NewVersion = NuGetVersion.Parse("2.0.0"),
+                    UpdatedFiles = [],
+                    ParentDependencyName = "Parent.Package",
+                    ParentNewVersion = NuGetVersion.Parse("2.0.0"),
+                }
+            )
+        ];
+
+        // dependency was updated by updating parent 2 levels up
+        yield return
+        [
+            // topLevelDependencies
+            ImmutableArray.Create(
+                new Dependency("Parent.Package", "1.0.0", DependencyType.PackageReference)
+            ),
+
+            // requestedUpdates
+            ImmutableArray.Create(
+                new Dependency("Super.Transitive.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // resolvedDependencies
+            ImmutableArray.Create(
+                new Dependency("Parent.Package", "2.0.0", DependencyType.PackageReference)
+            ),
+
+            // expectedUpdateOperations
+            ImmutableArray.Create<UpdateOperationBase>(
+                new ParentUpdate()
+                {
+                    DependencyName = "Super.Transitive.Package",
+                    NewVersion = NuGetVersion.Parse("2.0.0"),
+                    UpdatedFiles = [],
+                    ParentDependencyName = "Parent.Package",
+                    ParentNewVersion = NuGetVersion.Parse("2.0.0"),
+                }
+            )
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
@@ -1,0 +1,130 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Test.Utilities;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Update;
+
+public class UpdateOperationBaseTests
+{
+    [Fact]
+    public void GetReport()
+    {
+        // arrange
+        var updateOperations = new UpdateOperationBase[]
+        {
+            new DirectUpdate()
+            {
+                DependencyName = "Package.A",
+                NewVersion = NuGetVersion.Parse("1.0.0"),
+                UpdatedFiles = ["file/a.txt"]
+            },
+            new PinnedUpdate()
+            {
+                DependencyName = "Package.B",
+                NewVersion = NuGetVersion.Parse("2.0.0"),
+                UpdatedFiles = ["file/b.txt"]
+            },
+            new ParentUpdate()
+            {
+                DependencyName = "Package.C",
+                NewVersion = NuGetVersion.Parse("3.0.0"),
+                UpdatedFiles = ["file/c.txt"],
+                ParentDependencyName = "Package.D",
+                ParentNewVersion = NuGetVersion.Parse("4.0.0"),
+            },
+        };
+
+        // act
+        var actualReport = UpdateOperationBase.GenerateUpdateOperationReport(updateOperations);
+
+        // assert
+        var expectedReport = """
+            Performed the following updates:
+                - Updated Package.A to 1.0.0 in file/a.txt
+                - Pinned Package.B at 2.0.0 in file/b.txt
+                - Updated Package.C to 3.0.0 indirectly via Package.D/4.0.0 in file/c.txt
+            """.Replace("\r", "");
+        Assert.Equal(expectedReport, actualReport);
+    }
+
+    [Fact]
+    public void NormalizeUpdateOperationCollection_SortAndDistinct()
+    {
+        // arrange
+        var repoRootPath = "/repo/root";
+        var updateOperations = new UpdateOperationBase[]
+        {
+            new DirectUpdate()
+            {
+                DependencyName = "Dependency.Direct",
+                NewVersion = NuGetVersion.Parse("1.0.0"),
+                UpdatedFiles = ["/repo/root/file/a.txt"]
+            },
+            new PinnedUpdate()
+            {
+                DependencyName = "Dependency.Pinned",
+                NewVersion = NuGetVersion.Parse("2.0.0"),
+                UpdatedFiles = ["/repo/root/file/b.txt"]
+            },
+            // this is the same as the first item and will be removed
+            new DirectUpdate()
+            {
+                DependencyName = "Dependency.Direct",
+                NewVersion = NuGetVersion.Parse("1.0.0"),
+                UpdatedFiles = ["/repo/root/file/a.txt"]
+            },
+            new ParentUpdate()
+            {
+                DependencyName = "Dependency.Parent",
+                NewVersion = NuGetVersion.Parse("3.0.0"),
+                UpdatedFiles = ["/repo/root/file/c.txt"],
+                ParentDependencyName = "Dependency.Root",
+                ParentNewVersion = NuGetVersion.Parse("4.0.0"),
+            },
+        };
+
+        // act
+        var normalizedOperations = UpdateOperationBase.NormalizeUpdateOperationCollection(repoRootPath, updateOperations);
+        var normalizedDependencyNames = string.Join(", ", normalizedOperations.Select(o => o.DependencyName));
+
+        // assert
+        var expectedDependencyNames = "Dependency.Direct, Dependency.Parent, Dependency.Pinned";
+        Assert.Equal(expectedDependencyNames, normalizedDependencyNames);
+    }
+
+    [Fact]
+    public void NormalizeUpdateOperationCollection_CombinedOnTypeAndDependency()
+    {
+        // arrange
+        var repoRootPath = "/repo/root";
+        var updateOperations = new UpdateOperationBase[]
+        {
+            // both operations are the same type, same dependency, same version => files are combined
+            new DirectUpdate()
+            {
+                DependencyName = "Dependency.Direct",
+                NewVersion = NuGetVersion.Parse("1.0.0"),
+                UpdatedFiles = ["/repo/root/file/b.txt"]
+            },
+            new DirectUpdate()
+            {
+                DependencyName = "Dependency.Direct",
+                NewVersion = NuGetVersion.Parse("1.0.0"),
+                UpdatedFiles = ["/repo/root/file/a.txt"]
+            },
+        };
+
+        // act
+        var normalizedOperations = UpdateOperationBase.NormalizeUpdateOperationCollection(repoRootPath, updateOperations);
+
+        // assert
+        var singleUpdate = Assert.Single(normalizedOperations);
+        var directUpdate = Assert.IsType<DirectUpdate>(singleUpdate);
+        Assert.Equal("Dependency.Direct", directUpdate.DependencyName);
+        Assert.Equal(NuGetVersion.Parse("1.0.0"), directUpdate.NewVersion);
+        AssertEx.Equal(["/file/a.txt", "/file/b.txt"], directUpdate.UpdatedFiles);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Test.Updater;
+using NuGetUpdater.Core.Test.Utilities;
 using NuGetUpdater.Core.Updater;
 
 using Xunit;
@@ -191,6 +192,10 @@ public abstract class UpdateWorkerTestBase : TestBase
         else
         {
             Assert.Null(actualResult.Error);
+            if (expectedResult is not null)
+            {
+                AssertEx.Equal(expectedResult.UpdateOperations, actualResult.UpdateOperations, UpdateOperationBaseComparer.Instance);
+            }
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
@@ -18,6 +18,7 @@ public partial class UpdateWorkerTests
             var result = new UpdateOperationResult()
             {
                 Error = new PrivateSourceAuthenticationFailure(["<some package feed>"]),
+                UpdateOperations = [],
             };
             var resultFilePath = Path.Combine(temporaryDirectory.DirectoryPath, "update-result.json");
             await UpdaterWorker.WriteResultFile(result, resultFilePath, new TestLogger());

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackagesConfig.cs
@@ -2446,6 +2446,7 @@ public partial class UpdateWorkerTests
                 expectedResult: new()
                 {
                     Error = new PrivateSourceAuthenticationFailure([$"{http.BaseUrl.TrimEnd('/')}/index.json"]),
+                    UpdateOperations = [],
                 }
             );
         }
@@ -2576,6 +2577,7 @@ public partial class UpdateWorkerTests
                 expectedResult: new()
                 {
                     ErrorRegex = "Response status code does not indicate success",
+                    UpdateOperations = [],
                 }
             );
         }
@@ -2653,6 +2655,7 @@ public partial class UpdateWorkerTests
                 expectedResult: new()
                 {
                     Error = new DependencyNotFound("Unrelated.Package.1.0.0"),
+                    UpdateOperations = [],
                 }
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -171,7 +171,7 @@ public class MSBuildHelperTests : TestBase
             new("Package.C", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
             new("Package.D", "4.0.0", DependencyType.Unknown, TargetFrameworks: ["netstandard2.0"], IsTransitive: true),
         ];
-        Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
             temp.DirectoryPath,
             temp.DirectoryPath,
             "netstandard2.0",
@@ -424,7 +424,7 @@ public class MSBuildHelperTests : TestBase
             new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true),
         ];
 
-        Dependency[] actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
             temp.DirectoryPath,
             temp.DirectoryPath,
             "net8.0",
@@ -475,7 +475,7 @@ public class MSBuildHelperTests : TestBase
             {
                 new Dependency("Some.Package", "1.2.0", DependencyType.PackageReference),
                 new Dependency("Some.Other.Package", "1.0.0", DependencyType.PackageReference),
-            };
+            }.ToImmutableArray();
             var update = new[]
             {
                 new Dependency("Some.Other.Package", "1.2.0", DependencyType.PackageReference),
@@ -489,11 +489,11 @@ public class MSBuildHelperTests : TestBase
                 new TestLogger()
             );
             Assert.NotNull(resolvedDependencies);
-            Assert.Equal(2, resolvedDependencies.Length);
-            Assert.Equal("Some.Package", resolvedDependencies[0].Name);
-            Assert.Equal("1.2.0", resolvedDependencies[0].Version);
-            Assert.Equal("Some.Other.Package", resolvedDependencies[1].Name);
-            Assert.Equal("1.2.0", resolvedDependencies[1].Version);
+            Assert.Equal(2, resolvedDependencies.Value.Length);
+            Assert.Equal("Some.Package", resolvedDependencies.Value[0].Name);
+            Assert.Equal("1.2.0", resolvedDependencies.Value[0].Version);
+            Assert.Equal("Some.Other.Package", resolvedDependencies.Value[1].Name);
+            Assert.Equal("1.2.0", resolvedDependencies.Value[1].Version);
         }
         finally
         {
@@ -663,11 +663,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("CS-Script.Core", "1.3.1", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.Common", "3.4.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.Scripting.Common", "3.4.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("CS-Script.Core", "2.0.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -679,13 +679,13 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(3, resolvedDependencies.Length);
-        Assert.Equal("CS-Script.Core", resolvedDependencies[0].Name);
-        Assert.Equal("2.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
-        Assert.Equal("3.6.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Scripting.Common", resolvedDependencies[2].Name);
-        Assert.Equal("3.6.0", resolvedDependencies[2].Version);
+        Assert.Equal(3, resolvedDependencies.Value.Length);
+        Assert.Equal("CS-Script.Core", resolvedDependencies.Value[0].Name);
+        Assert.Equal("2.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies.Value[1].Name);
+        Assert.Equal("3.6.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Scripting.Common", resolvedDependencies.Value[2].Name);
+        Assert.Equal("3.6.0", resolvedDependencies.Value[2].Version);
     }
 
     // Updating a dependency (Microsoft.Bcl.AsyncInterfaces) of the root package (Azure.Core) will require the root package to also update, but since the dependency is not in the existing list, we do not include it
@@ -710,11 +710,11 @@ public class MSBuildHelperTests : TestBase
         var dependencies = new[]
         {
             new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.1.1", DependencyType.Unknown)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -726,9 +726,9 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Single(resolvedDependencies);
-        Assert.Equal("Azure.Core", resolvedDependencies[0].Name);
-        Assert.Equal("1.22.0", resolvedDependencies[0].Version);
+        Assert.Single(resolvedDependencies.Value);
+        Assert.Equal("Azure.Core", resolvedDependencies.Value[0].Name);
+        Assert.Equal("1.22.0", resolvedDependencies.Value[0].Version);
     }
 
     // Adding a reference
@@ -755,11 +755,11 @@ public class MSBuildHelperTests : TestBase
         var dependencies = new[]
         {
             new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -771,11 +771,11 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(2, resolvedDependencies.Length);
-        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[0].Name);
-        Assert.Equal("1.0.2", resolvedDependencies[0].Version);
-        Assert.Equal("Newtonsoft.Json", resolvedDependencies[1].Name);
-        Assert.Equal("13.0.1", resolvedDependencies[1].Version);
+        Assert.Equal(2, resolvedDependencies.Value.Length);
+        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies.Value[0].Name);
+        Assert.Equal("1.0.2", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Newtonsoft.Json", resolvedDependencies.Value[1].Name);
+        Assert.Equal("13.0.1", resolvedDependencies.Value[1].Version);
     }
 
     // Updating unreferenced dependency
@@ -807,11 +807,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.Compilers", "4.9.2", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -823,13 +823,13 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(3, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
+        Assert.Equal(3, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies.Value[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[2].Version);
     }
 
     // Updating referenced dependency
@@ -861,11 +861,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.Common", "4.9.2", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -877,15 +877,15 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(4, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[1].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[3].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[3].Version);
+        Assert.Equal(4, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies.Value[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies.Value[3].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[3].Version);
     }
 
     // A combination of the third and fourth test, to measure efficiency of updating separate families
@@ -918,12 +918,12 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.CSharp", "4.9.2", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.VisualBasic", "4.9.2", DependencyType.PackageReference),
             new Dependency("Newtonsoft.Json.Bson", "1.0.2", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
             new Dependency("Newtonsoft.Json", "13.0.1", DependencyType.Unknown)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -935,17 +935,17 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(5, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies[0].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies[2].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies[3].Name);
-        Assert.Equal("1.0.2", resolvedDependencies[3].Version);
-        Assert.Equal("Newtonsoft.Json", resolvedDependencies[4].Name);
-        Assert.Equal("13.0.1", resolvedDependencies[4].Version);
+        Assert.Equal(5, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.Compilers", resolvedDependencies.Value[0].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.VisualBasic", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Newtonsoft.Json.Bson", resolvedDependencies.Value[3].Name);
+        Assert.Equal("1.0.2", resolvedDependencies.Value[3].Version);
+        Assert.Equal("Newtonsoft.Json", resolvedDependencies.Value[4].Name);
+        Assert.Equal("13.0.1", resolvedDependencies.Value[4].Version);
     }
 
     // Two top level packages (Buildalyzer), (Microsoft.CodeAnalysis.CSharp.Scripting) that share a dependency (Microsoft.CodeAnalysis.Csharp)
@@ -995,11 +995,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "3.10.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.CSharp", "3.10.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.Common", "3.10.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Buildalyzer", "7.0.1", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
 
         // act
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
@@ -1021,7 +1021,7 @@ public class MSBuildHelperTests : TestBase
             "Microsoft.CodeAnalysis.Common/4.0.1"
         };
         Assert.NotNull(resolvedDependencies);
-        var actualDependencies = resolvedDependencies.Select(d => $"{d.Name}/{d.Version}").ToArray();
+        var actualDependencies = resolvedDependencies.Value.Select(d => $"{d.Name}/{d.Version}").ToArray();
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
@@ -1055,13 +1055,12 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.CSharp.Scripting", "4.8.0", DependencyType.PackageReference),
             new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
             new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
-
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
             new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1073,15 +1072,15 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(4, resolvedDependencies.Length);
-        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[2].Name);
-        Assert.Equal("1.1.1", resolvedDependencies[2].Version);
-        Assert.Equal("Azure.Core", resolvedDependencies[3].Name);
-        Assert.Equal("1.22.0", resolvedDependencies[3].Version);
+        Assert.Equal(4, resolvedDependencies.Value.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies.Value[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies.Value[2].Name);
+        Assert.Equal("1.1.1", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Azure.Core", resolvedDependencies.Value[3].Name);
+        Assert.Equal("1.22.0", resolvedDependencies.Value[3].Version);
     }
 
     // Similar to the last test, except Microsoft.CodeAnalysis.Common is in the existing list
@@ -1115,12 +1114,12 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.Bcl.AsyncInterfaces", "1.0.0", DependencyType.Unknown),
             new Dependency("Azure.Core", "1.21.0", DependencyType.PackageReference),
 
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.CodeAnalysis.Common", "4.10.0", DependencyType.PackageReference),
             new Dependency("Azure.Core", "1.22.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1132,17 +1131,17 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(5, resolvedDependencies.Length);
-        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies[1].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
-        Assert.Equal("4.10.0", resolvedDependencies[2].Version);
-        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies[3].Name);
-        Assert.Equal("1.1.1", resolvedDependencies[3].Version);
-        Assert.Equal("Azure.Core", resolvedDependencies[4].Name);
-        Assert.Equal("1.22.0", resolvedDependencies[4].Version);
+        Assert.Equal(5, resolvedDependencies.Value.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies.Value[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Scripting", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.10.0", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Microsoft.Bcl.AsyncInterfaces", resolvedDependencies.Value[3].Name);
+        Assert.Equal("1.1.1", resolvedDependencies.Value[3].Version);
+        Assert.Equal("Azure.Core", resolvedDependencies.Value[4].Name);
+        Assert.Equal("1.22.0", resolvedDependencies.Value[4].Version);
     }
 
     // Out of scope test: AutoMapper.Extensions.Microsoft.DependencyInjection's versions are not yet compatible
@@ -1173,11 +1172,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("AutoMapper.Extensions.Microsoft.DependencyInjection", "12.0.1", DependencyType.PackageReference),
             new Dependency("AutoMapper", "12.0.1", DependencyType.PackageReference),
             new Dependency("AutoMapper.Collection", "9.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("AutoMapper.Collection", "10.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1189,13 +1188,13 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(3, resolvedDependencies.Length);
-        Assert.Equal("AutoMapper.Extensions.Microsoft.DependencyInjection", resolvedDependencies[0].Name);
-        Assert.Equal("12.0.1", resolvedDependencies[0].Version);
-        Assert.Equal("AutoMapper", resolvedDependencies[1].Name);
-        Assert.Equal("12.0.1", resolvedDependencies[1].Version);
-        Assert.Equal("AutoMapper.Collection", resolvedDependencies[2].Name);
-        Assert.Equal("9.0.0", resolvedDependencies[2].Version);
+        Assert.Equal(3, resolvedDependencies.Value.Length);
+        Assert.Equal("AutoMapper.Extensions.Microsoft.DependencyInjection", resolvedDependencies.Value[0].Name);
+        Assert.Equal("12.0.1", resolvedDependencies.Value[0].Version);
+        Assert.Equal("AutoMapper", resolvedDependencies.Value[1].Name);
+        Assert.Equal("12.0.1", resolvedDependencies.Value[1].Version);
+        Assert.Equal("AutoMapper.Collection", resolvedDependencies.Value[2].Name);
+        Assert.Equal("9.0.0", resolvedDependencies.Value[2].Version);
     }
 
     // Two dependencies (Microsoft.Extensions.Caching.Memory), (Microsoft.EntityFrameworkCore.Analyzers) used by the same parent (Microsoft.EntityFrameworkCore), updating one of the dependencies
@@ -1222,11 +1221,11 @@ public class MSBuildHelperTests : TestBase
         {
             new Dependency("Microsoft.EntityFrameworkCore", "7.0.11", DependencyType.PackageReference),
             new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.11", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.Extensions.Caching.Memory", "8.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1238,11 +1237,11 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(2, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[0].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[1].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[1].Version);
+        Assert.Equal(2, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies.Value[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies.Value[1].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[1].Version);
     }
 
     // Updating referenced package
@@ -1274,11 +1273,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
             new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
             new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "7.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1290,15 +1289,15 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(4, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
-        Assert.Equal("7.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
-        Assert.Equal("7.0.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
-        Assert.Equal("7.0.0", resolvedDependencies[2].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies[3].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[3].Version);
+        Assert.Equal(4, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies.Value[0].Name);
+        Assert.Equal("7.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies.Value[1].Name);
+        Assert.Equal("7.0.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies.Value[2].Name);
+        Assert.Equal("7.0.0", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Analyzers", resolvedDependencies.Value[3].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[3].Version);
     }
 
     // Updating unreferenced package
@@ -1328,11 +1327,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.EntityFrameworkCore.Design", "7.0.0", DependencyType.PackageReference),
             new Dependency("Microsoft.EntityFrameworkCore.Relational", "7.0.0", DependencyType.PackageReference),
             new Dependency("Microsoft.EntityFrameworkCore", "7.0.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", DependencyType.PackageReference)
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1344,13 +1343,13 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(3, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies[0].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies[1].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies[2].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[2].Version);
+        Assert.Equal(3, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Design", resolvedDependencies.Value[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore.Relational", resolvedDependencies.Value[1].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.EntityFrameworkCore", resolvedDependencies.Value[2].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[2].Version);
     }
 
     // Updating a referenced transitive dependency
@@ -1382,11 +1381,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1398,15 +1397,15 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(4, resolvedDependencies.Length);
-        Assert.Equal("System.Collections.Immutable", resolvedDependencies[0].Name);
-        Assert.Equal("8.0.0", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[1].Name);
-        Assert.Equal("4.8.0", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[2].Name);
-        Assert.Equal("4.8.0", resolvedDependencies[2].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[3].Name);
-        Assert.Equal("4.8.0", resolvedDependencies[3].Version);
+        Assert.Equal(4, resolvedDependencies.Value.Length);
+        Assert.Equal("System.Collections.Immutable", resolvedDependencies.Value[0].Name);
+        Assert.Equal("8.0.0", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.8.0", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.8.0", resolvedDependencies.Value[2].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies.Value[3].Name);
+        Assert.Equal("4.8.0", resolvedDependencies.Value[3].Version);
     }
 
     // Similar to the last test, with the "grandchild" (System.Collections.Immutable) not in the existing list
@@ -1435,12 +1434,11 @@ public class MSBuildHelperTests : TestBase
             new Dependency("Microsoft.CodeAnalysis.CSharp.Workspaces", "4.8.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.CSharp", "4.8.0", DependencyType.PackageReference),
             new Dependency("Microsoft.CodeAnalysis.Common", "4.8.0", DependencyType.PackageReference),
-
-        };
+        }.ToImmutableArray();
         var update = new[]
         {
             new Dependency("System.Collections.Immutable", "8.0.0", DependencyType.PackageReference),
-        };
+        }.ToImmutableArray();
 
         var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflicts(
             tempDirectory.DirectoryPath,
@@ -1452,13 +1450,13 @@ public class MSBuildHelperTests : TestBase
             new TestLogger()
         );
         Assert.NotNull(resolvedDependencies);
-        Assert.Equal(3, resolvedDependencies.Length);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies[0].Name);
-        Assert.Equal("4.9.2", resolvedDependencies[0].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies[1].Name);
-        Assert.Equal("4.9.2", resolvedDependencies[1].Version);
-        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies[2].Name);
-        Assert.Equal("4.9.2", resolvedDependencies[2].Version);
+        Assert.Equal(3, resolvedDependencies.Value.Length);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp.Workspaces", resolvedDependencies.Value[0].Name);
+        Assert.Equal("4.9.2", resolvedDependencies.Value[0].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", resolvedDependencies.Value[1].Name);
+        Assert.Equal("4.9.2", resolvedDependencies.Value[1].Version);
+        Assert.Equal("Microsoft.CodeAnalysis.Common", resolvedDependencies.Value[2].Name);
+        Assert.Equal("4.9.2", resolvedDependencies.Value[2].Version);
     }
     #endregion
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -8,6 +8,7 @@ namespace NuGetUpdater.Core;
 public record ExperimentsManager
 {
     public bool InstallDotnetSdks { get; init; } = false;
+    public bool NativeUpdater { get; init; } = false;
     public bool UseLegacyDependencySolver { get; init; } = false;
     public bool UseDirectDiscovery { get; init; } = false;
 
@@ -16,6 +17,7 @@ public record ExperimentsManager
         return new()
         {
             ["nuget_install_dotnet_sdks"] = InstallDotnetSdks,
+            ["nuget_native_updater"] = NativeUpdater,
             ["nuget_legacy_dependency_solver"] = UseLegacyDependencySolver,
             ["nuget_use_direct_discovery"] = UseDirectDiscovery,
         };
@@ -26,6 +28,7 @@ public record ExperimentsManager
         return new ExperimentsManager()
         {
             InstallDotnetSdks = IsEnabled(experiments, "nuget_install_dotnet_sdks"),
+            NativeUpdater = IsEnabled(experiments, "nuget_native_updater"),
             UseLegacyDependencySolver = IsEnabled(experiments, "nuget_legacy_dependency_solver"),
             UseDirectDiscovery = IsEnabled(experiments, "nuget_use_direct_discovery"),
         };

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
@@ -1,3 +1,5 @@
+using NuGetUpdater.Core.Updater;
+
 namespace NuGetUpdater.Core;
 
 internal static class LockFileUpdater

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -1,9 +1,12 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 
 using Microsoft.Language.Xml;
 
+using NuGet.Frameworks;
 using NuGet.Versioning;
 
+using NuGetUpdater.Core.Updater;
 using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core;
@@ -21,7 +24,7 @@ namespace NuGetUpdater.Core;
 /// </remarks>
 internal static class PackageReferenceUpdater
 {
-    public static async Task UpdateDependencyAsync(
+    public static async Task<IEnumerable<UpdateOperationBase>> UpdateDependencyAsync(
         string repoRootPath,
         string projectPath,
         string dependencyName,
@@ -60,45 +63,67 @@ internal static class PackageReferenceUpdater
 
         if (!await DoesDependencyRequireUpdateAsync(repoRootPath, projectPath, tfms, topLevelDependencies, dependencyName, newDependencyVersion, experimentsManager, logger))
         {
-            return;
+            return [];
         }
 
+        var updateOperations = new List<UpdateOperationBase>();
         var peerDependencies = await GetUpdatedPeerDependenciesAsync(repoRootPath, projectPath, tfms, dependencyName, newDependencyVersion, experimentsManager, logger);
         if (experimentsManager.UseLegacyDependencySolver)
         {
             if (isTransitive)
             {
-                await UpdateTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, buildFiles, experimentsManager, logger);
+                var updatedFiles = await UpdateTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, buildFiles, experimentsManager, logger);
+                updateOperations.Add(new PinnedUpdate()
+                {
+                    DependencyName = dependencyName,
+                    NewVersion = NuGetVersion.Parse(newDependencyVersion),
+                    UpdatedFiles = [.. updatedFiles],
+                });
             }
             else
             {
                 if (peerDependencies is null)
                 {
-                    return;
+                    return updateOperations;
                 }
 
-                await UpdateTopLevelDepdendency(repoRootPath, buildFiles, tfms, dependencyName, previousDependencyVersion, newDependencyVersion, peerDependencies, experimentsManager, logger);
+                var topLevelUpdateOperations = await UpdateTopLevelDepdendency(repoRootPath, buildFiles, tfms, dependencyName, previousDependencyVersion, newDependencyVersion, peerDependencies, experimentsManager, logger);
+                updateOperations.AddRange(topLevelUpdateOperations);
             }
         }
         else
         {
             if (peerDependencies is null)
             {
-                return;
+                return updateOperations;
             }
 
-            await UpdateDependencyWithConflictResolution(repoRootPath, buildFiles, tfms, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, peerDependencies, experimentsManager, logger);
+            var conflictResolutionUpdateOperations = await UpdateDependencyWithConflictResolution(
+                repoRootPath,
+                buildFiles,
+                tfms,
+                projectPath,
+                dependencyName,
+                previousDependencyVersion,
+                newDependencyVersion,
+                isTransitive,
+                peerDependencies,
+                experimentsManager,
+                logger);
+            updateOperations.AddRange(conflictResolutionUpdateOperations);
         }
 
         if (!await AreDependenciesCoherentAsync(repoRootPath, projectPath, dependencyName, buildFiles, tfms, experimentsManager, logger))
         {
-            return;
+            // should we return an empty set because we failed?
+            return updateOperations;
         }
 
         await SaveBuildFilesAsync(buildFiles, logger);
+        return updateOperations;
     }
 
-    public static async Task UpdateDependencyWithConflictResolution(
+    public static async Task<IEnumerable<UpdateOperationBase>> UpdateDependencyWithConflictResolution(
         string repoRootPath,
         ImmutableArray<ProjectBuildFile> buildFiles,
         string[] targetFrameworks,
@@ -111,17 +136,20 @@ internal static class PackageReferenceUpdater
         ExperimentsManager experimentsManager,
         ILogger logger)
     {
-        var topLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles).ToArray();
+        var topLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles).ToImmutableArray();
         var isDependencyTopLevel = topLevelDependencies.Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
-        var dependenciesToUpdate = new[] { new Dependency(dependencyName, newDependencyVersion, DependencyType.PackageReference) };
+        var dependenciesToUpdate = new[] { new Dependency(dependencyName, newDependencyVersion, DependencyType.PackageReference) }.ToImmutableArray();
+        var updateOperations = new List<UpdateOperationBase>();
 
         // update the initial dependency...
-        TryUpdateDependencyVersion(buildFiles, dependencyName, previousDependencyVersion, newDependencyVersion, logger);
+        var (_, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, dependencyName, previousDependencyVersion, newDependencyVersion, logger);
+        updateOperations.AddRange(updateOperationsPerformed);
 
         // ...and the peer dependencies...
         foreach (var (packageName, packageVersion) in peerDependencies.Where(kvp => string.Compare(kvp.Key, dependencyName, StringComparison.OrdinalIgnoreCase) != 0))
         {
-            TryUpdateDependencyVersion(buildFiles, packageName, previousDependencyVersion: null, newDependencyVersion: packageVersion, logger);
+            (_, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, packageName, previousDependencyVersion: null, newDependencyVersion: packageVersion, logger);
+            updateOperations.AddRange(updateOperationsPerformed);
         }
 
         // ...and everything else
@@ -136,21 +164,164 @@ internal static class PackageReferenceUpdater
                     continue;
                 }
 
-                var isDependencyInResolutionSet = resolvedDependencies.Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
+                var isDependencyInResolutionSet = resolvedDependencies.Value.Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
                 if (isTransitive && !isDependencyTopLevel && isDependencyInResolutionSet)
                 {
                     // a transitive dependency had to be pinned; add it here
-                    await UpdateTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, buildFiles, experimentsManager, logger);
+                    var updatedFiles = await UpdateTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, buildFiles, experimentsManager, logger);
                 }
 
                 // update all resolved dependencies that aren't the initial dependency
-                foreach (var resolvedDependency in resolvedDependencies
+                foreach (var resolvedDependency in resolvedDependencies.Value
                                                     .Where(d => !d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
                                                     .Where(d => d.Version is not null))
                 {
-                    TryUpdateDependencyVersion(buildFiles, resolvedDependency.Name, previousDependencyVersion: null, newDependencyVersion: resolvedDependency.Version!, logger);
+                    (_, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, resolvedDependency.Name, previousDependencyVersion: null, newDependencyVersion: resolvedDependency.Version!, logger);
+                    updateOperations.AddRange(updateOperationsPerformed);
+                }
+
+                updateOperationsPerformed = await ComputeUpdateOperations(repoRootPath, projectPath, tfm, topLevelDependencies, dependenciesToUpdate, resolvedDependencies.Value, experimentsManager, logger);
+                updateOperations.AddRange(updateOperationsPerformed.Select(u => u with { UpdatedFiles = [projectFile.Path] }));
+            }
+        }
+
+        return updateOperations;
+    }
+
+    internal static async Task<IEnumerable<UpdateOperationBase>> ComputeUpdateOperations(
+        string repoRoot,
+        string projectPath,
+        string targetFramework,
+        ImmutableArray<Dependency> topLevelDependencies,
+        ImmutableArray<Dependency> requestedUpdates,
+        ImmutableArray<Dependency> resolvedDependencies,
+        ExperimentsManager experimentsManager,
+        ILogger logger
+    )
+    {
+        var topLevelNames = topLevelDependencies.Select(d => d.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var requestedVersions = requestedUpdates.ToDictionary(d => d.Name, d => NuGetVersion.Parse(d.Version!), StringComparer.OrdinalIgnoreCase);
+        var resolvedVersions = resolvedDependencies
+            .Select(d => (d.Name, NuGetVersion.TryParse(d.Version, out var version), version))
+            .Where(d => d.Item2)
+            .ToDictionary(d => d.Item1, d => d.Item3!, StringComparer.OrdinalIgnoreCase);
+
+        var (packageParents, packageVersions) = await GetPackageGraphForDependencies(repoRoot, projectPath, targetFramework, resolvedDependencies, experimentsManager, logger);
+        var updateOperations = new List<UpdateOperationBase>();
+        foreach (var (requestedDependencyName, requestedDependencyVersion) in requestedVersions)
+        {
+            var isDependencyTopLevel = topLevelNames.Contains(requestedDependencyName);
+            var isDependencyInResolvedSet = resolvedVersions.ContainsKey(requestedDependencyName);
+            switch ((isDependencyTopLevel, isDependencyInResolvedSet))
+            {
+                case (true, true):
+                    // direct update performed
+                    var resolvedVer = resolvedVersions[requestedDependencyName];
+                    updateOperations.Add(new DirectUpdate()
+                    {
+                        DependencyName = requestedDependencyName,
+                        NewVersion = resolvedVer,
+                        UpdatedFiles = [],
+                    });
+                    break;
+                case (false, true):
+                    // pinned transitive update
+                    updateOperations.Add(new PinnedUpdate()
+                    {
+                        DependencyName = requestedDependencyName,
+                        NewVersion = resolvedVersions[requestedDependencyName],
+                        UpdatedFiles = [],
+                    });
+                    break;
+                case (false, false):
+                    // walk the first parent all the way up to find a top-level dependency that resulted in the desired change
+                    string? rootPackageName = null;
+                    var currentPackageName = requestedDependencyName;
+                    while (packageParents.TryGetValue(currentPackageName, out var parentSet))
+                    {
+                        currentPackageName = parentSet.First();
+                        if (topLevelNames.Contains(currentPackageName))
+                        {
+                            rootPackageName = currentPackageName;
+                            break;
+                        }
+                    }
+
+                    if (rootPackageName is not null)
+                    {
+                        updateOperations.Add(new ParentUpdate()
+                        {
+                            DependencyName = requestedDependencyName,
+                            NewVersion = requestedVersions[requestedDependencyName],
+                            UpdatedFiles = [],
+                            ParentDependencyName = rootPackageName,
+                            ParentNewVersion = packageVersions[rootPackageName],
+                        });
+                    }
+                    break;
+                case (true, false):
+                    // dependency is top-level, but not in the resolved versions; this can happen if an unrelated package has a wildcard
+                    break;
+            }
+        }
+
+        return [.. updateOperations];
+    }
+
+    private static async Task<(Dictionary<string, HashSet<string>> PackageParents, Dictionary<string, NuGetVersion> PackageVersions)> GetPackageGraphForDependencies(string repoRoot, string projectPath, string targetFramework, ImmutableArray<Dependency> topLevelDependencies, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        var packageParents = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var packageVersions = new Dictionary<string, NuGetVersion>(StringComparer.OrdinalIgnoreCase);
+        var tempDir = Directory.CreateTempSubdirectory("_package_graph_for_dependencies_");
+        try
+        {
+            // generate project.assets.json
+            var parsedTargetFramework = NuGetFramework.Parse(targetFramework);
+            var tempProject = await MSBuildHelper.CreateTempProjectAsync(tempDir, repoRoot, projectPath, targetFramework, topLevelDependencies, experimentsManager, logger, importDependencyTargets: !experimentsManager.UseDirectDiscovery);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["build", tempProject, "/t:_ReportDependencies"], tempDir.FullName, experimentsManager);
+            var assetsJsonPath = Path.Join(tempDir.FullName, "obj", "project.assets.json");
+            var assetsJsonContent = await File.ReadAllTextAsync(assetsJsonPath);
+
+            // build reverse dependency graph
+            var assets = JsonDocument.Parse(assetsJsonContent).RootElement;
+            foreach (var tfmObject in assets.GetProperty("targets").EnumerateObject())
+            {
+                var reportedTargetFramework = NuGetFramework.Parse(tfmObject.Name);
+                if (reportedTargetFramework != parsedTargetFramework)
+                {
+                    // not interested in this target framework
+                    continue;
+                }
+
+                foreach (var parentObject in tfmObject.Value.EnumerateObject())
+                {
+                    var parts = parentObject.Name.Split('/');
+                    var parentName = parts[0];
+                    var parentVersion = parts[1];
+                    packageVersions[parentName] = NuGetVersion.Parse(parentVersion);
+
+                    if (parentObject.Value.TryGetProperty("dependencies", out var dependencies))
+                    {
+                        foreach (var childObject in dependencies.EnumerateObject())
+                        {
+                            var childName = childObject.Name;
+                            var parentSet = packageParents.GetOrAdd(childName, () => new(StringComparer.OrdinalIgnoreCase));
+                            parentSet.Add(parentName);
+                        }
+                    }
                 }
             }
+
+            return (packageParents, packageVersions);
+        }
+        catch (Exception ex)
+        {
+            logger.Error($"Error while generating package graph: {ex.Message}");
+            throw;
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
         }
     }
 
@@ -227,7 +398,8 @@ internal static class PackageReferenceUpdater
         return true;
     }
 
-    private static async Task UpdateTransitiveDependencyAsync(
+    /// <returns>The updated files.</returns>
+    private static async Task<IEnumerable<string>> UpdateTransitiveDependencyAsync(
         string repoRootPath,
         string projectPath,
         string dependencyName,
@@ -237,16 +409,19 @@ internal static class PackageReferenceUpdater
         ILogger logger
     )
     {
+        IEnumerable<string> updatedFiles;
         var directoryPackagesWithPinning = buildFiles.OfType<ProjectBuildFile>()
             .FirstOrDefault(bf => IsCpmTransitivePinningEnabled(bf));
         if (directoryPackagesWithPinning is not null)
         {
-            PinTransitiveDependency(directoryPackagesWithPinning, dependencyName, newDependencyVersion, logger);
+            updatedFiles = PinTransitiveDependency(directoryPackagesWithPinning, dependencyName, newDependencyVersion, logger);
         }
         else
         {
-            await AddTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, experimentsManager, logger);
+            updatedFiles = await AddTransitiveDependencyAsync(repoRootPath, projectPath, dependencyName, newDependencyVersion, experimentsManager, logger);
         }
+
+        return updatedFiles;
     }
 
     private static bool IsCpmTransitivePinningEnabled(ProjectBuildFile buildFile)
@@ -271,7 +446,8 @@ internal static class PackageReferenceUpdater
         return isTransitivePinningEnabled is not null && string.Equals(isTransitivePinningEnabled, "true", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static void PinTransitiveDependency(ProjectBuildFile directoryPackages, string dependencyName, string newDependencyVersion, ILogger logger)
+    /// <returns>The updated files.</returns>
+    private static IEnumerable<string> PinTransitiveDependency(ProjectBuildFile directoryPackages, string dependencyName, string newDependencyVersion, ILogger logger)
     {
         var existingPackageVersionElement = directoryPackages.ItemNodes
             .Where(e => e.Name.Equals("PackageVersion", StringComparison.OrdinalIgnoreCase) &&
@@ -288,7 +464,7 @@ internal static class PackageReferenceUpdater
         if (lastPackageVersion is null)
         {
             logger.Info($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not pinned.");
-            return;
+            return [];
         }
 
         var lastItemGroup = lastPackageVersion.Parent;
@@ -324,7 +500,7 @@ internal static class PackageReferenceUpdater
             else
             {
                 logger.Info("      Existing PackageVersion element version was already correct.");
-                return;
+                return [];
             }
 
             updatedItemGroup = lastItemGroup.ReplaceChildElement(existingPackageVersionElement, updatedPackageVersionElement);
@@ -332,10 +508,14 @@ internal static class PackageReferenceUpdater
 
         var updatedXml = directoryPackages.Contents.ReplaceNode(lastItemGroup.AsNode, updatedItemGroup.AsNode);
         directoryPackages.Update(updatedXml);
+
+        return [directoryPackages.Path];
     }
 
-    private static async Task AddTransitiveDependencyAsync(string repoRootPath, string projectPath, string dependencyName, string newDependencyVersion, ExperimentsManager experimentsManager, ILogger logger)
+    /// <returns>The updated files.</returns>
+    private static async Task<IEnumerable<string>> AddTransitiveDependencyAsync(string repoRootPath, string projectPath, string dependencyName, string newDependencyVersion, ExperimentsManager experimentsManager, ILogger logger)
     {
+        var updatedFiles = new[] { projectPath }; // assume this worked unless...
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
         await MSBuildHelper.HandleGlobalJsonAsync(projectDirectory, repoRootPath, experimentsManager, async () =>
         {
@@ -351,10 +531,13 @@ internal static class PackageReferenceUpdater
             if (exitCode != 0)
             {
                 logger.Warn($"    Transitive dependency [{dependencyName}/{newDependencyVersion}] was not added.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+                updatedFiles = [];
             }
 
             return exitCode;
         }, logger, retainMSBuildSdks: true);
+
+        return updatedFiles;
     }
 
     /// <summary>
@@ -371,7 +554,7 @@ internal static class PackageReferenceUpdater
         ILogger logger)
     {
         var newDependency = new[] { new Dependency(dependencyName, newDependencyVersion, DependencyType.Unknown) };
-        var tfmsAndDependencies = new Dictionary<string, Dependency[]>();
+        var tfmsAndDependencies = new Dictionary<string, ImmutableArray<Dependency>>();
         foreach (var tfm in tfms)
         {
             var dependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(repoRootPath, projectPath, tfm, newDependency, experimentsManager, logger);
@@ -415,7 +598,7 @@ internal static class PackageReferenceUpdater
         return packagesAndVersions;
     }
 
-    private static async Task UpdateTopLevelDepdendency(
+    private static async Task<IEnumerable<UpdateOperationBase>> UpdateTopLevelDepdendency(
         string repoRootPath,
         ImmutableArray<ProjectBuildFile> buildFiles,
         string[] targetFrameworks,
@@ -427,25 +610,29 @@ internal static class PackageReferenceUpdater
         ILogger logger)
     {
         // update dependencies...
-        var result = TryUpdateDependencyVersion(buildFiles, dependencyName, previousDependencyVersion, newDependencyVersion, logger);
-        if (result == UpdateResult.NotFound)
+        var updateOperations = new List<UpdateOperationBase>();
+        var (updateResult, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, dependencyName, previousDependencyVersion, newDependencyVersion, logger);
+        if (updateResult == UpdateResult.NotFound)
         {
             logger.Info($"    Root package [{dependencyName}/{previousDependencyVersion}] was not updated; skipping dependencies.");
-            return;
+            return [];
         }
+
+        updateOperations.AddRange(updateOperationsPerformed);
 
         foreach (var (packageName, packageVersion) in peerDependencies.Where(kvp => string.Compare(kvp.Key, dependencyName, StringComparison.OrdinalIgnoreCase) != 0))
         {
-            TryUpdateDependencyVersion(buildFiles, packageName, previousDependencyVersion: null, newDependencyVersion: packageVersion, logger);
+            (_, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, packageName, previousDependencyVersion: null, newDependencyVersion: packageVersion, logger);
+            updateOperations.AddRange(updateOperationsPerformed);
         }
 
         // ...and make them all coherent
-        Dependency[] updatedTopLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles).ToArray();
+        var topLevelDependencies = MSBuildHelper.GetTopLevelPackageDependencyInfos(buildFiles).ToImmutableArray();
         foreach (ProjectBuildFile projectFile in buildFiles)
         {
             foreach (string tfm in targetFrameworks)
             {
-                var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflictsWithBruteForce(repoRootPath, projectFile.Path, tfm, updatedTopLevelDependencies, experimentsManager, logger);
+                var resolvedDependencies = await MSBuildHelper.ResolveDependencyConflictsWithBruteForce(repoRootPath, projectFile.Path, tfm, topLevelDependencies, experimentsManager, logger);
                 if (resolvedDependencies is null)
                 {
                     logger.Info($"    Unable to resolve dependency conflicts for {projectFile.Path}.");
@@ -453,7 +640,7 @@ internal static class PackageReferenceUpdater
                 }
 
                 // ensure the originally requested dependency was resolved to the correct version
-                var specificResolvedDependency = resolvedDependencies.Where(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var specificResolvedDependency = resolvedDependencies.Value.Where(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 if (specificResolvedDependency is null)
                 {
                     logger.Info($"    Unable to resolve requested dependency for {dependencyName} in {projectFile.Path}.");
@@ -467,17 +654,24 @@ internal static class PackageReferenceUpdater
                 }
 
                 // update all versions
-                foreach (Dependency resolvedDependency in resolvedDependencies
+                foreach (Dependency resolvedDependency in resolvedDependencies.Value
                                                           .Where(d => !d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
                                                           .Where(d => d.Version is not null))
                 {
-                    TryUpdateDependencyVersion(buildFiles, resolvedDependency.Name, previousDependencyVersion: null, newDependencyVersion: resolvedDependency.Version!, logger);
+                    (_, updateOperationsPerformed) = TryUpdateDependencyVersion(buildFiles, resolvedDependency.Name, previousDependencyVersion: null, newDependencyVersion: resolvedDependency.Version!, logger);
+                    updateOperations.AddRange(updateOperationsPerformed);
                 }
+
+                updateOperationsPerformed = await ComputeUpdateOperations(repoRootPath, projectFile.Path, tfm, topLevelDependencies, [new Dependency(dependencyName, newDependencyVersion, DependencyType.PackageReference)], resolvedDependencies.Value, experimentsManager, logger);
+                updateOperations.AddRange(updateOperationsPerformed.Select(u => u with { UpdatedFiles = [projectFile.Path] }));
             }
         }
+
+        return updateOperations;
     }
 
-    private static UpdateResult TryUpdateDependencyVersion(
+    /// <returns>The updated files.</returns>
+    private static (UpdateResult, IEnumerable<UpdateOperationBase>) TryUpdateDependencyVersion(
         ImmutableArray<ProjectBuildFile> buildFiles,
         string dependencyName,
         string? previousDependencyVersion,
@@ -488,6 +682,7 @@ internal static class PackageReferenceUpdater
         var foundUnsupported = false;
         var updateWasPerformed = false;
         var propertyNames = new List<string>();
+        var updateOperations = new List<UpdateOperationBase>();
 
         // First we locate all the PackageReference, GlobalPackageReference, or PackageVersion which set the Version
         // or VersionOverride attribute. In the simplest case we can update the version attribute directly then move
@@ -526,6 +721,12 @@ internal static class PackageReferenceUpdater
                         {
                             logger.Info($"    Found incorrect [{packageNode.Name}] version attribute in [{buildFile.RelativePath}].");
                             updateNodes.Add(versionAttribute);
+                            updateOperations.Add(new DirectUpdate()
+                            {
+                                DependencyName = dependencyName,
+                                NewVersion = NuGetVersion.Parse(newDependencyVersion),
+                                UpdatedFiles = [buildFile.Path],
+                            });
                         }
                         else if (previousDependencyVersion == null && NuGetVersion.TryParse(currentVersion, out var previousVersion))
                         {
@@ -536,6 +737,12 @@ internal static class PackageReferenceUpdater
 
                                 logger.Info($"    Found incorrect peer [{packageNode.Name}] version attribute in [{buildFile.RelativePath}].");
                                 updateNodes.Add(versionAttribute);
+                                updateOperations.Add(new DirectUpdate()
+                                {
+                                    DependencyName = dependencyName,
+                                    NewVersion = NuGetVersion.Parse(newDependencyVersion),
+                                    UpdatedFiles = [buildFile.Path],
+                                });
                             }
                         }
                         else if (string.Equals(currentVersion, newDependencyVersion, StringComparison.Ordinal))
@@ -566,6 +773,12 @@ internal static class PackageReferenceUpdater
                             if (versionElement is XmlElementSyntax elementSyntax)
                             {
                                 updateNodes.Add(elementSyntax);
+                                updateOperations.Add(new DirectUpdate()
+                                {
+                                    DependencyName = dependencyName,
+                                    NewVersion = NuGetVersion.Parse(newDependencyVersion),
+                                    UpdatedFiles = [buildFile.Path],
+                                });
                             }
                             else
                             {
@@ -583,6 +796,12 @@ internal static class PackageReferenceUpdater
                                 if (versionElement is XmlElementSyntax elementSyntax)
                                 {
                                     updateNodes.Add(elementSyntax);
+                                    updateOperations.Add(new DirectUpdate()
+                                    {
+                                        DependencyName = dependencyName,
+                                        NewVersion = NuGetVersion.Parse(newDependencyVersion),
+                                        UpdatedFiles = [buildFile.Path],
+                                    });
                                 }
                                 else
                                 {
@@ -706,13 +925,14 @@ internal static class PackageReferenceUpdater
             }
         }
 
-        return updateWasPerformed
+        var updateResult = updateWasPerformed
             ? UpdateResult.Updated
             : foundCorrect
                 ? UpdateResult.Correct
                 : foundUnsupported
                     ? UpdateResult.NotSupported
                     : UpdateResult.NotFound;
+        return (updateResult, updateOperations);
     }
 
     private static IEnumerable<IXmlElementSyntax> FindPackageNodes(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -7,6 +7,7 @@ using System.Xml.XPath;
 using Microsoft.Language.Xml;
 
 using NuGet.CommandLine;
+using NuGet.Versioning;
 
 using NuGetUpdater.Core.Updater;
 using NuGetUpdater.Core.Utilities;
@@ -25,7 +26,7 @@ namespace NuGetUpdater.Core;
 /// <remarks>
 internal static partial class PackagesConfigUpdater
 {
-    public static async Task UpdateDependencyAsync(
+    public static async Task<IEnumerable<UpdateOperationBase>> UpdateDependencyAsync(
         string repoRootPath,
         string projectPath,
         string dependencyName,
@@ -44,7 +45,7 @@ internal static partial class PackagesConfigUpdater
         if (packagesSubDirectory is null)
         {
             logger.Info($"    Project [{projectPath}] does not reference this dependency.");
-            return;
+            return [];
         }
 
         logger.Info($"    Using packages directory [{packagesSubDirectory}] for project [{projectPath}].");
@@ -95,10 +96,18 @@ internal static partial class PackagesConfigUpdater
         projectBuildFile.NormalizeDirectorySeparatorsInProject();
 
         // Update binding redirects
-        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, dependencyName, newDependencyVersion);
+        var updatedConfigFiles = await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, dependencyName, newDependencyVersion);
 
         logger.Info("    Writing project file back to disk");
         await projectBuildFile.SaveAsync();
+
+        var updateResult = new DirectUpdate()
+        {
+            DependencyName = dependencyName,
+            NewVersion = NuGetVersion.Parse(newDependencyVersion),
+            UpdatedFiles = [projectPath, packagesConfigPath, .. updatedConfigFiles],
+        };
+        return [updateResult];
     }
 
     private static void RunNugetUpdate(List<string> updateArgs, List<string> restoreArgs, string projectDirectory, ILogger logger)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 using NuGet.Versioning;
 
@@ -8,8 +9,12 @@ using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Updater;
 
+[JsonDerivedType(typeof(DirectUpdate))]
+[JsonDerivedType(typeof(PinnedUpdate))]
+[JsonDerivedType(typeof(ParentUpdate))]
 public abstract record UpdateOperationBase
 {
+    public abstract string Type { get; }
     public required string DependencyName { get; init; }
     public required NuGetVersion NewVersion { get; init; }
     public required ImmutableArray<string> UpdatedFiles { get; init; }
@@ -106,18 +111,21 @@ public abstract record UpdateOperationBase
 
 public record DirectUpdate : UpdateOperationBase
 {
+    public override string Type => nameof(DirectUpdate);
     public override string GetReport() => $"Updated {DependencyName} to {NewVersion} in {string.Join("", UpdatedFiles)}";
     public sealed override string ToString() => GetString();
 }
 
 public record PinnedUpdate : UpdateOperationBase
 {
+    public override string Type => nameof(PinnedUpdate);
     public override string GetReport() => $"Pinned {DependencyName} at {NewVersion} in {string.Join("", UpdatedFiles)}";
     public sealed override string ToString() => GetString();
 }
 
 public record ParentUpdate : UpdateOperationBase, IEquatable<UpdateOperationBase>
 {
+    public override string Type => nameof(ParentUpdate);
     public required string ParentDependencyName { get; init; }
     public required NuGetVersion ParentNewVersion { get; init; }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -1,0 +1,201 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Utilities;
+
+
+namespace NuGetUpdater.Core.Updater;
+
+public abstract record UpdateOperationBase
+{
+    public required string DependencyName { get; init; }
+    public required NuGetVersion NewVersion { get; init; }
+    public required ImmutableArray<string> UpdatedFiles { get; init; }
+
+    public abstract string GetReport();
+
+    internal static string GenerateUpdateOperationReport(IEnumerable<UpdateOperationBase> updateOperations)
+    {
+        var updateMessages = updateOperations.Select(u => u.GetReport()).ToImmutableArray();
+        if (updateMessages.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var separator = "\n    ";
+        var report = $"Performed the following updates:{separator}{string.Join(separator, updateMessages.Select(m => $"- {m}"))}";
+        return report;
+    }
+
+    internal static ImmutableArray<UpdateOperationBase> NormalizeUpdateOperationCollection(string repoRootPath, IEnumerable<UpdateOperationBase> updateOperations)
+    {
+        var groupedByKindWithCombinedFiles = updateOperations
+            .GroupBy(u => (u.GetType(), u.DependencyName, u.NewVersion))
+            .Select(g =>
+            {
+                if (g.Key.Item1 == typeof(DirectUpdate))
+                {
+                    return new DirectUpdate()
+                    {
+                        DependencyName = g.Key.DependencyName,
+                        NewVersion = g.Key.NewVersion,
+                        UpdatedFiles = [.. g.SelectMany(u => u.UpdatedFiles)],
+                    } as UpdateOperationBase;
+                }
+                else if (g.Key.Item1 == typeof(PinnedUpdate))
+                {
+                    return new PinnedUpdate()
+                    {
+                        DependencyName = g.Key.DependencyName,
+                        NewVersion = g.Key.NewVersion,
+                        UpdatedFiles = [.. g.SelectMany(u => u.UpdatedFiles)],
+                    };
+                }
+                else if (g.Key.Item1 == typeof(ParentUpdate))
+                {
+                    var parentUpdate = (ParentUpdate)g.First();
+                    return new ParentUpdate()
+                    {
+                        DependencyName = g.Key.DependencyName,
+                        NewVersion = g.Key.NewVersion,
+                        UpdatedFiles = [.. g.SelectMany(u => u.UpdatedFiles)],
+                        ParentDependencyName = parentUpdate.ParentDependencyName,
+                        ParentNewVersion = parentUpdate.ParentNewVersion,
+                    };
+                }
+                else
+                {
+                    throw new NotImplementedException(g.Key.Item1.FullName);
+                }
+            })
+            .ToImmutableArray();
+        var withNormalizedAndDistinctPaths = groupedByKindWithCombinedFiles
+            .Select(u => u with { UpdatedFiles = [.. u.UpdatedFiles.Select(f => Path.GetRelativePath(repoRootPath, f).FullyNormalizedRootedPath()).Distinct(PathComparer.Instance).OrderBy(f => f, StringComparer.Ordinal)] })
+            .ToImmutableArray();
+        var uniqueUpdateOperations = withNormalizedAndDistinctPaths.Distinct(UpdateOperationBaseComparer.Instance).ToImmutableArray();
+        var ordered = uniqueUpdateOperations
+            .OrderBy(u => u.GetType().Name)
+            .ThenBy(u => u.DependencyName)
+            .ThenBy(u => u.NewVersion)
+            .ThenBy(u => u.UpdatedFiles.Length)
+            .ThenBy(u => string.Join(",", u.UpdatedFiles))
+            .ThenBy(u => u is ParentUpdate parentUpdate ? parentUpdate.ParentDependencyName : string.Empty)
+            .ThenBy(u => u is ParentUpdate parentUpdate ? parentUpdate.ParentNewVersion : u.NewVersion)
+            .ToImmutableArray();
+        return ordered;
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(DependencyName);
+        hash.Add(NewVersion);
+        hash.Add(UpdatedFiles.Length);
+        for (int i = 0; i < UpdatedFiles.Length; i++)
+        {
+            hash.Add(UpdatedFiles[i]);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    protected string GetString() => $"{GetType().Name} {{ {nameof(DependencyName)} = {DependencyName}, {nameof(NewVersion)} = {NewVersion}, {nameof(UpdatedFiles)} = {string.Join(",", UpdatedFiles)} }}";
+}
+
+public record DirectUpdate : UpdateOperationBase
+{
+    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} in {string.Join("", UpdatedFiles)}";
+    public sealed override string ToString() => GetString();
+}
+
+public record PinnedUpdate : UpdateOperationBase
+{
+    public override string GetReport() => $"Pinned {DependencyName} at {NewVersion} in {string.Join("", UpdatedFiles)}";
+    public sealed override string ToString() => GetString();
+}
+
+public record ParentUpdate : UpdateOperationBase, IEquatable<UpdateOperationBase>
+{
+    public required string ParentDependencyName { get; init; }
+    public required NuGetVersion ParentNewVersion { get; init; }
+
+    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} indirectly via {ParentDependencyName}/{ParentNewVersion} in {string.Join("", UpdatedFiles)}";
+
+    bool IEquatable<UpdateOperationBase>.Equals(UpdateOperationBase? other)
+    {
+        if (!base.Equals(other))
+        {
+            return false;
+        }
+
+        if (other is not ParentUpdate otherParentUpdate)
+        {
+            return false;
+        }
+
+        return ParentDependencyName == otherParentUpdate.ParentDependencyName
+            && ParentNewVersion == otherParentUpdate.ParentNewVersion;
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(base.GetHashCode());
+        hash.Add(ParentDependencyName);
+        hash.Add(ParentNewVersion);
+        return hash.ToHashCode();
+    }
+
+    public sealed override string ToString() => $"{GetType().Name} {{ {nameof(DependencyName)} = {DependencyName}, {nameof(NewVersion)} = {NewVersion}, {nameof(ParentDependencyName)} = {ParentDependencyName}, {nameof(ParentNewVersion)} = {ParentNewVersion}, {nameof(UpdatedFiles)} = {string.Join(",", UpdatedFiles)} }}";
+}
+
+public class UpdateOperationBaseComparer : IEqualityComparer<UpdateOperationBase>
+{
+    public static UpdateOperationBaseComparer Instance = new();
+
+    public bool Equals(UpdateOperationBase? x, UpdateOperationBase? y)
+    {
+        if (x is null && y is null)
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x.GetType() != y.GetType())
+        {
+            return false;
+        }
+
+        if (x.DependencyName != y.DependencyName ||
+            x.NewVersion != y.NewVersion ||
+            !x.UpdatedFiles.SequenceEqual(y.UpdatedFiles))
+        {
+            return false;
+        }
+
+        if (x is ParentUpdate px && y is ParentUpdate py)
+        {
+            // the `.GetType()` check above ensures this is safe
+            if (px.ParentDependencyName != py.ParentDependencyName ||
+                px.ParentNewVersion != py.ParentNewVersion)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int GetHashCode([DisallowNull] UpdateOperationBase obj) => obj.GetHashCode();
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationResult.cs
@@ -1,5 +1,8 @@
+using System.Collections.Immutable;
+
 namespace NuGetUpdater.Core.Updater;
 
 public record UpdateOperationResult : NativeResult
 {
+    public required ImmutableArray<UpdateOperationBase> UpdateOperations { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -41,10 +42,10 @@ public class UpdaterWorker : IUpdaterWorker
     // this is a convenient method for tests
     internal async Task<UpdateOperationResult> RunWithErrorHandlingAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
     {
-        UpdateOperationResult result = new(); // assumed to be ok until proven otherwise
         try
         {
-            result = await RunAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+            var result = await RunAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+            return result;
         }
         catch (Exception ex)
         {
@@ -52,13 +53,15 @@ public class UpdaterWorker : IUpdaterWorker
             {
                 workspacePath = Path.GetFullPath(Path.Join(repoRootPath, workspacePath));
             }
-            result = new()
-            {
-                Error = JobErrorBase.ErrorFromException(ex, _jobId, workspacePath),
-            };
-        }
 
-        return result;
+            var error = JobErrorBase.ErrorFromException(ex, _jobId, workspacePath);
+            var result = new UpdateOperationResult()
+            {
+                UpdateOperations = [],
+                Error = error,
+            };
+            return result;
+        }
     }
 
     public async Task<UpdateOperationResult> RunAsync(string repoRootPath, string workspacePath, string dependencyName, string previousDependencyVersion, string newDependencyVersion, bool isTransitive)
@@ -76,29 +79,43 @@ public class UpdaterWorker : IUpdaterWorker
             await GlobalJsonUpdater.UpdateDependencyAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, _logger);
         }
 
+        UpdateOperationResult result;
         var extension = Path.GetExtension(workspacePath).ToLowerInvariant();
         switch (extension)
         {
             case ".sln":
-                await RunForSolutionAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                result = await RunForSolutionAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             case ".proj":
-                await RunForProjFileAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                result = await RunForProjFileAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             case ".csproj":
             case ".fsproj":
             case ".vbproj":
-                await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                result = await RunForProjectAsync(repoRootPath, workspacePath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
                 break;
             default:
                 _logger.Info($"File extension [{extension}] is not supported.");
+                result = new UpdateOperationResult()
+                {
+                    UpdateOperations = [],
+                };
                 break;
+        }
+
+        result = result with { UpdateOperations = UpdateOperationBase.NormalizeUpdateOperationCollection(repoRootPath, result.UpdateOperations) };
+
+        if (!_experimentsManager.NativeUpdater)
+        {
+            // native updater reports the changes elsewhere
+            var updateReport = UpdateOperationBase.GenerateUpdateOperationReport(result.UpdateOperations);
+            _logger.Info(updateReport);
         }
 
         _logger.Info("Update complete.");
 
         _processedProjectPaths.Clear();
-        return new UpdateOperationResult();
+        return result;
     }
 
     internal static async Task WriteResultFile(UpdateOperationResult result, string resultOutputPath, ILogger logger)
@@ -109,7 +126,7 @@ public class UpdaterWorker : IUpdaterWorker
         await File.WriteAllTextAsync(resultOutputPath, resultJson);
     }
 
-    private async Task RunForSolutionAsync(
+    private async Task<UpdateOperationResult> RunForSolutionAsync(
         string repoRootPath,
         string solutionPath,
         string dependencyName,
@@ -118,14 +135,21 @@ public class UpdaterWorker : IUpdaterWorker
         bool isTransitive)
     {
         _logger.Info($"Running for solution [{Path.GetRelativePath(repoRootPath, solutionPath)}]");
+        var updateOperations = new List<UpdateOperationBase>();
         var projectPaths = MSBuildHelper.GetProjectPathsFromSolution(solutionPath);
         foreach (var projectPath in projectPaths)
         {
-            await RunForProjectAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+            var projectResult = await RunForProjectAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+            updateOperations.AddRange(projectResult.UpdateOperations);
         }
+
+        return new UpdateOperationResult()
+        {
+            UpdateOperations = updateOperations.ToImmutableArray(),
+        };
     }
 
-    private async Task RunForProjFileAsync(
+    private async Task<UpdateOperationResult> RunForProjFileAsync(
         string repoRootPath,
         string projFilePath,
         string dependencyName,
@@ -137,21 +161,31 @@ public class UpdaterWorker : IUpdaterWorker
         if (!File.Exists(projFilePath))
         {
             _logger.Info($"File [{projFilePath}] does not exist.");
-            return;
+            return new UpdateOperationResult()
+            {
+                UpdateOperations = [],
+            };
         }
 
+        var updateOperations = new List<UpdateOperationBase>();
         var projectFilePaths = MSBuildHelper.GetProjectPathsFromProject(projFilePath);
         foreach (var projectFullPath in projectFilePaths)
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project
             if (File.Exists(projectFullPath))
             {
-                await RunForProjectAsync(repoRootPath, projectFullPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                var projectResult = await RunForProjectAsync(repoRootPath, projectFullPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                updateOperations.AddRange(projectResult.UpdateOperations);
             }
         }
+
+        return new UpdateOperationResult()
+        {
+            UpdateOperations = updateOperations.ToImmutableArray(),
+        };
     }
 
-    private async Task RunForProjectAsync(
+    private async Task<UpdateOperationResult> RunForProjectAsync(
         string repoRootPath,
         string projectPath,
         string dependencyName,
@@ -163,21 +197,31 @@ public class UpdaterWorker : IUpdaterWorker
         if (!File.Exists(projectPath))
         {
             _logger.Info($"File [{projectPath}] does not exist.");
-            return;
+            return new UpdateOperationResult()
+            {
+                UpdateOperations = [],
+            };
         }
 
+        var updateOperations = new List<UpdateOperationBase>();
         var projectFilePaths = MSBuildHelper.GetProjectPathsFromProject(projectPath);
         foreach (var projectFullPath in projectFilePaths.Concat([projectPath]))
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project
             if (File.Exists(projectFullPath))
             {
-                await RunUpdaterAsync(repoRootPath, projectFullPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                var performedOperations = await RunUpdaterAsync(repoRootPath, projectFullPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive);
+                updateOperations.AddRange(performedOperations);
             }
         }
+
+        return new UpdateOperationResult()
+        {
+            UpdateOperations = updateOperations.ToImmutableArray(),
+        };
     }
 
-    private async Task RunUpdaterAsync(
+    private async Task<IEnumerable<UpdateOperationBase>> RunUpdaterAsync(
         string repoRootPath,
         string projectPath,
         string dependencyName,
@@ -187,22 +231,25 @@ public class UpdaterWorker : IUpdaterWorker
     {
         if (_processedProjectPaths.Contains(projectPath))
         {
-            return;
+            return [];
         }
 
         _processedProjectPaths.Add(projectPath);
 
         _logger.Info($"Updating project [{projectPath}]");
 
+        var updateOperations = new List<UpdateOperationBase>();
         var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(projectPath, ProjectHelper.PathFormat.Full);
         var packagesConfigFullPath = additionalFiles.Where(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesConfigFileName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
         if (packagesConfigFullPath is not null)
         {
-            await PackagesConfigUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, packagesConfigFullPath, _logger);
+            var packagesConfigOperations = await PackagesConfigUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, packagesConfigFullPath, _logger);
+            updateOperations.AddRange(packagesConfigOperations);
         }
 
         // Some repos use a mix of packages.config and PackageReference
-        await PackageReferenceUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, _experimentsManager, _logger);
+        var packageReferenceOperations = await PackageReferenceUpdater.UpdateDependencyAsync(repoRootPath, projectPath, dependencyName, previousDependencyVersion, newDependencyVersion, isTransitive, _experimentsManager, _logger);
+        updateOperations.AddRange(packageReferenceOperations);
 
         // Update lock file if exists
         var packagesLockFullPath = additionalFiles.Where(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesLockJsonFileName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
@@ -210,5 +257,7 @@ public class UpdaterWorker : IUpdaterWorker
         {
             await LockFileUpdater.UpdateLockFileAsync(repoRootPath, projectPath, _experimentsManager, _logger);
         }
+
+        return updateOperations;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -20,7 +20,7 @@ public class UpdaterWorker : IUpdaterWorker
     internal static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
-        Converters = { new JsonStringEnumConverter() },
+        Converters = { new JsonStringEnumConverter(), new VersionConverter() },
     };
 
     public UpdaterWorker(string jobId, ExperimentsManager experimentsManager, ILogger logger)
@@ -118,11 +118,17 @@ public class UpdaterWorker : IUpdaterWorker
         return result;
     }
 
+    internal static string Serialize(UpdateOperationResult result)
+    {
+        var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
+        return resultJson;
+    }
+
     internal static async Task WriteResultFile(UpdateOperationResult result, string resultOutputPath, ILogger logger)
     {
         logger.Info($"  Writing update result to [{resultOutputPath}].");
 
-        var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
+        var resultJson = Serialize(result);
         await File.WriteAllTextAsync(resultOutputPath, resultJson);
     }
 


### PR DESCRIPTION
This PR tracks all update operations performed and reports the results in the log.

There are several parts to this PR:

1. All update operations are classified as `DirectUpdate`, `PinnedUpdate`, or `ParentUpdate`.
   1. `DirectUpdate` is where a package version was changed, e.g., from `1.0.0` to `1.0.1`.
   2. `PinnedUpdate` is where a transitive dependency had to be pinned to a specific version.  From the user's perspective it appears that we added a new dependency.
   3. `ParentUpdate` is where a transitive dependency could be updated by updating another top-level dependency.
 2. Where we directly edit files on disk, we return the kind of update performed.
 3. When the dependency solver is invoked, it would be too messy to track all updates so instead the function `PackageReferenceUpdater.ComputeUpdateOperations()` was added.  That function takes the list of existing top-level dependencies, the list of dependencies requiring an update, and the final resolved set of dependencies.  From this it's able to determine exactly what happened.
 4. Once all update operations have been gathered, they're passed to another function, `UpdateOperationBase.NormalizeUpdateOperationCollection()` which will do several things.
    1. Group updates based on the type of the update performed and the dependency name and version.  This is necessary because several parts of the update process might individually report that they updated `Some.Package` to `1.0.1`, but separately in `project.csproj` and `Directory.Packages.props`.  This combines these into a single entity with both file paths.
    2. Dedup updates.  This is similar to the above item; separate update steps could have reported the same behavior, but we only want to report it to the user once.
    3. Path normalization, e.g., remove the first part of the path on disk to only report the path in the repo.  `C:\temp\repo\src\project.csproj` is noisy, but reporting `/src/project.csproj` is easier to read.
5. Generate a simple report of the operations performed via `UpdateOperationBase.GenerateUpdateOperationReport()`.

For item 3 above where update operations are generated from the dependency solver, I wanted to ensure I had a clean set of values so much of this PR is converting `Dependency[]` to `ImmutableArray<Dependency>` to ensure nothing was getting changed out from under me.

I manually updated 3 tests in `UpdateWorkerTests.PackageReference.cs` to verify the proper set of `UpdateOperations` was calculated.  Everything else was a targeted unit test.

For the current update process, `UpdaterWorker.cs` emits the update operation report in `RunAsync()` but only if the experiment `nuget_native_updater` is not set.  This is because we only have this information at this single point and we want to output it somewhere before it's lost.

For an end-to-end update, i.e., when `nuget_native_updater` is `true` we instead report that at the end of `RunWorker.cs` because that encompasses all update operations and we only want to report at the end.

`PackageReferenceUpdaterTests.cs` contains tests for the new `ComputeUpdateOperations()` function that is used to determine what the dependency solver did.

`UpdateOperationBaseTests.cs` verifies the generated report as well as the collect/dedup/sort/etc. operations described in item 4 above.