### PR TITLE
Add sigstore attestations for our published gems

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -23,4 +23,4 @@ jobs:
 
       # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.
       # `rake release` causes problems because it tries to push a git tag, but we've already manually tagged the release as part of the `gems-bump-version` workflow.
-      - run: gem install rake && rake gems:release
+      - run: gem exec rake gems:release

--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ namespace :gems do
           sleep(2)
           begin
             sh "gem exec sigstore-cli:0.2.1 sign #{gem_path} --bundle #{gem_attestation_path}"
-            sh "gem push --attestation #{gem_attestation_path} #{gem_path}"
+            sh "gem push #{gem_path} --attestation #{gem_attestation_path}"
             break
           rescue StandardError => e
             puts "! `gem push` failed with error: #{e}"

--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,9 @@ namespace :gems do
 
     GEMSPECS.each do |gemspec_path|
       gem_name = File.basename(gemspec_path).sub(/\.gemspec$/, "")
-      gem_path = "pkg/#{gem_name}-#{Dependabot::VERSION}.gem"
+      gem_name_and_version = "#{gem_name}-#{Dependabot::VERSION}"
+      gem_path = "pkg/#{gem_name_and_version}.gem"
+      gem_attestation_path = "pkg/#{gem_name_and_version}.sigstore.json"
 
       attempts = 0
       loop do
@@ -80,7 +82,8 @@ namespace :gems do
           attempts += 1
           sleep(2)
           begin
-            sh "gem push #{gem_path}"
+            sh "gem exec sigstore-cli:0.2.1 sign #{gem_path} --bundle #{gem_attestation_path}"
+            sh "gem push --attestation #{gem_attestation_path} #{gem_path}"
             break
           rescue StandardError => e
             puts "! `gem push` failed with error: #{e}"
@@ -92,7 +95,7 @@ namespace :gems do
   end
 
   task :clean do
-    FileUtils.rm(Dir["pkg/*.gem"])
+    FileUtils.rm(Dir["pkg/*.gem", "pkg/*.sigstore.json"])
   end
 end
 


### PR DESCRIPTION
This adds sigstore attestations for our published gems.

We do not need to provide an OIDC token to the sigstore client because by default it will request the token from the GitHub Actions environment: https://github.com/sigstore/sigstore-ruby/blob/9ac72d3c27edcd791c8c831316447f0ab7dfb407/cli/lib/sigstore/cli/id_token.rb#L45-L68

The code inspiration for this change came from:
* https://github.com/84codes/rubocop-eighty-four-codes/pull/16
* https://github.com/rubygems/release-gem/pull/11

You can see an example attestation here: https://rubygems.org/gems/sigstore/versions/0.2.1

Related:
* https://github.com/dependabot/dependabot-core/issues/12009