### PR TITLE
surface json parse errors from nuget

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using Newtonsoft.Json;
+
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -97,6 +99,11 @@ internal static class VersionFinder
             {
                 // if anything goes wrong here, the package source obviously doesn't contain the requested package
                 continue;
+            }
+            catch (JsonReaderException ex)
+            {
+                // unable to parse server response
+                throw new BadResponseException(ex.Message, source.Source);
             }
 
             var feedVersions = (await feed.GetVersions(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/BadResponseException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/BadResponseException.cs
@@ -1,0 +1,12 @@
+namespace NuGetUpdater.Core;
+
+internal class BadResponseException : Exception
+{
+    public string Uri { get; }
+
+    public BadResponseException(string message, string uri)
+        : base(message)
+    {
+        Uri = uri;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -50,6 +50,7 @@ public abstract record JobErrorBase : MessageBase
         return ex switch
         {
             BadRequirementException badRequirement => new BadRequirement(badRequirement.Message),
+            BadResponseException badResponse => new PrivateSourceBadResponse([badResponse.Uri]),
             DependencyNotFoundException dependencyNotFound => new DependencyNotFound(string.Join(", ", dependencyNotFound.Dependencies)),
             HttpRequestException httpRequest => httpRequest.StatusCode switch
             {


### PR DESCRIPTION
Found during a manual log audit.

When querying a NuGet feed for updated packages, invalid JSON will cause an unknown error.  This catches that error and transforms it into a well-known error.