### PR TITLE
Remove redundant flag enable_file_parser_python_local from uv

### DIFF
--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -88,17 +88,11 @@ module Dependabot
 
       sig { returns(Ecosystem::VersionManager) }
       def package_manager
-        if Experiments.enabled?(:enable_file_parser_python_local)
-          Dependabot.logger.info("Detected package manager : #{detected_package_manager.name}")
-        end
-
         @package_manager ||= T.let(detected_package_manager, T.nilable(Ecosystem::VersionManager))
       end
 
       sig { returns(Ecosystem::VersionManager) }
       def detected_package_manager
-        setup_python_environment if Experiments.enabled?(:enable_file_parser_python_local)
-
         PackageManager.new(T.must(detect_uv_version))
       end
 
@@ -146,11 +140,6 @@ module Dependabot
 
       sig { returns(String) }
       def python_raw_version
-        if Experiments.enabled?(:enable_file_parser_python_local)
-          Dependabot.logger.info("Detected python version: #{language_version_manager.python_version}")
-          Dependabot.logger.info("Detected python major minor version: #{language_version_manager.python_major_minor}")
-        end
-
         language_version_manager.python_version
       end
 

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -112,10 +112,6 @@ module Dependabot
       end
 
       def resolver
-        if Dependabot::Experiments.enabled?(:enable_file_parser_python_local)
-          Dependabot.logger.info("Python package resolver : #{resolver_type}")
-        end
-
         case resolver_type
         when :pip_compile then pip_compile_version_resolver
         when :requirements then pip_version_resolver

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -75,9 +75,6 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
   before do
     stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
     allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_file_parser_python_local)
-      .and_return(false)
-    allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_cooldown_for_uv)
       .and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
The feature flag `enable_file_parser_python_local` was carried over from the python ecosystem and is not required for `uv`. This PR removes it from the `uv` ecosystem.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
Dry runs have been passing without setting this feature flag.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
