### PR TITLE
`mark_as_processed` api endpoint should use the `PATCH` verb

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -50,10 +50,10 @@ public partial class EntryPointTests
                 },
                 expectedUrls:
                 [
-                    "/update_jobs/TEST-ID/update_dependency_list",
-                    "/update_jobs/TEST-ID/increment_metric",
-                    "/update_jobs/TEST-ID/create_pull_request",
-                    "/update_jobs/TEST-ID/mark_as_processed",
+                    "POST /update_jobs/TEST-ID/update_dependency_list",
+                    "POST /update_jobs/TEST-ID/increment_metric",
+                    "POST /update_jobs/TEST-ID/create_pull_request",
+                    "PATCH /update_jobs/TEST-ID/mark_as_processed",
                 ]
             );
         }
@@ -79,9 +79,9 @@ public partial class EntryPointTests
             await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, tempDirectory.DirectoryPath);
 
             var actualUrls = new List<string>();
-            using var http = TestHttpServer.CreateTestStringServer(url =>
+            using var http = TestHttpServer.CreateTestStringServer((method, url) =>
             {
-                actualUrls.Add(new Uri(url).PathAndQuery);
+                actualUrls.Add($"{method} {new Uri(url).PathAndQuery}");
                 return (200, "ok");
             });
             var args = new List<string>()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -57,7 +57,7 @@ public class HttpApiHandler : IApiHandler
 
     public async Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
     {
-        await PostAsJson("mark_as_processed", markAsProcessed);
+        await PatchAsJson("mark_as_processed", markAsProcessed);
     }
 
     internal static string Serialize(object body)
@@ -70,11 +70,20 @@ public class HttpApiHandler : IApiHandler
         return payload;
     }
 
-    private async Task PostAsJson(string endpoint, object body)
+    private Task PostAsJson(string endpoint, object body) => SendAsJson(endpoint, body, "POST");
+    private Task PatchAsJson(string endpoint, object body) => SendAsJson(endpoint, body, "PATCH");
+
+    private async Task SendAsJson(string endpoint, object body, string method)
     {
+        var uri = $"{_apiUrl}/update_jobs/{_jobId}/{endpoint}";
         var payload = Serialize(body);
         var content = new StringContent(payload, Encoding.UTF8, "application/json");
-        var response = await HttpClient.PostAsync($"{_apiUrl}/update_jobs/{_jobId}/{endpoint}", content);
+        var httpMethod = new HttpMethod(method);
+        var message = new HttpRequestMessage(httpMethod, uri)
+        {
+            Content = content
+        };
+        var response = await HttpClient.SendAsync(message);
         var _ = response.EnsureSuccessStatusCode();
     }
 }


### PR DESCRIPTION
From an internal experiment we found that the API call to `mark_as_processed` at the end of a job should use the HTTP method `PATCH` but was using `POST`.  This PR fixes that.  Most of the change was so this could be directly tested.