### PR TITLE
call separate endpoints for unknown errors

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -111,7 +111,7 @@ public class CloneWorkerTests
 
         // assert
         Assert.Equal(1, result);
-        var expectedParseErrorObject = testApiHandler.ReceivedMessages.Single(m => m.Type == typeof(UnknownError));
+        var expectedParseErrorObject = testApiHandler.ReceivedMessages.First(m => m.Type == typeof(UnknownError));
         var unknownError = (UnknownError)expectedParseErrorObject.Object;
         Assert.Equal("JsonException", unknownError.Details["error-class"]);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -1,0 +1,69 @@
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test.Utilities;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class HttpApiHandlerTests
+{
+    [Theory]
+    [MemberData(nameof(ErrorsAreSentToTheCorrectEndpointTestData))]
+    public async Task ErrorsAreSentToTheCorrectEndpoint(JobErrorBase error, params string[] expectedEndpoints)
+    {
+        // arrange
+        var actualEndpoints = new List<string>();
+        using var http = TestHttpServer.CreateTestStringServer((method, url) =>
+        {
+            var expectedPrefix = "/update_jobs/TEST-ID/";
+            var actualPathAndQuery = new Uri(url).PathAndQuery;
+            if (!actualPathAndQuery.StartsWith(expectedPrefix))
+            {
+                throw new Exception($"Didn't find expected prefix: [{expectedPrefix}]");
+            }
+
+            actualEndpoints.Add(actualPathAndQuery[expectedPrefix.Length..]);
+            return (200, "ok");
+        });
+        var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID");
+
+        // act
+        await handler.RecordUpdateJobError(error);
+
+        // assert
+        AssertEx.Equal(expectedEndpoints, actualEndpoints);
+    }
+
+    [Fact]
+    public void ErrorsAreSentToTheCorrectEndpoint_AllTypesAreTested()
+    {
+        var remainingErrorTypes = typeof(JobErrorBase).Assembly
+            .GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(JobErrorBase)))
+            .Select(t => t.Name)
+            .ToHashSet();
+        foreach (var testData in ErrorsAreSentToTheCorrectEndpointTestData())
+        {
+            var seenErrorType = testData[0].GetType().Name;
+            remainingErrorTypes.Remove(seenErrorType);
+        }
+
+        Assert.Empty(remainingErrorTypes);
+    }
+
+    public static IEnumerable<object[]> ErrorsAreSentToTheCorrectEndpointTestData()
+    {
+        yield return [new BadRequirement("unused"), "record_update_job_error"];
+        yield return [new DependencyFileNotFound("unused"), "record_update_job_error"];
+        yield return [new DependencyFileNotParseable("unused"), "record_update_job_error"];
+        yield return [new DependencyNotFound("unused"), "record_update_job_error"];
+        yield return [new JobRepoNotFound("unused"), "record_update_job_error"];
+        yield return [new PrivateSourceAuthenticationFailure(["unused"]), "record_update_job_error"];
+        yield return [new PrivateSourceBadResponse(["unused"]), "record_update_job_error"];
+        yield return [new PullRequestExistsForLatestVersion("unused", "unused"), "record_update_job_error"];
+        yield return [new SecurityUpdateNotNeeded("unused"), "record_update_job_error"];
+        yield return [new UnknownError(new Exception("unused"), "unused"), "record_update_job_error", "record_update_job_unknown_error", "increment_metric"];
+        yield return [new UpdateNotPossible(["unused"]), "record_update_job_error"];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/TestApiHandler.cs
@@ -1,5 +1,4 @@
 using NuGetUpdater.Core.Run;
-using NuGetUpdater.Core.Run.ApiModel;
 
 namespace NuGetUpdater.Core.Test;
 
@@ -9,45 +8,9 @@ internal class TestApiHandler : IApiHandler
 
     public IEnumerable<(Type Type, object Object)> ReceivedMessages => _receivedMessages;
 
-    public Task RecordUpdateJobError(JobErrorBase error)
+    public Task SendAsync(string endpoint, object body, string method)
     {
-        _receivedMessages.Add((error.GetType(), error));
-        return Task.CompletedTask;
-    }
-
-    public Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList)
-    {
-        _receivedMessages.Add((updatedDependencyList.GetType(), updatedDependencyList));
-        return Task.CompletedTask;
-    }
-
-    public Task IncrementMetric(IncrementMetric incrementMetric)
-    {
-        _receivedMessages.Add((incrementMetric.GetType(), incrementMetric));
-        return Task.CompletedTask;
-    }
-
-    public Task CreatePullRequest(CreatePullRequest createPullRequest)
-    {
-        _receivedMessages.Add((createPullRequest.GetType(), createPullRequest));
-        return Task.CompletedTask;
-    }
-
-    public Task ClosePullRequest(ClosePullRequest closePullRequest)
-    {
-        _receivedMessages.Add((closePullRequest.GetType(), closePullRequest));
-        return Task.CompletedTask;
-    }
-
-    public Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
-    {
-        _receivedMessages.Add((updatePullRequest.GetType(), updatePullRequest));
-        return Task.CompletedTask;
-    }
-
-    public Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
-    {
-        _receivedMessages.Add((markAsProcessed.GetType(), markAsProcessed));
+        _receivedMessages.Add((body.GetType(), body));
         return Task.CompletedTask;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -1,10 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record UnknownError : JobErrorBase
 {
+    [JsonIgnore]
+    public Exception Exception { get; init; }
+
     public UnknownError(Exception ex, string jobId)
         : base("unknown_error")
     {
+        Exception = ex;
         Details["error-class"] = ex.GetType().Name;
         Details["error-message"] = ex.Message;
         Details["error-backtrace"] = ex.StackTrace ?? "<unknown>";

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -2,8 +2,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-using NuGetUpdater.Core.Run.ApiModel;
-
 namespace NuGetUpdater.Core.Run;
 
 public class HttpApiHandler : IApiHandler
@@ -25,55 +23,7 @@ public class HttpApiHandler : IApiHandler
         _jobId = jobId;
     }
 
-    public async Task RecordUpdateJobError(JobErrorBase error)
-    {
-        await PostAsJson("record_update_job_error", error);
-    }
-
-    public async Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList)
-    {
-        await PostAsJson("update_dependency_list", updatedDependencyList);
-    }
-
-    public async Task IncrementMetric(IncrementMetric incrementMetric)
-    {
-        await PostAsJson("increment_metric", incrementMetric);
-    }
-
-    public async Task CreatePullRequest(CreatePullRequest createPullRequest)
-    {
-        await PostAsJson("create_pull_request", createPullRequest);
-    }
-
-    public async Task ClosePullRequest(ClosePullRequest closePullRequest)
-    {
-        await PostAsJson("close_pull_request", closePullRequest);
-    }
-
-    public async Task UpdatePullRequest(UpdatePullRequest updatePullRequest)
-    {
-        await PostAsJson("update_pull_request", updatePullRequest);
-    }
-
-    public async Task MarkAsProcessed(MarkAsProcessed markAsProcessed)
-    {
-        await PatchAsJson("mark_as_processed", markAsProcessed);
-    }
-
-    internal static string Serialize(object body)
-    {
-        var wrappedBody = new
-        {
-            Data = body
-        };
-        var payload = JsonSerializer.Serialize(wrappedBody, SerializerOptions);
-        return payload;
-    }
-
-    private Task PostAsJson(string endpoint, object body) => SendAsJson(endpoint, body, "POST");
-    private Task PatchAsJson(string endpoint, object body) => SendAsJson(endpoint, body, "PATCH");
-
-    private async Task SendAsJson(string endpoint, object body, string method)
+    public async Task SendAsync(string endpoint, object body, string method)
     {
         var uri = $"{_apiUrl}/update_jobs/{_jobId}/{endpoint}";
         var payload = Serialize(body);
@@ -85,5 +35,15 @@ public class HttpApiHandler : IApiHandler
         };
         var response = await HttpClient.SendAsync(message);
         var _ = response.EnsureSuccessStatusCode();
+    }
+
+    internal static string Serialize(object body)
+    {
+        var wrappedBody = new
+        {
+            Data = body
+        };
+        var payload = JsonSerializer.Serialize(wrappedBody, SerializerOptions);
+        return payload;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -4,11 +4,37 @@ namespace NuGetUpdater.Core.Run;
 
 public interface IApiHandler
 {
-    Task RecordUpdateJobError(JobErrorBase error);
-    Task UpdateDependencyList(UpdatedDependencyList updatedDependencyList);
-    Task IncrementMetric(IncrementMetric incrementMetric);
-    Task CreatePullRequest(CreatePullRequest createPullRequest);
-    Task ClosePullRequest(ClosePullRequest closePullRequest);
-    Task UpdatePullRequest(UpdatePullRequest updatePullRequest);
-    Task MarkAsProcessed(MarkAsProcessed markAsProcessed);
+    Task SendAsync(string endpoint, object body, string method);
+}
+
+public static class IApiHandlerExtensions
+{
+    public static async Task RecordUpdateJobError(this IApiHandler handler, JobErrorBase error)
+    {
+        await handler.PostAsJson("record_update_job_error", error);
+        if (error is UnknownError unknown)
+        {
+            await handler.PostAsJson("record_update_job_unknown_error", error);
+            var increment = new IncrementMetric()
+            {
+                Metric = "updater.update_job_unknown_error",
+                Tags =
+                {
+                    ["package_manager"] = "nuget",
+                    ["class_name"] = unknown.Exception.GetType().Name
+                },
+            };
+            await handler.IncrementMetric(increment);
+        }
+    }
+
+    public static Task UpdateDependencyList(this IApiHandler handler, UpdatedDependencyList updatedDependencyList) => handler.PostAsJson("update_dependency_list", updatedDependencyList);
+    public static Task IncrementMetric(this IApiHandler handler, IncrementMetric incrementMetric) => handler.PostAsJson("increment_metric", incrementMetric);
+    public static Task CreatePullRequest(this IApiHandler handler, CreatePullRequest createPullRequest) => handler.PostAsJson("create_pull_request", createPullRequest);
+    public static Task ClosePullRequest(this IApiHandler handler, ClosePullRequest closePullRequest) => handler.PostAsJson("close_pull_request", closePullRequest);
+    public static Task UpdatePullRequest(this IApiHandler handler, UpdatePullRequest updatePullRequest) => handler.PostAsJson("update_pull_request", updatePullRequest);
+    public static Task MarkAsProcessed(this IApiHandler handler, MarkAsProcessed markAsProcessed) => handler.PatchAsJson("mark_as_processed", markAsProcessed);
+
+    private static Task PostAsJson(this IApiHandler handler, string endpoint, object body) => handler.SendAsync(endpoint, body, "POST");
+    private static Task PatchAsJson(this IApiHandler handler, string endpoint, object body) => handler.SendAsync(endpoint, body, "PATCH");
 }


### PR DESCRIPTION
A manual audit of some logs shows that for an unknown error, the common Ruby code hits 3 API endpoints: `record_update_job_error`, `record_update_job_unknown_error`, and `increment_metric`.

This PR updates the native C# updater to do the same.

During this I realized that the design of `IApiHandler` was too complicated so it's been simplified to a single method `SendAsync()` and everything else is an extension method.  This makes unit testing more consistent.