### PR TITLE
Apply Cooldown for Release Tags in `npm_and_yarn` Ecosystem

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -326,12 +326,16 @@ module Dependabot
                                    .find { |r| dist_tags.include?(r[:requirement]) }
                                    &.fetch(:requirement)
 
+          releases = package_details&.releases
+
+          releases = filter_by_cooldown(releases) if releases
+
           if dist_tag_req
-            release = find_dist_tag_release(dist_tag_req, package_details&.releases)
+            release = find_dist_tag_release(dist_tag_req, releases)
             return release.version if release && !release.yanked?
           end
 
-          latest_release = find_dist_tag_release("latest", package_details&.releases)
+          latest_release = find_dist_tag_release("latest", releases)
 
           return nil unless latest_release
 
@@ -355,7 +359,7 @@ module Dependabot
 
           return nil unless dist_tag_version && !dist_tag_version.empty?
 
-          release = package_details&.releases&.find { |r| r.version == Version.new(dist_tag_version) }
+          release = releases.find { |r| r.version == Version.new(dist_tag_version) }
 
           release
         end


### PR DESCRIPTION
### What are you trying to accomplish?

This change applies cooldown logic for release tags in the `npm_and_yarn` ecosystem. It ensures that the cooldown behavior is respected when determining the latest version based on release tags. The goal is to improve the update checker's handling of release versions and integrate cooldown filtering, aligning the behavior with other ecosystems that already use this feature.

### Anything you want to highlight for special attention from reviewers?

- The focus is on applying cooldown behavior for release tags in the `npm_and_yarn` ecosystem.
- The code changes include modifications to the `LatestVersionFinder` and related methods to support cooldown tags.
- The feature flag for cooldown control has been integrated into the version selection process.

### How will you know you've accomplished your goal?

- Once merged, the cooldown behavior for release tags will be successfully applied, allowing the update checker to respect cooldown logic when selecting release versions.
- Tests will verify that the cooldown behavior is correctly applied for release tags in the `npm_and_yarn` ecosystem.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.