### PR TITLE
report missing package version when possible

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1559,7 +1559,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             {
                 Path = "",
                 Projects = [],
-                Error = new DependencyNotFound("Transitive.Dependency"),
+                Error = new DependencyNotFound("Transitive.Dependency/>= 4.5.6"),
             }
         );
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1810,7 +1810,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "Unable to find package Some.Package with version (= 1.2.3)",
             // expectedError
-            new DependencyNotFound("Some.Package"),
+            new DependencyNotFound("Some.Package/= 1.2.3"),
         ];
 
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -1033,7 +1033,18 @@ internal static partial class MSBuildHelper
         var matches = patterns.Select(p => p.Match(output)).Where(m => m.Success);
         if (matches.Any())
         {
-            var packages = matches.Select(m => m.Groups["PackageName"].Value).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            var packages = matches.Select(m =>
+                {
+                    var packageName = m.Groups["PackageName"].Value;
+                    if (m.Groups.TryGetValue("PackageVersion", out var versionGroup))
+                    {
+                        packageName = $"{packageName}/{versionGroup.Value}";
+                    }
+
+                    return packageName;
+                })
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
             throw new DependencyNotFoundException(packages);
         }
     }


### PR DESCRIPTION
The output of various MSBuild and NuGet operations is scanned to generate appropriate error messages and in once instance we're told that while a package exists on the feed, a specific version isn't present.

This PR updates that error message to include this version information to make investigations easier.