### PR TITLE
Refactor branch naming strategy for docker dependencies with digests.

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -152,7 +152,7 @@ module Dependabot
               return current_tag
             end
 
-            return format_digest_branch_name(current_tag, current_digest) if current_tag
+            format_digest_branch_name(current_tag, current_digest) if current_tag
           else
             dependency.version
           end
@@ -228,10 +228,10 @@ module Dependabot
           )
         end
 
-        sig {
+        sig do
           params(requirements: T.nilable(T::Array[T::Hash[Symbol,
                                                           T.untyped]])).returns([T.nilable(String), T.nilable(String)])
-        }
+        end
         def extract_tag_and_digest(requirements)
           return [nil, nil] unless requirements
 

--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -142,11 +142,34 @@ module Dependabot
             return new_ref(dependency) if ref_changed?(dependency) && new_ref(dependency)
 
             T.must(dependency.version)[0..6]
-          elsif dependency.version == dependency.previous_version &&
-                package_manager == "docker"
-            dependency.requirements
-                      .filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-                      .first.split(":").last[0..6]
+          elsif package_manager == "docker"
+            current_tag = dependency.requirements.filter_map do |r|
+              r.dig(:source, "tag") || r.dig(:source, :tag)
+            end.first
+            previous_tag = dependency.previous_requirements.filter_map do |r|
+              r.dig(:source, "tag") || r.dig(:source, :tag)
+            end.first
+            current_digest = dependency.requirements.filter_map do |r|
+              r.dig(:source, "digest") || r.dig(:source, :digest)
+            end.first
+            previous_digest = dependency.previous_requirements.filter_map do |r|
+              r.dig(:source, "digest") || r.dig(:source, :digest)
+            end.first
+
+            # If the tag hasn't changed, but the digest has, we need to include the digest
+            if current_tag == previous_tag && current_digest != previous_digest
+              digest_parts = current_digest&.split(':')
+              if current_tag && !current_tag.empty?
+                # If the tag isn't empty, we need to include it in the branch name
+                "#{current_tag}-#{digest_parts&.first}#{digest_parts&.last&.slice(0, 6)}"
+              else
+                # If the tag is empty, just use the digest
+                "#{digest_parts&.first}#{digest_parts&.last&.slice(0, 6)}"
+              end
+            elsif current_tag != previous_tag
+              # If the tag has changed, we don't need to include the digest
+              current_tag
+            end
           else
             dependency.version
           end

--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -240,7 +240,7 @@ module Dependabot
           [tag, digest]
         end
 
-        sig { params(tag: T.nilable(String), digest: T.nilable(String)).returns(String) }
+        sig { params(tag: T.nilable(String), digest: T.nilable(String)).returns(T.nilable(String)) }
         def format_digest_branch_name(tag, digest)
           return tag if digest.nil?
 

--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -146,19 +146,22 @@ module Dependabot
             current_tag = dependency.requirements.filter_map do |r|
               r.dig(:source, "tag") || r.dig(:source, :tag)
             end.first
+
             previous_tag = dependency.previous_requirements.filter_map do |r|
               r.dig(:source, "tag") || r.dig(:source, :tag)
             end.first
+
             current_digest = dependency.requirements.filter_map do |r|
               r.dig(:source, "digest") || r.dig(:source, :digest)
             end.first
+
             previous_digest = dependency.previous_requirements.filter_map do |r|
               r.dig(:source, "digest") || r.dig(:source, :digest)
             end.first
 
             # If the tag hasn't changed, but the digest has, we need to include the digest
             if current_tag == previous_tag && current_digest != previous_digest
-              digest_parts = current_digest&.split(':')
+              digest_parts = current_digest&.split(":")
               if current_tag && !current_tag.empty?
                 # If the tag isn't empty, we need to include it in the branch name
                 "#{current_tag}-#{digest_parts&.first}#{digest_parts&.last&.slice(0, 6)}"

--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -159,7 +159,7 @@ module Dependabot
           elsif current_tag != previous_tag
             current_tag
           else
-            format_digest_branch_name(current_tag, current_digest) if current_tag
+            format_digest_branch_name(current_tag, current_digest)
           end
         end
 
@@ -251,9 +251,9 @@ module Dependabot
 
           digest_parts = digest.split(":")
           if tag && !tag.empty?
-            "#{tag}-#{digest_parts.first}#{digest_parts.last&.slice(0, 6)}"
+            "#{tag}-#{digest_parts.first}-#{digest_parts.last&.slice(0, 6)}"
           else
-            "#{digest_parts.first}#{digest_parts.last&.slice(0, 6)}"
+            "#{digest_parts.first}-#{digest_parts.last&.slice(0, 6)}"
           end
         end
       end

--- a/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
       let(:previous_version) { "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
 
       it "truncates the version to just the digest when no tag is present" do
-        expect(new_branch_name).to eq("dependabot/docker/ubuntu-sha256183054")
+        expect(new_branch_name).to eq("dependabot/docker/ubuntu-sha256-183054")
       end
 
       context "when there is a tag present with only a digest change" do
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
         end
 
         it "includes the tag and digest" do
-          expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256183054")
+          expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256-183054")
         end
       end
 

--- a/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
@@ -487,44 +487,66 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
     end
 
     context "with a Docker digest update" do
+      let(:source) do
+        {
+          digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+        }
+      end
+      let(:previous_source) do
+        {
+          digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      end
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "ubuntu",
-          version: "17.10",
+          version: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005",
           previous_version: previous_version,
           package_manager: "docker",
           requirements: [{
             file: "Dockerfile",
             requirement: nil,
             groups: [],
-            source: {
-              type: "digest",
-              digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8d" \
-                      "fc38288cf73aa07485005"
-            }
+            source: source
           }],
           previous_requirements: [{
             file: "Dockerfile",
             requirement: nil,
             groups: [],
-            source: {
-              type: "digest",
-              digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
-                      "aaaaaaaaaaaaaaaaaaaaa"
-            }
+            source: previous_source
           }]
         )
       end
-      let(:previous_version) { "17.10" }
+      let(:previous_version) { "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
 
-      it "truncates the version" do
-        expect(new_branch_name).to eq("dependabot/docker/ubuntu-1830542")
+      it "truncates the version to just the digest when no tag is present" do
+        expect(new_branch_name).to eq("dependabot/docker/ubuntu-sha256183054")
       end
 
-      context "when there is a tag change" do
-        let(:previous_version) { "17.04" }
+      context "when there is a tag present with only a digest change" do
+        let(:version) { "17.10@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+        let(:previous_version) { "17.10@sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+        let(:source) do
+          { tag: "17.10", digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+        end
+        let(:previous_source) do
+          { tag: "17.10", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+        end
+        it "includes the tag and digest" do
+          expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256183054")
+        end
+      end
 
-        it "includes the tag rather than the SHA" do
+      context "when there is a tag and digest change" do
+        let(:version) { "17.10@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+        let(:previous_version) { "17.10@sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+        let(:source) do
+          { tag: "17.10", digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005" }
+        end
+        let(:previous_source) do
+          { tag: "17.04", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+        end
+        it "includes the tag without the digest" do
           expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10")
         end
       end

--- a/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/solo_strategy_spec.rb
@@ -532,6 +532,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
         let(:previous_source) do
           { tag: "17.10", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
         end
+
         it "includes the tag and digest" do
           expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256183054")
         end
@@ -546,6 +547,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::SoloStrategy do
         let(:previous_source) do
           { tag: "17.04", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
         end
+
         it "includes the tag without the digest" do
           expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10")
         end

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
       let(:previous_version) { "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
 
       it "truncates the version to just the digest when no tag is present" do
-        expect(new_branch_name).to eq("dependabot/docker/ubuntu-sha256183054")
+        expect(new_branch_name).to eq("dependabot/docker/ubuntu-sha256-183054")
       end
 
       context "when there is a tag present with only a digest change" do
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         end
 
         it "includes the tag and digest" do
-          expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256183054")
+          expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256-183054")
         end
       end
 

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -532,6 +532,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         let(:previous_source) do
           { tag: "17.10", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
         end
+
         it "includes the tag and digest" do
           expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10-sha256183054")
         end
@@ -546,6 +547,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         let(:previous_source) do
           { tag: "17.04", digest: "sha256:2167a21baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
         end
+
         it "includes the tag without the digest" do
           expect(new_branch_name).to eq("dependabot/docker/ubuntu-17.10")
         end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -261,9 +261,9 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful") }
 
       context "when the version starts with a number" do
-        let(:version) { "309403913" }
+        let(:version) { "309403913c7f0848e6616446edec909b55d53571" }
 
-        it { is_expected.to eq("309403913") }
+        it { is_expected.to eq("309403913c7f0848e6616446edec909b55d53571") }
       end
     end
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -261,9 +261,9 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful") }
 
       context "when the version starts with a number" do
-        let(:version) { "sha256:309403913c7f0848e6616446edec909b55d53571" }
+        let(:version) { "309403913" }
 
-        it { is_expected.to eq("sha256:309403913c7f0848e6616446edec909b55d53571") }
+        it { is_expected.to eq("309403913") }
       end
     end
 


### PR DESCRIPTION
The main change from my previous PR (#11977) was to add the digest to the version if the digest changed.
Previously, the version would be only the tag, even if the digest changed and the tag didn't. The version would only include the digest if no tag was present.

The solo-strategy for branch naming had a special case for docker where it checked if the versions were equal (which after my change, they never would be, because either the tag, digest, or both would be different) so this PR fixes that, and also shortens the branch name to just the first 6 characters of the digest vs the whole 64 characters

Example new branch names:
- for an update on `ubuntu` with only a digest change: `dependabot/docker/ubuntu-sha256-183054`
- for an update on `ubuntu` where the tag `17.10` doesn't change, but the digest does: `dependabot/docker/ubuntu-17.10-sha256-183054`
- for an update on `ubuntu` where the tag `17.10` changes from `17.04`, and the digest changes: `dependabot/docker/ubuntu-17.10`

### What are you trying to accomplish?

Customers were reporting an issue where due to the increased length of the branch names, there were other issues cropping up. So, by trimming the branch name to include only the first 6 characters of the digest, the issue should be resolved.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

Branch names no longer include the entire sha256 digest.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
