### PR TITLE
Revert "Update go mod version before running `go mod tidy -e`"

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -200,21 +200,6 @@ module Dependabot
         def run_go_mod_tidy
           return unless tidy?
 
-          # Extract the Go version from the go.mod file (assuming the format is 'go 1.23.0')
-          go_version = `grep '^go ' go.mod`.strip.split.last
-
-          # Extract the major and minor version (e.g., "1.23") from the full version
-          formatted_version = T.must(go_version).split(".").first(2).join(".")
-
-          # Apply the sed commands to fix go.mod before running `go mod tidy`
-          sed_command_go = "sed -i 's/go #{go_version}/go #{formatted_version}/' go.mod"
-          Dependabot.logger.info "Running: #{sed_command_go}"
-          Open3.capture3(environment, sed_command_go)
-
-          sed_command_toolchain = "sed -i '/toolchain/d' go.mod"
-          Dependabot.logger.info "Running: #{sed_command_toolchain}"
-          Open3.capture3(environment, sed_command_toolchain)
-
           command = "go mod tidy -e"
 
           # we explicitly don't raise an error for 'go mod tidy' and silently


### PR DESCRIPTION
Reverts dependabot/dependabot-core#11815


As per the discussion with @jakecoffman I am reverting this.