### PR TITLE
add retry logic to API calls

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -39,7 +39,7 @@ public class HttpApiHandlerTests
         using var http = TestHttpServer.CreateTestServer((method, url) =>
         {
             // no error content returned
-            return (500, null);
+            return (400, null);
         });
         var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID");
 
@@ -51,12 +51,12 @@ public class HttpApiHandlerTests
         }));
 
         // assert
-        var expectedMessage = $"500 (InternalServerError)";
+        var expectedMessage = $"400 (BadRequest)";
         Assert.Equal(expectedMessage, exception.Message);
     }
 
     [Fact]
-    public async Task ApiCallsAreAutomaticallyRetried()
+    public async Task ApiCallsAreAutomaticallyRetriedWhenTheServerThrowsAnError()
     {
         // arrange
         var requestCount = 0;
@@ -77,6 +77,23 @@ public class HttpApiHandlerTests
         {
             Metric = "test",
         });
+    }
+
+    [Fact]
+    public async Task ApiCallsAreNotRetriedOnABadRequest()
+    {
+        // arrange
+        var requestCount = 0;
+        using var http = TestHttpServer.CreateTestServer((method, url) =>
+        {
+            requestCount++;
+            return (400, Array.Empty<byte>());
+        });
+        var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID");
+
+        // act
+        await Assert.ThrowsAsync<HttpRequestException>(() => handler.IncrementMetric(new() { Metric = "test" }));
+        Assert.True(requestCount == 1, $"Expected only 1 request, but received {requestCount}.");
     }
 
     [Theory]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -52,7 +52,9 @@ public static class IApiHandlerExtensions
                 await action();
                 return;
             }
-            catch (HttpRequestException) when (retryCount < MaxRetries)
+            catch (HttpRequestException ex)
+            when (retryCount < MaxRetries &&
+                (ex.StatusCode is null || ((int)ex.StatusCode) / 100 == 5))
             {
                 retryCount++;
                 await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(MinRetryDelay, MaxRetryDelay)));


### PR DESCRIPTION
Implement retry logic around all API calls, mirroring what happens in the common Ruby code [here](https://github.com/dependabot/dependabot-core/blob/845d4f27f03f7bd62e12891ca9651f93768e7c35/updater/lib/dependabot/api_client.rb#L52-L59).