### PR TITLE
change rate limiting error in nuget updater

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1247,6 +1247,83 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         );
     }
 
+    [Fact]
+    public async Task ReportsPrivateSourceBadResponseFailure()
+    {
+        static (int, string) TestHttpHandler(string uriString)
+        {
+            var uri = new Uri(uriString, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                // initial request is good
+                "/index.json" => (200, $$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/query",
+                                "@type": "SearchQueryService"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """),
+                // all other requests are unauthorized
+                _ => (429, "{}"),
+            };
+        }
+        // override various nuget locations
+        using var tempDir = new TemporaryDirectory();
+        using var _ = new TemporaryEnvironment(
+        [
+            ("NUGET_PACKAGES", Path.Combine(tempDir.DirectoryPath, "NUGET_PACKAGES")),
+            ("NUGET_HTTP_CACHE_PATH", Path.Combine(tempDir.DirectoryPath, "NUGET_HTTP_CACHE_PATH")),
+            ("NUGET_SCRATCH", Path.Combine(tempDir.DirectoryPath, "NUGET_SCRATCH")),
+            ("NUGET_PLUGINS_CACHE_PATH", Path.Combine(tempDir.DirectoryPath, "NUGET_PLUGINS_CACHE_PATH")),
+        ]);
+        using var http = TestHttpServer.CreateTestStringServer(TestHttpHandler);
+        var experimentsManager = new ExperimentsManager() { UseDirectDiscovery = true };
+        await TestDiscoveryAsync(
+            experimentsManager: experimentsManager,
+            workspacePath: "",
+            files:
+            [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.2.3" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <clear />
+                        <add key="private_feed" value="{http.BaseUrl.TrimEnd('/')}/index.json" allowInsecureConnections="true" />
+                      </packageSources>
+                    </configuration>
+                    """),
+            ],
+            expectedResult: new()
+            {
+                Error = new PrivateSourceBadResponse([$"{http.BaseUrl.TrimEnd('/')}/index.json"]),
+                Path = "",
+                Projects = [],
+            }
+        );
+    }
+
     [LinuxOnlyFact]
     public async Task DiscoverySucceedsWhenNoWindowsAppRefPackageCanBeFound()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -651,6 +651,14 @@ public class SerializationTests
 
         yield return
         [
+            new PrivateSourceBadResponse(["url1", "url2"]),
+            """
+            {"data":{"error-type":"private_source_bad_response","error-details":{"source":"(url1|url2)"}}}
+            """
+        ];
+
+        yield return
+        [
             new PullRequestExistsForLatestVersion("dep", "ver"),
             """
             {"data":{"error-type":"pull_request_exists_for_latest_version","error-details":{"dependency-name":"dep","dependency-version":"ver"}}}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -30,6 +30,7 @@ public abstract record JobErrorBase : MessageBase
             {
                 HttpStatusCode.Unauthorized or
                 HttpStatusCode.Forbidden => new PrivateSourceAuthenticationFailure(NuGetContext.GetPackageSourceUrls(currentDirectory)),
+                HttpStatusCode.TooManyRequests => new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory)),
                 _ => new UnknownError(ex, jobId),
             },
             InvalidProjectFileException invalidProjectFile => new DependencyFileNotParseable(invalidProjectFile.ProjectFile),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceBadResponse.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceBadResponse.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PrivateSourceBadResponse : JobErrorBase
+{
+    public PrivateSourceBadResponse(string[] urls)
+        : base("private_source_bad_response")
+    {
+        Details["source"] = $"({string.Join("|", urls)})";
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -968,6 +968,7 @@ internal static partial class MSBuildHelper
         ThrowOnMissingFile(output);
         ThrowOnMissingPackages(output);
         ThrowOnUpdateNotPossible(output);
+        ThrowOnRateLimitExceeded(output);
     }
 
     private static void ThrowOnUnauthenticatedFeed(string stdout)
@@ -982,6 +983,19 @@ internal static partial class MSBuildHelper
         if (unauthorizedMessageSnippets.Any(stdout.Contains))
         {
             throw new HttpRequestException(message: stdout, inner: null, statusCode: System.Net.HttpStatusCode.Unauthorized);
+        }
+    }
+
+    private static void ThrowOnRateLimitExceeded(string stdout)
+    {
+        var rateLimitMessageSnippets = new string[]
+        {
+            "Response status code does not indicate success: 429",
+            "429 (Too Many Requests)",
+        };
+        if (rateLimitMessageSnippets.Any(stdout.Contains))
+        {
+            throw new HttpRequestException(message: stdout, inner: null, statusCode: System.Net.HttpStatusCode.TooManyRequests);
         }
     }
 

--- a/nuget/lib/dependabot/nuget/native_helpers.rb
+++ b/nuget/lib/dependabot/nuget/native_helpers.rb
@@ -348,6 +348,8 @@ module Dependabot
           raise BadRequirementError, T.let(error_details.fetch("message"), String)
         when "private_source_authentication_failure"
           raise PrivateSourceAuthenticationFailure, T.let(error_details.fetch("source"), String)
+        when "private_source_bad_response"
+          raise PrivateSourceBadResponse, T.let(error_details.fetch("source"), String)
         when "update_not_possible"
           raise UpdateNotPossible, T.let(error_details.fetch("dependencies"), T::Array[String])
         when "unknown_error"

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
           Error: {
             "error-type": "private_source_bad_response",
             "error-details": {
-              message: "some-url"
+              source: "some-url"
             }
           }
         }.to_json

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -244,6 +244,20 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
       it { is_expected.to be_a Dependabot::PrivateSourceAuthenticationFailure }
     end
 
+    context "when a feed rate limit is reached" do
+      let(:json) do
+        {
+          Error: {
+            "error-type": "private_source_bad_response",
+            "error-details": {
+              message: "some-url",
+            }
+          }
+        }.to_json
+      end
+      it { is_expected.to be_a Dependabot::PrivateSourceBadResponse }
+    end
+
     context "when an update is not possible" do
       let(:json) do
         {

--- a/nuget/spec/dependabot/nuget/native_helpers_spec.rb
+++ b/nuget/spec/dependabot/nuget/native_helpers_spec.rb
@@ -250,11 +250,12 @@ RSpec.describe Dependabot::Nuget::NativeHelpers do
           Error: {
             "error-type": "private_source_bad_response",
             "error-details": {
-              message: "some-url",
+              message: "some-url"
             }
           }
         }.to_json
       end
+
       it { is_expected.to be_a Dependabot::PrivateSourceBadResponse }
     end
 


### PR DESCRIPTION
Currently in the nuget updater if a feed starts to return 429s and we are unable to restore packages it gets reported as a `dependency_file_not_found error` 

This PR changes these to get reported as `private_source_bad_response`.