### PR TITLE
Remove feature flag `enable_beta_ecosystems` check from bun ecosystem

### DIFF
--- a/bun/lib/dependabot/bun/file_fetcher.rb
+++ b/bun/lib/dependabot/bun/file_fetcher.rb
@@ -98,8 +98,6 @@ module Dependabot
 
       sig { returns(T.nilable(T.any(Integer, String))) }
       def bun_version
-        return @bun_version = nil unless allow_beta_ecosystems?
-
         @bun_version ||= T.let(
           package_manager_helper.setup(BunPackageManager::NAME),
           T.nilable(T.any(Integer, String))

--- a/bun/spec/dependabot/bun/file_fetcher_spec.rb
+++ b/bun/spec/dependabot/bun/file_fetcher_spec.rb
@@ -73,32 +73,13 @@ RSpec.describe Dependabot::Bun::FileFetcher do
     describe "fetching and parsing the bun.lock" do
       before do
         allow(Dependabot::Experiments).to receive(:enabled?)
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:enable_bun_ecosystem).and_return(enable_beta_ecosystems)
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:enable_beta_ecosystems).and_return(enable_beta_ecosystems)
       end
 
-      context "when the experiment :enable_beta_ecosystems is inactive" do
-        let(:enable_beta_ecosystems) { false }
-
-        it "does not fetch or parse the the bun.lock" do
-          expect(file_fetcher_instance.files.map(&:name))
-            .to match_array(%w(package.json))
-          expect(file_fetcher_instance.ecosystem_versions)
-            .to match({ package_managers: { "unknown" => an_instance_of(Integer) } })
-        end
-      end
-
-      context "when the experiment :enable_beta_ecosystems is active" do
-        let(:enable_beta_ecosystems) { true }
-
-        it "fetches and parses the bun.lock" do
-          expect(file_fetcher_instance.files.map(&:name))
-            .to match_array(%w(package.json bun.lock))
-          expect(file_fetcher_instance.ecosystem_versions)
-            .to match({ package_managers: { "bun" => an_instance_of(Integer) } })
-        end
+      it "fetches and parses the bun.lock" do
+        expect(file_fetcher_instance.files.map(&:name))
+          .to match_array(%w(package.json bun.lock))
+        expect(file_fetcher_instance.ecosystem_versions)
+          .to match({ package_managers: { "bun" => an_instance_of(Integer) } })
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This change removes the `enable_beta_ecosystems` feature flag check from the Bun ecosystem. The feature flag is no longer needed, and this update ensures that the Bun ecosystem operates without being dependent on this flag, simplifying the code and improving maintainability.

### Anything you want to highlight for special attention from reviewers?

Please ensure that removing this feature flag does not affect any other functionality related to the Bun ecosystem. Since the flag is not in active use anymore, the goal is to eliminate redundant checks while ensuring the Bun ecosystem continues to function as expected without the flag.

### How will you know you've accomplished your goal?

- Ensure that the Bun ecosystem functions as expected without any issues after the feature flag check is removed.
- All tests should pass, and there should be no errors related to the feature flag removal or the Bun ecosystem.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.