### PR TITLE
Handle when the version is an empty string

### DIFF
--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -148,10 +148,10 @@ module Dependabot
 
       sig { params(lowest_non_vulnerable_version: T.nilable(String)).returns(String) }
       def earliest_fixed_version_message(lowest_non_vulnerable_version)
-        if lowest_non_vulnerable_version
+        if lowest_non_vulnerable_version && !lowest_non_vulnerable_version.empty?
           "The earliest fixed version is #{lowest_non_vulnerable_version}."
         else
-          "Dependabot could not find a non-vulnerable version"
+          "Dependabot could not find an allowed non-vulnerable version"
         end
       end
 


### PR DESCRIPTION
As explained in https://github.com/dependabot/dependabot-core/issues/11948, we need to handle when this is an empty string, or we get a confusing error message.

Fix: https://github.com/dependabot/dependabot-core/issues/11948

Related:
* https://github.com/dependabot/dependabot-core/pull/11949