### PR TITLE
mock well-known SDK packages

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -27,7 +27,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         {
             // this package ships with the SDK and is automatically added for F# projects but should be manually added here to make the test consistent
             // only direct package discovery finds this, though
-            expectedDependencies.Add(new Dependency("FSharp.Core", "9.0.100", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true));
+            expectedDependencies.Add(new Dependency("FSharp.Core", MockNuGetPackage.FSharpCorePackageVersion.Value, DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true));
         }
 
         var experimentsManager = new ExperimentsManager() { UseDirectDiscovery = useDirectDiscovery };

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -346,6 +346,15 @@ namespace NuGetUpdater.Core.Test
             }
         });
 
+        public static readonly Lazy<string> FSharpCorePackageVersion = new(() =>
+        {
+            var fsharpPropsPath = Path.Combine(Path.GetDirectoryName(BundledVersionsPropsPath.Value)!, "FSharp", "Microsoft.FSharp.Core.NetSdk.props");
+            var fsharpPropsDocument = XDocument.Load(fsharpPropsPath);
+            var fsharpCoreVersionElement = fsharpPropsDocument.XPathSelectElement("//*[name()='FSCorePackageVersion']")!;
+            var fsharpCoreVersion = fsharpCoreVersionElement.Value;
+            return fsharpCoreVersion;
+        });
+
         private static readonly Dictionary<string, MockNuGetPackage> WellKnownPackages = new();
         public static MockNuGetPackage WellKnownReferencePackage(string packageName, string targetFramework, (string Path, byte[] Content)[]? files = null)
         {
@@ -370,7 +379,7 @@ namespace NuGetUpdater.Core.Test
                 }
 
                 string expectedVersion = matchingFrameworkElement.Attribute("TargetingPackVersion")!.Value;
-                return new(
+                WellKnownPackages[key] = new MockNuGetPackage(
                     $"{packageName}.Ref",
                     expectedVersion,
                     AdditionalMetadata:
@@ -440,6 +449,33 @@ namespace NuGetUpdater.Core.Test
             return WellKnownPackages[key];
         }
 
+        public static MockNuGetPackage WellKnownWindowsSdkRefPackage(string windowsSdkVersion)
+        {
+            var packageName = "Microsoft.Windows.SDK.NET.Ref";
+            var key = $"{packageName}/{windowsSdkVersion}";
+            if (!WellKnownPackages.ContainsKey(key))
+            {
+                var propsDocument = XDocument.Load(BundledVersionsPropsPath.Value);
+                var sdkTpmElement = propsDocument.XPathSelectElement($"/Project/ItemGroup/WindowsSdkSupportedTargetPlatformVersion[@Include='{windowsSdkVersion}']")!;
+                var packageVersion = sdkTpmElement.Attribute("WindowsSdkPackageVersion")!.Value!;
+                var package = new MockNuGetPackage(packageName, packageVersion, Files: [
+                    ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
+                        <FileList Name="Windows SDK .NET 6.0">
+                          <!-- contents omitted -->
+                        </FileList>
+                        """)),
+                    ("data/RuntimeList.xml", Encoding.UTF8.GetBytes("""
+                        <FileList Name="Windows SDK .NET 6.0" TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="6.0" FrameworkName="Microsoft.Windows.SDK.NET.Ref">
+                          <!-- contents omitted -->
+                        </FileList>
+                        """))
+                ]);
+                WellKnownPackages[key] = package;
+            }
+
+            return WellKnownPackages[key];
+        }
+
         public static MockNuGetPackage[] CommonPackages { get; } =
         [
             CreateSimplePackage("NETStandard.Library", "2.0.3", "netstandard2.0"),
@@ -456,7 +492,6 @@ namespace NuGetUpdater.Core.Test
             WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net7.0"),
             WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net8.0"),
             WellKnownReferencePackage("Microsoft.WindowsDesktop.App", "net9.0"),
-            WellKnownHostPackage("Microsoft.NETCore.App", "net8.0"),
         ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.PackageReference.cs
@@ -382,19 +382,7 @@ public partial class UpdateWorkerTests
                     MockNuGetPackage.CreateSimplePackage("Some.Package", "9.0.1", "net8.0"),
                     MockNuGetPackage.CreateSimplePackage("Some.Package", "13.0.1", "net8.0"),
                     // necessary for the `net8.0-windows10.0.19041.0` TFM
-                    new("Microsoft.Windows.SDK.NET.Ref", "10.0.19041.54", Files:
-                    [
-                        ("data/FrameworkList.xml", Encoding.UTF8.GetBytes("""
-                            <FileList Name="Windows SDK .NET 6.0">
-                              <!-- contents omitted -->
-                            </FileList>
-                            """)),
-                        ("data/RuntimeList.xml", Encoding.UTF8.GetBytes("""
-                            <FileList Name="Windows SDK .NET 6.0" TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="6.0" FrameworkName="Microsoft.Windows.SDK.NET.Ref">
-                              <!-- contents omitted -->
-                            </FileList>
-                            """)),
-                    ]),
+                    MockNuGetPackage.WellKnownWindowsSdkRefPackage("10.0.19041.0"),
                 ],
                 // initial
                 projectContents: $"""


### PR DESCRIPTION
Two well-known packages, `FSharp.Core` and `Microsoft.Windows.SDK.NET.Ref` are required by the SDK, but possibly with updated version numbers.

This PR scans the installed SDK to mock those packages with whatever is necessary.  This is to prevent continual updates to these tests.  No functional change.