### PR TITLE
fix spacing between reported updated files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -112,14 +112,14 @@ public abstract record UpdateOperationBase
 public record DirectUpdate : UpdateOperationBase
 {
     public override string Type => nameof(DirectUpdate);
-    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} in {string.Join("", UpdatedFiles)}";
+    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} in {string.Join(", ", UpdatedFiles)}";
     public sealed override string ToString() => GetString();
 }
 
 public record PinnedUpdate : UpdateOperationBase
 {
     public override string Type => nameof(PinnedUpdate);
-    public override string GetReport() => $"Pinned {DependencyName} at {NewVersion} in {string.Join("", UpdatedFiles)}";
+    public override string GetReport() => $"Pinned {DependencyName} at {NewVersion} in {string.Join(", ", UpdatedFiles)}";
     public sealed override string ToString() => GetString();
 }
 
@@ -129,7 +129,7 @@ public record ParentUpdate : UpdateOperationBase, IEquatable<UpdateOperationBase
     public required string ParentDependencyName { get; init; }
     public required NuGetVersion ParentNewVersion { get; init; }
 
-    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} indirectly via {ParentDependencyName}/{ParentNewVersion} in {string.Join("", UpdatedFiles)}";
+    public override string GetReport() => $"Updated {DependencyName} to {NewVersion} indirectly via {ParentDependencyName}/{ParentNewVersion} in {string.Join(", ", UpdatedFiles)}";
 
     bool IEquatable<UpdateOperationBase>.Equals(UpdateOperationBase? other)
     {


### PR DESCRIPTION
Simple formatting fix.  When reporting updated files, an empty string doesn't suffice.