### PR TITLE
Excluding flutter symlink submodule from file_fetcher

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -879,7 +879,7 @@ module Dependabot
           path = T.must(info.last)
 
           # Exclude the symlink named 'flutter' by checking if it's a symlink
-          if path == 'flutter' && type == '160000'
+          if path == "flutter" && type == "160000"
             FileUtils.rm_rf(File.join(directory, dir_path, path))
             next
           end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -256,6 +256,7 @@ module Dependabot
 
         linked_path = symlinked_subpath(clean_path)
         type = "symlink" if linked_path
+        debugger if type == "symlink"
         symlink_target = clean_path.sub(T.must(linked_path), @linked_paths.dig(linked_path, :path)) if type == "symlink"
 
         DependencyFile.new(
@@ -867,6 +868,7 @@ module Dependabot
 
       sig { params(path: String).returns(T::Array[String]) }
       def find_submodules(path)
+        full_path = path
         SharedHelpers.run_shell_command(
           <<~CMD
             git -C #{path} ls-files --stage
@@ -876,6 +878,12 @@ module Dependabot
 
           type = info.first
           path = T.must(info.last)
+
+          # Exclude the symlink named 'flutter' by checking if it's a symlink
+          if path == 'flutter' && type == '160000'
+            FileUtils.rm_rf(File.join(directory, full_path, path))
+            next
+          end
 
           next path if type == DependencyFile::Mode::SUBMODULE
         end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -256,7 +256,6 @@ module Dependabot
 
         linked_path = symlinked_subpath(clean_path)
         type = "symlink" if linked_path
-        debugger if type == "symlink"
         symlink_target = clean_path.sub(T.must(linked_path), @linked_paths.dig(linked_path, :path)) if type == "symlink"
 
         DependencyFile.new(
@@ -868,7 +867,7 @@ module Dependabot
 
       sig { params(path: String).returns(T::Array[String]) }
       def find_submodules(path)
-        full_path = path
+        dir_path = path
         SharedHelpers.run_shell_command(
           <<~CMD
             git -C #{path} ls-files --stage
@@ -881,7 +880,7 @@ module Dependabot
 
           # Exclude the symlink named 'flutter' by checking if it's a symlink
           if path == 'flutter' && type == '160000'
-            FileUtils.rm_rf(File.join(directory, full_path, path))
+            FileUtils.rm_rf(File.join(directory, dir_path, path))
             next
           end
 


### PR DESCRIPTION
### What are you trying to accomplish?

When running the Flutter update command with the flutter folder present in the current directory, it causes updates to support files. Since there’s no option to exclude the flutter symlink folder during `git clone` (without updating the host repo content), I decided to remove the folder after cloning.

With these changes, I’m seeing the expected results, and no support files need to be updated when creating a pull request.

### Anything you want to highlight for special attention from reviewers?

I’ve had a discussion with @jakecoffman, and there’s an FR ticket raised about this. It mentions that the PR is not being generated, even though the log summary indicates that the PR was created.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
