### PR TITLE
Use a URL that won't respond

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -37,8 +37,9 @@ module Dependabot
             (?<=require\s)php(?:\-[^\s\/]+)?\s.*?\s(?=->) # composer v2
           }x
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
-        SOURCE_TIMED_OUT_REGEX =
-          /The "(?<url>[^"]+packages\.json)".*timed out/
+
+        # Example Timeout error from Composer 2.7.7: "curl error 28 while downloading https://example.com:81/packages.json: Failed to connect to example.com port 81 after 9853 ms: Connection timed out" # rubocop:disable Layout/LineLength
+        SOURCE_TIMED_OUT_REGEX = %r{curl error 28 while downloading (?<url>https?://.+/packages\.json): }
 
         def initialize(credentials:, dependency:, dependency_files:,
                        requirements_to_unlock:, latest_allowable_version:)

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -343,10 +343,9 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       after { ENV.delete("COMPOSER_PROCESS_TIMEOUT") }
 
       it "raises a Dependabot::PrivateSourceTimedOut error" do
-        pending("TODO: this URL has no DNS record post GitHub acquisition, so switch to a routable URL that hangs")
         expect { resolver.latest_resolvable_version }
           .to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
-            expect(error.source).to eq("https://composer.dependabot.com")
+            expect(error.source).to eq("https://example.com:81")
           end
       end
     end

--- a/composer/spec/fixtures/projects/unreachable_private_registry/composer.json
+++ b/composer/spec/fixtures/projects/unreachable_private_registry/composer.json
@@ -2,7 +2,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://composer.dependabot.com/"
+            "url": "https://example.com:81/"
         },
         {
             "packagist.org": false


### PR DESCRIPTION
`https://composer.dependabot.com` no longer has a DNS record now that Dependabot was acquired by GitHub. And we can't just stub the URL because the call is happening within the `composer` subprocess, not in our ruby process.

This helpful StackOverflow pointed out that example.com is owned by IANA so should be safe, and port 81 is never expected to respond: https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error

Alternatively, we could use a non-routable IP but that may return different errors depending on the topology of the LAN where it's running.

This is a continuation of https://github.com/dependabot/dependabot-core/pull/6776, as a borked Codespace weirdly pushed a massive commit and force-closed that PR and won't let me re-open it. 😢 