### PR TITLE
Update Dependabot to use the correct Docker Hub registry URL

### DIFF
--- a/docker/lib/dependabot/shared/utils/credentials_finder.rb
+++ b/docker/lib/dependabot/shared/utils/credentials_finder.rb
@@ -15,7 +15,7 @@ module Dependabot
         extend T::Sig
 
         AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+)\.amazonaws\.com/
-        DEFAULT_DOCKER_HUB_REGISTRY = "registry.hub.docker.com"
+        DEFAULT_DOCKER_HUB_REGISTRY = "registry-1.docker.io"
 
         sig { params(credentials: T::Array[Dependabot::Credential], private_repository_type: String).void }
         def initialize(credentials, private_repository_type: "docker_registry")


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot is currently referencing the deprecated Docker Hub registry base URL:
```
DEFAULT_DOCKER_HUB_REGISTRY = "registry.hub.docker.com"
```
Since registry.hub.docker.com is no longer functional, users have been experiencing issues with pulling and pushing images, preventing them from receiving the latest updates.

### Anything you want to highlight for special attention from reviewers?

This PR updates the registry URL to align with Docker's current endpoint: `registry-1.docker.io`

Ref: https://github.com/docker/hub-feedback/issues/1253#issuecomment-345443679

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
