### PR TITLE
Update docker version to include digest if applicable

### DIFF
--- a/docker/lib/dependabot/shared/shared_file_parser.rb
+++ b/docker/lib/dependabot/shared/shared_file_parser.rb
@@ -33,7 +33,13 @@ module Dependabot
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T.nilable(String)) }
       def version_from(parsed_line)
-        parsed_line.fetch("tag") || parsed_line.fetch("digest")
+        return nil unless parsed_line.fetch("tag") || parsed_line.fetch("digest")
+
+        if parsed_line.fetch("tag") && parsed_line.fetch("digest")
+          "#{parsed_line.fetch('tag')}@sha256:#{parsed_line.fetch('digest')}"
+        else
+          parsed_line.fetch("tag") || "sha256:#{parsed_line.fetch('digest')}"
+        end
       end
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T::Hash[String, T.nilable(String)]) }
@@ -42,7 +48,7 @@ module Dependabot
 
         source[:registry] = parsed_line.fetch("registry") if parsed_line.fetch("registry")
         source[:tag] = parsed_line.fetch("tag") if parsed_line.fetch("tag")
-        source[:digest] = parsed_line.fetch("digest") if parsed_line.fetch("digest")
+        source[:digest] = "sha256:#{parsed_line.fetch('digest')}" if parsed_line.fetch("digest")
 
         source
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -158,14 +158,14 @@ RSpec.describe Dependabot::Docker::FileParser do
             requirement: nil,
             groups: [],
             file: "Dockerfile",
-            source: { digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+            source: { digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
           }]
         end
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+          expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "Dockerfile",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -284,7 +284,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::Docker::FileParser do
                   groups: [],
                   file: "Dockerfile",
                   source: {
-                    digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                    digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                             "fc38288cf73aa07485005"
                   }
                 }]
@@ -344,7 +344,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("ubuntu")
-                expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                                                  "fc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
@@ -380,14 +380,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "Dockerfile",
           source: {
             tag: "12.04.5",
-            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end
@@ -831,7 +831,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "digest.yaml",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -840,7 +840,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -873,14 +873,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "digest_and_tag.yaml",
           source: {
             tag: "12.04.5",
-            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -380,7 +380,8 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                                         "fc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
@@ -873,7 +874,8 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                                         "fc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],


### PR DESCRIPTION
### What are you trying to accomplish?

Update digest handling to include sha256 prefix in source digest and add the digest to the version response if present.

### Anything you want to highlight for special attention from reviewers?

Tags and digests are both part of a "version" for container images. If a digest is present, it takes precedence for specifying the image contents regardless of the tag present.

So, for scenarios where both the tag and digest are both present, then `version` should be in the form of `tag@sha256:digest`

The current approach only returns the tag for `version` even if a digest is present. Only returning the digest (without `sha256:`) if no tag was present.

### How will you know you've accomplished your goal?

Updated specs to check for it.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.