### PR TITLE
don't import from special `Pkg*` properties

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -31,6 +31,8 @@ public class SpecialFilePatcherTests
 
     public static IEnumerable<object[]> SpecialImportsConditionPatcherTestData()
     {
+        // magic file names
+
         // one-off test to verify namespaces don't interfere
         yield return
         [
@@ -92,6 +94,23 @@ public class SpecialFilePatcherTests
               <Import Project="Some\Path\Microsoft.TextTemplating.targets" Condition="false" />
               <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
               <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+
+        // magic property segments
+        yield return
+        [
+            // fileContent
+            """
+            <Project>
+              <Import Project="$(PkgSome_Package)\build\Some.Package.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project>
+              <Import Project="$(PkgSome_Package)\build\Some.Package.targets" Condition="false" />
             </Project>
             """
         ];


### PR DESCRIPTION
A `<PackageReference>` element can optionally specify a `GeneratePathProperty="true"` attribute which will result in the creation of a special MSBuild property with the prefix `Pkg` that points to the location where the package was restored and unpacked.  E.g., for a package named `Some.Package` a property named `PkgSome_Package` will be created with a value `/home/user/.nuget/packages/some.package/1.0.0`.

If one of these properties is used to explicitly import a `.props` or `.targets` file, this can cause dependency discovery to fail.

The fix is to expand our pattern of `<Import Project="..." />` values to ignore to also search for the substring `$(Pkg`.