### PR TITLE
Introduce PackageLatestVersionFinder for `npm_and_yarn` behind feature flag Part-2

### DIFF
--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -153,7 +153,7 @@ module Dependabot
         versions = filter_prerelease_versions(versions)
         versions = filter_ignored_versions(versions)
         versions = filter_out_of_range_versions(versions)
-
+        versions = apply_post_fetch_latest_versions_filter(versions)
         versions.max
       end
 

--- a/common/lib/dependabot/package/package_release.rb
+++ b/common/lib/dependabot/package/package_release.rb
@@ -22,9 +22,9 @@ module Dependabot
           downloads: T.nilable(Integer),
           url: T.nilable(String),
           package_type: T.nilable(String),
-          language: T.nilable(Dependabot::Package::PackageLanguage)
-        )
-          .void
+          language: T.nilable(Dependabot::Package::PackageLanguage),
+          details: T::Hash[String, T.untyped]
+        ).void
       end
       def initialize(
         version:,
@@ -35,7 +35,8 @@ module Dependabot
         downloads: nil,
         url: nil,
         package_type: nil,
-        language: nil
+        language: nil,
+        details: {}
       )
         @version = T.let(version, Dependabot::Version)
         @released_at = T.let(released_at, T.nilable(Time))
@@ -46,6 +47,7 @@ module Dependabot
         @url = T.let(url, T.nilable(String))
         @package_type = T.let(package_type, T.nilable(String))
         @language = T.let(language, T.nilable(Dependabot::Package::PackageLanguage))
+        @details = T.let(details, T::Hash[String, T.untyped])
       end
 
       sig { returns(Dependabot::Version) }
@@ -74,6 +76,9 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Package::PackageLanguage)) }
       attr_reader :language
+
+      sig { returns(T::Hash[String, T.untyped]) }
+      attr_reader :details
 
       sig { returns(T::Boolean) }
       def yanked?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -184,7 +184,8 @@ module Dependabot
               latest: latest_version.to_s == version,
               url: package_version_url(version),
               package_type: package_type,
-              language: package_language(details)
+              language: package_language(details),
+              details: details
             )
           end.sort_by(&:version).reverse
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -265,7 +265,8 @@ module Dependabot
         def possible_releases(filter_ignored: true)
           releases = possible_previous_releases.reject(&:yanked?)
 
-          releases = filter_releases(releases) if filter_ignored
+          return filter_releases(releases) if filter_ignored
+
           releases
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -63,6 +63,34 @@ module Dependabot
           @package_details
         end
 
+        sig do
+          returns(T.nilable(Dependabot::Version))
+        end
+        def latest_version_from_registry
+          fetch_latest_version(language_version: nil)
+        end
+
+        sig do
+          override.params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+                  .returns(T.nilable(Dependabot::Version))
+        end
+        def latest_version_with_no_unlock(language_version: nil)
+          with_custom_registry_rescue do
+            return unless valid_npm_details?
+            return version_from_dist_tags if specified_dist_tag_requirement?
+
+            super
+          end
+        end
+
+        sig do
+          params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def lowest_security_fix_version(language_version: nil)
+          fetch_lowest_security_fix_version(language_version: language_version)
+        end
+
         # This method is for latest_version_from_registry
         sig do
           params(language_version: T.nilable(T.any(String, Dependabot::Version)))
@@ -79,13 +107,6 @@ module Dependabot
 
             super
           end
-        end
-
-        sig do
-          returns(T.nilable(Dependabot::Version))
-        end
-        def latest_version_from_registry
-          fetch_latest_version(language_version: nil)
         end
 
         sig do
@@ -147,8 +168,9 @@ module Dependabot
         end
 
         sig do
-          override.params(language_version: T.nilable(T.any(String, Dependabot::Version)))
-                  .returns(T.nilable(Dependabot::Version))
+          override
+            .params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T.nilable(Dependabot::Version))
         end
         def fetch_lowest_security_fix_version(language_version:) # rubocop:disable Lint/UnusedMethodArgument
           with_custom_registry_rescue do
@@ -161,40 +183,21 @@ module Dependabot
                 possible_versions(filter_ignored: false)
               end
 
-            secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
-              T.unsafe(secure_versions),
-              security_advisories
-            )
+            secure_versions =
+              Dependabot::UpdateCheckers::VersionFilters
+              .filter_vulnerable_versions(
+                T.unsafe(secure_versions),
+                security_advisories
+              )
             secure_versions = filter_ignored_versions(secure_versions)
             secure_versions = filter_lower_versions(secure_versions)
 
             # Apply lazy filtering for yanked versions (min or max logic)
-            secure_versions = lazy_filter_yanked_versions_by_min_max(secure_versions, check_max: true)
+            secure_versions = lazy_filter_yanked_versions_by_min_max(secure_versions, check_max: false)
 
             # Return the lowest non-yanked version
             secure_versions.max
           end
-        end
-
-        sig do
-          override.params(language_version: T.nilable(T.any(String, Dependabot::Version)))
-                  .returns(T.nilable(Dependabot::Version))
-        end
-        def latest_version_with_no_unlock(language_version: nil)
-          with_custom_registry_rescue do
-            return unless valid_npm_details?
-            return version_from_dist_tags if specified_dist_tag_requirement?
-
-            super
-          end
-        end
-
-        sig do
-          params(language_version: T.nilable(T.any(String, Dependabot::Version)))
-            .returns(T.nilable(Dependabot::Version))
-        end
-        def lowest_security_fix_version(language_version: nil)
-          fetch_lowest_security_fix_version(language_version: language_version)
         end
 
         sig do
@@ -217,23 +220,53 @@ module Dependabot
 
         sig do
           params(filter_ignored: T::Boolean)
-            .returns(T::Array[Dependabot::Version])
+            .returns(T::Array[T::Array[T.untyped]])
         end
         def possible_versions_with_details(filter_ignored: true)
-          versions = possible_previous_releases_with_details
-                     .reject(&:yanked?).map(&:version).reverse
+          possible_releases(filter_ignored: filter_ignored).map { |r| [r.version, r.details] }
+        end
 
-          return filter_ignored_versions(versions) if filter_ignored
+        sig do
+          params(releases: T::Array[Dependabot::Package::PackageRelease])
+            .returns(T::Array[Dependabot::Package::PackageRelease])
+        end
+        def filter_releases(releases)
+          filtered =
+            releases
+            .reject do |release|
+              ignore_requirements.any? { |r| r.satisfied_by?(release.version) }
+            end
+          if @raise_on_ignored &&
+             filter_lower_releases(filtered).empty? &&
+             filter_lower_releases(releases).any?
+            raise Dependabot::AllVersionsIgnored
+          end
 
-          versions
+          if releases.count > filtered.count
+            Dependabot.logger.info("Filtered out #{releases.count - filtered.count} ignored versions")
+          end
+          filtered
+        end
+
+        sig do
+          params(releases: T::Array[Dependabot::Package::PackageRelease])
+            .returns(T::Array[Dependabot::Package::PackageRelease])
+        end
+        def filter_lower_releases(releases)
+          return releases unless dependency.numeric_version
+
+          releases.select { |release| release.version > dependency.numeric_version }
         end
 
         sig do
           params(filter_ignored: T::Boolean)
-            .returns(T::Array[Dependabot::Version])
+            .returns(T::Array[Dependabot::Package::PackageRelease])
         end
-        def possible_versions_from_release(filter_ignored: true)
-          possible_versions_with_details(filter_ignored: filter_ignored)
+        def possible_releases(filter_ignored: true)
+          releases = possible_previous_releases.reject(&:yanked?)
+
+          releases = filter_releases(releases) if filter_ignored
+          releases
         end
 
         sig do
@@ -241,11 +274,11 @@ module Dependabot
             .returns(T::Array[Gem::Version])
         end
         def possible_versions(filter_ignored: true)
-          possible_versions_from_release(filter_ignored: filter_ignored)
+          possible_releases(filter_ignored: filter_ignored).map(&:version)
         end
 
         sig { returns(T::Array[Dependabot::Package::PackageRelease]) }
-        def possible_previous_releases_with_details
+        def possible_previous_releases
           (package_details&.releases || [])
             .reject do |r|
             r.version.prerelease? && !related_to_current_pre?(T.unsafe(r.version))
@@ -255,7 +288,7 @@ module Dependabot
 
         sig { returns(T::Array[[Dependabot::Version, T::Hash[String, T.nilable(String)]]]) }
         def possible_previous_versions_with_details
-          possible_previous_releases_with_details.map do |r|
+          possible_previous_releases.map do |r|
             [r.version, { "deprecated" => r.yanked? ? "yanked" : nil }]
           end
         end
@@ -468,8 +501,11 @@ module Dependabot
               possible_versions(filter_ignored: false)
             end
 
-          secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions,
-                                                                                                  security_advisories)
+          secure_versions = Dependabot::UpdateCheckers::VersionFilters
+                            .filter_vulnerable_versions(
+                              secure_versions,
+                              security_advisories
+                            )
           secure_versions = filter_ignored_versions(secure_versions)
           secure_versions = filter_lower_versions(secure_versions)
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
   let(:enable_corepack_for_npm_and_yarn) { true }
 
   # Variable to control the enabling feature flag for the cooldown
-  let(:enable_cooldown_for_npm_and_yarn) { false }
+  let(:enable_cooldown_for_npm_and_yarn) { true }
 
   before do
     stub_request(:get, react_dom_registry_listing_url)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   let(:enable_corepack_for_npm_and_yarn) { true }
 
   # Variable to control the enabling feature flag for the cooldown
-  let(:enable_cooldown_for_npm_and_yarn) { false }
+  let(:enable_cooldown_for_npm_and_yarn) { true }
 
   before do
     stub_request(:get, registry_listing_url)
@@ -371,15 +371,27 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
     let(:dependency_files) { project_dependency_files("npm6/no_lockfile") }
 
-    it "delegates to LatestVersionFinder" do
-      expect(described_class::LatestVersionFinder).to receive(:new).with(
-        dependency: dependency,
-        credentials: credentials,
-        dependency_files: dependency_files,
-        ignored_versions: ignored_versions,
-        raise_on_ignored: false,
-        security_advisories: security_advisories
-      ).and_call_original
+    it "delegates to (Package)LatestVersionFinder" do
+      if Dependabot::Experiments.enabled?(:enable_cooldown_for_npm_and_yarn)
+        expect(described_class::PackageLatestVersionFinder).to receive(:new).with(
+          dependency: dependency,
+          credentials: credentials,
+          dependency_files: dependency_files,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: false,
+          security_advisories: security_advisories,
+          cooldown_options: nil
+        ).and_call_original
+      else
+        expect(described_class::LatestVersionFinder).to receive(:new).with(
+          dependency: dependency,
+          credentials: credentials,
+          dependency_files: dependency_files,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: false,
+          security_advisories: security_advisories
+        ).and_call_original
+      end
 
       expect(checker.latest_version).to eq(Dependabot::NpmAndYarn::Version.new("1.7.0"))
     end
@@ -832,14 +844,26 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       let(:req_string) { "^1.0.0" }
 
       it "delegates to LatestVersionFinder" do
-        expect(described_class::LatestVersionFinder).to receive(:new).with(
-          dependency: dependency,
-          credentials: credentials,
-          dependency_files: dependency_files,
-          ignored_versions: ignored_versions,
-          raise_on_ignored: false,
-          security_advisories: security_advisories
-        ).and_call_original
+        if Dependabot::Experiments.enabled?(:enable_cooldown_for_npm_and_yarn)
+          expect(described_class::PackageLatestVersionFinder).to receive(:new).with(
+            dependency: dependency,
+            credentials: credentials,
+            dependency_files: dependency_files,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: false,
+            security_advisories: security_advisories,
+            cooldown_options: nil
+          ).and_call_original
+        else
+          expect(described_class::LatestVersionFinder).to receive(:new).with(
+            dependency: dependency,
+            credentials: credentials,
+            dependency_files: dependency_files,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: false,
+            security_advisories: security_advisories
+          ).and_call_original
+        end
 
         expect(checker.latest_resolvable_version_with_no_unlock)
           .to eq(Dependabot::NpmAndYarn::Version.new("1.7.0"))
@@ -969,13 +993,19 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       dummy_version_resolver =
         instance_double(described_class::VersionResolver)
 
+      latest_version_finder = if Dependabot::Experiments.enabled?(:enable_cooldown_for_npm_and_yarn)
+                                described_class::PackageLatestVersionFinder
+                              else
+                                described_class::LatestVersionFinder
+                              end
+
       expect(described_class::VersionResolver)
         .to receive(:new)
         .with(
           dependency: dependency,
           credentials: credentials,
           dependency_files: dependency_files,
-          latest_version_finder: described_class::LatestVersionFinder,
+          latest_version_finder: latest_version_finder,
           latest_allowable_version: updated_version,
           repo_contents_path: nil,
           dependency_group: nil,
@@ -1380,13 +1410,19 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       dummy_version_resolver =
         instance_double(described_class::VersionResolver)
 
+      latest_version_finder = if Dependabot::Experiments.enabled?(:enable_cooldown_for_npm_and_yarn)
+                                described_class::PackageLatestVersionFinder
+                              else
+                                described_class::LatestVersionFinder
+                              end
+
       expect(described_class::VersionResolver)
         .to receive(:new)
         .with(
           dependency: dependency,
           credentials: credentials,
           dependency_files: dependency_files,
-          latest_version_finder: described_class::LatestVersionFinder,
+          latest_version_finder: latest_version_finder,
           latest_allowable_version: Dependabot::NpmAndYarn::Version.new("1.7.0"),
           repo_contents_path: nil,
           dependency_group: nil,


### PR DESCRIPTION
### What are you trying to accomplish?

This PR ensures that the cooldown logic is properly applied in the npm_and_yarn ecosystem's Latest Version Finder by passing the cooldown parameter from the abstract UpdateChecker. Additionally, the npm_and_yarn Latest Version Finder is refactored to extend the generic Package Latest Version Finder, aligning with other ecosystems and improving consistency.

The changes are part of the task to standardize the `npm_and_yarn` client, generic latest version finder, and cooldown filtering for Dependabot. This update address the issue https://github.com/dependabot/dependabot-core/issues/3651 where the goal is to improve version filtering by applying cooldown settings and aligning with the broader implementation across ecosystems.

This PR is a continuation of the following PR:
-  https://github.com/dependabot/dependabot-core/pull/11900

### Anything you want to highlight for special attention from reviewers?

This PR combines logic related to both cooldown handling and refactoring to use a more generic version finder. The major points to review include:
- Ensure the cooldown filtering is applied correctly when selecting the latest version.
- Verify the `npm_and_yarn` version finder now inherits from the generic `PackageLatestVersionFinder` and behaves as expected.
- Review the implementation and usage of cooldown parameters across both the abstract and ecosystem-specific classes.
- The feature is behind feature flag, `enable_cooldown_for_npm_and_yarn`

### How will you know you've accomplished your goal?

- The feature flag-based cooldown logic should be applied consistently across `npm_and_yarn` version filtering.
- Tests related to version filtering and cooldown behavior should pass successfully without regressions.
- Code changes should align with the structure of other package ecosystems like pip, demonstrating the application of similar cooldown filtering logic.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
