### PR TITLE
Remove `"master"` branch hardcoding for Hex

### DIFF
--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -109,7 +109,7 @@ defmodule Parser do
     %{
       type: "git",
       url: repo_url,
-      branch: opts[:branch] || "master",
+      branch: opts[:branch],
       ref: ref
     }
   end

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Dependabot::Hex::FileParser do
               source: {
                 type: "git",
                 url: "https://github.com/dependabot-fixtures/phoenix.git",
-                branch: "master",
+                branch: nil,
                 ref: "v1.2.0"
               }
             }],
@@ -271,7 +271,7 @@ RSpec.describe Dependabot::Hex::FileParser do
                 source: {
                   type: "git",
                   url: "https://github.com/dependabot-fixtures/phoenix.git",
-                  branch: "master",
+                  branch: nil,
                   ref: "v1.2.0"
                 }
               }],


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Remove `"master"` branch hardcoding from Hex dependency parsing.

<!-- What issues does this affect or fix? -->

This is broken out from #7131, continuing to address #6202.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

The solution here was removing the branch hardcoding from the related test expected values as well. I think `nil` should work there; having both `:ref` and `:branch` set for a git dependency doesn't seem quite right anyway.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Passing tests.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
