### PR TITLE
Add `rust-toolchain` parser

### DIFF
--- a/cargo/lib/dependabot/cargo/file_parser/toolchain_channel_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser/toolchain_channel_parser.rb
@@ -1,0 +1,59 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/file_parsers/base"
+
+module Dependabot
+  module Cargo
+    class FileParser < Dependabot::FileParsers::Base
+      class ToolchainChannelParser
+        extend T::Sig
+
+        sig { params(toolchain: String).void }
+        def initialize(toolchain)
+          @toolchain = toolchain
+        end
+
+        # Parse Rust toolchain and extract components (channel, date, version)
+        #
+        # This doesn't support the full range of Rust toolchain formats, but we cover
+        # those that Dependabot is likely to encounter.
+        #
+        # See https://rust-lang.github.io/rustup/concepts/toolchains.html
+        sig { returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
+        def parse
+          case toolchain
+          # Specific version like 1.72.0 or 1.72
+          when /^\d+\.\d+(\.\d+)?$/
+            {
+              channel: nil,
+              date: nil,
+              version: toolchain
+            }
+          # With date: nightly-2025-01-0, beta-2025-01-0, stable-2025-01-0
+          when /^(nightly|beta|stable)-(\d{4}-\d{2}-\d{2})$/
+            {
+              channel: ::Regexp.last_match(1),
+              date: ::Regexp.last_match(2),
+              version: nil
+            }
+          # Without date: nightly, beta, stable
+          when "nightly", "beta", "stable"
+            {
+              channel: toolchain,
+              date: nil,
+              version: nil
+            }
+          end
+        end
+
+        private
+
+        sig { returns(String) }
+        attr_reader :toolchain
+      end
+    end
+  end
+end

--- a/cargo/lib/dependabot/cargo/file_parser/toolchain_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser/toolchain_parser.rb
@@ -1,0 +1,93 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "toml-rb"
+
+require "dependabot/dependency"
+require "dependabot/errors"
+require "dependabot/file_parsers/base"
+
+require "dependabot/cargo/file_parser/toolchain_channel_parser"
+
+module Dependabot
+  module Cargo
+    class FileParser < Dependabot::FileParsers::Base
+      class ToolchainParser
+        extend T::Sig
+
+        sig { params(toolchain_file: Dependabot::DependencyFile).void }
+        def initialize(toolchain_file)
+          @toolchain_file = toolchain_file
+        end
+
+        sig { returns(T.nilable(Dependabot::Dependency)) }
+        def parse
+          return unless toolchain_file.content
+
+          raw_toolchain_channel = extract_toolchain_channel
+          toolchain_channel = parse_toolchain_channel(raw_toolchain_channel)
+
+          return if toolchain_channel.nil?
+
+          Dependency.new(
+            name: "rust-toolchain",
+            version: raw_toolchain_channel,
+            requirements: [],
+            package_manager: "cargo",
+            metadata: {
+              toolchain_channel: toolchain_channel
+            }
+          )
+        end
+
+        private
+
+        sig { returns(String) }
+        def extract_toolchain_channel
+          @extract_toolchain_channel ||= T.let(extract_toolchain_file, T.nilable(String))
+        end
+
+        sig { returns(String) }
+        def extract_toolchain_file
+          content = T.must(toolchain_file.content).strip
+
+          case toolchain_file.name
+          when /\.toml$/
+            parse_toml_toolchain(content)
+          else
+            parse_plaintext_toolchain(content)
+          end
+        end
+
+        sig { params(content: String).returns(String) }
+        def parse_toml_toolchain(content)
+          parsed = TomlRB.parse(content)
+
+          channel = parsed.dig("toolchain", "channel")
+          return channel if channel
+
+          Dependabot.logger.warn("No toolchain section found in rust-toolchain.toml file.")
+          raise Dependabot::DependencyFileNotParseable, "rust-toolchain.toml"
+        rescue TomlRB::ParseError => e
+          Dependabot.logger.warn("Failed to parse rust-toolchain.toml file: #{e.message}")
+          raise Dependabot::DependencyFileNotParseable, "rust-toolchain.toml"
+        end
+
+        sig { params(content: String).returns(String) }
+        def parse_plaintext_toolchain(content) = content.strip
+
+        sig { params(raw_toolchain_channel: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
+        def parse_toolchain_channel(raw_toolchain_channel)
+          ToolchainChannelParser.new(
+            raw_toolchain_channel
+          ).parse
+        end
+
+        # Using shorthand accessor notation
+        sig { returns(Dependabot::DependencyFile) }
+        attr_reader :toolchain_file
+      end
+    end
+  end
+end

--- a/cargo/spec/dependabot/cargo/file_parser/toolchain_channel_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser/toolchain_channel_parser_spec.rb
@@ -1,0 +1,121 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/cargo/file_parser/toolchain_channel_parser"
+
+RSpec.describe Dependabot::Cargo::FileParser::ToolchainChannelParser do
+  describe "#parse" do
+    subject(:parser) { described_class.new(toolchain) }
+
+    context "with a specific version" do
+      context "with major and minor version" do
+        let(:toolchain) { "1.72" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to be_nil
+          expect(result[:date]).to be_nil
+          expect(result[:version]).to eq("1.72")
+        end
+      end
+
+      context "with major, minor, and patch version" do
+        let(:toolchain) { "1.72.0" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to be_nil
+          expect(result[:date]).to be_nil
+          expect(result[:version]).to eq("1.72.0")
+        end
+      end
+    end
+
+    context "with a channel and date" do
+      context "with nightly channel" do
+        let(:toolchain) { "nightly-2020-12-31" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("nightly")
+          expect(result[:date]).to eq("2020-12-31")
+          expect(result[:version]).to be_nil
+        end
+      end
+
+      context "with beta channel" do
+        let(:toolchain) { "beta-2020-12-31" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("beta")
+          expect(result[:date]).to eq("2020-12-31")
+          expect(result[:version]).to be_nil
+        end
+      end
+
+      context "with stable channel" do
+        let(:toolchain) { "stable-2020-12-31" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("stable")
+          expect(result[:date]).to eq("2020-12-31")
+          expect(result[:version]).to be_nil
+        end
+      end
+    end
+
+    context "with a channel only" do
+      context "with nightly channel" do
+        let(:toolchain) { "nightly" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("nightly")
+          expect(result[:date]).to be_nil
+          expect(result[:version]).to be_nil
+        end
+      end
+
+      context "with beta channel" do
+        let(:toolchain) { "beta" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("beta")
+          expect(result[:date]).to be_nil
+          expect(result[:version]).to be_nil
+        end
+      end
+
+      context "with stable channel" do
+        let(:toolchain) { "stable" }
+
+        it "returns the correct toolchain channel details" do
+          result = parser.parse
+          expect(result[:channel]).to eq("stable")
+          expect(result[:date]).to be_nil
+          expect(result[:version]).to be_nil
+        end
+      end
+    end
+
+    context "with invalid format" do
+      let(:toolchain) { "invalid-format" }
+
+      it "returns nil" do
+        expect(parser.parse).to be_nil
+      end
+    end
+
+    context "with empty string" do
+      let(:toolchain) { "" }
+
+      it "returns nil" do
+        expect(parser.parse).to be_nil
+      end
+    end
+  end
+end

--- a/cargo/spec/dependabot/cargo/file_parser/toolchain_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser/toolchain_parser_spec.rb
@@ -1,0 +1,180 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/cargo/file_parser/toolchain_parser"
+require "dependabot/dependency_file"
+
+RSpec.describe Dependabot::Cargo::FileParser::ToolchainParser do
+  let(:parser) { described_class.new(toolchain_file) }
+
+  describe "#parse" do
+    subject(:dependency) { parser.parse }
+
+    context "with a plaintext toolchain file" do
+      let(:toolchain_file) do
+        Dependabot::DependencyFile.new(
+          name: "rust-toolchain",
+          content: toolchain_content
+        )
+      end
+
+      context "with a specific version" do
+        let(:toolchain_content) { "1.72.0" }
+
+        it "returns a dependency with the correct details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("rust-toolchain")
+          expect(dependency.version).to eq("1.72.0")
+          expect(dependency.requirements).to eq([])
+          expect(dependency.package_manager).to eq("cargo")
+          expect(dependency.metadata[:toolchain_channel]).to eq({
+            channel: nil,
+            date: nil,
+            version: "1.72.0"
+          })
+        end
+      end
+
+      context "with a channel" do
+        let(:toolchain_content) { "nightly" }
+
+        it "returns a dependency with the correct details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("rust-toolchain")
+          expect(dependency.version).to eq("nightly")
+          expect(dependency.requirements).to eq([])
+          expect(dependency.package_manager).to eq("cargo")
+          expect(dependency.metadata[:toolchain_channel]).to eq({
+            channel: "nightly",
+            date: nil,
+            version: nil
+          })
+        end
+      end
+
+      context "with a channel and date" do
+        let(:toolchain_content) { "nightly-2023-05-15" }
+
+        it "returns a dependency with the correct details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("rust-toolchain")
+          expect(dependency.version).to eq("nightly-2023-05-15")
+          expect(dependency.requirements).to eq([])
+          expect(dependency.package_manager).to eq("cargo")
+          expect(dependency.metadata[:toolchain_channel]).to eq({
+            channel: "nightly",
+            date: "2023-05-15",
+            version: nil
+          })
+        end
+      end
+    end
+
+    context "with a TOML toolchain file" do
+      let(:toolchain_file) do
+        Dependabot::DependencyFile.new(
+          name: "rust-toolchain.toml",
+          content: toolchain_content
+        )
+      end
+
+      context "with a simple channel specification" do
+        let(:toolchain_content) do
+          <<~TOML
+            [toolchain]
+            channel = "1.72.0"
+          TOML
+        end
+
+        it "returns a dependency with the correct details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("rust-toolchain")
+          expect(dependency.version).to eq("1.72.0")
+          expect(dependency.requirements).to eq([])
+          expect(dependency.package_manager).to eq("cargo")
+          expect(dependency.metadata[:toolchain_channel]).to eq({
+            channel: nil,
+            date: nil,
+            version: "1.72.0"
+          })
+        end
+      end
+
+      context "with a nightly channel specification" do
+        let(:toolchain_content) do
+          <<~TOML
+            [toolchain]
+            channel = "nightly-2023-05-15"
+            components = ["rustfmt", "clippy"]
+          TOML
+        end
+
+        it "returns a dependency with the correct details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("rust-toolchain")
+          expect(dependency.version).to eq("nightly-2023-05-15")
+          expect(dependency.requirements).to eq([])
+          expect(dependency.package_manager).to eq("cargo")
+          expect(dependency.metadata[:toolchain_channel]).to eq({
+            channel: "nightly",
+            date: "2023-05-15",
+            version: nil
+          })
+        end
+      end
+
+      context "with a missing channel in TOML" do
+        let(:toolchain_content) do
+          <<~TOML
+            [toolchain]
+            components = ["rustfmt", "clippy"]
+          TOML
+        end
+
+        it "raises a DependencyFileNotParseable error" do
+          expect { dependency }.to raise_error(Dependabot::DependencyFileNotParseable)
+        end
+      end
+
+      context "with invalid TOML" do
+        let(:toolchain_content) do
+          <<~TOML
+            [toolchain
+            channel = "1.72.0"
+          TOML
+        end
+
+        it "raises a DependencyFileNotParseable error" do
+          expect { dependency }.to raise_error(Dependabot::DependencyFileNotParseable)
+        end
+      end
+    end
+
+    context "with an empty file" do
+      let(:toolchain_file) do
+        Dependabot::DependencyFile.new(
+          name: "rust-toolchain",
+          content: ""
+        )
+      end
+
+      it "returns nil" do
+        expect(dependency).to be_nil
+      end
+    end
+
+    context "with a nil content file" do
+      let(:toolchain_file) do
+        Dependabot::DependencyFile.new(
+          name: "rust-toolchain",
+          content: nil
+        )
+      end
+
+      it "returns nil" do
+        expect(dependency).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Initial support for parsing `rust-toolchain` files.

See #1702 for more context.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

`ToolchainChannelParser` doesn't support the full range of possible Rust toolchain formats[^1], but it does support:
1. The most common formats
2. Those that Dependabot can update

Also note, that this isn't hooked up to anything yet.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Unit tests pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

[^1]: https://rust-lang.github.io/rustup/concepts/toolchains.html