### PR TITLE
report content from server error messages in exception

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -34,7 +34,16 @@ public class HttpApiHandler : IApiHandler
             Content = content
         };
         var response = await HttpClient.SendAsync(message);
-        var _ = response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseContent = await response.Content.ReadAsStringAsync();
+            if (!string.IsNullOrEmpty(responseContent))
+            {
+                responseContent = string.Concat(": ", responseContent);
+            }
+
+            throw new HttpRequestException(message: $"{(int)response.StatusCode} ({response.StatusCode}){responseContent}", inner: null, statusCode: response.StatusCode);
+        }
     }
 
     internal static string Serialize(object body)


### PR DESCRIPTION
The NuGet native updater submits messages directly to the dependabot server, but in the case of a malformed request the error logs would only report `400 (Bad Request)` or similar.  Some server error messages have a string body that contains additional information.

This PR reads that content and throws an exception with this additional information to make investigations easier.