### PR TITLE
Update docker version to include digest if applicable - Fixed

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -155,7 +155,7 @@ module Dependabot
 
         image = "#{repo}:#{tag}"
         image.prepend("#{registry}/") if registry
-        image << "@sha256:#{digest}/" if digest
+        image << "@#{digest}/" if digest
         [image]
       end
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -427,7 +427,7 @@ module Dependabot
 
       sig { params(tag: String).returns(T.nilable(String)) }
       def fetch_digest_of(tag)
-        docker_registry_client.manifest_digest(docker_repo_name, tag) #&.delete_prefix("sha256:")
+        docker_registry_client.manifest_digest(docker_repo_name, tag)
       rescue *transient_docker_errors => e
         attempt ||= 1
         attempt += 1

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -427,7 +427,7 @@ module Dependabot
 
       sig { params(tag: String).returns(T.nilable(String)) }
       def fetch_digest_of(tag)
-        docker_registry_client.manifest_digest(docker_repo_name, tag)&.delete_prefix("sha256:")
+        docker_registry_client.manifest_digest(docker_repo_name, tag) #&.delete_prefix("sha256:")
       rescue *transient_docker_errors => e
         attempt ||= 1
         attempt += 1

--- a/docker/lib/dependabot/shared/shared_file_parser.rb
+++ b/docker/lib/dependabot/shared/shared_file_parser.rb
@@ -33,7 +33,13 @@ module Dependabot
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T.nilable(String)) }
       def version_from(parsed_line)
-        parsed_line.fetch("tag") || parsed_line.fetch("digest")
+        return nil unless parsed_line.fetch("tag") || parsed_line.fetch("digest")
+
+        if parsed_line.fetch("tag") && parsed_line.fetch("digest")
+          "#{parsed_line.fetch('tag')}@sha256:#{parsed_line.fetch('digest')}"
+        else
+          parsed_line.fetch("tag") || "sha256:#{parsed_line.fetch('digest')}"
+        end
       end
 
       sig { params(parsed_line: T::Hash[String, T.nilable(String)]).returns(T::Hash[String, T.nilable(String)]) }
@@ -42,7 +48,7 @@ module Dependabot
 
         source[:registry] = parsed_line.fetch("registry") if parsed_line.fetch("registry")
         source[:tag] = parsed_line.fetch("tag") if parsed_line.fetch("tag")
-        source[:digest] = parsed_line.fetch("digest") if parsed_line.fetch("digest")
+        source[:digest] = "sha256:#{parsed_line.fetch('digest')}" if parsed_line.fetch("digest")
 
         source
       end

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -92,7 +92,7 @@ module Dependabot
           end
         old_declaration +=
           if specified_with_digest?(old_source)
-            "@sha256:#{old_digest}"
+            "@#{old_digest}"
           else
             ""
           end
@@ -103,7 +103,7 @@ module Dependabot
 
         previous_content.gsub(old_declaration_regex) do |old_dec|
           old_dec
-            .gsub("@sha256:#{old_digest}", "@sha256:#{new_digest}")
+            .gsub("@#{old_digest}", "@#{new_digest}")
             .gsub(":#{old_tag}", ":#{new_tag}")
         end
       end
@@ -160,7 +160,7 @@ module Dependabot
       def new_yaml_image(file)
         element = T.must(dependency).requirements.find { |r| r[:file] == file.name }
         prefix = element&.dig(:source, :registry) ? "#{element.fetch(:source)[:registry]}/" : ""
-        digest = element&.dig(:source, :digest) ? "@sha256:#{element.fetch(:source)[:digest]}" : ""
+        digest = element&.dig(:source, :digest) ? "@#{element.fetch(:source)[:digest]}" : ""
         tag = element&.dig(:source, :tag) ? ":#{element.fetch(:source)[:tag]}" : ""
         "#{prefix}#{T.must(dependency).name}#{tag}#{digest}"
       end
@@ -169,7 +169,7 @@ module Dependabot
       def old_yaml_images(file)
         T.must(previous_requirements(file)).map do |r|
           prefix = r.fetch(:source)[:registry] ? "#{r.fetch(:source)[:registry]}/" : ""
-          digest = r.fetch(:source)[:digest] ? "@sha256:#{r.fetch(:source)[:digest]}" : ""
+          digest = r.fetch(:source)[:digest] ? "@#{r.fetch(:source)[:digest]}" : ""
           tag = r.fetch(:source)[:tag] ? ":#{r.fetch(:source)[:tag]}" : ""
           "#{prefix}#{T.must(dependency).name}#{tag}#{digest}"
         end
@@ -179,7 +179,7 @@ module Dependabot
       def old_helm_tags(file)
         T.must(previous_requirements(file)).map do |r|
           tag = r.fetch(:source)[:tag] || ""
-          digest = r.fetch(:source)[:digest] ? "@sha256:#{r.fetch(:source)[:digest]}" : ""
+          digest = r.fetch(:source)[:digest] ? "@#{r.fetch(:source)[:digest]}" : ""
           "#{tag}#{digest}"
         end
       end
@@ -188,7 +188,7 @@ module Dependabot
       def new_helm_tag(file)
         element = T.must(dependency).requirements.find { |r| r[:file] == file.name }
         tag = T.must(element).dig(:source, :tag) || ""
-        digest = T.must(element).dig(:source, :digest) ? "@sha256:#{T.must(element).dig(:source, :digest)}" : ""
+        digest = T.must(element).dig(:source, :digest) ? "@#{T.must(element).dig(:source, :digest)}" : ""
         "#{tag}#{digest}"
       end
 

--- a/docker/spec/dependabot/docker/common/shared_examples_for_docker_update_checkers.rb
+++ b/docker/spec/dependabot/docker/common/shared_examples_for_docker_update_checkers.rb
@@ -112,7 +112,7 @@ RSpec.shared_examples "a Docker update checker" do
         context "when digest is up-to-date" do
           let(:source) do
             {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97" \
                       "eba880ebf600d68608"
             }
           end
@@ -610,7 +610,7 @@ RSpec.shared_examples "a Docker update checker" do
               groups: [],
               file: file_name,
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }]
@@ -636,7 +636,7 @@ RSpec.shared_examples "a Docker update checker" do
               groups: [],
               file: file_name,
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608",
                 tag: "17.10"
               }

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -158,14 +158,14 @@ RSpec.describe Dependabot::Docker::FileParser do
             requirement: nil,
             groups: [],
             file: "Dockerfile",
-            source: { digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+            source: { digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
           }]
         end
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("my-fork/ubuntu")
-          expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+          expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "Dockerfile",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -284,7 +284,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::Docker::FileParser do
                   groups: [],
                   file: "Dockerfile",
                   source: {
-                    digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                    digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                             "fc38288cf73aa07485005"
                   }
                 }]
@@ -344,7 +344,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("ubuntu")
-                expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                                                  "fc38288cf73aa07485005")
                 expect(dependency.requirements).to eq(expected_requirements)
               end
@@ -380,14 +380,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "Dockerfile",
           source: {
             tag: "12.04.5",
-            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end
@@ -831,7 +831,7 @@ RSpec.describe Dependabot::Docker::FileParser do
               groups: [],
               file: "digest.yaml",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -840,7 +840,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -873,14 +873,14 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "digest_and_tag.yaml",
           source: {
             tag: "12.04.5",
-            digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
           }
         }])
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -380,7 +380,8 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                                         "fc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],
@@ -873,7 +874,8 @@ RSpec.describe Dependabot::Docker::FileParser do
       it "determines the correct version" do
         expect(dependency).to be_a(Dependabot::Dependency)
         expect(dependency.name).to eq("ubuntu")
-        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+        expect(dependency.version).to eq("12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                                         "fc38288cf73aa07485005")
         expect(dependency.requirements).to eq([{
           requirement: nil,
           groups: [],

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             file: "Dockerfile",
             source: {
               tag: "3.10.6",
-              digest: "8d1f943ceaaf3b3ce05df5c0926e7958836b048b70" \
+              digest: "sha256:8d1f943ceaaf3b3ce05df5c0926e7958836b048b70" \
                       "0176bf9c56d8f37ac13fca"
             }
           }, {
@@ -360,7 +360,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             file: "Dockerfile",
             source: {
               tag: "3.10.6-slim",
-              digest: "c8ef926b002a8371fff6b4f40142dcc6d6f7e217f7" \
+              digest: "sha256:c8ef926b002a8371fff6b4f40142dcc6d6f7e217f7" \
                       "afce2c2d1ed2e6c28e2b7c"
             }
           }],
@@ -371,7 +371,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "Dockerfile",
               source: {
                 tag: "3.10.5",
-                digest: "bdf0079de4094afdb26b94d9f89b716499436282c9" \
+                digest: "sha256:bdf0079de4094afdb26b94d9f89b716499436282c9" \
                         "72461d945a87899c015c23"
               }
             },
@@ -381,7 +381,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "Dockerfile",
               source: {
                 tag: "3.10.5-slim",
-                digest: "bdf0079de4094afdb26b94d9f89b716499436282c9" \
+                digest: "sha256:bdf0079de4094afdb26b94d9f89b716499436282c9" \
                         "72461d945a87899c015c23"
               }
             }
@@ -541,7 +541,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             file: "Dockerfile",
             source: {
               # corresponds to the tag "17.10"
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }],
@@ -551,7 +551,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             file: "Dockerfile",
             source: {
               # corresponds to the tag "12.04.5"
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }],
@@ -585,7 +585,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
                 file: "Dockerfile",
                 source: {
                   tag: "17.10",
-                  digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                  digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                           "ca97eba880ebf600d68608"
                 }
               }],
@@ -595,7 +595,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
                 file: "Dockerfile",
                 source: {
                   tag: "12.04.5",
-                  digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                  digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                           "dfc38288cf73aa07485005"
                 }
               }],
@@ -624,7 +624,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "Dockerfile",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }],
@@ -634,7 +634,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "Dockerfile",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005"
               }
             }],
@@ -681,7 +681,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "Dockerfile",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }, {
@@ -689,7 +689,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608",
               tag: "17.10"
             }
@@ -699,7 +699,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "Dockerfile",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }, {
@@ -707,7 +707,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005",
               tag: "12.04.5"
             }
@@ -743,7 +743,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608",
                 tag: "17.10"
               }
@@ -753,7 +753,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005",
                 tag: "12.04.5"
               }
@@ -1074,7 +1074,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest.yaml",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }],
@@ -1083,7 +1083,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest.yaml",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }],
@@ -1126,7 +1126,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
                 file: "digest_and_tag.yaml",
                 source: {
                   tag: "17.10",
-                  digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                  digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                           "ca97eba880ebf600d68608"
                 }
               }],
@@ -1136,7 +1136,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
                 file: "digest_and_tag.yaml",
                 source: {
                   tag: "12.04.5",
-                  digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                  digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                           "dfc38288cf73aa07485005"
                 }
               }],
@@ -1171,7 +1171,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "private_digest.yaml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }],
@@ -1181,7 +1181,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "private_digest.yaml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005"
               }
             }],
@@ -1234,7 +1234,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest.yaml",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }, {
@@ -1242,7 +1242,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest_and_tag.yaml",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608",
               tag: "17.10"
             }
@@ -1252,7 +1252,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest.yaml",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }, {
@@ -1260,7 +1260,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "digest_and_tag.yaml",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005",
               tag: "12.04.5"
             }
@@ -1297,7 +1297,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "digest_and_tag.yaml",
               source: {
                 tag: "17.10",
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }],
@@ -1307,7 +1307,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "digest_and_tag.yaml",
               source: {
                 tag: "12.04.5",
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005"
               }
             }],

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         context "when the digest is up-to-date" do
           let(:source) do
             {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97" \
                       "eba880ebf600d68608"
             }
           end
@@ -170,13 +170,13 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
 
       context "when the digest is out-to-date" do
-        let(:digest) { "c5dcd377b75ca89f40a7b4284c05c58be4cd43d089f83af1333e56bde33d579f" }
+        let(:digest) { "sha256:c5dcd377b75ca89f40a7b4284c05c58be4cd43d089f83af1333e56bde33d579f" }
 
         it { is_expected.to be_truthy }
       end
 
       context "when the digest is up-to-date" do
-        let(:latest_digest) { "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608" }
+        let(:latest_digest) { "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608" }
         let(:digest) { latest_digest }
 
         it { is_expected.to be_falsy }
@@ -229,7 +229,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       let(:source) do
         {
           registry: "registry.access.redhat.com",
-          digest: "3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120"
+          digest: "sha256:3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120"
         }
       end
       let(:version) { "8.5" }
@@ -261,9 +261,9 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful") }
 
       context "when the version starts with a number" do
-        let(:version) { "309403913c7f0848e6616446edec909b55d53571" }
+        let(:version) { "sha256:309403913c7f0848e6616446edec909b55d53571" }
 
-        it { is_expected.to eq("309403913c7f0848e6616446edec909b55d53571") }
+        it { is_expected.to eq("sha256:309403913c7f0848e6616446edec909b55d53571") }
       end
     end
 
@@ -1387,7 +1387,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the docker registry only knows about versions older than the current version" do
       let(:dependency_name) { "jetstack/cert-manager-controller" }
       let(:version) { "v1.7.2" }
-      let(:digest) { "1815870847a48a9a6f177b90005d8df273e79d00830c21af9d43e1b5d8d208b4" }
+      let(:digest) { "sha256:1815870847a48a9a6f177b90005d8df273e79d00830c21af9d43e1b5d8d208b4" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,
@@ -1399,7 +1399,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             source: {
               registry: "quay.io",
               tag: "v1.7.2",
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
             }
           }],
           package_manager: "docker"
@@ -1547,7 +1547,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
               groups: [],
               file: "Dockerfile",
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }]
@@ -1573,7 +1573,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
               groups: [],
               file: "Dockerfile",
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608",
                 tag: "17.10"
               }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes the issue from #11971, that was due to my PR #11938, and was reverted in #11976
### Anything you want to highlight for special attention from reviewers?

The main issue was that `sha256:` was hardcoded in a lot of places around the docker codebase. By adding `sha256:` to the digest everywhere (which will help with #11943) it broke a lot of these checks.

### How will you know you've accomplished your goal?

Specs are updated, and tested with the cli against the dependabot-action repo
`dependabot update docker github/dependabot-action --directory /docker --dep dependabot/dependabot-updater-bun`

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
