### PR TITLE
Bump Rubocop target Ruby version from 3.1 to 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - "dry-run/**/*"
     - "bundler/helpers/spec_helpers/*"
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true

--- a/bun/lib/dependabot/bun/update_checker.rb
+++ b/bun/lib/dependabot/bun/update_checker.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "set"
-
 require "dependabot/git_commit_checker"
 require "dependabot/requirements_update_strategy"
 require "dependabot/shared_helpers"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.version = Dependabot::VERSION
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.3.0"
   spec.required_rubygems_version = ">= 3.3.7"
 
   spec.require_path = "lib"

--- a/common/lib/dependabot/utils.rb
+++ b/common/lib/dependabot/utils.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "tmpdir"
-require "set"
 require "sorbet-runtime"
 
 require "dependabot/requirement"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "set"
-
 require "dependabot/git_commit_checker"
 require "dependabot/requirements_update_strategy"
 require "dependabot/shared_helpers"

--- a/nuget/lib/dependabot/nuget/cache_manager.rb
+++ b/nuget/lib/dependabot/nuget/cache_manager.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "set"
 require "sorbet-runtime"
 
 require "dependabot/file_fetchers"

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -1,12 +1,12 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/nuget/discovery/discovery_json_reader"
 require "dependabot/nuget/native_helpers"
-require "set"
-require "sorbet-runtime"
 
 module Dependabot
   module Nuget


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

This is part of several PRs to split the Ruby 3.4 upgrade in https://github.com/dependabot/dependabot-core/pull/11681 out into lower-risk PRs.

This bumps the targeted Ruby version in Rubocop to 3.3 which called unnecessary requires of "set" as it's loaded automatically as of Ruby 3.2

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
