### PR TITLE
ensure pinned transitive dependency isn't overwritten by subsequent updates to the same file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/ProjectBuildFile.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Files/ProjectBuildFile.cs
@@ -8,12 +8,14 @@ internal sealed class ProjectBuildFile : XmlBuildFile
         => Parse(basePath, path, File.ReadAllText(path));
 
     public static ProjectBuildFile Parse(string basePath, string path, string xml)
-        => new(basePath, path, Parser.ParseText(xml));
+        => new(basePath, path, Parse(xml));
 
     public ProjectBuildFile(string basePath, string path, XmlDocumentSyntax contents)
         : base(basePath, path, contents)
     {
     }
+
+    public static XmlDocumentSyntax Parse(string contents) => Parser.ParseText(contents);
 
     public IXmlElementSyntax ProjectNode => Contents.RootSyntax;
 


### PR DESCRIPTION
This fixes a very specific bug.

Generally file updates are tracked in memory, but in some cases we use an external tool to update files on disk.  If we do one of these on-disk updates followed by an in-memory update, the on-disk update will be overwritten/discarded.  This PR fixes that behavior by explicitly refreshing the in-memory copy.

A scenario where this would occur and the result is the following:

1. The dependency solver decides a transitive pin is required...
2. ...AND another package needs to be updated

The end result is that step 1 will be lost when the result of step 2 is written back to disk.  The user would see this as a package getting updated and their CI failing because the original pinned dependency was still on the old version.

This is such a specific issue that I've changed 2 methods from `private` to `internal` to avoid an overly complex unit test.