### PR TITLE
only parse TFM, not RID from assets JSON

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -461,7 +461,9 @@ internal static class SdkProjectDiscovery
                     {
                         foreach (var tfmObject in tfmObjects.EnumerateObject())
                         {
-                            var reportedTargetFramework = NuGetFramework.Parse(tfmObject.Name);
+                            // TFM might have a RID suffix after a slash that we can't parse
+                            var tfmParts = tfmObject.Name.Split('/');
+                            var reportedTargetFramework = NuGetFramework.Parse(tfmParts[0]);
                             if (reportedTargetFramework == parsedTfm)
                             {
                                 foreach (var packageObject in tfmObject.Value.EnumerateObject())


### PR DESCRIPTION
We may need to parse a target framework from a `project.assets.json` file and in certain instances there will be a runtime identifier suffix after a slash which causes the function `NuGetFramework.Parse()` to throw.

The fix is to split on the slash and only parse the first part.  If there was no slash, a single string is returned, so that doesn't have to be special cased.

This fixes an issue found during a manual log audit following yesterday's deploy of #12219.