### PR TITLE
Raise and log an error if helm registry response is a string

### DIFF
--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -227,8 +227,13 @@ module Dependabot
         )
 
         Dependabot.logger.info("Received response from #{index_url} with status #{response.status}")
+        parsed_result = YAML.safe_load(response.body)
 
-        YAML.safe_load(response.body)
+        unless parsed_result.is_a?(Hash)
+          raise Dependabot::DependencyFileNotParseable, "Expected YAML to parse into a Hash, got String instead"
+        end
+
+        parsed_result
       rescue Excon::Error => e
         Dependabot.logger.error("Error fetching Helm index from #{index_url}: #{e.message}")
         nil

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -219,6 +219,25 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
       it "returns the latest version from the index" do
         expect(latest_chart_version).to eq(Dependabot::Docker::Version.new("20.11.3"))
       end
+
+      context "when the request returns a string" do
+        before do
+          stub_request(:get, "#{repo_url}/index.yaml")
+            .to_return(
+              status: 200,
+              body: "Not found"
+            )
+        end
+
+        it "returns nil" do
+          expect(latest_chart_version).to be_nil
+        end
+
+        it "logs an error" do
+          expect(Dependabot.logger).to receive(:error).with(/Error parsing Helm index/)
+          latest_chart_version
+        end
+      end
     end
 
     context "with an oci protocol" do


### PR DESCRIPTION
### What are you trying to accomplish?

Raise and log an error if the helm registry response is a string. Some responses from the Helm registry are strings, which should be returned as YAML after it was parse.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### How will you know you've accomplished your goal?

We will log an error if the response from the Helm registry is a string, and the response will be returned as YAML after it was parsed

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
