### PR TITLE
Adding date, time and symbol to permitted classes for helm yaml parsing

### DIFF
--- a/helm/lib/dependabot/helm/file_parser.rb
+++ b/helm/lib/dependabot/helm/file_parser.rb
@@ -78,7 +78,7 @@ module Dependabot
       sig { params(dependency_set: DependencySet).void }
       def parse_chart_yaml_files(dependency_set)
         helm_chart_files.each do |chart_file|
-          yaml = YAML.safe_load(T.must(chart_file.content), aliases: true)
+          yaml = YAML.safe_load(T.must(chart_file.content), aliases: true, permitted_classes: [Date, Time, Symbol])
           next unless yaml.is_a?(Hash)
 
           parse_dependencies(yaml, chart_file, dependency_set) if yaml["dependencies"].is_a?(Array)
@@ -88,7 +88,7 @@ module Dependabot
       sig { params(dependency_set: DependencySet).void }
       def parse_values_yaml_files(dependency_set)
         helm_values_files.each do |values_file|
-          yaml = YAML.safe_load(T.must(values_file.content), aliases: true)
+          yaml = YAML.safe_load(T.must(values_file.content), aliases: true, permitted_classes: [Date, Time, Symbol])
           next unless yaml.is_a?(Hash)
 
           find_images_in_hash(yaml).each do |image_details|

--- a/helm/spec/dependabot/helm/file_parser_spec.rb
+++ b/helm/spec/dependabot/helm/file_parser_spec.rb
@@ -135,6 +135,38 @@ RSpec.describe Dependabot::Helm::FileParser do
         end
       end
     end
+
+    describe "YAML.safe_load with permitted_classes" do
+      context "with Chart.yaml" do
+        subject(:dependency) { dependencies.first }
+
+        let(:helmfile_fixture_name) { "chart_permitted_classes.yaml" }
+
+        it "is able to parse yaml with date, time, and symbol" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("redis")
+          expect(dependency.version).to eq("17.11.3")
+        end
+      end
+
+      context "with values.yaml" do
+        subject(:dependency) { dependencies.first }
+
+        let(:helmfile_fixture_name) { "values_permitted_classes.yaml" }
+        let(:helmfile) do
+          Dependabot::DependencyFile.new(
+            name: "values.yaml",
+            content: helmfile_body
+          )
+        end
+
+        it "is able to parse yaml with date, time, and symbol" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("nginx")
+          expect(dependency.version).to eq("1.25.3")
+        end
+      end
+    end
   end
 
   describe "version_from with environment variables" do

--- a/helm/spec/fixtures/helm/v3/chart_permitted_classes.yaml
+++ b/helm/spec/fixtures/helm/v3/chart_permitted_classes.yaml
@@ -1,0 +1,11 @@
+# Chart.yaml - Main chart definition
+apiVersion: v2
+name: example-service
+version: 0.1.0
+dependencies:
+  - name: redis
+    date: 2023-01-01
+    time: 2023-01-01 12:00:00
+    symbol: :test_symbol
+    version: 17.11.3
+    repository: https://charts.bitnami.com/bitnami

--- a/helm/spec/fixtures/helm/v3/values_permitted_classes.yaml
+++ b/helm/spec/fixtures/helm/v3/values_permitted_classes.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: nginx
+  date: 2023-01-01
+  time: 2023-01-01 12:00:00
+  symbol: :test_symbol
+  pullPolicy: IfNotPresent
+  tag: "1.25.3"
+


### PR DESCRIPTION
### What are you trying to accomplish?

Adding `Date`, `Time`, and `Symbol` to the permitted classes for YAML parsing in the helm ecosystem. This is needed because `YAML.safe_load` tries to parse dates from values.yaml files, resulting in "Tried to load unspecified class: Date" errors when attempting to run on private dependabot runners.

This affects dependabot's ability to properly parse and update Helm charts.

Related comment: @kuhnroyal https://github.com/dependabot/dependabot-core/issues/2237#issuecomment-2775085909

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The change is straightforward - adding three permitted class types to the existing YAML.safe_load

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The dependabot runners will successfully parse Helm YAML files containing date values without throwing "Tried to load unspecified class" errors. Tests involving Helm chart updates will pass, and the ecosystem will function correctly alongside the others (GHA, Gradle, Dart, Python) that are already working

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
