### PR TITLE
make messages proper markdown

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -39,7 +39,7 @@ public class MessageReportTests
             // expected
             """
             Error type: illformed_requirement
-              - message: unparseable
+            - message: unparseable
             """
         ];
 
@@ -53,8 +53,8 @@ public class MessageReportTests
             // expected
             """
             ClosePullRequest: up_to_date
-              - Dependency1
-              - Dependency2
+            - Dependency1
+            - Dependency2
             """
         ];
 
@@ -86,8 +86,8 @@ public class MessageReportTests
             // expected
             """
             CreatePullRequest
-              - Dependency1/1.2.3
-              - Dependency2/4.5.6
+            - Dependency1/1.2.3
+            - Dependency2/4.5.6
             """
         ];
 
@@ -98,8 +98,8 @@ public class MessageReportTests
             // expected
             """
             Error type: dependency_file_not_found
-              - message: custom message
-              - file-path: path/to/file.txt
+            - message: custom message
+            - file-path: path/to/file.txt
             """
         ];
 
@@ -110,8 +110,8 @@ public class MessageReportTests
             // expected
             """
             Error type: dependency_file_not_parseable
-              - message: custom message
-              - file-path: path/to/file.txt
+            - message: custom message
+            - file-path: path/to/file.txt
             """
         ];
 
@@ -122,7 +122,7 @@ public class MessageReportTests
             // expected
             """
             Error type: dependency_not_found
-              - source: Some.Dependency
+            - source: Some.Dependency
             """
         ];
 
@@ -133,7 +133,7 @@ public class MessageReportTests
             // expected
             """
             Error type: job_repo_not_found
-              - message: custom message
+            - message: custom message
             """
         ];
 
@@ -144,7 +144,7 @@ public class MessageReportTests
             // expected
             """
             Error type: private_source_authentication_failure
-              - source: (url1|url2)
+            - source: (url1|url2)
             """
         ];
 
@@ -155,7 +155,7 @@ public class MessageReportTests
             // expected
             """
             Error type: private_source_bad_response
-              - source: (url1|url2)
+            - source: (url1|url2)
             """
         ];
 
@@ -166,8 +166,8 @@ public class MessageReportTests
             // expected
             """
             Error type: pull_request_exists_for_latest_version
-              - dependency-name: Some.Dependency
-              - dependency-version: 1.2.3
+            - dependency-name: Some.Dependency
+            - dependency-version: 1.2.3
             """
         ];
 
@@ -178,7 +178,7 @@ public class MessageReportTests
             // expected
             """
             Error type: security_update_not_needed
-              - dependency-name: Some.Dependency
+            - dependency-name: Some.Dependency
             """
         ];
 
@@ -189,11 +189,11 @@ public class MessageReportTests
             // expected
             """
             Error type: unknown_error
-              - error-class: NotImplementedException
-              - error-message: error message
-              - error-backtrace: <unknown>
-              - package-manager: nuget
-              - job-id: TEST-JOB-ID
+            - error-class: NotImplementedException
+            - error-message: error message
+            - error-backtrace: <unknown>
+            - package-manager: nuget
+            - job-id: TEST-JOB-ID
             """
         ];
 
@@ -204,7 +204,7 @@ public class MessageReportTests
             // expected
             """
             Error type: update_not_possible
-              - dependencies: Dependency1, Dependency2
+            - dependencies: Dependency1, Dependency2
             """
         ];
 
@@ -224,8 +224,8 @@ public class MessageReportTests
             // expected
             """
             UpdatePullRequest
-              - Dependency1
-              - Dependency2
+            - Dependency1
+            - Dependency2
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -58,7 +58,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-                - Updated Some.Package to 1.2.3 in a.txt
+            - Updated Some.Package to 1.2.3 in a.txt
             """
         ];
 
@@ -86,7 +86,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-                - Updated Some.Package to 1.2.3 in a.txt
+            - Updated Some.Package to 1.2.3 in a.txt
             """
         ];
 
@@ -132,10 +132,10 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-                - Updated Package.A to 1.0.0 in a1.txt
-                - Updated Package.A to 2.0.0 in a2.txt
-                - Updated Package.B to 3.0.0 in b1.txt
-                - Updated Package.B to 4.0.0 in b2.txt
+            - Updated Package.A to 1.0.0 in a1.txt
+            - Updated Package.A to 2.0.0 in a2.txt
+            - Updated Package.B to 3.0.0 in b1.txt
+            - Updated Package.B to 4.0.0 in b2.txt
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
@@ -43,9 +43,9 @@ public class UpdateOperationBaseTests
         // assert
         var expectedReport = """
             Performed the following updates:
-                - Updated Package.A to 1.0.0 in file/a.txt
-                - Pinned Package.B at 2.0.0 in file/b.txt
-                - Updated Package.C to 3.0.0 indirectly via Package.D/4.0.0 in file/c.txt
+            - Updated Package.A to 1.0.0 in file/a.txt
+            - Pinned Package.B at 2.0.0 in file/b.txt
+            - Updated Package.C to 3.0.0 indirectly via Package.D/4.0.0 in file/c.txt
             """.Replace("\r", "");
         Assert.Equal(expectedReport, actualReport);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
@@ -17,7 +17,7 @@ public sealed record ClosePullRequest : MessageBase
         report.AppendLine($"{nameof(ClosePullRequest)}: {Reason}");
         foreach (var dependencyName in DependencyNames)
         {
-            report.AppendLine($"  - {dependencyName}");
+            report.AppendLine($"- {dependencyName}");
         }
 
         return report.ToString().Trim();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
@@ -30,7 +30,7 @@ public sealed record CreatePullRequest : MessageBase
         report.AppendLine(nameof(CreatePullRequest));
         foreach (var d in dependencyNames)
         {
-            report.AppendLine($"  - {d}");
+            report.AppendLine($"- {d}");
         }
 
         return report.ToString().Trim();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -33,7 +33,7 @@ public abstract record JobErrorBase : MessageBase
                 valueString = string.Join(", ", strings);
             }
 
-            report.AppendLine($"  - {key}: {valueString}");
+            report.AppendLine($"- {key}: {valueString}");
         }
 
         return report.ToString().Trim();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
@@ -36,7 +36,7 @@ public sealed record UpdatePullRequest : MessageBase
         report.AppendLine(nameof(UpdatePullRequest));
         foreach (var d in dependencyNames)
         {
-            report.AppendLine($"  - {d}");
+            report.AppendLine($"- {d}");
         }
 
         return report.ToString().Trim();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -29,8 +29,7 @@ public abstract record UpdateOperationBase
             return string.Empty;
         }
 
-        var separator = "\n    ";
-        var report = $"Performed the following updates:{separator}{string.Join(separator, updateMessages.Select(m => $"- {m}"))}";
+        var report = $"Performed the following updates:\n{string.Join("\n", updateMessages.Select(m => $"- {m}"))}";
         return report;
     }
 


### PR DESCRIPTION
The NuGet end-to-end updater outputs a short report of the operations performed and the log gets a similar treatment.  That output isn't quite proper markdown because list items are indented.

This PR fixes the formatting of those messages to make them proper markdown.