### PR TITLE
Avoid adding current job group dependencies to the handled list

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -147,6 +147,13 @@ module Dependabot
             excluding_dependencies[directory]&.include?(dep)
           end
 
+          # Avoid adding current job group dependencies to the handled list, as it would block this job group updates.
+          if job_group
+            existing_group_dependencies = dependencies_in_existing_pr_for_group(T.must(job_group))
+                                          .filter_map { |dep| dep["dependency-name"] }
+            current_dependencies -= existing_group_dependencies
+          end
+
           add_handled_dependencies(current_dependencies.concat(dependencies_in_existing_prs.filter_map do |dep|
             dep["dependency-name"]
           end))


### PR DESCRIPTION
### What are you trying to accomplish?

Avoid adding current job group dependencies to the handled list, as it would block this job group updates.

### Anything you want to highlight for special attention from reviewers?

Scenario I am trying to fix:

In the group configuration, the first group listed behaves as expected (covering major, minor, and patch group updates). For instance:
```
groups:
      major:
        update-types:
          - "major"
        patterns:
          - "*"
      minor:
        update-types:
          - "minor"
        patterns:
          - "*"
      patch:
        update-types:
          - "patch"
        patterns:
          - "*"
```

On the initial run, everything works as intended, generating three PRs—one for each group.

However, when the workflow is rerun without merging or closing the existing PRs:
- The "major" group functions correctly (as it is listed first in the configuration).
- The other two PRs are closed with the message `closed: update_no_longer_possible`, which is unexpected behavior.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
