### PR TITLE
add missing pattern for unauthenticated feed

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1776,6 +1776,14 @@ public class MSBuildHelperTests : TestBase
         yield return
         [
             // output
+            "Response status code does not indicate success: 401",
+            // expectedError
+            new PrivateSourceAuthenticationFailure(["http://localhost/test-feed"]),
+        ];
+
+        yield return
+        [
+            // output
             "Response status code does not indicate success: 403",
             // expectedError
             new PrivateSourceAuthenticationFailure(["http://localhost/test-feed"]),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -979,6 +979,7 @@ internal static partial class MSBuildHelper
             "The plugin credential provider could not acquire credentials",
             "401 (Unauthorized)",
             "error NU1301: Unable to load the service index for source",
+            "Response status code does not indicate success: 401",
             "Response status code does not indicate success: 403",
         };
         if (unauthorizedMessageSnippets.Any(stdout.Contains))


### PR DESCRIPTION
Found during a manual log scan.

This adds another error message pattern that was missed before.