### PR TITLE
Use explicit uri parser when fetching abs_uri regexp

### DIFF
--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -174,7 +174,7 @@ module Dependabot
 
       sig { params(dependency_url: String).returns(String) }
       def self.clean_dependency_url(dependency_url)
-        return dependency_url unless URI::DEFAULT_PARSER.regexp[:ABS_URI].match?(dependency_url)
+        return dependency_url unless URI::RFC2396_PARSER.regexp[:ABS_URI].match?(dependency_url)
 
         url = URI.parse(dependency_url)
         url.user = nil

--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -472,7 +472,7 @@ module Dependabot
         def validate_index(index_url)
           return false unless index_url
 
-          return true if index_url.match?(URI::DEFAULT_PARSER.regexp[:ABS_URI])
+          return true if index_url.match?(URI::RFC2396_PARSER.regexp[:ABS_URI])
 
           raise Dependabot::DependencyFileNotResolvable,
                 "Invalid URL: #{sanitized_url(index_url)}"

--- a/uv/lib/dependabot/uv/package/package_details_fetcher.rb
+++ b/uv/lib/dependabot/uv/package/package_details_fetcher.rb
@@ -472,7 +472,7 @@ module Dependabot
         def validate_index(index_url)
           return false unless index_url
 
-          return true if index_url.match?(URI::DEFAULT_PARSER.regexp[:ABS_URI])
+          return true if index_url.match?(URI::RFC2396_PARSER.regexp[:ABS_URI])
 
           raise Dependabot::DependencyFileNotResolvable,
                 "Invalid URL: #{sanitized_url(index_url)}"


### PR DESCRIPTION
### What are you trying to accomplish?

This prevents `URI::DEFAULT_PARSER.regexp[:ABS_URI]` returning nil if `uri` gem is updated to version beyond `1`. Because gemspec does not define a range for `uri` gem, if a project uses `dependabot-core` and has a more recent version of uri, nil will be returned because `DEFAULT_PARSER` has changed starting from version 1 and does not define `:ABS_URI` key in regexp hash. This problem would probably also happen at some point if some transitive dependency updates the `uri` gem.

By using explicit parser, it should preserve the original behavior regardless of version used. 

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

I compared the outputs on older and newer versions or `uri` and tests should validate this change as well.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
