### PR TITLE
include all stack information for unknown errors

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -190,8 +190,7 @@ public class MessageReportTests
             """
             Error type: unknown_error
             - error-class: NotImplementedException
-            - error-message: error message
-               <unknown>
+            - error-message: System.NotImplementedException: error message
             - package-manager: nuget
             - job-id: TEST-JOB-ID
             """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -3515,8 +3515,8 @@ public class RunWorkerTests
                         var stackTraceOffset = message.IndexOf('\n');
                         if (stackTraceOffset >= 0)
                         {
-                            var messageWithGenericStacktrace = $"{message[..stackTraceOffset]}\n{UnknownError.UnknownStackTrace}";
-                            unknown.Details["error-message"] = messageWithGenericStacktrace;
+                            var messageWithoutStackTrace = message[..stackTraceOffset].TrimEnd('\r');
+                            unknown.Details["error-message"] = messageWithoutStackTrace;
                         }
 
                         newObject = unknown;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace NuGetUpdater.Core.Test.Run;
 
-public class SerializationTests
+public class SerializationTests : TestBase
 {
     [Fact]
     public void DeserializeJob()
@@ -260,7 +260,7 @@ public class SerializationTests
     }
 
     [Theory]
-    [MemberData(nameof(DeserializeErrorTypesData))]
+    [MemberData(nameof(SerializeErrorTypesData))]
     public void SerializeError(JobErrorBase error, string expectedSerialization)
     {
         var actual = HttpApiHandler.Serialize(error);
@@ -273,7 +273,7 @@ public class SerializationTests
         var untestedTypes = typeof(JobErrorBase).Assembly.GetTypes()
             .Where(t => t.IsSubclassOf(typeof(JobErrorBase)))
             .ToHashSet();
-        foreach (object?[] data in DeserializeErrorTypesData())
+        foreach (object?[] data in SerializeErrorTypesData())
         {
             var testedErrorType = data[0]!.GetType();
             untestedTypes.Remove(testedErrorType);
@@ -595,7 +595,42 @@ public class SerializationTests
         Assert.Equal(expected, actual);
     }
 
-    public static IEnumerable<object?[]> DeserializeErrorTypesData()
+    [Fact]
+    public void SerializeRealUnknownErrorWithInnerException()
+    {
+        // arrange
+        using var tempDir = new TemporaryDirectory();
+        var action = new Action(() =>
+        {
+            try
+            {
+                throw new NotImplementedException("inner message");
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("outer message", ex);
+            }
+        });
+        var ex = Assert.Throws<InvalidOperationException>(action);
+
+        // act
+        var error = JobErrorBase.ErrorFromException(ex, "TEST-JOB-ID", tempDir.DirectoryPath);
+
+        // assert
+        // real exception message should look like this:
+        // System.InvalidOperationException: outer message
+        //  ---> System.NotImplementedException: inner message
+        //    at Namespace.Class.Method() in file.cs:line 123
+        //    --- End of inner exception stack trace ---
+        //    at Namespace.Class.Method() in file.cs:line 456
+        var errorMessage = Assert.IsType<string>(error.Details["error-message"]);
+        var lines = errorMessage.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+        Assert.Equal("System.InvalidOperationException: outer message", lines[0]);
+        Assert.Equal(" ---> System.NotImplementedException: inner message", lines[1]);
+        Assert.Contains("   --- End of inner exception stack trace ---", lines[2..]);
+    }
+
+    public static IEnumerable<object?[]> SerializeErrorTypesData()
     {
         yield return
         [
@@ -673,7 +708,7 @@ public class SerializationTests
         [
             new UnknownError(new Exception("some message"), "JOB-ID"),
             """
-            {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"some message\n   \u003Cunknown\u003E","error-backtrace":"","package-manager":"nuget","job-id":"JOB-ID"}}}
+            {"data":{"error-type":"unknown_error","error-details":{"error-class":"Exception","error-message":"System.Exception: some message","error-backtrace":"","package-manager":"nuget","job-id":"JOB-ID"}}}
             """
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UnknownError.cs
@@ -7,8 +7,6 @@ public record UnknownError : JobErrorBase
     [JsonIgnore]
     public Exception Exception { get; init; }
 
-    public static readonly string UnknownStackTrace = "   <unknown>";
-
     public UnknownError(Exception ex, string jobId)
         : base("unknown_error")
     {
@@ -18,7 +16,7 @@ public record UnknownError : JobErrorBase
         // stacktrace.  Since we're not in Ruby we can set an empty string there and append the .NET stacktrace to
         // the message.
         Details["error-class"] = ex.GetType().Name;
-        Details["error-message"] = $"{ex.Message}\n{ex.StackTrace ?? UnknownStackTrace}";
+        Details["error-message"] = ex.ToString();
         Details["error-backtrace"] = "";
         Details["package-manager"] = "nuget";
         Details["job-id"] = jobId;


### PR DESCRIPTION
When an exception is turned into an `unknown_error` for reporting, oftentimes the exception will have the `InnerException` property set with additional information, but that's not currently exposed.

This PR switches to using the `ToString()` method directly on the exception because it includes the message, call stack, and all inner exceptions' messages and callstacks making investigations easier.