### PR TITLE
Convert oci to https when fetching index.yaml files

### DIFF
--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -107,8 +107,10 @@ module Dependabot
 
       sig { params(repo_url: String).returns(String) }
       def build_index_url(repo_url)
-        repo_url_trimmed = repo_url.to_s.strip.chomp("/")
-        "#{repo_url_trimmed}/index.yaml"
+        repo_url_trimmed = repo_url.strip.chomp("/")
+        normalized_repo_url = repo_url_trimmed.gsub("oci://", "https://")
+
+        "#{normalized_repo_url}/index.yaml"
       end
 
       sig { override.returns(T::Boolean) }
@@ -218,7 +220,7 @@ module Dependabot
       def fetch_helm_chart_index(index_url)
         Dependabot.logger.info("Fetching Helm chart index from #{index_url}")
         response = Excon.get(
-          index_url.gsub("oci://", "https://"),
+          index_url,
           idempotent: true,
           middlewares: Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
         )

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -217,9 +217,8 @@ module Dependabot
       sig { params(index_url: String).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
       def fetch_helm_chart_index(index_url)
         Dependabot.logger.info("Fetching Helm chart index from #{index_url}")
-
         response = Excon.get(
-          index_url,
+          index_url.gsub("oci://", "https://"),
           idempotent: true,
           middlewares: Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
         )

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -219,6 +219,7 @@ module Dependabot
       sig { params(index_url: String).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
       def fetch_helm_chart_index(index_url)
         Dependabot.logger.info("Fetching Helm chart index from #{index_url}")
+
         response = Excon.get(
           index_url,
           idempotent: true,


### PR DESCRIPTION
### What are you trying to accomplish?
Fix Helm `index.yaml` fetcher to convert oci repository urls to https when fetching chart indexes. 

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The updater can't find chart versions in oci repositories that fallback to searching the registries `index.yaml`. Helm repositories contain `index.yaml` files that list all available charts and versions.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Oci urls are properly converted before making http requests, ensuring users with oci-based Helm repositories can successfully find updates for their dependencies.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
