### PR TITLE
expand pattern for unparseable files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1860,6 +1860,14 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new DependencyNotFound("Some.Package"),
         ];
+
+        yield return
+        [
+            // output
+            "This part is not reported.\nAn error occurred while reading file '/path/to/packages.config': Some error message.\nThis part is not reported.",
+            // expectedError
+            new DependencyFileNotParseable("/path/to/packages.config", "Some error message."),
+        ];
     }
 
     public static IEnumerable<object[]> GetTopLevelPackageDependencyInfosTestData()


### PR DESCRIPTION
If NuGet can't parse a `packages.config` file we're explicitly told that as well as why.

This PR expands our error pattern matcher to pull out this information so we can report `dependency_file_not_parseable`.

Found during a manual scan of the logs.