### PR TITLE
Fix Bug Caused by Sorbet Typing `T.must` for `npm_and_yarn`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -340,7 +340,8 @@ module Dependabot
       def latest_resolvable_transitive_security_fix_version_with_no_unlock
         versions = T.let([], T::Array[Gem::Version])
 
-        versions.push(T.must(latest_released_version)) if latest_released_version
+        latest_released_ver = latest_released_version
+        versions.push(latest_released_ver) if latest_released_ver
 
         fix_possible = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
           versions,


### PR DESCRIPTION
**What are you trying to accomplish?**

This change addresses a bug caused by improper usage of Sorbet's `T.must` typing, which led to type mismatches. The bug was fixed by correctly handling the `T.must` constraint to prevent incorrect assumptions about nilability.

- **Why:** Ensuring proper typing is critical for maintaining code correctness, especially with Sorbet's strict type system. This fix resolves the issues with nil checking and improves type safety.

**Anything you want to highlight for special attention from reviewers?**

The solution involved adjusting the way `T.must` was used across specific functions, ensuring it aligns with expected nilability rules. I chose this approach to maintain type safety while avoiding unnecessary type assertions.

**How will you know you've accomplished your goal?**

- The issue should no longer appear in the code, and the type errors related to `T.must` should be resolved.
- The fix has been validated by running the full test suite and confirming that the typing issue is no longer present.
- All tests pass, and the bug no longer affects the functionality.

---

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.