### PR TITLE
report transitive packages with no assembly assets

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: main
+  SMOKE_TEST_BRANCH: dev/brettfo/nuget-transitive-package-no-assemblies
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -1,9 +1,11 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
 using Microsoft.Build.Logging.StructuredLogger;
 
+using NuGet.Frameworks;
 using NuGet.Versioning;
 
 using NuGetUpdater.Core.Utilities;
@@ -39,6 +41,8 @@ internal static class SdkProjectDiscovery
     // these packages are resolved during restore, but aren't really updatable and shouldn't be reported as dependencies
     private static readonly HashSet<string> NonReportedPackgeNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
+        "Microsoft.NETCore.Platforms",
+        "Microsoft.NETCore.Targets",
         "NETStandard.Library"
     };
 
@@ -83,6 +87,9 @@ internal static class SdkProjectDiscovery
 
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesReplacedBySdkPerProject = new(PathComparer.Instance);
         //    projectPath                tfm        packageName  packageVersion
+
+        Dictionary<string, Dictionary<string, HashSet<string>>> packageDependencies = new(PathComparer.Instance);
+        //    projectPath                tfm  packageNames
 
         Dictionary<string, Dictionary<string, string>> resolvedProperties = new(PathComparer.Instance);
         //    projectPath       propertyName  propertyValue
@@ -228,6 +235,28 @@ internal static class SdkProjectDiscovery
                                         }
                                     }
                                 }
+
+                                // track all referenced projects in case they have no assemblies and can't be otherwise reported
+                                if (addItem.Name.Equals("PackageDependencies", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var projectEvaluation = GetNearestProjectEvaluation(node);
+                                    if (projectEvaluation is not null)
+                                    {
+                                        var specificPackageDeps = packageDependencies.GetOrAdd(projectEvaluation.ProjectFile, () => new(StringComparer.OrdinalIgnoreCase));
+                                        var tfm = GetPropertyValueFromProjectEvaluation(projectEvaluation, "TargetFramework");
+                                        if (tfm is not null)
+                                        {
+                                            var packagesByTfm = specificPackageDeps.GetOrAdd(tfm, () => new(StringComparer.OrdinalIgnoreCase));
+                                            foreach (var package in addItem.Children.OfType<Item>())
+                                            {
+                                                if (!NonReportedPackgeNames.Contains(package.Name))
+                                                {
+                                                    packagesByTfm.Add(package.Name);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                             break;
                         case Target target when target.Name == "_HandlePackageFileConflicts":
@@ -330,7 +359,7 @@ internal static class SdkProjectDiscovery
         }
 
         // and done
-        var projectDiscoveryResults = BuildResults(
+        var projectDiscoveryResults = await BuildResults(
             repoRootPath,
             workspacePath,
             packagesPerProject,
@@ -338,6 +367,7 @@ internal static class SdkProjectDiscovery
             packagesReplacedBySdkPerProject,
             topLevelPackagesPerProject,
             resolvedProperties,
+            packageDependencies,
             referencedProjects,
             importedFiles,
             additionalFiles
@@ -345,7 +375,7 @@ internal static class SdkProjectDiscovery
         return projectDiscoveryResults;
     }
 
-    private static ImmutableArray<ProjectDiscoveryResult> BuildResults(
+    private static async Task<ImmutableArray<ProjectDiscoveryResult>> BuildResults(
         string repoRootPath,
         string workspacePath,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesPerProject,
@@ -353,13 +383,14 @@ internal static class SdkProjectDiscovery
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesReplacedBySdkPerProject,
         Dictionary<string, Dictionary<string, HashSet<string>>> topLevelPackagesPerProject,
         Dictionary<string, Dictionary<string, string>> resolvedProperties,
+        Dictionary<string, Dictionary<string, HashSet<string>>> packageDependencies,
         Dictionary<string, HashSet<string>> referencedProjects,
         Dictionary<string, HashSet<string>> importedFiles,
         Dictionary<string, HashSet<string>> additionalFiles
     )
     {
         var projectDiscoveryResults = new List<ProjectDiscoveryResult>();
-        foreach (var projectPath in packagesPerProject.Keys.OrderBy(p => p)) //packagesPerProject.Keys.OrderBy(p => p).Select(projectPath =>
+        foreach (var projectPath in packagesPerProject.Keys.OrderBy(p => p))
         {
             // gather some project-level information
             var packagesByTfm = packagesPerProject[projectPath];
@@ -400,12 +431,72 @@ internal static class SdkProjectDiscovery
                 .SelectMany(kvp => kvp.Value)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+            var propertiesForProject = resolvedProperties.GetOrAdd(projectPath, () => new(StringComparer.OrdinalIgnoreCase));
+            var assetsJson = new Lazy<JsonElement?>(() =>
+            {
+                if (propertiesForProject.TryGetValue("ProjectAssetsFile", out var assetsFilePath))
+                {
+                    var assetsContent = File.ReadAllText(assetsFilePath);
+                    var assets = JsonDocument.Parse(assetsContent).RootElement;
+                    return assets;
+                }
+
+                return null;
+            });
+
             // create dependencies
             var tfms = packagesByTfm.Keys.OrderBy(tfm => tfm).ToImmutableArray();
             var groupedDependencies = new Dictionary<string, Dependency>(StringComparer.OrdinalIgnoreCase);
             foreach (var tfm in tfms)
             {
+                var parsedTfm = NuGetFramework.Parse(tfm);
                 var packages = packagesByTfm[tfm];
+
+                // augment with any packages that might not have reported assemblies
+                var assetsPackageVersions = new Lazy<Dictionary<string, string>>(() =>
+                {
+                    var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    if (assetsJson.Value is { } assets &&
+                        assets.TryGetProperty("targets", out var tfmObjects))
+                    {
+                        foreach (var tfmObject in tfmObjects.EnumerateObject())
+                        {
+                            var reportedTargetFramework = NuGetFramework.Parse(tfmObject.Name);
+                            if (reportedTargetFramework == parsedTfm)
+                            {
+                                foreach (var packageObject in tfmObject.Value.EnumerateObject())
+                                {
+                                    var parts = packageObject.Name.Split('/');
+                                    if (parts.Length == 2)
+                                    {
+                                        var packageName = parts[0];
+                                        var packageVersion = parts[1];
+                                        result[packageName] = packageVersion;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    return result;
+                });
+                var packageDepsForProject = packageDependencies.GetOrAdd(projectPath, () => new(StringComparer.OrdinalIgnoreCase));
+                var packageDepsForTfm = packageDepsForProject.GetOrAdd(tfm, () => new(StringComparer.OrdinalIgnoreCase));
+                foreach (var packageDepName in packageDepsForTfm)
+                {
+                    if (packages.ContainsKey(packageDepName))
+                    {
+                        // we already know about this
+                        continue;
+                    }
+
+                    // otherwise find the corresponding version through project.assets.json
+                    if (assetsPackageVersions.Value.TryGetValue(packageDepName, out var packageDepVersion))
+                    {
+                        packages[packageDepName] = packageDepVersion;
+                    }
+                }
+
                 foreach (var package in packages)
                 {
                     var packageName = package.Key;


### PR DESCRIPTION
# This PR should not be merged as-is; it contains a temporary commit to redirect the smoke tests.

## This needs to be simultaneously merged with dependabot/smoke-tests#288

NuGet dependencies are discovered by examining an MSBuild binary log.  Previously we only looked in collections like `RuntimeCopyLocalItems`, etc., but those groups were only populated if a package had runtime assets to contribute like a `.dll`.

If a package didn't contain any runtime assets, e.g., it only provided `.props`/`.targets` _or_ it was a roll-up package meant to pull in others, it wouldn't get reported in the dependency list.

The fix entails tracking the item group `PackageDependencies` which is populated with all NuGet packages used during restore, whether they contain runtime assets or not.  Any package name in that group that we don't have a version for is a package that didn't have runtime assets.  We can then match that package name with the contents of the generated `project.assets.json` to see exactly which version was used.  That information is then added to the running package collection so it can be reported.

Several smoke tests will be updated to account for these newly-reported packages.

----

Temporary commit 61e153e6f7e5a957767a9ce8d5fd19e8c45b5775 shows passing smoke tests [here](https://github.com/dependabot/dependabot-core/actions/runs/14891722969/job/41825149555?pr=12219) and passing unit tests [here](https://github.com/dependabot/dependabot-core/actions/runs/14891723153/job/41825125591?pr=12219).  The parent of that commit is 651b769fdadbb23920178e9481c9bcb80e2aaa9a which is what should eventually be merged into `main`.