### PR TITLE
improve exception=>error mapping

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Text.Json;
+
+using NuGet.Protocol.Core.Types;
+
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class JobErrorBaseTests : TestBase
+{
+    [Theory]
+    [MemberData(nameof(GenerateErrorFromExceptionTestData))]
+    public async Task GenerateErrorFromException(Exception exception, JobErrorBase expectedError)
+    {
+        // arrange
+        // some error types require a NuGet.Config file to be present
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+            ("NuGet.Config", """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="some_package_feed" value="http://nuget.example.com/v3/index.json" allowInsecureConnections="true" />
+                  </packageSources>
+                </configuration>
+                """)
+        );
+
+        // act
+        var actualError = JobErrorBase.ErrorFromException(exception, "TEST-JOB-ID", tempDir.DirectoryPath);
+
+        // assert
+        var actualErrorJson = JsonSerializer.Serialize(actualError, RunWorker.SerializerOptions);
+        var expectedErrorJson = JsonSerializer.Serialize(expectedError, RunWorker.SerializerOptions);
+        Assert.Equal(expectedErrorJson, actualErrorJson);
+    }
+
+    public static IEnumerable<object[]> GenerateErrorFromExceptionTestData()
+    {
+        // internal error from package feed
+        yield return
+        [
+            new HttpRequestException("nope", null, HttpStatusCode.InternalServerError),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+        ];
+
+        // inner exception turns into private_source_bad_response
+        yield return
+        [
+            new FatalProtocolException("nope", new HttpRequestException("nope", null, HttpStatusCode.InternalServerError)),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+        ];
+
+        // top-level exception turns into private_source_authentication_failure
+        yield return
+        [
+            new HttpRequestException("nope", null, HttpStatusCode.Unauthorized),
+            new PrivateSourceAuthenticationFailure(["http://nuget.example.com/v3/index.json"]),
+        ];
+
+        // inner exception turns into private_source_authentication_failure
+        yield return
+        [
+            // the NuGet libraries commonly do this
+            new FatalProtocolException("nope", new HttpRequestException("nope", null, HttpStatusCode.Unauthorized)),
+            new PrivateSourceAuthenticationFailure(["http://nuget.example.com/v3/index.json"]),
+        ];
+
+        // unknown errors all the way down; report the initial top-level error
+        yield return
+        [
+            new Exception("outer", new Exception("inner")),
+            new UnknownError(new Exception("outer", new Exception("inner")), "TEST-JOB-ID"),
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -47,24 +47,57 @@ public abstract record JobErrorBase : MessageBase
 
     public static JobErrorBase ErrorFromException(Exception ex, string jobId, string currentDirectory)
     {
-        return ex switch
+        switch (ex)
         {
-            BadRequirementException badRequirement => new BadRequirement(badRequirement.Message),
-            BadResponseException badResponse => new PrivateSourceBadResponse([badResponse.Uri]),
-            DependencyNotFoundException dependencyNotFound => new DependencyNotFound(string.Join(", ", dependencyNotFound.Dependencies)),
-            HttpRequestException httpRequest => httpRequest.StatusCode switch
-            {
-                HttpStatusCode.Unauthorized or
-                HttpStatusCode.Forbidden => new PrivateSourceAuthenticationFailure(NuGetContext.GetPackageSourceUrls(currentDirectory)),
-                HttpStatusCode.TooManyRequests => new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory)),
-                HttpStatusCode.ServiceUnavailable => new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory)),
-                _ => new UnknownError(ex, jobId),
-            },
-            InvalidProjectFileException invalidProjectFile => new DependencyFileNotParseable(invalidProjectFile.ProjectFile),
-            MissingFileException missingFile => new DependencyFileNotFound(missingFile.FilePath, missingFile.Message),
-            UnparseableFileException unparseableFile => new DependencyFileNotParseable(unparseableFile.FilePath, unparseableFile.Message),
-            UpdateNotPossibleException updateNotPossible => new UpdateNotPossible(updateNotPossible.Dependencies),
-            _ => new UnknownError(ex, jobId),
-        };
+            case BadRequirementException badRequirement:
+                return new BadRequirement(badRequirement.Message);
+            case BadResponseException badResponse:
+                return new PrivateSourceBadResponse([badResponse.Uri]);
+            case DependencyNotFoundException dependencyNotFound:
+                return new DependencyNotFound(string.Join(", ", dependencyNotFound.Dependencies));
+            case HttpRequestException httpRequest:
+                if (httpRequest.StatusCode is null)
+                {
+                    return new UnknownError(ex, jobId);
+                }
+
+                switch (httpRequest.StatusCode)
+                {
+                    case HttpStatusCode.Unauthorized:
+                    case HttpStatusCode.Forbidden:
+                        return new PrivateSourceAuthenticationFailure(NuGetContext.GetPackageSourceUrls(currentDirectory));
+                    case HttpStatusCode.TooManyRequests:
+                    case HttpStatusCode.ServiceUnavailable:
+                        return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory));
+                    default:
+                        if ((int)httpRequest.StatusCode / 100 == 5)
+                        {
+                            return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory));
+                        }
+
+                        return new UnknownError(ex, jobId);
+                }
+            case InvalidProjectFileException invalidProjectFile:
+                return new DependencyFileNotParseable(invalidProjectFile.ProjectFile);
+            case MissingFileException missingFile:
+                return new DependencyFileNotFound(missingFile.FilePath, missingFile.Message);
+            case UnparseableFileException unparseableFile:
+                return new DependencyFileNotParseable(unparseableFile.FilePath, unparseableFile.Message);
+            case UpdateNotPossibleException updateNotPossible:
+                return new UpdateNotPossible(updateNotPossible.Dependencies);
+            default:
+                // if a more specific inner exception was encountered, use that, otherwise...
+                if (ex.InnerException is not null)
+                {
+                    var innerError = ErrorFromException(ex.InnerException, jobId, currentDirectory);
+                    if (innerError is not UnknownError)
+                    {
+                        return innerError;
+                    }
+                }
+
+                // ...return the whole thing
+                return new UnknownError(ex, jobId);
+        }
     }
 }


### PR DESCRIPTION
The NuGet libraries will oftentimes repeat a failed HTTP call and eventually throw a `FatalProtocolException` with an inner exception with more specific detail.

This PR delves into the `InnerException` property and if it can generate a better error from that, it will use it, otherwise the entire outer exception is used to include as much data as possible.

A manual scan of logs showed that a `FatalProtocolException` could be wrapping an issue where the server was really returning `403` which should have been mapped to `private_source_authentication_failure` and this now fixes that.

The same log scanning exercise showed instances of private NuGet feeds returning a `5xx` error code, sometimes wrapped in NuGet's `FatalProtocolException`, sometimes bare.  This turns all of those exceptions into `private_source_bad_response`.

The bulk of the `switch` statement remains the same, but it had to be turned from an expression into a statement.  The major changes are the check for a `5xx` response and the `default` case of looking at `InnerException`.