### PR TITLE
Fixing typo `helm_repository` to `helm_registry`

### DIFF
--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -180,7 +180,7 @@ module Dependabot
       def authenticate_registry_source(repo_url)
         return unless repo_url
 
-        repo_creds = Shared::Utils::CredentialsFinder.new(@credentials, private_repository_type: "helm_repository")
+        repo_creds = Shared::Utils::CredentialsFinder.new(@credentials, private_repository_type: "helm_registry")
                                                      .credentials_for_registry(repo_url)
         return unless repo_creds
 

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
   end
   let(:credentials) do
     [Dependabot::Credential.new({
-      "type" => "helm_repository",
+      "type" => "helm_registry",
       "registry" => repo_url,
       "username" => username,
       "password" => password


### PR DESCRIPTION
### What are you trying to accomplish?

Replacing the typo `helm_repository` with `helm_registry` in the `helm` ecosystem

thanks to @thalescosta for spotting this

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->


### How will you know you've accomplished your goal?

Dependabot will get the correct credentials for the `helm_registry` type

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
