### PR TITLE
build(deps): bump terraform from 1.11.4 to 1.12.0

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -2,13 +2,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/
-ARG TERRAFORM_VERSION=1.11.4
+ARG TERRAFORM_VERSION=1.12.0
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ARG TERRAFORM_AMD64_CHECKSUM=1ce994251c00281d6845f0f268637ba50c0005657eb3cf096b92f753b42ef4dc
+ARG TERRAFORM_AMD64_CHECKSUM=c71fd5d500a7e4d869bf5d12176c72d1dfc00440b862116797694361671f77c8
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_arm64.zip"
-ARG TERRAFORM_ARM64_CHECKSUM=a43d1d0da9b9bab214a8305a39db0e40869572594ccf50c416a7756499143633
+ARG TERRAFORM_ARM64_CHECKSUM=8174792e28419601db6445f3252f792bc84c14358f6fe1c65d2951d89b36fadf
 
 RUN cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \


### PR DESCRIPTION
### What are you trying to accomplish?

Making Dependabot work with Terraform 1.12.0.

https://github.com/hashicorp/terraform/releases/tag/v1.12.0
https://releases.hashicorp.com/terraform/1.12.0/

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The build output will show if the image will build successfully.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
