### PR TITLE
Create branch naming strategy for multi-ecosystem updates

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -76,7 +76,7 @@ module Dependabot
 
       private
 
-      sig { returns(T.nilable(Dependabot::PullRequestCreator::BranchNamer::Base)) }
+      sig { returns(Dependabot::PullRequestCreator::BranchNamer::Base) }
       def strategy
         @strategy ||= T.let(
           if multi_ecosystem_name

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -8,6 +8,7 @@ require "dependabot/metadata_finders"
 require "dependabot/pull_request_creator"
 require "dependabot/pull_request_creator/branch_namer/solo_strategy"
 require "dependabot/pull_request_creator/branch_namer/dependency_group_strategy"
+require "dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy"
 
 module Dependabot
   class PullRequestCreator
@@ -38,6 +39,9 @@ module Dependabot
       sig { returns(T::Boolean) }
       attr_reader :includes_security_fixes
 
+      sig { returns(T.nilable(String)) }
+      attr_reader :multi_ecosystem_name
+
       sig do
         params(
           dependencies: T::Array[Dependabot::Dependency],
@@ -47,12 +51,13 @@ module Dependabot
           separator: String,
           prefix: String,
           max_length: T.nilable(Integer),
-          includes_security_fixes: T::Boolean
+          includes_security_fixes: T::Boolean,
+          multi_ecosystem_name: T.nilable(String)
         )
           .void
       end
       def initialize(dependencies:, files:, target_branch:, dependency_group: nil, separator: "/",
-                     prefix: "dependabot", max_length: nil, includes_security_fixes: false)
+                     prefix: "dependabot", max_length: nil, includes_security_fixes: false, multi_ecosystem_name: nil)
         @dependencies  = dependencies
         @files         = files
         @target_branch = target_branch
@@ -61,6 +66,7 @@ module Dependabot
         @prefix        = prefix
         @max_length    = max_length
         @includes_security_fixes = includes_security_fixes
+        @multi_ecosystem_name = multi_ecosystem_name
       end
 
       sig { returns(String) }
@@ -70,31 +76,57 @@ module Dependabot
 
       private
 
-      sig { returns(Dependabot::PullRequestCreator::BranchNamer::Base) }
+      sig { returns(T.nilable(Dependabot::PullRequestCreator::BranchNamer::Base)) }
       def strategy
         @strategy ||= T.let(
-          if dependency_group.nil?
-            SoloStrategy.new(
-              dependencies: dependencies,
-              files: files,
-              target_branch: target_branch,
-              separator: separator,
-              prefix: prefix,
-              max_length: max_length
-            )
+          if multi_ecosystem_name
+            build_multi_ecosystem_strategy
+          elsif dependency_group.nil?
+            build_solo_strategy
           else
-            DependencyGroupStrategy.new(
-              dependencies: dependencies,
-              files: files,
-              target_branch: target_branch,
-              dependency_group: T.must(dependency_group),
-              includes_security_fixes: includes_security_fixes,
-              separator: separator,
-              prefix: prefix,
-              max_length: max_length
-            )
+            build_dependency_group_strategy
           end,
           T.nilable(Dependabot::PullRequestCreator::BranchNamer::Base)
+        )
+      end
+
+      sig { returns(Dependabot::PullRequestCreator::BranchNamer::MultiEcosystemStrategy) }
+      def build_multi_ecosystem_strategy
+        MultiEcosystemStrategy.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          includes_security_fixes: includes_security_fixes,
+          separator: separator,
+          prefix: prefix,
+          max_length: max_length,
+          multi_ecosystem_name: T.must(multi_ecosystem_name)
+        )
+      end
+
+      sig { returns(Dependabot::PullRequestCreator::BranchNamer::SoloStrategy) }
+      def build_solo_strategy
+        SoloStrategy.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          separator: separator,
+          prefix: prefix,
+          max_length: max_length
+        )
+      end
+
+      sig { returns(Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrategy) }
+      def build_dependency_group_strategy
+        DependencyGroupStrategy.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          dependency_group: T.must(dependency_group),
+          includes_security_fixes: includes_security_fixes,
+          separator: separator,
+          prefix: prefix,
+          max_length: max_length
         )
       end
     end

--- a/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
@@ -1,0 +1,80 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/pull_request_creator/branch_namer/base"
+
+module Dependabot
+  class PullRequestCreator
+    class BranchNamer
+      class MultiEcosystemStrategy < Base
+        extend T::Sig
+
+        sig do
+          params(
+            dependencies: T::Array[Dependabot::Dependency],
+            files: T::Array[Dependabot::DependencyFile],
+            target_branch: T.nilable(String),
+            includes_security_fixes: T::Boolean,
+            separator: String,
+            prefix: String,
+            max_length: T.nilable(Integer),
+            multi_ecosystem_name: T.nilable(String)
+          )
+            .void
+        end
+        def initialize(dependencies:, files:, target_branch:, includes_security_fixes:,
+                       separator: "/", prefix: "dependabot", max_length: nil, multi_ecosystem_name: nil)
+          super(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            separator: separator,
+            prefix: prefix,
+            max_length: max_length,
+          )
+
+          @multi_ecosystem_name = multi_ecosystem_name
+          @includes_security_fixes = includes_security_fixes
+        end
+
+        sig { override.returns(String) }
+        def new_branch_name
+          sanitize_branch_name(File.join(prefixes, group_name_with_dependency_digest))
+        end
+
+        private
+
+        sig { returns(String) }
+        attr_reader :multi_ecosystem_name
+
+        sig { returns(T::Array[String]) }
+        def prefixes
+          [
+            prefix,
+            target_branch
+          ].compact
+        end
+
+        sig { returns(String) }
+        def group_name_with_dependency_digest
+          if @includes_security_fixes
+            "group-security-#{multi_ecosystem_name}-#{dependency_digest}"
+          else
+            "#{multi_ecosystem_name}-#{dependency_digest}"
+          end
+        end
+
+        sig { returns(T.nilable(String)) }
+        def dependency_digest
+          @dependency_digest ||= T.let(
+            Digest::MD5.hexdigest(dependencies.map do |dependency|
+                                    "#{dependency.name}-#{dependency.removed? ? 'removed' : dependency.version}"
+                                  end.sort.join(",")).slice(0, 10),
+            T.nilable(String)
+          )
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
@@ -16,15 +16,15 @@ module Dependabot
             files: T::Array[Dependabot::DependencyFile],
             target_branch: T.nilable(String),
             includes_security_fixes: T::Boolean,
+            multi_ecosystem_name: String,
             separator: String,
             prefix: String,
             max_length: T.nilable(Integer),
-            multi_ecosystem_name: T.nilable(String)
           )
             .void
         end
-        def initialize(dependencies:, files:, target_branch:, includes_security_fixes:,
-                       separator: "/", prefix: "dependabot", max_length: nil, multi_ecosystem_name: nil)
+        def initialize(dependencies:, files:, target_branch:, includes_security_fixes:, multi_ecosystem_name:,
+                       separator: "/", prefix: "dependabot", max_length: nil)
           super(
             dependencies: dependencies,
             files: files,

--- a/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
@@ -19,7 +19,7 @@ module Dependabot
             multi_ecosystem_name: String,
             separator: String,
             prefix: String,
-            max_length: T.nilable(Integer),
+            max_length: T.nilable(Integer)
           )
             .void
         end

--- a/common/spec/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy_spec.rb
@@ -1,0 +1,223 @@
+# typed: false
+# frozen_string_literal: true
+
+require "digest"
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/dependency_group"
+require "dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy"
+
+RSpec.describe Dependabot::PullRequestCreator::BranchNamer::MultiEcosystemStrategy do
+  subject(:namer) do
+    described_class.new(
+      dependencies: dependencies,
+      files: [gemfile, package_json],
+      target_branch: target_branch,
+      separator: separator,
+      max_length: max_length,
+      includes_security_fixes: includes_security_fixes,
+      multi_ecosystem_name: multi_ecosystem_name
+    )
+  end
+
+  let(:multi_ecosystem_name) { "my_multi_ecosystem" }
+  let(:dependencies) { [ruby_dependency, npm_dependency] }
+  let(:ruby_dependency) do
+    Dependabot::Dependency.new(
+      name: "business",
+      version: "1.5.0",
+      previous_version: "1.4.0",
+      package_manager: "bundler",
+      requirements: [],
+      previous_requirements: []
+    )
+  end
+  let(:npm_dependency) do
+    Dependabot::Dependency.new(
+      name: "lodash",
+      version: "1.1.0",
+      previous_version: "1.0.0",
+      package_manager: "npm_and_yarn",
+      requirements: [],
+      previous_requirements: []
+    )
+  end
+
+  let(:gemfile) do
+    Dependabot::DependencyFile.new(
+      name: "Gemfile",
+      content: "anything",
+      directory: "/"
+    )
+  end
+
+  let(:package_json) do
+    Dependabot::DependencyFile.new(
+      name: "package.json",
+      content: "anything",
+      directory: "/"
+    )
+  end
+
+  let(:max_length) { nil }
+  let(:includes_security_fixes) { false }
+
+  describe "#new_branch_name" do
+    subject(:new_branch_name) { namer.new_branch_name }
+
+    context "with defaults for separator, target branch and files in the root" do
+      let(:target_branch) { "" }
+      let(:separator) { "/" }
+
+      it "returns the name of the multi-ecosystem prefixed correctly" do
+        expect(namer.new_branch_name).to start_with("dependabot/my_multi_ecosystem")
+      end
+
+      it "generates a deterministic branch name for a given set of dependencies" do
+        branch_name = namer.new_branch_name
+        new_namer = described_class.new(
+          dependencies: dependencies,
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          includes_security_fixes: includes_security_fixes,
+          multi_ecosystem_name: multi_ecosystem_name
+        )
+        sleep 1 # ensure the timestamp changes
+        expect(new_namer.new_branch_name).to eql(branch_name)
+      end
+
+      it "generates a different branch name for a different set of dependencies for the same multi-ecosystem" do
+        removed_dependency = Dependabot::Dependency.new(
+          name: "old_business",
+          version: "1.4.0",
+          previous_version: "1.4.0",
+          package_manager: "bundler",
+          requirements: [],
+          previous_requirements: [],
+          removed: true
+        )
+
+        new_namer = described_class.new(
+          dependencies: [ruby_dependency, removed_dependency],
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          includes_security_fixes: includes_security_fixes,
+          multi_ecosystem_name: multi_ecosystem_name
+        )
+        expect(new_namer.new_branch_name).not_to eql(namer.new_branch_name)
+      end
+
+      it "generates the same branch name regardless of the order of dependencies" do
+        removed_dependency = Dependabot::Dependency.new(
+          name: "old_business",
+          version: "1.4.0",
+          previous_version: "1.4.0",
+          package_manager: "bundler",
+          requirements: [],
+          previous_requirements: [],
+          removed: true
+        )
+
+        forward_namer = described_class.new(
+          dependencies: [ruby_dependency, removed_dependency],
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          includes_security_fixes: includes_security_fixes,
+          multi_ecosystem_name: multi_ecosystem_name
+        )
+
+        backward_namer = described_class.new(
+          dependencies: [removed_dependency, ruby_dependency],
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          includes_security_fixes: includes_security_fixes,
+          multi_ecosystem_name: multi_ecosystem_name
+        )
+
+        expect(forward_namer.new_branch_name).to eql(backward_namer.new_branch_name)
+      end
+    end
+
+    context "with a multi-ecosystem security update" do
+      let(:target_branch) { "" }
+      let(:separator) { "/" }
+      let(:includes_security_fixes) { true }
+
+      it "returns the name of the security multi-ecosystem prefixed correctly" do
+        expect(namer.new_branch_name).to eq("dependabot/group-security-my_multi_ecosystem-9ccbdf484a")
+      end
+    end
+
+    context "with a custom separator" do
+      let(:target_branch) { "" }
+      let(:separator) { "_" }
+
+      it "returns the name of the multi-ecosystem prefixed correctly" do
+        expect(namer.new_branch_name).to start_with("dependabot_my_multi_ecosystem")
+      end
+    end
+
+    context "with a maximum length" do
+      let(:target_branch) { "" }
+      let(:separator) { "/" }
+
+      context "with a maximum length longer than branch name" do
+        let(:max_length) { 50 }
+        let(:multi_ecosystem_name) { "mitt_multi_ecosystem_longer" }
+
+        it { is_expected.to eq("dependabot/mitt_multi_ecosystem_longer-9ccbdf484a") }
+        its(:length) { is_expected.to eq(49) }
+      end
+
+      context "with a maximum length shorter than branch name" do
+        let(:multi_ecosystem_name) { "business-and-work-and-desks-and-tables-and-chairs" }
+        let(:sha1_digest) { Digest::SHA1.hexdigest("dependabot/#{multi_ecosystem_name}-9ccbdf484a") }
+
+        context "with a maximum length longer than sha1 length" do
+          let(:max_length) { 50 }
+
+          it { is_expected.to eq("dependabot#{sha1_digest}") }
+          its(:length) { is_expected.to eq(50) }
+        end
+
+        context "with a maximum length equal than sha1 length" do
+          let(:max_length) { 40 }
+
+          it { is_expected.to eq(sha1_digest) }
+          its(:length) { is_expected.to eq(40) }
+        end
+
+        context "with a maximum length shorter than sha1 length" do
+          let(:max_length) { 20 }
+
+          it { is_expected.to eq(sha1_digest[0...20]) }
+          its(:length) { is_expected.to eq(20) }
+        end
+      end
+    end
+
+    context "when dealing with the files targeting a branch" do
+      let(:target_branch) { "develop" }
+      let(:separator) { "/" }
+
+      it "returns the name of the multi-ecosystem prefixed correctly" do
+        expect(namer.new_branch_name).to start_with("dependabot/develop/my_multi_ecosystem-9ccbdf484a")
+      end
+    end
+
+    context "when dealing with files in a multi-ecosystem targeting a branch" do
+      let(:target_branch) { "develop" }
+      let(:separator) { "_" }
+
+      it "returns the name of the multi-ecosystem prefixed correctly" do
+        expect(namer.new_branch_name).to start_with("dependabot_develop_my_multi_ecosystem-9ccbdf484a")
+      end
+    end
+  end
+end

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -696,5 +696,24 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         branch_namer.new_branch_name
       end
     end
+
+    context "when a multi-ecosystem is present" do
+      it "delegates to a multi-ecosystem strategy" do
+        strategy = instance_double(described_class::MultiEcosystemStrategy)
+        allow(described_class::MultiEcosystemStrategy).to receive(:new).and_return(strategy)
+
+        branch_namer =
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            multi_ecosystem_name: "multi_ecosystem"
+          )
+
+        expect(strategy).to receive(:new_branch_name).and_return("dependabot/multi_ecosystem")
+
+        expect(branch_namer.new_branch_name).to eq("dependabot/multi_ecosystem")
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Currently we are using dependency groups for branch naming, but we need to use the multi-ecosystem name directly for branch naming in multi-ecosystem updates. This change updates the branch naming strategy to use the `multi_ecosystem_name` parameter to generate consistent branch names for updates spanning multiple package managers.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The branch names now follow the pattern `dependabot/{multi_ecosystem_name}-{hash}` and maintain deterministic generation regardless of dependency order.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Branch names use the multi-ecosystem name directly instead of dependency group references when running multi-ecosystem updates

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
