### PR TITLE
Make Sorbet `strict` mode opt-out at the file-level

### DIFF
--- a/bun/.rubocop.yml
+++ b/bun/.rubocop.yml
@@ -1,4 +1,18 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/bun/file_updater/bun_lockfile_updater.rb
+    - lib/dependabot/bun/file_updater/package_json_preparer.rb
+    - lib/dependabot/bun/native_helpers.rb
+    - lib/dependabot/bun/requirement.rb
+    - lib/dependabot/bun/update_checker/conflicting_dependency_resolver.rb
+    - lib/dependabot/bun/update_checker/dependency_files_builder.rb
+    - lib/dependabot/bun/update_checker/library_detector.rb
+    - lib/dependabot/bun/update_checker/requirements_updater.rb
+    - lib/dependabot/bun/update_checker/subdependency_version_resolver.rb
+    - lib/dependabot/bun/update_checker/vulnerability_auditor.rb

--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -6,7 +6,25 @@ inherit_mode:
 
 Sorbet/TrueSigil:
   Exclude:
-    - "helpers/**/monkey_patches/*.rb"
+    - "helpers/**/*.rb"
 
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - "helpers/**/*.rb"
+    - lib/dependabot/bundler/file_parser.rb
+    - lib/dependabot/bundler/file_updater/git_pin_replacer.rb
+    - lib/dependabot/bundler/file_updater/git_source_remover.rb
+    - lib/dependabot/bundler/file_updater/lockfile_updater.rb
+    - lib/dependabot/bundler/file_updater/requirement_replacer.rb
+    - lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+    - lib/dependabot/bundler/file_updater.rb
+    - lib/dependabot/bundler/metadata_finder.rb
+    - lib/dependabot/bundler/requirement.rb
+    - lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
+    - lib/dependabot/bundler/update_checker/file_preparer.rb
+    - lib/dependabot/bundler/update_checker/force_updater.rb
+    - lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+    - lib/dependabot/bundler/update_checker/requirements_updater.rb
+    - lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+    - lib/dependabot/bundler/update_checker/version_resolver.rb
+    - lib/dependabot/bundler/update_checker.rb

--- a/cargo/.rubocop.yml
+++ b/cargo/.rubocop.yml
@@ -1,4 +1,22 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/cargo/file_fetcher.rb
+    - lib/dependabot/cargo/file_parser.rb
+    - lib/dependabot/cargo/file_updater/lockfile_updater.rb
+    - lib/dependabot/cargo/file_updater/manifest_updater.rb
+    - lib/dependabot/cargo/file_updater.rb
+    - lib/dependabot/cargo/helpers.rb
+    - lib/dependabot/cargo/metadata_finder.rb
+    - lib/dependabot/cargo/registry_fetcher.rb
+    - lib/dependabot/cargo/requirement.rb
+    - lib/dependabot/cargo/update_checker/file_preparer.rb
+    - lib/dependabot/cargo/update_checker/requirements_updater.rb
+    - lib/dependabot/cargo/update_checker/version_resolver.rb
+    - lib/dependabot/cargo/update_checker.rb
+    - lib/dependabot/cargo/version.rb

--- a/composer/.rubocop.yml
+++ b/composer/.rubocop.yml
@@ -1,4 +1,16 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/composer/file_fetcher.rb
+    - lib/dependabot/composer/file_updater/lockfile_updater.rb
+    - lib/dependabot/composer/file_updater/manifest_updater.rb
+    - lib/dependabot/composer/metadata_finder.rb
+    - lib/dependabot/composer/update_checker/latest_version_finder.rb
+    - lib/dependabot/composer/update_checker/requirements_updater.rb
+    - lib/dependabot/composer/update_checker/version_resolver.rb
+    - lib/dependabot/composer/version.rb

--- a/gradle/.rubocop.yml
+++ b/gradle/.rubocop.yml
@@ -1,4 +1,17 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/gradle/file_parser/property_value_finder.rb
+    - lib/dependabot/gradle/file_parser/repositories_finder.rb
+    - lib/dependabot/gradle/file_parser.rb
+    - lib/dependabot/gradle/file_updater/property_value_updater.rb
+    - lib/dependabot/gradle/file_updater.rb
+    - lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
+    - lib/dependabot/gradle/update_checker/version_finder.rb
+    - lib/dependabot/gradle/update_checker.rb
+    - lib/dependabot/gradle/version.rb

--- a/hex/.rubocop.yml
+++ b/hex/.rubocop.yml
@@ -1,4 +1,17 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/hex/file_updater/lockfile_updater.rb
+    - lib/dependabot/hex/file_updater/mixfile_requirement_updater.rb
+    - lib/dependabot/hex/file_updater/mixfile_updater.rb
+    - lib/dependabot/hex/requirement.rb
+    - lib/dependabot/hex/update_checker/file_preparer.rb
+    - lib/dependabot/hex/update_checker/requirements_updater.rb
+    - lib/dependabot/hex/update_checker/version_resolver.rb
+    - lib/dependabot/hex/update_checker.rb
+    - lib/dependabot/hex/version.rb

--- a/npm_and_yarn/.rubocop.yml
+++ b/npm_and_yarn/.rubocop.yml
@@ -1,4 +1,23 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
+    - lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+    - lib/dependabot/npm_and_yarn/file_updater/bun_lockfile_updater.rb
+    - lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
+    - lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+    - lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+    - lib/dependabot/npm_and_yarn/metadata_finder.rb
+    - lib/dependabot/npm_and_yarn/native_helpers.rb
+    - lib/dependabot/npm_and_yarn/requirement.rb
+    - lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
+    - lib/dependabot/npm_and_yarn/update_checker/dependency_files_builder.rb
+    - lib/dependabot/npm_and_yarn/update_checker/library_detector.rb
+    - lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+    - lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+    - lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb

--- a/python/.rubocop.yml
+++ b/python/.rubocop.yml
@@ -1,4 +1,22 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/python/authed_url_builder.rb
+    - lib/dependabot/python/file_fetcher.rb
+    - lib/dependabot/python/file_updater/requirement_file_updater.rb
+    - lib/dependabot/python/file_updater/requirement_replacer.rb
+    - lib/dependabot/python/file_updater/setup_file_sanitizer.rb
+    - lib/dependabot/python/package/package_registry_finder.rb
+    - lib/dependabot/python/requirement.rb
+    - lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+    - lib/dependabot/python/update_checker/pip_version_resolver.rb
+    - lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+    - lib/dependabot/python/update_checker/poetry_version_resolver.rb
+    - lib/dependabot/python/update_checker/requirements_updater.rb
+    - lib/dependabot/python/update_checker.rb
+    - lib/dependabot/python/version.rb

--- a/silent/.rubocop.yml
+++ b/silent/.rubocop.yml
@@ -1,4 +1,6 @@
 inherit_from: ../.rubocop.yml
 
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/silent/requirement.rb
+    - lib/dependabot/silent/update_checker.rb

--- a/updater/.rubocop.yml
+++ b/updater/.rubocop.yml
@@ -1,4 +1,16 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/base_command.rb
+    - lib/dependabot/file_fetcher_command.rb
+    - lib/dependabot/update_files_command.rb
+    - lib/dependabot/updater/dependency_group_change_batch.rb
+    - lib/dependabot/updater/group_update_refreshing.rb
+    - lib/dependabot/updater/operations.rb
+    - lib/dependabot/updater/security_update_helpers.rb
+    - lib/dependabot/updater.rb

--- a/uv/.rubocop.yml
+++ b/uv/.rubocop.yml
@@ -1,4 +1,23 @@
 inherit_from: ../.rubocop.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 Sorbet/StrictSigil:
-  Enabled: false
+  Exclude:
+    - lib/dependabot/uv/authed_url_builder.rb
+    - lib/dependabot/uv/file_fetcher.rb
+    - lib/dependabot/uv/file_parser/python_requirement_parser.rb
+    - lib/dependabot/uv/file_updater/compile_file_updater.rb
+    - lib/dependabot/uv/file_updater/lock_file_updater.rb
+    - lib/dependabot/uv/file_updater/requirement_replacer.rb
+    - lib/dependabot/uv/metadata_finder.rb
+    - lib/dependabot/uv/package/package_registry_finder.rb
+    - lib/dependabot/uv/requirement.rb
+    - lib/dependabot/uv/update_checker/lock_file_resolver.rb
+    - lib/dependabot/uv/update_checker/pip_compile_version_resolver.rb
+    - lib/dependabot/uv/update_checker/pip_version_resolver.rb
+    - lib/dependabot/uv/update_checker/requirements_updater.rb
+    - lib/dependabot/uv/update_checker.rb
+    - lib/dependabot/uv/version.rb


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
The change I previously made in #11885 made Sorbet strict mode opt-out at the ecosystem level. This change tightens that up a little bit, by making it opt-out at the file level. This means that newly added files, anywhere in the repository **must** be Sorbet strict typed.

The intention is that files will be removed from the `Exclude` list as they are strict-typed.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
N/A

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
Rubocop passes

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
