### PR TITLE
Fix Docker Compose Specs Related to Requirements Digest with Sha256

### DIFF
--- a/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
               groups: [],
               file: "docker-compose.yml",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8d" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
                         "fc38288cf73aa07485005"
               }
             }]
@@ -198,7 +198,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
                   file: "docker-compose.yml",
                   source: {
                     registry: "registry-host.io:5000",
-                    digest: "18305429afa14ea462f810146ba44d4363ae76" \
+                    digest: "sha256:18305429afa14ea462f810146ba44d4363ae76" \
                             "e4c8dfc38288cf73aa07485005"
                   }
                 }]

--- a/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_parser_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
             expect(dependency.name).to eq("ubuntu")
-            expect(dependency.version).to eq("18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
+            expect(dependency.version).to eq("sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005")
             expect(dependency.requirements).to eq(expected_requirements)
           end
         end
@@ -208,7 +208,7 @@ RSpec.describe Dependabot::DockerCompose::FileParser do
                 expect(dependency).to be_a(Dependabot::Dependency)
                 expect(dependency.name).to eq("myreg/ubuntu")
                 expect(dependency.version).to eq(
-                  "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+                  "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
                 )
                 expect(dependency.requirements).to eq(expected_requirements)
               end

--- a/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }],
@@ -352,7 +352,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
                 groups: [],
                 file: "docker-compose.yml",
                 source: {
-                  digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                  digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                           "ca97eba880ebf600d68608",
                   tag: "17.10"
                 }
@@ -362,7 +362,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
                 groups: [],
                 file: "docker-compose.yml",
                 source: {
-                  digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                  digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                           "dfc38288cf73aa07485005",
                   tag: "12.04.5"
                 }
@@ -396,7 +396,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               file: "docker-compose.yml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608"
               }
             }],
@@ -406,7 +406,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               file: "docker-compose.yml",
               source: {
                 registry: "registry-host.io:5000",
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005"
               }
             }],
@@ -457,7 +457,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
           }, {
@@ -465,7 +465,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608",
               tag: "17.10"
             }
@@ -475,7 +475,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "docker-compose.yml",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
           }, {
@@ -483,7 +483,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
             groups: [],
             file: "custom-name",
             source: {
-              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005",
               tag: "12.04.5"
             }
@@ -523,7 +523,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                         "ca97eba880ebf600d68608",
                 tag: "17.10"
               }
@@ -533,7 +533,7 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
               groups: [],
               file: "custom-name",
               source: {
-                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                         "dfc38288cf73aa07485005",
                 tag: "12.04.5"
               }


### PR DESCRIPTION
### What are you trying to accomplish?

This PR addresses an issue in Docker Compose specs where digests in image references were not correctly prefixed with `sha256:`. Specifically, when a digest is included in Docker Compose image references, it should be in the format `sha256:<digest>`, but this was not being enforced. The change ensures that any digest included in Docker Compose image references will be correctly prefixed with `sha256:`.

### Anything you want to highlight for special attention from reviewers?

- The main focus of this change is on fixing Docker Compose image references where the digest did not include the `sha256:` prefix.
- Please pay special attention to the handling of image digests in the test cases to ensure that this fix is applied consistently.

### How will you know you've accomplished your goal?

- All Docker Compose spec tests should pass, and the image digest should now always be prefixed with `sha256:`.
- You can verify the fix by checking the tests for Docker Compose image references, particularly those involving digests, and ensuring that the digest format is consistent.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
