### PR TITLE
Bump Swift version from 6.0 to 6.1

### DIFF
--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -25,7 +25,7 @@ USER dependabot
 
 # https://www.swift.org/download/
 # https://github.com/apple/swift-org-website/blob/main/_data/builds/swift_releases.yml
-ARG SWIFT_VERSION=6.0.1
+ARG SWIFT_VERSION=6.1
 ARG SWIFT_UBUNTU_VERSION=ubuntu22.04
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VERSION}-aarch64"; fi \

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::Swift::FileParser do
       it "returns the correct package manager" do
         expect(package_manager.name).to eq "swift"
         expect(package_manager.requirement).to be_nil
-        expect(package_manager.version.to_s).to eq "6.0.1.pre.dev"
+        expect(package_manager.version.to_s).to eq "6.1.0"
       end
     end
 
@@ -331,7 +331,7 @@ RSpec.describe Dependabot::Swift::FileParser do
       it "returns the correct language" do
         expect(language.name).to eq "swift"
         expect(language.requirement).to be_nil
-        expect(language.version.to_s).to eq "6.0.1"
+        expect(language.version.to_s).to eq "6.1"
       end
     end
   end


### PR DESCRIPTION
I'm seeing the following error on dependabot jobs where Swift version tools are 6.1. 

`updater | 2025/04/14 10:07:31 ERROR <job_997942662> error: 'repo': package 'repo' is using Swift tools version 6.1.0 but the installed version is 6.0.1`

This fixes that by bumping the version of Swift to 6.1.