### PR TITLE
add pattern for missing package

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1852,6 +1852,14 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new UpdateNotPossible(["Some.Package.1.2.3"]),
         ];
+
+        yield return
+        [
+            // output
+            "Failed to fetch results from V2 feed at 'http://nuget.example.com/FindPackagesById()?id='Some.Package'&semVerLevel=2.0.0' with following message : Response status code does not indicate success: 404.",
+            // expectedError
+            new DependencyNotFound("Some.Package"),
+        ];
     }
 
     public static IEnumerable<object[]> GetTopLevelPackageDependencyInfosTestData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -1029,6 +1029,7 @@ internal static partial class MSBuildHelper
             new Regex(@"Unable to find package (?<PackageName>[^ ]+)\. No packages exist with this id in source\(s\): (?<PackageSource>.*)$", RegexOptions.Multiline),
             new Regex(@"Unable to find package (?<PackageName>[^ ]+) with version \((?<PackageVersion>[^)]+)\)"),
             new Regex(@"Could not resolve SDK ""(?<PackageName>[^ ]+)""\."),
+            new Regex(@"Failed to fetch results from V2 feed at '.*FindPackagesById\(\)\?id='(?<PackageName>[^']+)'&semVerLevel=2\.0\.0' with following message : Response status code does not indicate success: 404\."),
         };
         var matches = patterns.Select(p => p.Match(output)).Where(m => m.Success);
         if (matches.Any())


### PR DESCRIPTION
A manual review of internal logs showed another pattern that NuGet can return when a package isn't found.