### PR TITLE
Use Trusted Publishing for RubyGems rather than hardcoded API key

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -13,13 +13,14 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
-      - run: |
-          [ -d ~/.gem ] || mkdir ~/.gem
-          echo "---" > ~/.gem/credentials
-          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY_WITH_SCOPE_LIMITED_TO_PUSH }}" > ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-          gem install rake && rake gems:release
+
+      - uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+
+      # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.
+      # `rake release` causes problems because it tries to push a git tag, but we've already manually tagged the release as part of the `gems-bump-version` workflow.
+      - run: gem install rake && rake gems:release


### PR DESCRIPTION
Switch to using Trusted Publishing for publishing the Dependabot gems to RubyGems. This is much more secure than using a hardcoded API key.

Before putting up this PR, I configured RubyGems to treat this workflow as a trusted publisher for _all_ of the gems published by this workflow.

Context:
* https://blog.rubygems.org/2023/12/14/trusted-publishing.html
* https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

Related: 
* https://github.com/dependabot/dependabot-core/issues/9786

While this should fix ☝️, I'm not marking it that way as I want to follow all the verification steps listed in https://github.com/dependabot/dependabot-core/issues/9786#issuecomment-2781096230 to confirm it worked before closing it.