### PR TITLE
escape dependency url spaces with `%20` before querying

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -220,6 +220,9 @@ module Dependabot
             new_source&.fetch(:url)
           end
 
+        # spaces must be escaped in base URL
+        registry_url = registry_url.gsub(" ", "%20")
+
         # NPM registries expect slashes to be escaped
         escaped_dependency_name = dependency.name.gsub("/", "%2F")
         "#{registry_url}/#{escaped_dependency_name}"


### PR DESCRIPTION
Escape spaces in NPM dependency URLs so they can be properly queried.

NPM uses the value of the `resolved` property in `package-lock.json` as a dependency's URL.  When this URL is queried to generate a PR description, if this URL contains spaces (not uncommon in Azure DevOps NPM feeds) then the query fails eventually resulting in an empty PR body.

This PR escapes the spaces in the source URL so the URL parse and query is successful.  Similar behavior was observed a few lines down where slashes in a package name are individually escaped.

Manually verified against an internal repo with spaces in the `resolved` property.

Fixes #12172