### PR TITLE
ensure out-of-proc changes to CPM are recorded

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
@@ -55,7 +55,7 @@ public class PackageReferenceUpdaterTests
 
         // assert
         await buildFile.SaveAsync();
-        var actualContents = await File.ReadAllTextAsync(fullProjectPath);
+        var actualContents = await File.ReadAllTextAsync(fullProjectPath, TestContext.Current.CancellationToken);
         var expectedContents = """
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
@@ -69,6 +69,104 @@ public class PackageReferenceUpdaterTests
             </Project>
             """;
         Assert.Equal(expectedContents, actualContents);
+    }
+
+    [Fact]
+    public async Task DirectBuildFileChangesAreMaintainedWhenPinningTransitiveDependency_DirectoryPackagesPropsIsDiscovered()
+    {
+        // arrange
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+        [
+            ("project.csproj", """
+                 <Project Sdk="Microsoft.NET.Sdk">
+                   <PropertyGroup>
+                     <TargetFramework>net9.0</TargetFramework>
+                   </PropertyGroup>
+                   <ItemGroup>
+                     <PackageReference Include="Completely.Different.Package" />
+                     <PackageReference Include="Some.Package" />
+                   </ItemGroup>
+                 </Project>
+                 """),
+            ("Directory.Packages.props", """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageVersion Include="Completely.Different.Package" Version="1.0.0" />
+                    <PackageVersion Include="Some.Package" Version="1.0.0" />
+                  </ItemGroup>
+                </Project>
+                """)
+        ]);
+        var packages = new[]
+        {
+             MockNuGetPackage.CreateSimplePackage("Completely.Different.Package", "1.0.0", "net9.0"),
+             MockNuGetPackage.CreateSimplePackage("Completely.Different.Package", "2.0.0", "net9.0"),
+             MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0", [(null, [("Transitive.Package", "1.0.0")])]),
+             MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net9.0"),
+             MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0"),
+         };
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, tempDir.DirectoryPath);
+        var fullProjectPath = Path.Combine(tempDir.DirectoryPath, "project.csproj");
+        var fullDirectoryPackagesPath = Path.Combine(tempDir.DirectoryPath, "Directory.Packages.props");
+        var buildFiles = new[]
+        {
+            ProjectBuildFile.Open(tempDir.DirectoryPath, fullProjectPath),
+            ProjectBuildFile.Open(tempDir.DirectoryPath, fullDirectoryPackagesPath)
+        }.ToImmutableArray();
+        var experimentsManager = new ExperimentsManager();
+
+        // act
+        // pin transitive dependency
+        var updatedFiles = await PackageReferenceUpdater.UpdateTransitiveDependencyAsync(
+            tempDir.DirectoryPath,
+            fullProjectPath,
+            "Transitive.Package",
+            "2.0.0",
+            buildFiles,
+            experimentsManager,
+            new TestLogger());
+
+        // subsequent update should not overwrite previous change
+        PackageReferenceUpdater.TryUpdateDependencyVersion(buildFiles, "Completely.Different.Package", "1.0.0", "2.0.0", new TestLogger());
+
+        // assert
+        foreach (var bf in buildFiles)
+        {
+            await bf.SaveAsync();
+        }
+
+        var actualProjectContents = await File.ReadAllTextAsync(fullProjectPath, TestContext.Current.CancellationToken);
+        var expectedProjectContents = """
+             <Project Sdk="Microsoft.NET.Sdk">
+               <PropertyGroup>
+                 <TargetFramework>net9.0</TargetFramework>
+               </PropertyGroup>
+               <ItemGroup>
+                 <PackageReference Include="Completely.Different.Package" />
+                 <PackageReference Include="Some.Package" />
+                 <PackageReference Include="Transitive.Package" />
+               </ItemGroup>
+             </Project>
+             """;
+        Assert.Equal(expectedProjectContents.Replace("\r", ""), actualProjectContents.Replace("\r", ""));
+
+        var actualDirectoryPackagesContents = await File.ReadAllTextAsync(fullDirectoryPackagesPath, TestContext.Current.CancellationToken);
+        var expectedDirectoryPackagesContents = """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Completely.Different.Package" Version="2.0.0" />
+                <PackageVersion Include="Some.Package" Version="1.0.0" />
+                <PackageVersion Include="Transitive.Package" Version="2.0.0" />
+              </ItemGroup>
+            </Project>
+            """;
+        Assert.Equal(expectedDirectoryPackagesContents.Replace("\r", ""), actualDirectoryPackagesContents.Replace("\r", ""));
     }
 
     [Theory]


### PR DESCRIPTION
Similar to #11966, if an out-of-process tool updates `Directory.Packages.props` on disk, ensure subsequent updates don't overwrite the first.

In this case the external process emits a message that's very easy to find and parse to determine if that file was edited.