### PR TITLE
Explicitly use `RFC2396` instead of `DEFAULT_PARSER`

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -297,7 +297,7 @@ module Dependabot
       sig { params(url: String).returns(Excon::Response) }
       def get(url)
         response = Excon.get(
-          URI::DEFAULT_PARSER.escape(url),
+          URI::RFC2396_PARSER.escape(url),
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
           # Setting to false to prevent Excon retries, use BitbucketWithRetries for retries.


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

In Ruby 3.4 `URI::DEFAULT_PARSER` changed from `RFC2396` to `RFC3986`[^1]. This change makes our use of `RFC2396` explicit instead of implicit.

This migration was partially completed in #12170. This change just finishes the migration.

This is a part of the Ruby 3.4 upgrade #11681

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

We should migrate from RFC2396 to RFC3986 at some point in the future. This work is tracked in #12327

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

[^1]: https://github.com/ruby/uri/pull/107