### PR TITLE
Refactor: Update Bundler Versioning to Use Bundler::Version Instead of Gem::Version

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -59,7 +59,7 @@ module Dependabot
 
           ruby_version =
             RUBY_VERSIONS
-            .map { |v| Gem::Version.new(v) }.sort
+            .map { |v| Dependabot::Bundler::Version.new(v) }.sort
             .find { |v| requirement.satisfied_by?(v) }
 
           unless ruby_version

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -130,10 +130,10 @@ module Dependabot
 
         updated_dependencies.none? do |dep|
           old_version = dep.previous_version
-          next unless Gem::Version.correct?(old_version)
-          next if Gem::Version.new(old_version).prerelease?
+          next unless Dependabot::Bundler::Version.correct?(old_version)
+          next if Dependabot::Bundler::Version.new(old_version).prerelease?
 
-          Gem::Version.new(dep.version).prerelease?
+          Dependabot::Bundler::Version.new(dep.version).prerelease?
         end
       rescue Dependabot::DependencyFileNotResolvable
         false

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -215,13 +215,13 @@ module Dependabot
           lower_bound_req = updated_version_req_lower_bound(filename)
 
           return lower_bound_req if latest_allowable_version.nil?
-          return lower_bound_req unless Gem::Version.correct?(latest_allowable_version)
+          return lower_bound_req unless Bundler::Version.correct?(latest_allowable_version)
 
           lower_bound_req + ", <= #{latest_allowable_version}"
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        def updated_version_req_lower_bound(filename)
+        def updated_version_req_lower_bound(filename) # rubocop:disable Metrics/CyclomaticComplexity
           original_req = dependency.requirements
                                    .find { |r| r.fetch(:file) == filename }
                                    &.fetch(:requirement)
@@ -234,9 +234,9 @@ module Dependabot
               dependency.requirements.map { |r| r[:requirement] }
                         .reject { |req_string| req_string.start_with?("<") }
                         .select { |req_string| req_string.match?(VERSION_REGEX) }
-                        .map { |req_string| req_string.match(VERSION_REGEX) }
-                        .select { |version| Gem::Version.correct?(version) }
-                        .max_by { |version| Gem::Version.new(version) }
+                        .map { |req_string| req_string.match(VERSION_REGEX)&.to_s }
+                        .select { |version| Bundler::Version.correct?(version) }
+                        .max_by { |version| Bundler::Version.new(version) }
 
             ">= #{version_for_requirement || 0}"
           end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -72,8 +72,11 @@ module Dependabot
 
           relevant_versions = dependency_source.versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
-          relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,
-                                                                                                    security_advisories)
+          relevant_versions = Dependabot::UpdateCheckers::VersionFilters
+                              .filter_vulnerable_versions(
+                                relevant_versions,
+                                security_advisories
+                              )
           relevant_versions = filter_ignored_versions(relevant_versions)
           relevant_versions = filter_lower_versions(relevant_versions)
 

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -40,7 +40,7 @@ module Dependabot
 
           # The latest version details for the dependency from a registry
           #
-          sig { returns(T::Array[Gem::Version]) }
+          sig { returns(T::Array[Dependabot::Bundler::Version]) }
           def versions
             return rubygems_versions if dependency.name == "bundler"
             return rubygems_versions unless gemfile
@@ -99,7 +99,7 @@ module Dependabot
                 )
 
                 JSON.parse(response.body)
-                    .map { |d| Gem::Version.new(d["number"]) }
+                    .map { |d| Dependabot::Bundler::Version.new(d["number"]) }
               end
           rescue JSON::ParserError, Excon::Error::Timeout
             @rubygems_versions = []
@@ -123,7 +123,7 @@ module Dependabot
                     credentials: credentials
                   }
                 ).map do |version_string|
-                  Gem::Version.new(version_string)
+                  Dependabot::Bundler::Version.new(version_string)
                 end
               end
           end

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -26,7 +26,7 @@ module Dependabot
         def initialize(requirements:, update_strategy:, updated_source:,
                        latest_version:, latest_resolvable_version:)
           @requirements = requirements
-          @latest_version = Gem::Version.new(latest_version) if latest_version
+          @latest_version = Dependabot::Bundler::Version.new(latest_version) if latest_version
           @updated_source = updated_source
           @update_strategy = update_strategy
 
@@ -35,7 +35,7 @@ module Dependabot
           return unless latest_resolvable_version
 
           @latest_resolvable_version =
-            Gem::Version.new(latest_resolvable_version)
+            Dependabot::Bundler::Version.new(latest_resolvable_version)
         end
 
         def updated_requirements
@@ -267,7 +267,9 @@ module Dependabot
         # Updates the version in a "<" or "<=" constraint to allow the given
         # version
         def update_greatest_version(requirement, version_to_be_permitted)
-          version_to_be_permitted = Gem::Version.new(version_to_be_permitted) if version_to_be_permitted.is_a?(String)
+          if version_to_be_permitted.is_a?(String)
+            version_to_be_permitted = Dependabot::Bundler::Version.new(version_to_be_permitted)
+          end
           op, version = requirement.requirements.first
           version = version.release if version.prerelease?
 

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -118,7 +118,7 @@ module Dependabot
                 # mismatch
                 return nil if ruby_version_incompatible?(details)
 
-                details[:version] = Gem::Version.new(details[:version])
+                details[:version] = Dependabot::Bundler::Version.new(details[:version])
               end
               details
             end

--- a/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
     described_class.new(replacement_version: replacement_version)
   end
 
-  let(:replacement_version) { Gem::Version.new("1.5.0") }
+  let(:replacement_version) { Dependabot::Bundler::Version.new("1.5.0") }
 
   describe "#rewrite" do
     subject(:rewrite) { sanitizer.rewrite(content) }
@@ -276,7 +276,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
       # rubocop:enable Lint/InterpolationCheck
 
       context "with a version constant used outside of a string" do
-        let(:content) { 'Spec.new { |s| Gem::Version.new("1.0.0") }' }
+        let(:content) { 'Spec.new { |s| Dependabot::Bundler::Version.new("1.0.0") }' }
 
         it { is_expected.to eq(content) }
       end

--- a/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      target_version: Gem::Version.new(target_version),
+      target_version: Dependabot::Bundler::Version.new(target_version),
       requirements_update_strategy: update_strategy,
       credentials: [{
         "type" => "git_source",

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           .to_return(status: 200, body: rubygems_response)
       end
 
-      its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+      its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
       it "only hits Rubygems once" do
         finder.latest_version_details
@@ -100,7 +100,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "with a gems.rb setup" do
         let(:dependency_files) { bundler_project_dependency_files("gems_rb") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "when the gem is Bundler" do
@@ -113,12 +113,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             .to_return(status: 200, body: rubygems_response)
         end
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
         context "when wrapped in a source block" do
           let(:dependency_files) { bundler_project_dependency_files("bundler_specified_in_source_bundler_specified") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
         end
       end
 
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "when the user is on the latest version" do
         let(:current_version) { "1.5.0" }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
         context "when raise_on_ignored is set" do
           let(:raise_on_ignored) { true }
@@ -171,7 +171,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "when the user has ignored all later versions" do
         let(:ignored_versions) { ["> 1.3.0"] }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.3.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.3.0")) }
 
         context "when raise_on_ignored is set" do
           let(:raise_on_ignored) { true }
@@ -185,7 +185,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "when the user is ignoring the latest version" do
         let(:ignored_versions) { [">= 1.5.0.a, < 1.6"] }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.0")) }
       end
 
       context "when the user has ignored all versions" do
@@ -214,31 +214,31 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             .to_return(status: 200, body: rubygems_response)
         end
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.6.0.beta")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.6.0.beta")) }
       end
 
       context "with a Ruby version specified" do
         let(:dependency_files) { bundler_project_dependency_files("explicit_ruby") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "when given a Gemfile that loads a .ruby-version file" do
         let(:dependency_files) { bundler_project_dependency_files("ruby_version_file") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "when the Gemfile loads a .tool-versions file" do
         let(:dependency_files) { bundler_project_dependency_files("tool_versions_file") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "with a gemspec and a Gemfile" do
         let(:dependency_files) { bundler_project_dependency_files("gemfile_small_example") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
         context "with a dependency that only appears in the gemspec" do
           let(:dependency_files) { bundler_project_dependency_files("gemfile_small_example") }
@@ -250,12 +250,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
               .to_return(status: 200, body: response)
           end
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
           context "when there is no default source" do
             let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_no_default_source_no_lockfile") }
 
-            its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+            its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
           end
         end
       end
@@ -263,13 +263,13 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "with only a gemspec" do
         let(:dependency_files) { bundler_project_dependency_files("gemspec_small_example_no_lockfile") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "with only a Gemfile" do
         let(:dependency_files) { bundler_project_dependency_files("no_lockfile") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
     end
 
@@ -294,7 +294,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         it "fetches the latest version details" do
           expect(result).to be_a(Hash)
           expect(result).not_to be_empty
-          expect(result[:version]).to eq(Gem::Version.new("1.4.0"))
+          expect(result[:version]).to eq(Dependabot::Bundler::Version.new("1.4.0"))
           expect(a_request(:get, rubygems_url + "versions/business.json")).to have_been_made.twice
         end
       end
@@ -303,7 +303,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         subject(:result) { finder.latest_version }
 
         it "fetches the latest version" do
-          expect(result).to eq(Gem::Version.new("1.4.0"))
+          expect(result).to eq(Dependabot::Bundler::Version.new("1.4.0"))
         end
       end
     end
@@ -348,18 +348,18 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           )
       end
 
-      its([:version]) { is_expected.to eq(Gem::Version.new("1.9.0")) }
+      its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.9.0")) }
 
       context "when specified as the default source" do
         let(:dependency_files) { bundler_project_dependency_files("specified_default_source") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.9.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.9.0")) }
       end
 
       context "when the user is ignoring the latest version" do
         let(:ignored_versions) { [">= 1.9.0.a, < 2.0"] }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "when we have bad authentication details" do
@@ -502,12 +502,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             )
         end
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
         context "when that is private" do
           let(:dependency_files) { bundler_project_dependency_files("private_git_source") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
         end
       end
     end
@@ -525,7 +525,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         let(:dependency_files) { bundler_project_dependency_files("path_source") }
 
         context "when that is not the gem we're checking" do
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
         end
 
         context "when that is the gem we're checking" do
@@ -559,7 +559,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           .to_return(status: 200, body: rubygems_response)
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.4.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.0")) }
     end
 
     context "with a private rubygems source" do
@@ -595,7 +595,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           )
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
     end
 
     context "with a git source" do

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("gemfile") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.0")) }
       end
 
       context "with a minor version specified that can update" do
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("minor_version_specified_gemfile") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.18.0")) }
       end
 
       context "when updating a dep blocked by a sub-dep" do
@@ -92,7 +92,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         let(:dependency_files) { bundler_project_dependency_files("blocked_by_subdep") }
 
         it "is still able to upgrade to the latest version by upgrading the subdep as well" do
-          expect(latest_resolvable_version_details[:version]).to eq(Gem::Version.new("2.0.0"))
+          expect(latest_resolvable_version_details[:version]).to eq(Dependabot::Bundler::Version.new("2.0.0"))
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("subdependency") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("0.7.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("0.7.0")) }
 
         context "when it will be removed if other sub-dependencies are updated" do
           let(:gemfile_fixture_name) { "subdependency_change" }
@@ -112,7 +112,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
           it "is updated" do
             skip("skipped due to https://github.com/dependabot/dependabot-core/issues/2364")
-            expect(latest_resolvable_version_details.version).to eq(Gem::Version.new("1.10.9"))
+            expect(latest_resolvable_version_details.version).to eq(Dependabot::Bundler::Version.new("1.10.9"))
           end
         end
       end
@@ -122,7 +122,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("bundler_specified") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.0")) }
 
         context "when attempting to update Bundler" do
           let(:dependency_name) { "bundler" }
@@ -143,7 +143,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         let(:dependency_files) { bundler_project_dependency_files("requires_bundler") }
 
         it "resolves version" do
-          expect(latest_resolvable_version_details[:version]).to eq(Gem::Version.new("3.0.0"))
+          expect(latest_resolvable_version_details[:version]).to eq(Dependabot::Bundler::Version.new("3.0.0"))
         end
       end
 
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("default_gem_specified") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.18.0")) }
       end
 
       context "with a version conflict at the latest version" do
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         # version compatible with the version of i18n in the Gemfile.lock.
         let(:dependency_files) { bundler_project_dependency_files("version_conflict_no_req_change") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("0.11.28")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("0.11.28")) }
 
         context "with a gems.rb and gems.locked" do
           let(:requirements) do
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
           let(:dependency_files) { bundler_project_dependency_files("version_conflict_no_req_change_gems_rb") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("0.11.28")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("0.11.28")) }
         end
       end
 
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         let(:dependency_files) { bundler_project_dependency_files("version_conflict_with_listed_subdep") }
 
         it "is still able to upgrade" do
-          expect(latest_resolvable_version_details[:version]).to be > Gem::Version.new("3.6.0")
+          expect(latest_resolvable_version_details[:version]).to be > Dependabot::Bundler::Version.new("3.6.0")
         end
       end
 
@@ -200,7 +200,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         # or greater.
         let(:dependency_files) { bundler_project_dependency_files("legacy_ruby") }
 
-        its([:version]) { is_expected.to eq(Gem::Version.new("1.4.6")) }
+        its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.6")) }
       end
 
       context "with a legacy Ruby when Bundler's compact index is down" do
@@ -247,7 +247,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
           let(:dependency_files) { bundler_project_dependency_files("legacy_ruby") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("3.0.2")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("3.0.2")) }
         end
 
         context "when the dependency has a required Ruby version range" do
@@ -268,7 +268,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("jruby") }
 
-        its([:version]) { is_expected.to be >= Gem::Version.new("1.4.6") }
+        its([:version]) { is_expected.to be >= Dependabot::Bundler::Version.new("1.4.6") }
       end
 
       context "when a gem has been yanked" do
@@ -277,7 +277,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         context "when it's that gem that we're attempting to bump" do
           let(:dependency_files) { bundler_project_dependency_files("minor_version_specified_yanked_gem") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.18.0")) }
         end
 
         context "when it's another gem" do
@@ -285,7 +285,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
           let(:requirement_string) { "~> 1.2" }
           let(:dependency_files) { bundler_project_dependency_files("minor_version_specified_yanked_gem") }
 
-          its([:version]) { is_expected.to eq(Gem::Version.new("1.3.1")) }
+          its([:version]) { is_expected.to eq(Dependabot::Bundler::Version.new("1.3.1")) }
         end
       end
 
@@ -426,7 +426,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         it "takes the minimum ruby version into account" do
           expect(resolver.latest_resolvable_version_details[:version])
-            .to eq(Gem::Version.new("2.0.1"))
+            .to eq(Dependabot::Bundler::Version.new("2.0.1"))
         end
 
         context "when that isn't satisfied by the dependencies" do
@@ -437,7 +437,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
           it "ignores the minimum ruby version in the gemspec" do
             expect(resolver.latest_resolvable_version_details[:version])
-              .to eq(Gem::Version.new("7.2.0"))
+              .to eq(Dependabot::Bundler::Version.new("7.2.0"))
           end
         end
       end
@@ -464,7 +464,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         # Mock the LatestVersionFinder to verify it receives cooldown_options
         latest_version_finder = instance_double(Dependabot::Bundler::UpdateChecker::LatestVersionFinder)
         allow(latest_version_finder)
-          .to receive(:latest_version_details).and_return({ version: Gem::Version.new("1.5.0") })
+          .to receive(:latest_version_details).and_return({ version: Dependabot::Bundler::Version.new("1.5.0") })
         allow(Dependabot::Bundler::UpdateChecker::LatestVersionFinder)
           .to receive(:new).and_return(latest_version_finder)
 

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           .to_return(status: 200, body: rubygems_response)
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
 
       context "when that only appears in the lockfile" do
         let(:dependency_files) { bundler_project_dependency_files("subdependency") }
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             .to_return(status: 200, body: rubygems_response)
         end
 
-        it { is_expected.to eq(Gem::Version.new("1.6.0.beta")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.6.0.beta")) }
       end
 
       context "when the gem isn't on Rubygems" do
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         let(:dependency_files) { bundler_project_dependency_files("includes_require_relative_gemfile") }
         let(:directory) { "app/" }
 
-        it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
 
       context "with a gem.rb and gems.locked setup" do
@@ -110,7 +110,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           }]
         end
 
-        it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         }]
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
     end
 
     context "with a private rubygems source" do
@@ -180,7 +180,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           )
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.9.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.9.0")) }
     end
 
     context "when given a git source" do
@@ -216,7 +216,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               .and_return(true)
           end
 
-          it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
         end
 
         context "when head of the gem's branch is not included in a release" do
@@ -289,7 +289,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 .and_return(true)
             end
 
-            it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+            it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
           end
 
           context "when the pin looks like a version" do
@@ -387,7 +387,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         # Mock the LatestVersionFinder to verify it receives cooldown_options
         latest_version_finder = instance_double(Dependabot::Bundler::UpdateChecker::LatestVersionFinder)
         allow(latest_version_finder)
-          .to receive(:latest_version_details).and_return({ version: Gem::Version.new("1.5.0") })
+          .to receive(:latest_version_details).and_return({ version: Dependabot::Bundler::Version.new("1.5.0") })
         allow(Dependabot::Bundler::UpdateChecker::LatestVersionFinder)
           .to receive(:new).and_return(latest_version_finder)
       end
@@ -425,7 +425,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       it "finds the lowest available non-vulnerable version" do
-        expect(lowest_security_fix_version).to eq(Gem::Version.new("1.3.0"))
+        expect(lowest_security_fix_version).to eq(Dependabot::Bundler::Version.new("1.3.0"))
       end
 
       context "with a security vulnerability" do
@@ -440,7 +440,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         it "finds the lowest available non-vulnerable version" do
-          expect(lowest_security_fix_version).to eq(Gem::Version.new("1.4.0"))
+          expect(lowest_security_fix_version).to eq(Dependabot::Bundler::Version.new("1.4.0"))
         end
       end
     end
@@ -462,7 +462,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
     context "with a latest version" do
       before do
-        allow(checker).to receive(:latest_version).and_return(Gem::Version.new(target_version))
+        allow(checker).to receive(:latest_version).and_return(Dependabot::Bundler::Version.new(target_version))
       end
 
       context "when the force updater raises" do
@@ -503,7 +503,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
     context "with a latest version" do
       before do
-        allow(checker).to receive(:latest_version).and_return(Gem::Version.new(target_version))
+        allow(checker).to receive(:latest_version).and_return(Dependabot::Bundler::Version.new(target_version))
       end
 
       context "when the force updater succeeds" do
@@ -647,7 +647,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         let(:dependency_name) { "i18n" }
         let(:current_version) { "0.7.0.beta1" }
 
-        it { is_expected.to eq(Gem::Version.new("0.7.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("0.7.0")) }
       end
 
       context "with no version specified" do
@@ -656,12 +656,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
         end
 
-        it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
 
         context "when the user is ignoring the latest version" do
           let(:ignored_versions) { [">= 1.7.0.a, < 2.0"] }
 
-          it { is_expected.to eq(Gem::Version.new("1.6.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.6.0")) }
         end
       end
 
@@ -676,7 +676,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           }]
         end
 
-        it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
       end
 
       context "with multiple requirements" do
@@ -690,7 +690,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           }]
         end
 
-        it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
       end
 
       context "with a gem.rb and gems.locked setup" do
@@ -700,7 +700,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           let(:dependency_name) { "i18n" }
           let(:current_version) { "0.7.0.beta1" }
 
-          it { is_expected.to eq(Gem::Version.new("0.7.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("0.7.0")) }
         end
 
         context "with a range requirement" do
@@ -714,7 +714,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             }]
           end
 
-          it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
         end
       end
     end
@@ -723,7 +723,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       context "with a downloaded gemspec" do
         let(:dependency_files) { bundler_project_dependency_files("path_source_no_overlap") }
 
-        it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
 
         it "doesn't persist any temporary changes to Bundler's root" do
           expect { checker.latest_resolvable_version }
@@ -733,20 +733,20 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         context "when that requires other files" do
           let(:dependency_files) { bundler_project_dependency_files("path_source_no_overlap_with_require") }
 
-          it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
         end
 
         context "when that is the gem we're checking" do
           let(:dependency_name) { "example" }
           let(:current_version) { "0.9.3" }
 
-          it { is_expected.to eq(Gem::Version.new("0.9.3")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("0.9.3")) }
         end
 
         context "when that has a .specification" do
           let(:dependency_files) { bundler_project_dependency_files("path_source_statesman") }
 
-          it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
         end
       end
     end
@@ -811,7 +811,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               .and_return(true)
           end
 
-          it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
         end
 
         context "when the dependency has never been released" do
@@ -895,7 +895,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 .and_return(true)
             end
 
-            it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+            it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
           end
 
           context "when the release appears to be a version" do
@@ -1120,7 +1120,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             allow(checker)
               .to receive(:latest_resolvable_version_details)
               .with(remove_git_source: true)
-              .and_return(version: Gem::Version.new("2.0.0"))
+              .and_return(version: Dependabot::Bundler::Version.new("2.0.0"))
           end
 
           it "raises a helpful error" do
@@ -1170,7 +1170,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             allow(checker)
               .to receive(:latest_resolvable_version_details)
               .with(remove_git_source: true)
-              .and_return(version: Gem::Version.new("2.0.0"))
+              .and_return(version: Dependabot::Bundler::Version.new("2.0.0"))
           end
 
           it { is_expected.to be_nil }
@@ -1182,7 +1182,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         let(:dependency_name) { "statesman" }
         let(:current_version) { "1.2" }
 
-        it { is_expected.to eq(Gem::Version.new("3.4.1")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("3.4.1")) }
 
         context "when dealing with a private instance" do
           let(:dependency_files) { bundler_project_dependency_files("private_git_source") }
@@ -1229,7 +1229,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         context "when dealing with a bad branch" do
           let(:dependency_files) { bundler_project_dependency_files("bad_branch") }
 
-          it { is_expected.to eq(Gem::Version.new("3.4.1")) }
+          it { is_expected.to eq(Dependabot::Bundler::Version.new("3.4.1")) }
         end
       end
     end
@@ -1241,14 +1241,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         [{ file: "Gemfile", requirement: "~> 1.2.0", groups: [], source: nil }]
       end
 
-      it { is_expected.to eq(Gem::Version.new("3.4.1")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("3.4.1")) }
 
       context "when the instance is old" do
         let(:dependency_files) { bundler_project_dependency_files("explicit_ruby_old") }
 
         it "Gem version is 2.0.1" do
           skip "This test intermittently fails, which often trips up external contributors"
-          expect(latest_resolvable_version).to eq(Gem::Version.new("2.0.1"))
+          expect(latest_resolvable_version).to eq(Dependabot::Bundler::Version.new("2.0.1"))
         end
       end
     end
@@ -1271,7 +1271,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
       it "doesn't just fall back to latest_version" do
         expect(checker.latest_resolvable_version)
-          .to eq(Gem::Version.new("1.13.0"))
+          .to eq(Dependabot::Bundler::Version.new("1.13.0"))
       end
 
       context "when the gemspec has a path" do
@@ -1292,7 +1292,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         it "doesn't just fall back to latest_version" do
           expect(checker.latest_resolvable_version)
-            .to eq(Gem::Version.new("1.13.0"))
+            .to eq(Dependabot::Bundler::Version.new("1.13.0"))
         end
       end
 
@@ -1302,7 +1302,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         it "takes the minimum ruby version into account" do
           expect(checker.latest_resolvable_version)
-            .to eq(Gem::Version.new("2.0.1"))
+            .to eq(Dependabot::Bundler::Version.new("2.0.1"))
         end
       end
 
@@ -1311,7 +1311,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         it "falls back to latest_version" do
           expect(checker.latest_resolvable_version)
-            .to eq(Gem::Version.new("1.13.0"))
+            .to eq(Dependabot::Bundler::Version.new("1.13.0"))
         end
       end
     end
@@ -1322,7 +1322,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it "falls back to latest_version" do
         dummy_version_resolver =
           checker.send(:version_resolver, remove_git_source: false)
-        dummy_version = Gem::Version.new("0.5.0")
+        dummy_version = Dependabot::Bundler::Version.new("0.5.0")
         allow(checker)
           .to receive(:version_resolver)
           .and_return(dummy_version_resolver)
@@ -1338,7 +1338,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
       it "doesn't just fall back to latest_version" do
         expect(checker.latest_resolvable_version)
-          .to eq(Gem::Version.new("1.13.0"))
+          .to eq(Dependabot::Bundler::Version.new("1.13.0"))
       end
 
       context "when dealing with a gem with a private git source" do
@@ -1426,7 +1426,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       let(:current_version) { "2.2.1" }
 
       context "when using bundler v2" do
-        it { is_expected.to eq(Gem::Version.new("3.0.0")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("3.0.0")) }
       end
     end
   end
@@ -1437,7 +1437,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     include_context "when stubbing rubygems compact index"
     include_context "when stubbing rubygems versions api"
 
-    it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+    it { is_expected.to eq(Dependabot::Bundler::Version.new("1.13.0")) }
 
     context "with a security vulnerability" do
       let(:security_advisories) do
@@ -1450,7 +1450,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         ]
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.5.0")) }
     end
   end
 
@@ -1461,7 +1461,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     include_context "when stubbing rubygems versions api"
 
     context "when given a gem from rubygems" do
-      it { is_expected.to eq(Gem::Version.new("1.4.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("1.4.0")) }
 
       context "with a version conflict at the latest version" do
         let(:dependency_files) { bundler_project_dependency_files("version_conflict_no_req_change") }
@@ -1473,7 +1473,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
         # The latest version of ibandit is 0.8.5, but 0.3.4 is the latest
         # version compatible with the version of i18n in the Gemfile.
-        it { is_expected.to eq(Gem::Version.new("0.3.4")) }
+        it { is_expected.to eq(Dependabot::Bundler::Version.new("0.3.4")) }
       end
     end
 
@@ -1483,7 +1483,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       let(:dependency_name) { "i18n" }
       let(:current_version) { "0.7.0.beta1" }
 
-      it { is_expected.to eq(Gem::Version.new("0.7.0")) }
+      it { is_expected.to eq(Dependabot::Bundler::Version.new("0.7.0")) }
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This change refactors the versioning logic within Bundler by updating the version handling to use `Bundler::Version` instead of `Gem::Version`. The goal is to standardize the versioning system used in Bundler and ensure compatibility with the latest versioning practices. This update will help improve the maintainability and consistency of version comparisons and handling across the Bundler codebase.

### Anything you want to highlight for special attention from reviewers?

- Review the code for any instances where `Gem::Version` is used and ensure it's replaced with `Bundler::Version`.
- Ensure that no regressions or unexpected behavior are introduced as a result of this change, particularly in version comparison logic.
- Make sure that all existing functionality works correctly with the updated versioning system.

### How will you know you've accomplished your goal?

- The full test suite passes with no regressions in version handling or logic.
- All version comparisons are correctly using `Bundler::Version`.
- Any new tests related to version handling are passing as expected.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
