### PR TITLE
prepopulate updater image with framework targeting packs

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/NuGetUpdater.Cli.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/NuGetUpdater.Cli.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
+    <_NETFrameworkTargetingPacksVersion>[1.0.3]</_NETFrameworkTargetingPacksVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,24 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup Label="Targeting packs required for .NET Framework in SDK-style projects">
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net35" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net451" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net452" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net47" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net471" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="$(_NETFrameworkTargetingPacksVersion)" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net481" Version="$(_NETFrameworkTargetingPacksVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If an SDK-style project references a .NET Framework version via, e.g., `<TargetFramework>net472</TargetFramework>` _AND_ if the build is done on Windows machines _AND_ if a custom NuGet feed is used that doesn't have the `Microsoft.NETFramework.ReferenceAssemblies.*` packages, dependency discovery can fail.

The solution is to force these packages to be pre-downloaded and installed in the updater image package cache so they don't need to be restored.