### PR TITLE
Prevent `simplecov` from spamming `stdout`

### DIFF
--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -28,6 +28,15 @@ SimpleCov.start do
   minimum_coverage line: 0, branch: 0
 end
 
+# Don't print the "Coverage report generated for..." messages
+# https://github.com/simplecov-ruby/simplecov/issues/992
+SimpleCov.at_exit do
+  original_file_descriptor = $stdout
+  $stdout.reopen("/dev/null")
+  SimpleCov.result.format!
+  $stdout.reopen(original_file_descriptor)
+end
+
 require "dependabot/dependency_file"
 require "dependabot/experiments"
 require "dependabot/registry_client"


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Prevent all the `Coverage report generated for test-process-...` messages from being spammed to `stdout` when running `bundle exec rspec`.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

See the upstream issue https://github.com/simplecov-ruby/simplecov/issues/992

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
