### PR TITLE
Fix swift updater image build

### DIFF
--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VE
   && DOWNLOAD_URL=https://download.swift.org/swift-${SWIFT_VERSION}-release/${SWIFT_SHORT_UBUNTU_VERSION}/swift-${SWIFT_VERSION}-RELEASE/${SWIFT_TARBALL} \
   && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}" > "/tmp/${SWIFT_TARBALL}" \
   && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}.sig" > "/tmp/${SWIFT_SIGNATURE}" \
-  && sh -c 'curl --connect-timeout 15 --retry 5 https://www.swift.org/keys/all-keys.asc | gpg --import -' \
+  && sh -c 'curl --location --compressed --connect-timeout 15 --retry 5 https://www.swift.org/keys/all-keys.asc | gpg --import -' \
   && gpg --keyserver hkp://keyserver.ubuntu.com --refresh-keys Swift \
   && gpg --verify /tmp/${SWIFT_SIGNATURE} \
   && mkdir /opt/swift \


### PR DESCRIPTION
### What are you trying to accomplish?

It looks like swift has changed how the keys are returned and now has a redirect as well as returning compressed output rather than plain txt file. You can easily test this by running command locally:

```console
curl --connect-timeout 15 --retry 5 https://www.swift.org/keys/all-keys.asc | gpg --import -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12193  100 12193    0     0  17438      0 --:--:-- --:--:-- --:--:-- 17418
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```

This change should fix this step and thus fix swift updater image building. I suspect it is still working in CI because it is fetching those steps from cache and not actually rebuilding them.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
