### PR TITLE
Don't coerce `nil` to `""` if no non-vulnerable version found

### DIFF
--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -69,7 +69,7 @@ module Dependabot
           (checker.lowest_resolvable_security_fix_version ||
            checker.dependency.version)&.to_s
         lowest_non_vulnerable_version =
-          checker.lowest_security_fix_version.to_s
+          checker.lowest_security_fix_version&.to_s
         conflicting_dependencies = checker.conflicting_dependencies
 
         Dependabot.logger.info(


### PR DESCRIPTION
As explained in https://github.com/dependabot/dependabot-core/issues/11948, we shouldn't be coercing this to an empty string if it's nil. 

Among other things, a later log line checks if it's nil and so an empty string results in a confusing error message.

It looks like this bug originally crept in here:
* https://github.com/dependabot/dependabot-core/pull/9929#discussion_r2023849120

Fix: https://github.com/dependabot/dependabot-core/issues/11948

Related:
* https://github.com/dependabot/dependabot-core/pull/11950