### PR TITLE
Fix Version Update Behavior for Versions with Dashes in Maven Ecosystem

### DIFF
--- a/maven/lib/dependabot/maven/package/package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/package/package_details_fetcher.rb
@@ -389,8 +389,8 @@ module Dependabot
           classifier = dependency.requirements.first&.dig(:metadata, :classifier)
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"
 
-          "#{base_url}/#{version.to_semver}/" \
-            "#{artifact_id}-#{version.to_semver}#{actual_classifier}.#{type}"
+          "#{base_url}/#{version}/" \
+            "#{artifact_id}-#{version}#{actual_classifier}.#{type}"
         end
 
         #           # Constructs the full URL by combining the repository URL, group path, and artifact ID

--- a/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
@@ -105,4 +105,44 @@ RSpec.describe Dependabot::Maven::Package::PackageDetailsFetcher do
       expect(fetcher.released?(unreleased_version)).to be(false)
     end
   end
+
+  describe "#dependency_files_url" do
+    it "correctly constructs the dependency files URL" do
+      expected_url = "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
+      version = Dependabot::Maven::Version.new("23.6-jre")
+
+      url = fetcher.send(:dependency_files_url, "https://repo.maven.apache.org/maven2", version)
+
+      expect(url).to eq(expected_url)
+    end
+  end
+
+  describe "#dependency_metadata_url" do
+    it "correctly constructs the metadata URL" do
+      expected_url = "https://repo.maven.apache.org/maven2/com/google/guava/guava/maven-metadata.xml"
+
+      url = fetcher.send(:dependency_metadata_url, "https://repo.maven.apache.org/maven2")
+
+      expect(url).to eq(expected_url)
+    end
+  end
+
+  describe "#dependency_base_url" do
+    it "correctly constructs the base URL" do
+      expected_url = "https://repo.maven.apache.org/maven2/com/google/guava/guava"
+
+      url = fetcher.send(:dependency_base_url, "https://repo.maven.apache.org/maven2")
+
+      expect(url).to eq(expected_url)
+    end
+  end
+
+  describe "#dependency_parts" do
+    it "splits the dependency name into group path and artifact ID" do
+      group_path, artifact_id = fetcher.send(:dependency_parts)
+
+      expect(group_path).to eq("com/google/guava")
+      expect(artifact_id).to eq("guava")
+    end
+  end
 end


### PR DESCRIPTION
#### **What are you trying to accomplish?**

This PR fixes an issue in the Maven ecosystem where Dependabot fails to propose updates when the version string contains dashes (`-`). This issue was introduced in `0.309.0`, and the incorrect URL generation for versions containing dashes prevents the updates from being proposed.

#### **What issues does this affect or fix?**

- **Issue Addressed**: The issue is caused by https://github.com/dependabot/dependabot-core/pull/12022 where dependency files url is constructed wrong. 
  
  - **Affected Package Ecosystem**: Maven
  - **Issue URL**: https://github.com/dependabot/dependabot-core/issues/12096

#### **Anything you want to highlight for special attention from reviewers?**

- The change ensures that version strings containing dashes (`-`) are properly handled when generating URLs for fetching dependency metadata.
- This fix includes updating the dependency files url version string by using `version` to string instead of `version.to_semver` string.

#### **How will you know you've accomplished your goal?**

- The issue will be considered fixed if Dependabot successfully after ensuring that the URL is correctly formed with the proper version formatting.

#### **Checklist**

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.