### PR TITLE
Pretty print the error details in the table

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -222,7 +222,7 @@ module Dependabot
     def job_errors_summary
       if Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
         job_errors = errors.filter_map do |error_type, error_details, dependency|
-          [error_type, error_details.to_json] if dependency.nil?
+          [error_type, JSON.pretty_generate(JSON.parse(error_details.to_json))] if dependency.nil?
         end
         return if job_errors.none?
 
@@ -257,7 +257,7 @@ module Dependabot
     def dependency_error_summary
       if Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
         dependency_errors = errors.filter_map do |error_type, error_details, dependency|
-          [dependency.name, error_type, error_details.to_json] unless dependency.nil?
+          [dependency.name, error_type, JSON.pretty_generate(JSON.parse(error_details.to_json))] unless dependency.nil?
         end
         return if dependency_errors.none?
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -627,7 +627,7 @@ RSpec.describe Dependabot::Service do
           expect(service.summary)
             .to include("Details")
           expect(service.summary)
-            .to include("What is fortran doing here?!")
+            .to include("\"message\": \"What is fortran doing here?!\"")
         end
       end
     end
@@ -662,7 +662,7 @@ RSpec.describe Dependabot::Service do
           expect(service.summary)
             .to include("Error Details")
           expect(service.summary)
-            .to include("0001 Undefined error. Inform Technical Support")
+            .to include("\"message\": \"0001 Undefined error. Inform Technical Support\"")
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Pretty print the error details in the table, vs one line of json

### Anything you want to highlight for special attention from reviewers?

Example of how it currently looks:
![image](https://github.com/user-attachments/assets/f62b2976-e03a-40bc-a158-38ccd342ea82)

After this PR:
![image](https://github.com/user-attachments/assets/cbdba34c-923a-447f-8c7e-806e092791c4)

### How will you know you've accomplished your goal?

The error details are formatted.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
