### PR TITLE
allow SDK installation from a two-part version

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -87,7 +87,7 @@ function Install-Sdks([string]$jobFilePath, [string]$repoContentsPath, [string]$
     $sdksToInstall = Get-SdkVersionsToInstall -repoRoot $rootDir -updateDirectories $candidateDirectories -installedSdks $installedSdks
     foreach ($sdkVersion in $sdksToInstall) {
         $versionParts = $sdkVersion.Split(".")
-        if ($versionParts.Length -eq 3 -and $versionParts[2] -eq "0") {
+        if (($versionParts.Length -eq 2) -or ($versionParts.Length -eq 3 -and $versionParts[2] -eq "0")) {
             $channelVersion = "$($versionParts[0]).$($versionParts[1])"
             Write-Host "Installing SDK from channel $channelVersion"
             & $dotnetInstallScriptPath --channel $channelVersion --install-dir $dotnetInstallDir


### PR DESCRIPTION
A repo's `global.json` file should list an SDK version to install like `8.0.100` but some repos found in the wild list a runtime version like `8.0.0` and we manually handle that case by detecting the third part of `.0` and doing a regular channel installation of `8.0`.

I've now found other repos that only list a channel value like `8.0` so this PR explicitly checks for a two-part version number and the line immediately below it rebuilds the exact same version and does a channel install just like before.

Fixes #12161