### PR TITLE
Use GitHub Artifact Attestations for container image signing

### DIFF
--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -26,8 +26,8 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Build dependabot-updater-core image
-        run: script/build common
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -35,21 +35,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push latest image
-        id: push
-        run: |
-          docker push "$UPDATER_CORE_IMAGE:latest"
-        
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.UPDATER_CORE_IMAGE }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-
-      - name: Push tagged image
+      - name: Determine version tag
+        id: version
         if: contains(github.ref, 'refs/tags')
         run: |
           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot.rb)"
-          docker tag "$UPDATER_CORE_IMAGE:latest" "$UPDATER_CORE_IMAGE:$VERSION"
-          docker push "$UPDATER_CORE_IMAGE:$VERSION"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push updater-core image
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: Dockerfile.updater-core
+          push: true
+          tags: |
+            ${{ env.UPDATER_CORE_IMAGE }}:latest
+            ${{ steps.version.outputs.tag && format('{0}:{1}', env.UPDATER_CORE_IMAGE, steps.version.outputs.tag) || '' }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            USER_UID=1000
+            USER_GID=1000
+          cache-from: type=registry,ref=${{ env.UPDATER_CORE_IMAGE }}:latest
+          cache-to: type=inline
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ env.UPDATER_CORE_IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -18,14 +18,13 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build dependabot-updater-core image
         run: script/build common
@@ -37,9 +36,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push latest image
+        id: push
         run: |
           docker push "$UPDATER_CORE_IMAGE:latest"
-          cosign sign --yes $(cosign triangulate --type=digest "$UPDATER_CORE_IMAGE:latest")
+        
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.UPDATER_CORE_IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
       - name: Push tagged image
         if: contains(github.ref, 'refs/tags')


### PR DESCRIPTION
This uses GitHub Artifact Attestations, which are based on Cosign's latest API, to attest container images.

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
