### PR TITLE
Refactor: Consistent Filtering of Releases in PackageLatestVersionFinder

### DIFF
--- a/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -180,7 +180,7 @@ module Dependabot
             .params(language_version: T.nilable(T.any(String, Dependabot::Version)))
             .returns(T.nilable(Dependabot::Version))
         end
-        def fetch_lowest_security_fix_version(language_version:) # rubocop:disable Lint/UnusedMethodArgument
+        def fetch_lowest_security_fix_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           with_custom_registry_rescue do
             return unless valid_npm_details?
 

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -97,9 +97,7 @@ module Dependabot
 
           release = relevant_versions.max_by(&:version)
 
-          return if release.nil?
-
-          { version: release.version }
+          { version: release&.version }
         end
 
         sig do

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -102,8 +102,11 @@ module Dependabot
           { version: release.version }
         end
 
-        sig { returns(T.nilable(Dependabot::Version)) }
-        def fetch_lowest_security_fix_version
+        sig do
+          params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def fetch_lowest_security_fix_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           return if dependency_source.git?
 
           relevant_versions = available_versions || []

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -107,7 +107,12 @@ module Dependabot
         def fetch_lowest_security_fix_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           return if dependency_source.git?
 
-          relevant_versions = available_versions || []
+          relevant_versions = dependency_source.versions.map do |version|
+            Dependabot::Package::PackageRelease.new(
+              version: version
+            )
+          end
+
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = Dependabot::UpdateCheckers::VersionFilters
                               .filter_vulnerable_versions(

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "excon"
@@ -26,12 +26,20 @@ module Dependabot
           ).fetch
         end
 
-        def latest_version
-          @latest_version ||= fetch_latest_version
+        sig do
+          override.params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+                  .returns(T.nilable(Dependabot::Version))
+        end
+        def latest_version(language_version: nil)
+          @latest_version ||= fetch_latest_version(language_version: language_version)
         end
 
-        def lowest_security_fix_version
-          @lowest_security_fix_version ||= fetch_lowest_security_fix_version(language_version: nil)
+        sig do
+          override.params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+                  .returns(T.nilable(Dependabot::Version))
+        end
+        def lowest_security_fix_version(language_version: nil)
+          @lowest_security_fix_version ||= fetch_lowest_security_fix_version(language_version: language_version)
         end
 
         protected
@@ -53,14 +61,23 @@ module Dependabot
 
         private
 
+        sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+        sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
+        sig { returns(T::Array[String]) }
         attr_reader :ignored_versions
+        sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
         attr_reader :security_advisories
 
-        def apply_post_fetch_lowest_security_fix_versions_filter(versions)
-          filter_prerelease_versions(versions)
+        sig do
+          override.params(releases: T::Array[Dependabot::Package::PackageRelease])
+                  .returns(T::Array[Dependabot::Package::PackageRelease])
+        end
+        def apply_post_fetch_lowest_security_fix_versions_filter(releases)
+          filter_prerelease_versions(releases)
         end
       end
     end

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -155,7 +155,7 @@ module Dependabot
         params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
       end
-      def fetch_lowest_security_fix_version(language_version:)
+      def fetch_lowest_security_fix_version(language_version: nil)
         releases = available_versions
         return unless releases
 

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -121,16 +121,16 @@ module Dependabot
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_latest_version(language_version: nil)
-        version_hashes = available_versions
-        return unless version_hashes
+        releases = available_versions
+        return unless releases
 
-        version_hashes = filter_yanked_versions(version_hashes)
-        version_hashes = filter_by_cooldown(version_hashes)
-        versions = filter_unsupported_versions(version_hashes, language_version)
-        versions = filter_prerelease_versions(versions)
-        versions = filter_ignored_versions(versions)
-        versions = apply_post_fetch_latest_versions_filter(versions)
-        versions.max_by(&:version)&.version
+        releases = filter_yanked_versions(releases)
+        releases = filter_by_cooldown(releases)
+        releases = filter_unsupported_versions(releases, language_version)
+        releases = filter_prerelease_versions(releases)
+        releases = filter_ignored_versions(releases)
+        releases = apply_post_fetch_latest_versions_filter(releases)
+        releases.max_by(&:version)&.version
       end
 
       sig do

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -130,15 +130,7 @@ module Dependabot
         versions = filter_prerelease_versions(versions)
         versions = filter_ignored_versions(versions)
         versions = apply_post_fetch_latest_versions_filter(versions)
-        versions.max
-      end
-
-      sig do
-        params(versions: T::Array[Dependabot::Version])
-          .returns(T::Array[Dependabot::Version])
-      end
-      def apply_post_fetch_latest_versions_filter(versions)
-        versions
+        versions.max_by(&:version)&.version
       end
 
       sig do
@@ -146,17 +138,17 @@ module Dependabot
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_latest_version_with_no_unlock(language_version:)
-        version_hashes = available_versions
-        return unless version_hashes
+        releases = available_versions
+        return unless releases
 
-        version_hashes = filter_yanked_versions(version_hashes)
-        version_hashes = filter_by_cooldown(version_hashes)
-        versions = filter_unsupported_versions(version_hashes, language_version)
-        versions = filter_prerelease_versions(versions)
-        versions = filter_ignored_versions(versions)
-        versions = filter_out_of_range_versions(versions)
-        versions = apply_post_fetch_latest_versions_filter(versions)
-        versions.max
+        releases = filter_yanked_versions(releases)
+        releases = filter_by_cooldown(releases)
+        releases = filter_unsupported_versions(releases, language_version)
+        releases = filter_prerelease_versions(releases)
+        releases = filter_ignored_versions(releases)
+        releases = filter_out_of_range_versions(releases)
+        releases = apply_post_fetch_latest_versions_filter(releases)
+        releases.max_by(&:version)&.version
       end
 
       sig do
@@ -164,27 +156,39 @@ module Dependabot
           .returns(T.nilable(Dependabot::Version))
       end
       def fetch_lowest_security_fix_version(language_version:)
-        version_hashes = available_versions
-        return unless version_hashes
+        releases = available_versions
+        return unless releases
 
-        version_hashes = filter_yanked_versions(version_hashes)
-        version_hashes = filter_by_cooldown(version_hashes)
-        versions = filter_unsupported_versions(version_hashes, language_version)
+        releases = filter_yanked_versions(releases)
+        releases = filter_by_cooldown(releases)
+        releases = filter_unsupported_versions(releases, language_version)
         # versions = filter_prerelease_versions(versions)
-        versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
-          versions,
-          security_advisories
-        )
-        versions = filter_ignored_versions(versions)
-        versions = filter_lower_versions(versions)
-        versions = apply_post_fetch_lowest_security_fix_versions_filter(versions)
+        releases = Dependabot::UpdateCheckers::VersionFilters
+                   .filter_vulnerable_versions(
+                     releases,
+                     security_advisories
+                   )
+        releases = filter_ignored_versions(releases)
+        releases = filter_lower_versions(releases)
+        releases = apply_post_fetch_lowest_security_fix_versions_filter(releases)
 
-        versions.min
+        releases.min_by(&:version)&.version
       end
 
-      sig { params(versions: T::Array[Dependabot::Version]).returns(T::Array[Dependabot::Version]) }
-      def apply_post_fetch_lowest_security_fix_versions_filter(versions)
-        versions
+      sig do
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
+      end
+      def apply_post_fetch_latest_versions_filter(releases)
+        releases
+      end
+
+      sig do
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
+      end
+      def apply_post_fetch_lowest_security_fix_versions_filter(releases)
+        releases
       end
 
       sig do
@@ -227,16 +231,16 @@ module Dependabot
           releases: T::Array[Dependabot::Package::PackageRelease],
           language_version: T.nilable(T.any(String, Dependabot::Version))
         )
-          .returns(T::Array[Dependabot::Version])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
       end
       def filter_unsupported_versions(releases, language_version)
         filtered = releases.filter_map do |release|
           language_requirement = release.language&.requirement
-          next release.version unless language_version
-          next release.version unless language_requirement
+          next release unless language_version
+          next release unless language_requirement
           next unless language_requirement.satisfied_by?(language_version)
 
-          release.version
+          release
         end
         if releases.count > filtered.count
           delta = releases.count - filtered.count
@@ -246,61 +250,69 @@ module Dependabot
       end
 
       sig do
-        params(versions_array: T::Array[Dependabot::Version])
-          .returns(T::Array[Dependabot::Version])
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
       end
-      def filter_prerelease_versions(versions_array)
-        return versions_array if wants_prerelease?
+      def filter_prerelease_versions(releases)
+        return releases if wants_prerelease?
 
-        filtered = versions_array.reject(&:prerelease?)
+        filtered = releases.reject { |release| release.version.prerelease? }
 
-        if versions_array.count > filtered.count
-          Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} pre-release versions")
+        if releases.count > filtered.count
+          Dependabot.logger.info("Filtered out #{releases.count - filtered.count} pre-release versions")
         end
 
         filtered
       end
 
       sig do
-        params(versions_array: T::Array[Dependabot::Version])
-          .returns(T::Array[Dependabot::Version])
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
       end
-      def filter_ignored_versions(versions_array)
-        filtered = versions_array
-                   .reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
-        if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(versions_array).any?
+      def filter_ignored_versions(releases)
+        filtered = releases
+                   .reject do |release|
+          ignore_requirements.any? do |r|
+            r.satisfied_by?(release.version)
+          end
+        end
+        if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(releases).any?
           raise Dependabot::AllVersionsIgnored
         end
 
-        if versions_array.count > filtered.count
-          Dependabot.logger.info("Filtered out #{versions_array.count - filtered.count} ignored versions")
+        if releases.count > filtered.count
+          Dependabot.logger.info("Filtered out #{releases.count - filtered.count} ignored versions")
         end
         filtered
       end
 
       sig do
-        params(versions_array: T::Array[Dependabot::Version])
-          .returns(T::Array[Dependabot::Version])
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
       end
-      def filter_lower_versions(versions_array)
-        return versions_array unless dependency.numeric_version
+      def filter_lower_versions(releases)
+        return releases unless dependency.numeric_version
 
-        versions_array.select { |version| version > dependency.numeric_version }
+        releases.select { |release| release.version > dependency.numeric_version }
       end
 
       sig do
-        params(versions_array: T::Array[Dependabot::Version])
-          .returns(T::Array[Dependabot::Version])
+        params(releases: T::Array[Dependabot::Package::PackageRelease])
+          .returns(T::Array[Dependabot::Package::PackageRelease])
       end
-      def filter_out_of_range_versions(versions_array)
+      def filter_out_of_range_versions(releases)
         reqs = dependency.requirements.filter_map do |r|
           next if r.fetch(:requirement).nil?
 
           requirement_class.requirements_array(r.fetch(:requirement))
         end
 
-        versions_array
-          .select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }
+        releases
+          .select do |release|
+          reqs.all? do |r|
+            r.any? { |o| o.satisfied_by?(release.version) }
+          end
+        end
       end
 
       sig { returns(T::Boolean) }
@@ -338,6 +350,7 @@ module Dependabot
 
         cooldown.default_days
       end
+
       sig { returns(T::Boolean) }
       def wants_prerelease?
         return version_class.new(dependency.version).prerelease? if dependency.version

--- a/common/lib/dependabot/package/package_release.rb
+++ b/common/lib/dependabot/package/package_release.rb
@@ -85,10 +85,8 @@ module Dependabot
         @yanked
       end
 
-      # Overriding the `==` method to compare two PackageRelease objects based on version
       sig { params(other: Object).returns(T::Boolean) }
       def ==(other)
-        # Ensure other is a PackageRelease object and compare versions
         return false unless other.is_a?(PackageRelease)
 
         version == other.version

--- a/common/lib/dependabot/package/package_release.rb
+++ b/common/lib/dependabot/package/package_release.rb
@@ -84,6 +84,20 @@ module Dependabot
       def yanked?
         @yanked
       end
+
+      # Overriding the `==` method to compare two PackageRelease objects based on version
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other)
+        # Ensure other is a PackageRelease object and compare versions
+        return false unless other.is_a?(PackageRelease)
+
+        version == other.version
+      end
+
+      sig { returns(String) }
+      def to_s
+        version.to_s
+      end
     end
   end
 end

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -211,3 +211,8 @@ TestRequirement = Class.new(Dependabot::Requirement) do
     super(requirements)
   end
 end
+
+# Define an anonymous subclass of Dependabot::Requirement for testing purposes
+TestVersion = Class.new(Dependabot::Version) do
+  # Initialize with a version string
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -180,7 +180,7 @@ module Dependabot
             .params(language_version: T.nilable(T.any(String, Dependabot::Version)))
             .returns(T.nilable(Dependabot::Version))
         end
-        def fetch_lowest_security_fix_version(language_version:) # rubocop:disable Lint/UnusedMethodArgument
+        def fetch_lowest_security_fix_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           with_custom_registry_rescue do
             return unless valid_npm_details?
 


### PR DESCRIPTION
### What are you trying to accomplish?

This change refactors the filtering logic for releases in `PackageLatestVersionFinder` to ensure consistent filtering across different version types. The goal is to apply the same filtering methodology to all releases, making the version filtering more robust and aligned with expected behavior across all ecosystems. This improves the maintainability and flexibility of version filtering.

### Anything you want to highlight for special attention from reviewers?

- Review the changes to the filtering logic for releases and ensure that all filtering now behaves consistently across different release types.
- Check that this update doesn't introduce any regressions or breaking changes in how versions are filtered.
- Verify that the logic for filtering releases works as expected, and the updates don't cause any unexpected behaviors.

### How will you know you've accomplished your goal?

- The full test suite passes without any regressions or issues in release filtering.
- All version filtering logic is now consistently applied, and no issues arise from the changes.
- Tests for the updated filtering logic pass successfully, confirming the correctness of the refactor.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
