### PR TITLE
Removing `docker_tag_component_comparison` feature flag

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -167,10 +167,6 @@ module Dependabot
 
       sig { params(original_tag: Dependabot::Docker::Tag).returns(T::Array[Dependabot::Docker::Tag]) }
       def comparable_tags_from_registry(original_tag)
-        unless Experiments.enabled?(:docker_tag_component_comparison)
-          return tags_from_registry.select { |tag| tag.comparable_to?(original_tag) }
-        end
-
         common_components = identify_common_components(tags_from_registry)
         original_components = extract_tag_components(original_tag.name, common_components)
         Dependabot.logger.info("Original tag components: #{original_components.join(',')}")

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1433,44 +1433,28 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
       end
 
-      context "with feature flag" do
+      it { is_expected.to eq("4-apache-202502070602") }
+
+      context "with multiple components to match" do
+        let(:version) { "3.3-nginx-alpine-202209221209" }
+
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:docker_tag_component_comparison).and_return(true)
-        end
-
-        it { is_expected.to eq("4-apache-202502070602") }
-
-        context "with multiple components to match" do
-          let(:version) { "3.3-nginx-alpine-202209221209" }
-
-          before do
-            stub_request(:head, repo_url + "manifests/4.11-nginx-alpine-202502070602")
-              .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
-            stub_request(:head, repo_url + "manifests/4-nginx-alpine-202502070602")
-              .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
-          end
-
-          it { is_expected.to eq("4-nginx-alpine-202502070602") }
-        end
-
-        context "when components are in a different order" do
-          before do
-            stub_request(:head, repo_url + "manifests/4-202502070602-apache")
-              .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
-          end
-
-          it { is_expected.to eq("4-apache-202502070602") }
-        end
-      end
-
-      context "without feature flag" do
-        before do
+          stub_request(:head, repo_url + "manifests/4.11-nginx-alpine-202502070602")
+            .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
           stub_request(:head, repo_url + "manifests/4-nginx-alpine-202502070602")
             .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:docker_tag_component_comparison).and_return(false)
         end
 
         it { is_expected.to eq("4-nginx-alpine-202502070602") }
+      end
+
+      context "when components are in a different order" do
+        before do
+          stub_request(:head, repo_url + "manifests/4-202502070602-apache")
+            .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
+        end
+
+        it { is_expected.to eq("4-apache-202502070602") }
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Removing feature flag `docker_tag_component_comparison` from the codebase

**closes: https://github.com/dependabot/dependabot-core/issues/8648**

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

n/a

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Dependabot will use image component comparison to select images to update to 

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
