### PR TITLE
Hex helper scripts to log to stderr instead of stdout

### DIFF
--- a/hex/helpers/lib/check_update.exs
+++ b/hex/helpers/lib/check_update.exs
@@ -1,3 +1,7 @@
+# Log to stderr instead of stdout
+:logger.remove_handler(:default)
+:logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
+
 defmodule UpdateChecker do
   def run(dependency_name) do
     # This is necessary because we can't specify :extra_applications to have :hex in other mixfiles.

--- a/hex/helpers/lib/do_update.exs
+++ b/hex/helpers/lib/do_update.exs
@@ -1,3 +1,7 @@
+# Log to stderr instead of stdout
+:logger.remove_handler(:default)
+:logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
+
 # This is necessary because we can't specify :extra_applications to have :hex in other mixfiles.
 Mix.ensure_application!(:hex)
 

--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -1,3 +1,7 @@
+# Log to stderr instead of stdout
+:logger.remove_handler(:default)
+:logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
+
 defmodule Parser do
   @allowed_scms [Hex.SCM, Mix.SCM.Git, Mix.SCM.Path]
 


### PR DESCRIPTION
Since these scripts communicate with run.exs by writing a piece of base64-encoded data to stdout, any log messages written to stdout breaks decoding of the result. Let's avoid that by logging any messages to stderr instead.

### What are you trying to accomplish?

I've noticed that Dependabot intermittently fails to update Hex dependencies with output like:

```
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: invalid external representation of a term

    :erlang.binary_to_term("\n10:07:02.927 [error] GenServer Hex.Registry.Server terminating
```

Here is one report of a similar problem: https://github.com/dependabot/dependabot-core/issues/3137

Separating log messages from the response written to stdout seems to fix that.

### Anything you want to highlight for special attention from reviewers?

An alternative solution that I considered is adding some kind of framing around the base64 data in the helper scripts, perhaps just prepending `RESULT:` to it, and then changing `run.exs` to look for that so that it only tries to decode the part of the output that contains the expected response. However, this would be a slightly bigger change, and also it would mean that any warnings would be hidden.

### How will you know you've accomplished your goal?

I've tested this locally with the dry run script. Without this change, I get the error message above, but with this change it produces diffs for dependency updates, as expected.

I'm not sure how to add a test for this. It seems like it's a race condition of some kind that triggers these messages, as it only happens sometimes, and it might be difficult to get that to happen in the tests.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, ~~including adding additional tests for new functionality.~~
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
