### PR TITLE
Publish gems using the version of RubyGems specified in `Dockerfile.updater-core`

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
 
+      - name: Install the RubyGems version specified in the Dockerfile.updater-core file
+        run: |
+          RUBYGEMS_VERSION=$(grep 'ARG RUBYGEMS_VERSION=' Dockerfile.updater-core | cut -d '=' -f 2)
+          gem update --system $RUBYGEMS_VERSION
+
       - uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
 
       # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.


### PR DESCRIPTION
Rather than inheriting the version of RubyGems bundled with Ruby, let's explicitly match the version of RubyGems specified in `Dockerfile.update-core`:
* This matches the rest of our prod/CI systems... so it feels a bit safer.
* It's more flexible because it lets us decouple the RubyGems version from the Ruby version.

I think this is a good idea overall, but the specific need for this arose because the `--attestations` flag was only recently added to the `gem push` command. So we need this for my recently merged Sigstore attestations PR:
* https://github.com/dependabot/dependabot-core/pull/12025

Luckily, @deivid-rodriguez already put in the effort to update the RubyGems version, so we just need to wire that up into this workflow as well:
* https://github.com/dependabot/dependabot-core/pull/11330

Until this PR is merged, we cannot publish our gems.