### PR TITLE
use update operation collection to generate PR body text

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
@@ -2,6 +2,7 @@ using NuGet.Versioning;
 
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
 
 using Xunit;
 
@@ -11,9 +12,9 @@ public class PullRequestMessageTests
 {
     [Theory]
     [MemberData(nameof(GetPullRequestApiMessageData))]
-    public void GetPullRequestApiMessage(Job job, DependencyFile[] updatedFiles, ReportedDependency[] updatedDependencies, MessageBase expectedMessage)
+    public void GetPullRequestApiMessage(Job job, DependencyFile[] updatedFiles, ReportedDependency[] updatedDependencies, UpdateOperationBase[] updateOperationsPerformed, MessageBase expectedMessage)
     {
-        var actualMessage = RunWorker.GetPullRequestApiMessage(job, updatedFiles, updatedDependencies, "TEST-COMMIT-SHA");
+        var actualMessage = RunWorker.GetPullRequestApiMessage(job, updatedFiles, updatedDependencies, [.. updateOperationsPerformed], "TEST-COMMIT-SHA");
         Assert.NotNull(actualMessage);
         actualMessage = actualMessage switch
         {
@@ -62,6 +63,16 @@ public class PullRequestMessageTests
                     Requirements = [],
                 }
             },
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Dependency",
+                    NewVersion = NuGetVersion.Parse("1.0.1"),
+                    UpdatedFiles = ["/src/project.csproj"]
+                }
+            },
             // expectedMessage
             new CreatePullRequest()
             {
@@ -106,6 +117,16 @@ public class PullRequestMessageTests
                     Requirements = [], // not used
                 }
             },
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Dependency",
+                    NewVersion = NuGetVersion.Parse("1.0.1"),
+                    UpdatedFiles = ["/src/project.csproj"]
+                }
+            },
             // expectedMessage
             new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "up_to_date" },
         ];
@@ -140,6 +161,8 @@ public class PullRequestMessageTests
             Array.Empty<DependencyFile>(),
             // updatedDependencies
             Array.Empty<ReportedDependency>(),
+            // updateOperationsPerformed
+            new UpdateOperationBase[] { },
             // expectedMessage
             new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependency_removed" },
         ];
@@ -181,6 +204,16 @@ public class PullRequestMessageTests
                     Name = "Some.Dependency",
                     Version = "1.0.1",
                     Requirements = [],
+                }
+            },
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Dependency",
+                    NewVersion = NuGetVersion.Parse("1.0.1"),
+                    UpdatedFiles = ["/src/project.csproj"]
                 }
             },
             // expectedMessage
@@ -234,6 +267,16 @@ public class PullRequestMessageTests
                     Name = "Some.Dependency",
                     Version = "1.0.1",
                     Requirements = [],
+                }
+            },
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Dependency",
+                    NewVersion = NuGetVersion.Parse("1.0.1"),
+                    UpdatedFiles = ["/src/project.csproj"]
                 }
             },
             // expectedMessage

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -1,5 +1,10 @@
+using System.Collections.Immutable;
+
+using NuGet.Versioning;
+
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
 
 using Xunit;
 
@@ -9,14 +14,22 @@ public class PullRequestTextTests
 {
     [Theory]
     [MemberData(nameof(GetPullRequestTextTestData))]
-    public void PullRequestText(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName, string expectedTitle, string expectedCommitMessage, string expectedBody)
+    public void PullRequestText(
+        Job job,
+        UpdateOperationBase[] updateOperationsPerformed,
+        string? dependencyGroupName,
+        string expectedTitle,
+        string expectedCommitMessage,
+        string expectedBody
+    )
     {
-        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
-        var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updatedDependencies, updatedFiles, dependencyGroupName);
-        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        var updateOperationsPerformedImmutable = updateOperationsPerformed.ToImmutableArray();
+        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updateOperationsPerformedImmutable, dependencyGroupName);
+        var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updateOperationsPerformedImmutable, dependencyGroupName);
+        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updateOperationsPerformedImmutable, dependencyGroupName);
         Assert.Equal(expectedTitle, actualTitle);
         Assert.Equal(expectedCommitMessage, actualCommitMessage);
-        Assert.Equal(expectedBody, actualBody);
+        Assert.Equal(expectedBody.Replace("\r", ""), actualBody);
     }
 
     public static IEnumerable<object?[]> GetPullRequestTextTestData()
@@ -26,18 +39,16 @@ public class PullRequestTextTests
         [
             // job
             FromCommitOptions(null),
-            // updatedDependencies
-            new []
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
             {
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Some.Package",
-                    Version = "1.2.3",
-                    Requirements = []
+                    DependencyName = "Some.Package",
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
                 }
             },
-            // updatedFiles
-            Array.Empty<DependencyFile>(),
             // dependencyGroupName
             null,
             // expectedTitle
@@ -45,7 +56,10 @@ public class PullRequestTextTests
             // expectedCommitMessage
             "Update Some.Package to 1.2.3",
             // expectedBody
-            "Update Some.Package to 1.2.3"
+            """
+            Performed the following updates:
+                - Updated Some.Package to 1.2.3 in a.txt
+            """
         ];
 
         // single dependency, prefix given
@@ -53,18 +67,16 @@ public class PullRequestTextTests
         [
             // job
             FromCommitOptions(new(){ Prefix = "[SECURITY] " }),
-            // updatedDependencies
-            new []
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
             {
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Some.Package",
-                    Version = "1.2.3",
-                    Requirements = []
+                    DependencyName = "Some.Package",
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
                 }
             },
-            // updatedFiles
-            Array.Empty<DependencyFile>(),
             // dependencyGroupName
             null,
             // expectedTitle
@@ -72,7 +84,10 @@ public class PullRequestTextTests
             // expectedCommitMessage
             "[SECURITY] Update Some.Package to 1.2.3",
             // expectedBody
-            "[SECURITY] Update Some.Package to 1.2.3"
+            """
+            Performed the following updates:
+                - Updated Some.Package to 1.2.3 in a.txt
+            """
         ];
 
         // multiple dependencies, multiple versions
@@ -80,36 +95,34 @@ public class PullRequestTextTests
         [
             // job
             FromCommitOptions(null),
-            // updatedDependencies
-            new[]
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
             {
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Package.A",
-                    Version = "1.0.0",
-                    Requirements = []
+                    DependencyName = "Package.A",
+                    NewVersion = NuGetVersion.Parse("1.0.0"),
+                    UpdatedFiles = ["a1.txt"]
                 },
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Package.A",
-                    Version = "2.0.0",
-                    Requirements = []
+                    DependencyName = "Package.A",
+                    NewVersion = NuGetVersion.Parse("2.0.0"),
+                    UpdatedFiles = ["a2.txt"]
                 },
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Package.B",
-                    Version = "3.0.0",
-                    Requirements = []
+                    DependencyName = "Package.B",
+                    NewVersion = NuGetVersion.Parse("3.0.0"),
+                    UpdatedFiles = ["b1.txt"]
                 },
-                new ReportedDependency()
+                new DirectUpdate()
                 {
-                    Name = "Package.B",
-                    Version = "4.0.0",
-                    Requirements = []
+                    DependencyName = "Package.B",
+                    NewVersion = NuGetVersion.Parse("4.0.0"),
+                    UpdatedFiles = ["b2.txt"]
                 },
             },
-            // updatedFiles
-            Array.Empty<DependencyFile>(),
             // dependencyGroupName
             null,
             // expectedTitle
@@ -117,7 +130,13 @@ public class PullRequestTextTests
             // expectedCommitMessage
             "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
             // expectedBody
-            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0"
+            """
+            Performed the following updates:
+                - Updated Package.A to 1.0.0 in a1.txt
+                - Updated Package.A to 2.0.0 in a2.txt
+                - Updated Package.B to 3.0.0 in b1.txt
+                - Updated Package.B to 4.0.0 in b2.txt
+            """
         ];
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -86,7 +86,7 @@ public class RunWorkerTests
                     CanUpdate = true,
                     UpdatedDependencies =
                     [
-                        new("Some.Package", "1.0.2", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package"),
+                        new("Some.Package", "1.0.1", DependencyType.Unknown, TargetFrameworks: ["net8.0"], InfoUrl: "https://nuget.example.com/some-package"),
                     ]
                 });
             }),
@@ -108,7 +108,14 @@ public class RunWorkerTests
                     """.SetEOL(EOL));
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = "Some.Package",
+                            NewVersion = NuGetVersion.Parse("1.0.1"),
+                            UpdatedFiles = ["/some-dir/project.csproj"]
+                        }
+                    ],
                 };
             }),
             expectedResult: new RunResult()
@@ -319,7 +326,20 @@ public class RunWorkerTests
                     """.SetEOL(EOL));
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = "Some.Package",
+                            NewVersion = NuGetVersion.Parse("1.0.1"),
+                            UpdatedFiles = ["/some-dir/project.csproj"]
+                        },
+                        new DirectUpdate()
+                        {
+                            DependencyName = "Some.Package2",
+                            NewVersion = NuGetVersion.Parse("1.0.1"),
+                            UpdatedFiles = ["/some-dir/project.csproj"]
+                        }
+                    ],
                 };
             }),
             expectedResult: new RunResult()
@@ -689,7 +709,14 @@ public class RunWorkerTests
 
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = packageName,
+                            NewVersion = NuGetVersion.Parse(newVersion),
+                            UpdatedFiles = [filePath]
+                        }
+                    ],
                 };
             }),
             expectedResult: new RunResult()
@@ -1102,7 +1129,14 @@ public class RunWorkerTests
 
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = packageName,
+                            NewVersion = NuGetVersion.Parse(newVersion),
+                            UpdatedFiles = [filePath]
+                        }
+                    ],
                 };
             }),
             expectedResult: new RunResult()
@@ -1567,7 +1601,14 @@ public class RunWorkerTests
                     """.SetEOL(EOL));
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = packageName,
+                            NewVersion = NuGetVersion.Parse(newVersion),
+                            UpdatedFiles = [filePath]
+                        }
+                    ],
                 };
             }),
             expectedResult: new RunResult()
@@ -2322,7 +2363,7 @@ public class RunWorkerTests
             }),
             updaterWorker: new TestUpdaterWorker(async input =>
             {
-                var (repoRoot, filePath, dependencyName, _previousVersion, _newVersion, _isTransitive) = input;
+                var (repoRoot, filePath, dependencyName, _previousVersion, newVersion, _isTransitive) = input;
                 var dependencyFilePath = Path.Join(repoRoot, filePath);
                 var updatedContent = dependencyName switch
                 {
@@ -2333,7 +2374,14 @@ public class RunWorkerTests
                 await File.WriteAllTextAsync(dependencyFilePath, updatedContent);
                 return new UpdateOperationResult()
                 {
-                    UpdateOperations = [],
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = dependencyName,
+                            NewVersion = NuGetVersion.Parse(newVersion),
+                            UpdatedFiles = [filePath]
+                        }
+                    ],
                 };
             }),
             expectedResult: new()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,44 +1,45 @@
-using NuGet.Versioning;
+using System.Collections.Immutable;
 
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
 
 namespace NuGetUpdater.Core.Run;
 
 public class PullRequestTextGenerator
 {
-    public static string GetPullRequestTitle(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    public static string GetPullRequestTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
         // simple version looks like
         //   Update Some.Package to 1.2.3
         // if multiple packages are updated to multiple versions, result looks like:
         //   Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0
-        var dependencySets = updatedDependencies
-            .GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+        var dependencySets = updateOperationsPerformed
+            .GroupBy(d => d.DependencyName, StringComparer.OrdinalIgnoreCase)
             .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
             .Select(g => new
             {
                 Name = g.Key,
                 Versions = g
-                    .Where(d => d.Version is not null)
-                    .Select(d => d.Version!)
-                    .OrderBy(d => NuGetVersion.Parse(d))
+                    .Select(d => d.NewVersion)
+                    .OrderBy(v => v)
                     .ToArray()
             })
             .ToArray();
         var updatedPartTitles = dependencySets
-            .Select(d => $"{d.Name} to {string.Join(", ", d.Versions)}")
+            .Select(d => $"{d.Name} to {string.Join(", ", d.Versions.Select(v => v.ToString()))}")
             .ToArray();
         var title = $"{job.CommitMessageOptions?.Prefix}Update {string.Join("; ", updatedPartTitles)}";
         return title;
     }
 
-    public static string GetPullRequestCommitMessage(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    public static string GetPullRequestCommitMessage(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        return GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        return GetPullRequestTitle(job, updateOperationsPerformed, dependencyGroupName);
     }
 
-    public static string GetPullRequestBody(Job job, ReportedDependency[] updatedDependencies, DependencyFile[] updatedFiles, string? dependencyGroupName = null)
+    public static string GetPullRequestBody(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        return GetPullRequestTitle(job, updatedDependencies, updatedFiles, dependencyGroupName);
+        var report = UpdateOperationBase.GenerateUpdateOperationReport(updateOperationsPerformed);
+        return report;
     }
 }


### PR DESCRIPTION
During an update process we gather a list of all operations performed and this is now used to generate the PR body text.

PR body will now look something like this:

```
Performed the following updates:
    - Updated Package.A to 1.0.0 in /src/client/library.csproj
    - Updated Package.B to 2.0.0 in /Directory.Build.props
```