### PR TITLE
Only sleep on errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,6 @@ namespace :gems do
         else
           puts "> Releasing #{gem_path}"
           attempts += 1
-          sleep(2)
           begin
             sh "gem exec sigstore-cli:0.2.1 sign #{gem_path} --bundle #{gem_attestation_path}"
             sh "gem push #{gem_path} --attestation #{gem_attestation_path}"
@@ -88,6 +87,8 @@ namespace :gems do
           rescue StandardError => e
             puts "! `gem push` failed with error: #{e}"
             raise if attempts >= 3
+
+            sleep(2)
           end
         end
       end


### PR DESCRIPTION
Gem publishing was taking a surprisingly long time.

Turns out this is because the `rakefile` task has a 2-second sleep between every publish. I suspect this was originally implemented due to rate limits or network flakiness, years ago when we only had a couple of gems.

However, the world has changed:
* RubyGems now implements separate rate limits for Gem push calls, and they're pretty generous: https://guides.rubygems.org/rubygems-org-rate-limits/
* We publish ~20 gems now, so sleeping for 2s adds up.

So let's only sleep on errors.

The smart fix is to switch to only looping/sleeping on transient errors like `429`'s. But this isn't critical code for us and we rarely hit errors, so the current retry implementation is good enough.