### PR TITLE
Remove Incorrect Bundler Import in Common to Fix PackageLatestVersionFinder Issue

### DIFF
--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -10,7 +10,6 @@ require "dependabot/security_advisory"
 require "dependabot/dependency"
 require "dependabot/update_checkers/version_filters"
 require "dependabot/registry_client"
-require "dependabot/bundler"
 require "dependabot/package/package_details"
 require "dependabot/package/release_cooldown_options"
 


### PR DESCRIPTION
### What are you trying to accomplish?

This change removes an incorrect import of Bundler from the `common` module, which was causing issues in the `PackageLatestVersionFinder` class. The import was mistakenly included, leading to errors, and its removal resolves these issues.

### Anything you want to highlight for special attention from reviewers?

The main change is the removal of the unnecessary Bundler import in the `common` module. This should be verified to ensure no unintended side effects occur due to the removal.

### How will you know you've accomplished your goal?

The issue causing errors related to the `PackageLatestVersionFinder` should be resolved. After removing the import, the functionality should return to normal without any issues arising from the incorrect import. 

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.