### PR TITLE
Sorbet: Update Returned Version Types for Generic PackageLatestVersionFinder 

### DIFF
--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -81,24 +81,24 @@ module Dependabot
       end
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
-          .returns(T.nilable(Gem::Version))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+          .returns(T.nilable(Dependabot::Version))
       end
       def latest_version(language_version: nil)
         @latest_version ||= fetch_latest_version(language_version: language_version)
       end
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
-          .returns(T.nilable(Gem::Version))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+          .returns(T.nilable(Dependabot::Version))
       end
       def latest_version_with_no_unlock(language_version: nil)
         @latest_version_with_no_unlock ||= fetch_latest_version_with_no_unlock(language_version: language_version)
       end
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
-          .returns(T.nilable(Gem::Version))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+          .returns(T.nilable(Dependabot::Version))
       end
       def lowest_security_fix_version(language_version: nil)
         @lowest_security_fix_version ||= fetch_lowest_security_fix_version(language_version: language_version)
@@ -117,7 +117,7 @@ module Dependabot
       protected
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_latest_version(language_version: nil)
@@ -133,13 +133,16 @@ module Dependabot
         versions.max
       end
 
-      sig { params(versions: T::Array[Dependabot::Version]).returns(T::Array[Dependabot::Version]) }
+      sig do
+        params(versions: T::Array[Dependabot::Version])
+          .returns(T::Array[Dependabot::Version])
+      end
       def apply_post_fetch_latest_versions_filter(versions)
         versions
       end
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_latest_version_with_no_unlock(language_version:)
@@ -157,7 +160,7 @@ module Dependabot
       end
 
       sig do
-        params(language_version: T.nilable(T.any(String, Version)))
+        params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_lowest_security_fix_version(language_version:)
@@ -222,7 +225,7 @@ module Dependabot
       sig do
         params(
           releases: T::Array[Dependabot::Package::PackageRelease],
-          language_version: T.nilable(T.any(String, Version))
+          language_version: T.nilable(T.any(String, Dependabot::Version))
         )
           .returns(T::Array[Dependabot::Version])
       end


### PR DESCRIPTION
### What are you trying to accomplish?

This change refactors the `PackageLatestVersionFinder` by updating the returned version types to use `Dependabot::Version` instead of previous types like `Gem::Version`. The goal is to make the filtering and handling of versions more consistent by ensuring the correct, more specific `Dependabot::Version` type is used, particularly for version filtering logic across all package ecosystems. This update improves maintainability and consistency across the codebase, aligning version handling with other parts of Dependabot.

### Anything you want to highlight for special attention from reviewers?

- Review the updates to the version handling logic in `PackageLatestVersionFinder`, especially the transition from `Gem::Version` to `Dependabot::Version`.
- Ensure that no unexpected behavior arises from this change in version typing and that all existing functionality remains intact.
- Check that the updated version types do not introduce any breaking changes, particularly in type handling and filtering logic.

### How will you know you've accomplished your goal?

- The full test suite passes without regressions or errors related to version handling.
- All version-related logic is using `Dependabot::Version` correctly, and no issues arise from the type changes.
- Tests for version handling logic pass as expected, confirming the correct use of the updated types.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses
