### PR TITLE
Revert "Update docker version to include digest if applicable"

### DIFF
--- a/docker/lib/dependabot/shared/shared_file_parser.rb
+++ b/docker/lib/dependabot/shared/shared_file_parser.rb
@@ -33,13 +33,7 @@ module Dependabot
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T.nilable(String)) }
       def version_from(parsed_line)
-        return nil unless parsed_line.fetch("tag") || parsed_line.fetch("digest")
-
-        if parsed_line.fetch("tag") && parsed_line.fetch("digest")
-          "#{parsed_line.fetch('tag')}@sha256:#{parsed_line.fetch('digest')}"
-        else
-          parsed_line.fetch("tag") || "sha256:#{parsed_line.fetch('digest')}"
-        end
+        parsed_line.fetch("tag") || parsed_line.fetch("digest")
       end
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T::Hash[String, T.nilable(String)]) }
@@ -48,7 +42,7 @@ module Dependabot
 
         source[:registry] = parsed_line.fetch("registry") if parsed_line.fetch("registry")
         source[:tag] = parsed_line.fetch("tag") if parsed_line.fetch("tag")
-        source[:digest] = "sha256:#{parsed_line.fetch('digest')}" if parsed_line.fetch("digest")
+        source[:digest] = parsed_line.fetch("digest") if parsed_line.fetch("digest")
 
         source
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -158,14 +158,14 @@ RSpec.describe Dependabot::Docker::FileParser do
             requirement: nil,
             groups: [],
             file: "Dockerfile",
-            source: { digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+            source: { digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
           }]
         end
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+          expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "Dockerfile",
               source: {
-                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -284,7 +284,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::Docker::FileParser do
                   groups: [],
                   file: "Dockerfile",
                   source: {
-                    digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                    digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                             "fc38288cf73aa07485005"
                   }
                 }]
@@ -344,7 +344,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("ubuntu")
-                expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                                                  "fc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
@@ -380,15 +380,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
-                                         "fc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "Dockerfile",
           source: {
             tag: "12.04.5",
-            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end
@@ -832,7 +831,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "digest.yaml",
               source: {
-                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -841,7 +840,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -874,15 +873,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
-                                         "fc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "digest_and_tag.yaml",
           source: {
             tag: "12.04.5",
-            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end


### PR DESCRIPTION
Reverts dependabot/dependabot-core#11938

Fixes #11971

We're also seeing the in https://github.com/github/dependabot-action so I was able to test locally and confirmed reverting it fixes the issue.