### PR TITLE
expand pattern for bad feed responses

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
@@ -47,10 +47,17 @@ public class JobErrorBaseTests : TestBase
             new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
         ];
 
-        // inner exception turns into private_source_bad_response
+        // inner exception turns into private_source_bad_response; 500
         yield return
         [
             new FatalProtocolException("nope", new HttpRequestException("nope", null, HttpStatusCode.InternalServerError)),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+        ];
+
+        // inner exception turns into private_source_bad_response; ResponseEnded
+        yield return
+        [
+            new FatalProtocolException("nope", new HttpRequestException("nope", new HttpIOException(HttpRequestError.ResponseEnded))),
             new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -58,6 +58,13 @@ public abstract record JobErrorBase : MessageBase
             case HttpRequestException httpRequest:
                 if (httpRequest.StatusCode is null)
                 {
+                    if (httpRequest.InnerException is HttpIOException ioException &&
+                        ioException.HttpRequestError == HttpRequestError.ResponseEnded)
+                    {
+                        // server hung up on us
+                        return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory));
+                    }
+
                     return new UnknownError(ex, jobId);
                 }
 


### PR DESCRIPTION
Seen during a manual log review.

Querying a NuGet feed can throw a `FatalProtocolException` with an inner `HttpRequestException` with no status code, but another internal `HttpIOException` indicating the server hung up on us.

Fortunately this pattern is very easy to match.