### PR TITLE
Ensure `.core-bash_history` file exists when debugging with Dependabot CLI

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -111,7 +111,7 @@ fi
 
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot"
-touch .core-bash_history
+touch .core-bash_history # allow bash history to persist across invocations
 mkdir -p dry-run tmp
 docker run --rm -ti \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \

--- a/script/dependabot
+++ b/script/dependabot
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+touch .core-bash_history # allow bash history to persist across invocations
+
 dependabot \
   -v "$(pwd)"/.core-bash_history:/home/dependabot/.bash_history \
   -v "$(pwd)"/updater/bin:/home/dependabot/dependabot-updater/bin \


### PR DESCRIPTION
I was trying to run `script/dependabot` within a Codespace when I got the following error:

    @jeffwidman ➜ /workspaces/dependabot-core (main ✗) $ script/dependabot update maven dsp-testing/test-dependabot-updates-9127 --debug
    cli | 2025/04/01 21:56:02 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2025/04/01 21:56:03 image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest is already up to date
    cli | 2025/04/01 21:56:03 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:113d9623e8852177b0027bd1c313bd1c1637058e4079fda9328b735cb4eabbf7
    cli | 2025/04/01 21:56:03 image ghcr.io/dependabot/dependabot-updater-maven is already up to date
    cli | 2025/04/01 21:56:03 using image ghcr.io/dependabot/dependabot-updater-maven at sha256:0126eb8f76eb69aeb72f6c50791d76c4bfe0993a411b70689a830ddc6592c86b
    cli | 2025/04/01 21:56:09 updater failure: failed to create updater container: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /workspaces/dependabot-core/.core-bash_history

The script is expecting to mount `.core-bash_history` but that file didn't exist so it crashed.

The intent of this file is to provide a persistent bash history, so `touch` is all we need. For more background see:
* https://github.com/dependabot/dependabot-core/pull/1896