### PR TITLE
move env vars to ecosystem locations

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -42,6 +42,7 @@ COPY --chown=dependabot:dependabot hex/helpers /opt/hex/helpers
 ENV MIX_HOME="/opt/hex/mix"
 # https://github.com/hexpm/hex/releases
 ENV HEX_VERSION="2.0.6"
+ENV HEX_CACERTS_PATH /etc/ssl/certs/ca-certificates.crt
 RUN bash /opt/hex/helpers/build
 
 COPY --chown=dependabot:dependabot hex $DEPENDABOT_HOME/hex

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -25,6 +25,8 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
+ENV REQUESTS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 

--- a/updater/bin/run
+++ b/updater/bin/run
@@ -7,10 +7,4 @@ if [ -z "$command" ]; then
   exit 1
 fi
 
-# Tell hex to use the system-wide CA bundle
-export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt
-
-# Tell python to use the system-wide CA bundle
-export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-
 bundle exec ruby "bin/${command}.rb"


### PR DESCRIPTION
### What are you trying to accomplish?

We should avoid letting ecosystem logic get into the updater project as it should be agnostic.

Also helps debug things at the container level if it doesn't require any Ruby invocations to set environment variables. I like using Dependabot CLI's `--debug` flag to enter intro an interactive session to debug Proxy issues. However if we're tucking the environment variables into the Ruby it's harder to debug without invoking those scripts.

But I think my first point stands on its own. 

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

This should be a no-op.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
