### PR TITLE
Testing "Use Trusted Publishing for RubyGems rather than hardcoded API key"

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -13,13 +13,14 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
-      - run: |
-          [ -d ~/.gem ] || mkdir ~/.gem
-          echo "---" > ~/.gem/credentials
-          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY_WITH_SCOPE_LIMITED_TO_PUSH }}" > ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-          gem install rake && rake gems:release
+
+      - uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+
+      # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.
+      # `rake release` causes problems because it tries to push a git tag, but we've already manually tagged the release as part of the `gems-bump-version` workflow.
+      - run: gem install rake && rake gems:release


### PR DESCRIPTION
This temporarily adds `workflow_dispatch` trigger to test:
* https://github.com/dependabot/dependabot-core/pull/11984