### PR TITLE
don't return evaluation for temporary projects

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -652,6 +652,12 @@ internal static class SdkProjectDiscovery
             projectEvaluation = build.FindEvaluation(project.EvaluationId);
         }
 
+        if (!File.Exists(projectEvaluation?.ProjectFile))
+        {
+            // WPF creates temporary projects during evaluation that no longer exist on disk for analysis, but they're not necessary for our purposes.
+            return null;
+        }
+
         return projectEvaluation;
     }
 


### PR DESCRIPTION
WPF project restore can create temporary projects with names like `*_abc123_wpftmp.csproj` that are deleted after MSBuild exists.  When analyzing project restore for dependencies, explicitly remove these temporary project files because they're not necessary for our purposes and can break later update steps.