### PR TITLE
move .NET callstack to the message field

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -191,7 +191,7 @@ public class MessageReportTests
             Error type: unknown_error
             - error-class: NotImplementedException
             - error-message: error message
-            - error-backtrace: <unknown>
+               <unknown>
             - package-manager: nuget
             - job-id: TEST-JOB-ID
             """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -3355,7 +3355,14 @@ public class RunWorkerTests
                         break;
                     // don't test callstacks
                     case UnknownError unknown:
-                        unknown.Details["error-backtrace"] = "<unknown>";
+                        var message = (string)unknown.Details["error-message"];
+                        var stackTraceOffset = message.IndexOf('\n');
+                        if (stackTraceOffset >= 0)
+                        {
+                            var messageWithGenericStacktrace = $"{message[..stackTraceOffset]}\n{UnknownError.UnknownStackTrace}";
+                            unknown.Details["error-message"] = messageWithGenericStacktrace;
+                        }
+
                         newObject = unknown;
                         break;
                     default:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -263,12 +263,6 @@ public class SerializationTests
     [MemberData(nameof(DeserializeErrorTypesData))]
     public void SerializeError(JobErrorBase error, string expectedSerialization)
     {
-        if (error is UnknownError unknown)
-        {
-            // special case the exception's call stack to make it testable
-            unknown.Details["error-backtrace"] = "TEST-BACKTRACE";
-        }
-
         var actual = HttpApiHandler.Serialize(error);
         Assert.Equal(expectedSerialization, actual);
     }
@@ -679,7 +673,7 @@ public class SerializationTests
         [
             new UnknownError(new Exception("some message"), "JOB-ID"),
             """
-            {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"some message","error-backtrace":"TEST-BACKTRACE","package-manager":"nuget","job-id":"JOB-ID"}}}
+            {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"some message\n   \u003Cunknown\u003E","error-backtrace":"","package-manager":"nuget","job-id":"JOB-ID"}}}
             """
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -27,6 +27,12 @@ public abstract record JobErrorBase : MessageBase
         report.AppendLine($"Error type: {Type}");
         foreach (var (key, value) in Details)
         {
+            if (this is UnknownError && key == "error-backtrace")
+            {
+                // there's nothing meaningful in this field
+                continue;
+            }
+
             var valueString = value.ToString();
             if (value is IEnumerable<string> strings)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -7,13 +7,19 @@ public record UnknownError : JobErrorBase
     [JsonIgnore]
     public Exception Exception { get; init; }
 
+    public static readonly string UnknownStackTrace = "   <unknown>";
+
     public UnknownError(Exception ex, string jobId)
         : base("unknown_error")
     {
         Exception = ex;
+
+        // The following object is parsed by the server and the `error-backtrace` property is expected to be a Ruby
+        // stacktrace.  Since we're not in Ruby we can set an empty string there and append the .NET stacktrace to
+        // the message.
         Details["error-class"] = ex.GetType().Name;
-        Details["error-message"] = ex.Message;
-        Details["error-backtrace"] = ex.StackTrace ?? "<unknown>";
+        Details["error-message"] = $"{ex.Message}\n{ex.StackTrace ?? UnknownStackTrace}";
+        Details["error-backtrace"] = "";
         Details["package-manager"] = "nuget";
         Details["job-id"] = jobId;
     }


### PR DESCRIPTION
When reporting an `unknown_error` the `error-backtrace` field is expected to be a Ruby callstack.

To prevent errors in the service, the .NET stack trace is now appended to the message and an empty string is used for the Ruby callstack.