### PR TITLE
Dev/brettfo/nuget eval project references

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -733,7 +733,8 @@ internal static class SdkProjectDiscovery
                         .Where(p => !p.SourceFilePath.StartsWith(".."))
                         .OrderBy(p => p.Name)
                         .ToImmutableArray();
-                    var referencedProjectPaths = MSBuildHelper.GetProjectPathsFromProject(projectPath)
+                    var referencedProjectPaths = await MSBuildHelper.GetProjectPathsFromProject(projectPath, experimentsManager, logger);
+                    var orderedReferencedProjectPaths = referencedProjectPaths
                         .Select(path => Path.GetRelativePath(workspacePath, path).NormalizePathToUnix())
                         .OrderBy(p => p)
                         .ToImmutableArray();
@@ -762,7 +763,7 @@ internal static class SdkProjectDiscovery
                         FilePath = Path.GetRelativePath(workspacePath, buildFile.Path).NormalizePathToUnix(),
                         Properties = properties,
                         TargetFrameworks = tfms,
-                        ReferencedProjectPaths = referencedProjectPaths,
+                        ReferencedProjectPaths = orderedReferencedProjectPaths,
                         Dependencies = allDependencies,
                         ImportedFiles = buildFiles.Where(b =>
                             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -11,6 +11,7 @@
     <None Include="DependencyDiscovery.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DependencyDiscoveryTargetingPacks.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DependencyDiscovery.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="ProjectDiscovery.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="TargetFrameworkReporter.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ProjectDiscovery.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ProjectDiscovery.targets
@@ -1,0 +1,10 @@
+<Project>
+  <Target Name="_ReportFileReferences" DependsOnTargets="_ReportProjectFiles;_ReportProjectReferences">
+  </Target>
+  <Target Name="_ReportProjectFiles" Condition="'@(ProjectFile)' != ''">
+    <Message Text="_ReportProjectFiles::ProjectFile=%(ProjectFile.FullPath)" Importance="High" />
+  </Target>
+  <Target Name="_ReportProjectReferences" Condition="'@(ProjectReference)' != ''">
+    <Message Text="_ReportProjectReferences::ProjectReference=%(ProjectReference.FullPath)" Importance="High" />
+  </Target>
+</Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdaterWorker.cs
@@ -174,7 +174,7 @@ public class UpdaterWorker : IUpdaterWorker
         }
 
         var updateOperations = new List<UpdateOperationBase>();
-        var projectFilePaths = MSBuildHelper.GetProjectPathsFromProject(projFilePath);
+        var projectFilePaths = await MSBuildHelper.GetProjectPathsFromProject(projFilePath, _experimentsManager, _logger);
         foreach (var projectFullPath in projectFilePaths)
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project
@@ -210,7 +210,7 @@ public class UpdaterWorker : IUpdaterWorker
         }
 
         var updateOperations = new List<UpdateOperationBase>();
-        var projectFilePaths = MSBuildHelper.GetProjectPathsFromProject(projectPath);
+        var projectFilePaths = await MSBuildHelper.GetProjectPathsFromProject(projectPath, _experimentsManager, _logger);
         foreach (var projectFullPath in projectFilePaths.Concat([projectPath]))
         {
             // If there is some MSBuild logic that needs to run to fully resolve the path skip the project


### PR DESCRIPTION
## Not yet ready for review; considering edge cases

When expanding a project's `<ProjectReference>` elements, we previously only parsed the MSBuild, but that could lead to properties like `$(MSBuildThisFileDirectory)` not being evaluated which then led to missing some project files or potentially a crash because an unevaluated MSBuild property could cause the file system globber to barf.

This PR performs a full MSBuild evaluation on the file to get the `%(FullPath)` metadata element of everything.

There is one instance of hackery that I should note: not all instances of `dirs.proj` are evaluable MSBuild so to get around that we create a temporary file in the same directory with the same contents but with an `<Import>` element to pull in our special `.targets` file.

Fixes #12000