### PR TITLE
improve native updater experiment flag

### DIFF
--- a/nuget/script/run
+++ b/nuget/script/run
@@ -1,10 +1,10 @@
 #!/bin/bash
 # shellcheck disable=all
 
-nuget_experiment_value=$(cat "$DEPENDABOT_JOB_PATH" | sed -En "s/-/_/pg" | jq '.job.experiments.nuget_native_updater')
-echo "NuGet native updater experiment value: $nuget_experiment_value"
+native_experiment_value=$(cat "$DEPENDABOT_JOB_PATH" | jq '.job.experiments | with_entries(.key |= sub("-";"_";"g")) .nuget_native_updater')
+echo "NuGet native updater experiment value: $native_experiment_value"
 
-if echo "$nuget_experiment_value" | grep -q 'true'; then
+if [ "$native_experiment_value" == "true" ]; then
     pwsh "$DEPENDABOT_HOME/dependabot-updater/bin/main.ps1" $*
 else
     "$DEPENDABOT_HOME/dependabot-updater/bin/run-original" $*


### PR DESCRIPTION
The NuGet updater script entry point queries the `job.json` file for a native updater flag, but that flag can have two different naming conventions, `nuget_native_updater` vs `nuget-native-updater`.

The previous version did a simple find/replace from `-` to `_` which isn't strictly correct.

This new version uses the built-in `jq` DSL to transform the key names.

No functional change, just future-proofing.

Manually verified locally.