### PR TITLE
make long title and commit messages easier to read

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -12,6 +12,26 @@ namespace NuGetUpdater.Core.Test.Run;
 
 public class PullRequestTextTests
 {
+    [Fact]
+    public void LongPullRequestTitleIsTrimmed()
+    {
+        var job = FromCommitOptions(null);
+        var updateOperations = new List<UpdateOperationBase>();
+        for (int i = 1; i <= 10; i++)
+        {
+            updateOperations.Add(new DirectUpdate()
+            {
+                DependencyName = $"Package{i}",
+                NewVersion = NuGetVersion.Parse($"{i}.0.0"),
+                UpdatedFiles = ["file.txt"],
+            });
+        }
+
+        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperations], dependencyGroupName: null);
+        var expectedTitle = "Update Package1 and 9 other dependencies";
+        Assert.Equal(expectedTitle, actualTitle);
+    }
+
     [Theory]
     [MemberData(nameof(GetPullRequestTextTestData))]
     public void PullRequestText(
@@ -82,7 +102,7 @@ public class PullRequestTextTests
             // expectedTitle
             "[SECURITY] Update Some.Package to 1.2.3",
             // expectedCommitMessage
-            "[SECURITY] Update Some.Package to 1.2.3",
+            "Update Some.Package to 1.2.3",
             // expectedBody
             """
             Performed the following updates:
@@ -128,7 +148,11 @@ public class PullRequestTextTests
             // expectedTitle
             "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
             // expectedCommitMessage
-            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
+            """
+            Update:
+            - Package.A to 1.0.0, 2.0.0
+            - Package.B to 3.0.0, 4.0.0
+            """,
             // expectedBody
             """
             Performed the following updates:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGet.Versioning;
+
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Updater;
 
@@ -7,34 +9,68 @@ namespace NuGetUpdater.Core.Run;
 
 public class PullRequestTextGenerator
 {
+    private const int MaxTitleLength = 70;
+
     public static string GetPullRequestTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
         // simple version looks like
         //   Update Some.Package to 1.2.3
         // if multiple packages are updated to multiple versions, result looks like:
         //   Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0
-        var dependencySets = updateOperationsPerformed
-            .GroupBy(d => d.DependencyName, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
-            .Select(g => new
-            {
-                Name = g.Key,
-                Versions = g
-                    .Select(d => d.NewVersion)
-                    .OrderBy(v => v)
-                    .ToArray()
-            })
-            .ToArray();
+        var dependencySets = GetDependencySets(updateOperationsPerformed);
         var updatedPartTitles = dependencySets
             .Select(d => $"{d.Name} to {string.Join(", ", d.Versions.Select(v => v.ToString()))}")
             .ToArray();
         var title = $"{job.CommitMessageOptions?.Prefix}Update {string.Join("; ", updatedPartTitles)}";
+
+        // don't let the title get too long
+        if (title.Length > MaxTitleLength && updatedPartTitles.Length >= 3)
+        {
+            title = $"{job.CommitMessageOptions?.Prefix}Update {dependencySets[0].Name} and {dependencySets.Length - 1} other dependencies";
+        }
+
         return title;
     }
 
     public static string GetPullRequestCommitMessage(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        return GetPullRequestTitle(job, updateOperationsPerformed, dependencyGroupName);
+        // updating a single dependency looks like
+        //   Update Some.Package to 1.2.3
+        // if multiple packages are updated, result looks like:
+        //   Update:
+        //   - Package.A to 1.0.0
+        //   - Package.B to 2.0.0
+        var dependencySets = GetDependencySets(updateOperationsPerformed);
+        if (dependencySets.Length == 1)
+        {
+            var depName = dependencySets[0].Name;
+            var depVersions = dependencySets[0].Versions.Select(v => v.ToString());
+            return $"Update {dependencySets[0].Name} to {string.Join(", ", depVersions)}";
+        }
+
+        var updatedParts = dependencySets
+            .Select(d => $"- {d.Name} to {string.Join(", ", d.Versions.Select(v => v.ToString()))}")
+            .ToArray();
+        var message = string.Join("\n", ["Update:", .. updatedParts]);
+        return message;
+    }
+
+    private static (string Name, NuGetVersion[] Versions)[] GetDependencySets(ImmutableArray<UpdateOperationBase> updateOperationsPerformed)
+    {
+        var dependencySets = updateOperationsPerformed
+            .GroupBy(d => d.DependencyName, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(g =>
+            {
+                var name = g.Key;
+                var versions = g
+                    .Select(d => d.NewVersion)
+                    .OrderBy(v => v)
+                    .ToArray();
+                return (name, versions);
+            })
+            .ToArray();
+        return dependencySets;
     }
 
     public static string GetPullRequestBody(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)


### PR DESCRIPTION
PRs that updated lots of dependencies were hard to read so this PR:
1. Simplifies the PR title.
2. Uses a markdown-like list for the commit message.

The tests have good examples of the new behavior.