### PR TITLE
Check docker image in helm can be updated

### DIFF
--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -264,6 +264,8 @@ module Dependabot
 
         Dependabot.logger.info("Docker UpdateChecker found latest version: #{latest_version || 'none'}")
 
+        return unless docker_checker.can_update?(requirements_to_unlock: :none)
+
         version_class.new(latest_version)
       end
 

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -236,6 +236,4 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
       end
     end
   end
-
-
 end

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
       end
 
       it { is_expected.to eq(Dependabot::Docker::Version.new("17.10")) }
+
+      context "when the docker image is can't be updated" do
+        let(:version) { "latest" }
+
+        it { is_expected.to be_nil }
+      end
     end
   end
 
@@ -230,4 +236,6 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
       end
     end
   end
+
+
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Adding validation to check if docker images can be updated before reporting new versions in the helm update checker. Previously, it would report updates even for immutable tags like "latest" which can't actually be updated.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Using the :none option with `can_update?` ensures we're only checking if the Docker image can be updated with its current constraints, consistent with how `latest_resolvable_version_with_no_unlock works` in the base update checker.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Dependabot only attempt to create bump prs when the docker images can be updated

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
