### PR TITLE
create scenario update handlers

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -50,8 +50,8 @@ public partial class EntryPointTests
                 },
                 expectedUrls:
                 [
-                    "POST /update_jobs/TEST-ID/update_dependency_list",
                     "POST /update_jobs/TEST-ID/increment_metric",
+                    "POST /update_jobs/TEST-ID/update_dependency_list",
                     "POST /update_jobs/TEST-ID/create_pull_request",
                     "PATCH /update_jobs/TEST-ID/mark_as_processed",
                 ]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -150,7 +150,12 @@ public class HttpApiHandlerTests
         yield return [new PrivateSourceAuthenticationFailure(["unused"]), "record_update_job_error"];
         yield return [new PrivateSourceBadResponse(["unused"]), "record_update_job_error"];
         yield return [new PullRequestExistsForLatestVersion("unused", "unused"), "record_update_job_error"];
+        yield return [new PullRequestExistsForSecurityUpdate([]), "record_update_job_error"];
+        yield return [new SecurityUpdateDependencyNotFound(), "record_update_job_error"];
+        yield return [new SecurityUpdateIgnored("unused"), "record_update_job_error"];
+        yield return [new SecurityUpdateNotFound("unused", "unused"), "record_update_job_error"];
         yield return [new SecurityUpdateNotNeeded("unused"), "record_update_job_error"];
+        yield return [new SecurityUpdateNotPossible("unused", "unused", "unused", []), "record_update_job_error"];
         yield return [new UnknownError(new Exception("unused"), "unused"), "record_update_job_error", "record_update_job_unknown_error", "increment_metric"];
         yield return [new UpdateNotPossible(["unused"]), "record_update_job_error"];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -82,6 +82,7 @@ public class MessageReportTests
                 CommitMessage = "unused",
                 PrTitle = "unused",
                 PrBody = "unused",
+                DependencyGroup = null, // unused
             },
             // expected
             """
@@ -174,11 +175,74 @@ public class MessageReportTests
         yield return
         [
             // message
+            new PullRequestExistsForSecurityUpdate([new("Some.Dependency", "1.2.3", DependencyType.PackageReference)]),
+            // expected
+            """
+            Error type: pull_request_exists_for_security_update
+            - updated-dependencies:
+              - - dependency-name: Some.Dependency
+                - dependency-version: 1.2.3
+                - dependency-removed: false
+            """
+        ];
+
+        yield return
+        [
+            // message
+            new SecurityUpdateDependencyNotFound(),
+            // expected
+            """
+            Error type: security_update_dependency_not_found
+            """
+        ];
+
+        yield return
+        [
+            // message
+            new SecurityUpdateIgnored("Some.Dependency"),
+            // expected
+            """
+            Error type: all_versions_ignored
+            - dependency-name: Some.Dependency
+            """
+        ];
+
+        yield return
+        [
+            // message
+            new SecurityUpdateNotFound("Some.Dependency", "1.2.3"),
+            // expected
+            """
+            Error type: security_update_not_found
+            - dependency-name: Some.Dependency
+            - dependency-version: 1.2.3
+            """
+        ];
+
+        yield return
+        [
+            // message
             new SecurityUpdateNotNeeded("Some.Dependency"),
             // expected
             """
             Error type: security_update_not_needed
             - dependency-name: Some.Dependency
+            """
+        ];
+
+        yield return
+        [
+            // message
+            new SecurityUpdateNotPossible("Some.Dependency", "1.2.3", "4.5.6", ["dep1", "dep2"]),
+            // expected
+            """
+            Error type: security_update_not_possible
+            - dependency-name: Some.Dependency
+            - latest-resolvable-version: 1.2.3
+            - lowest-non-vulnerable-version: 4.5.6
+            - conflicting-dependencies:
+              - dep1
+              - dep2
             """
         ];
 
@@ -203,7 +267,9 @@ public class MessageReportTests
             // expected
             """
             Error type: update_not_possible
-            - dependencies: Dependency1, Dependency2
+            - dependencies:
+              - Dependency1
+              - Dependency2
             """
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -7,6 +7,7 @@ using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test.Utilities;
 
 using Xunit;
 
@@ -14,6 +15,450 @@ namespace NuGetUpdater.Core.Test.Run;
 
 public class MiscellaneousTests
 {
+    [Theory]
+    [MemberData(nameof(IsDependencyIgnoredTestData))]
+    public void IsDependencyIgnored(Condition[] ignoreConditions, string dependencyName, string dependencyVersion, bool expectedIgnored)
+    {
+        // arrange
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "some/repo"
+            },
+            IgnoreConditions = ignoreConditions,
+        };
+
+        // act
+        var actualIsIgnored = job.IsDependencyIgnored(dependencyName, dependencyVersion);
+
+        // assert
+        Assert.Equal(expectedIgnored, actualIsIgnored);
+    }
+
+    public static IEnumerable<object[]> IsDependencyIgnoredTestData()
+    {
+        yield return
+        [
+            // ignoreConditions
+            new[]
+            {
+                new Condition()
+                {
+                    DependencyName = "Different.Dependency",
+                }
+            },
+            // dependencyName
+            "Some.Dependency",
+            // dependencyVersion
+            "1.2.3",
+            // expectedIgnored
+            false,
+        ];
+
+        yield return
+        [
+            // ignoreConditions
+            new[]
+            {
+                new Condition()
+                {
+                    DependencyName = "Some.Dependency",
+                    VersionRequirement = Requirement.Parse("> 2.0.0"),
+                }
+            },
+            // dependencyName
+            "Some.Dependency",
+            // dependencyVersion
+            "1.2.3",
+            // expectedIgnored
+            false,
+        ];
+
+        yield return
+        [
+            // ignoreConditions
+            new[]
+            {
+                new Condition()
+                {
+                    DependencyName = "Some.Dependency",
+                    VersionRequirement = Requirement.Parse("> 1.0.0"),
+                }
+            },
+            // dependencyName
+            "Some.Dependency",
+            // dependencyVersion
+            "1.2.3",
+            // expectedIgnored
+            true,
+        ];
+
+        yield return
+        [
+            // ignoreConditions
+            new[]
+            {
+                new Condition()
+                {
+                    DependencyName = "Some.*",
+                }
+            },
+            // dependencyName
+            "Some.Dependency",
+            // dependencyVersion
+            "1.2.3",
+            // expectedIgnored
+            true,
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyGroup_IsMatchTestData))]
+    public void DependencyGroup_IsMatch(string[]? patterns, string[]? excludePatterns, string dependencyName, bool expectedMatch)
+    {
+        var rules = new Dictionary<string, object>();
+        if (patterns is not null)
+        {
+            rules["patterns"] = patterns;
+        }
+
+        if (excludePatterns is not null)
+        {
+            rules["exclude-patterns"] = excludePatterns;
+        }
+
+        var group = new DependencyGroup()
+        {
+            Name = "TestGroup",
+            Rules = rules,
+        };
+        var matcher = group.GetGroupMatcher();
+        var isMatch = matcher.IsMatch(dependencyName);
+        Assert.Equal(expectedMatch, isMatch);
+    }
+
+    public static IEnumerable<object?[]> DependencyGroup_IsMatchTestData()
+    {
+        yield return
+        [
+            null, // patterns
+            null, // excludePatterns
+            "Some.Package", // dependencyName
+            true, // expectMatch
+        ];
+
+        yield return
+        [
+            new[] { "*" }, // patterns
+            null, // excludePatterns
+            "Some.Package", // dependencyName
+            true, // expectMatch
+        ];
+
+        yield return
+        [
+            new[] { "some.*" }, // patterns
+            null, // excludePatterns
+            "Some.Package", // dependencyName
+            true, // expectMatch
+        ];
+
+        yield return
+        [
+            null, // patterns
+            new[] { "some.*" }, // excludePatterns
+            "Some.Package", // dependencyName
+            false, // expectMatch
+        ];
+
+        yield return
+        [
+            new[] { "*" }, // patterns
+            new[] { "some.*" }, // excludePatterns
+            "Some.Package", // dependencyName
+            false, // expectMatch
+        ];
+
+        yield return
+        [
+            new[] { "*" }, // patterns
+            new[] { "other.*" }, // excludePatterns
+            "Some.Package", // dependencyName
+            true, // expectMatch
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(GetMatchingPullRequestTestData))]
+    public void GetMatchingPullRequest(Job job, IEnumerable<Dependency> dependencies, bool considerVersions, string? expectedGroupPrName, string[]? expectedPrDependencyNames)
+    {
+        var existingPr = job.GetExistingPullRequestForDependencies(dependencies, considerVersions);
+
+        if (expectedPrDependencyNames is null)
+        {
+            Assert.Null(existingPr);
+            return;
+        }
+        else
+        {
+            Assert.NotNull(existingPr);
+        }
+
+        Assert.Equal(expectedGroupPrName, existingPr.Item1);
+
+        var actualPrDependencyNames = existingPr.Item2
+            .Select(d => d.DependencyName)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        AssertEx.Equal(expectedPrDependencyNames, actualPrDependencyNames);
+    }
+
+    public static IEnumerable<object?[]> GetMatchingPullRequestTestData()
+    {
+        var source = new JobSource()
+        {
+            Provider = "github",
+            Repo = "test/repo",
+        };
+
+        // match found, version match
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "1.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.B", "2.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            true,
+            // expectedGroupPrName
+            null,
+            // expectedPrDependencyNames
+            new[] { "Dependency.A", "Dependency.B" },
+        ];
+
+        // match found, version agnostic
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "3.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.B", "4.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            false,
+            // expectedGroupPrName
+            null,
+            // expectedPrDependencyNames
+            new[] { "Dependency.A", "Dependency.B" },
+        ];
+
+        // match not found, version didn't match
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "1.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.B", "3.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            true,
+            // expectedGroupPrName
+            null,
+            // expectedPrDependencyNames
+            null,
+        ];
+
+        // no match found, missing a dependency
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "1.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            true,
+            // expectedGroupPrName
+            null,
+            // expectedPrDependencyNames
+            null,
+        ];
+
+        // no match found, extra dependency
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "1.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.B", "2.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.C", "3.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            false,
+            // expectedGroupPrName
+            null,
+            // expectedPrDependencyNames
+            null,
+        ];
+
+        // match found with group
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = source,
+                ExistingGroupPullRequests = [
+                    new()
+                    {
+                        DependencyGroupName = "test-group",
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Dependency.A",
+                                DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            },
+                            new()
+                            {
+                                DependencyName = "Dependency.B",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            }
+                        ]
+                    }
+                ]
+            },
+            // dependencies
+            new[]
+            {
+                new Dependency("Dependency.A", "1.0.0", DependencyType.Unknown),
+                new Dependency("Dependency.B", "2.0.0", DependencyType.Unknown),
+            },
+            // considerVersions
+            true,
+            // expectedGroupPrName
+            "test-group",
+            // expectedPrDependencyNames
+            new[] { "Dependency.A", "Dependency.B" },
+        ];
+    }
+
     [Theory]
     [MemberData(nameof(RequirementsFromIgnoredVersionsData))]
     public void RequirementsFromIgnoredVersions(string dependencyName, Condition[] ignoreConditions, Requirement[] expectedRequirements)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
@@ -82,6 +82,7 @@ public class PullRequestMessageTests
                 CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
                 PrTitle = RunWorkerTests.TestPullRequestTitle,
                 PrBody = RunWorkerTests.TestPullRequestBody,
+                DependencyGroup = null,
             }
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -29,6 +29,7 @@ public class RunWorkerTests
     public async Task UpdateSinglePackageProducedExpectedAPIMessages()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -224,6 +225,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -236,6 +238,7 @@ public class RunWorkerTests
         var repoMetadata = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package" />""");
         var repoMetadata2 = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package2" />""");
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages:
             [
                 MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", additionalMetadata: [repoMetadata]),
@@ -490,6 +493,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -500,6 +504,7 @@ public class RunWorkerTests
     public async Task ErrorsThrownFromDiscoveryWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages:
             [
             ],
@@ -556,6 +561,7 @@ public class RunWorkerTests
     public async Task ErrorsReturnedFromDiscoveryWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -596,6 +602,7 @@ public class RunWorkerTests
     public async Task ErrorsThrownFromAnalyzeWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -694,6 +701,7 @@ public class RunWorkerTests
     public async Task ErrorsReturnedFromAnalyzeWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -807,6 +815,7 @@ public class RunWorkerTests
     public async Task ErrorsThrownFromUpdaterWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -916,6 +925,7 @@ public class RunWorkerTests
     public async Task ErrorsReturnedFromUpdaterWorkerAreForwaredToApiHandler()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages: [],
             job: new Job()
             {
@@ -1040,6 +1050,7 @@ public class RunWorkerTests
         var repoMetadata = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package" />""");
         var repoMetadata2 = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package2" />""");
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages:
             [
                 MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", additionalMetadata: [repoMetadata]),
@@ -1372,6 +1383,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -1384,6 +1396,7 @@ public class RunWorkerTests
         var repoMetadata = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package" />""");
         var repoMetadata2 = XElement.Parse("""<repository type="git" url="https://nuget.example.com/some-package2" />""");
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             packages:
             [
                 MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0", additionalMetadata: [repoMetadata]),
@@ -1943,6 +1956,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -1953,6 +1967,7 @@ public class RunWorkerTests
     public async Task UpdatedFilesAreOnlyReportedOnce()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 PackageManager = "nuget",
@@ -2261,6 +2276,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA")
             ]
@@ -2271,6 +2287,7 @@ public class RunWorkerTests
     public async Task PackageListedInSecurityAdvisoriesSectionIsNotVulnerable()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 Source = new()
@@ -2361,6 +2378,7 @@ public class RunWorkerTests
     public async Task PackageListedInSecurityAdvisoriesSectionIsNotPresent()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 Source = new()
@@ -2451,6 +2469,7 @@ public class RunWorkerTests
     public async Task NonProjectFilesAreIncludedInPullRequest()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 Source = new()
@@ -2660,6 +2679,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
@@ -2670,6 +2690,7 @@ public class RunWorkerTests
     public async Task PullRequestAlreadyExistsForLatestVersion()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 Source = new()
@@ -2779,6 +2800,7 @@ public class RunWorkerTests
     public async Task AnalysisResultWithoutUpdatedDependenciesDoesNotCauseError()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new()
             {
                 Source = new()
@@ -2925,6 +2947,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
@@ -2945,6 +2968,7 @@ public class RunWorkerTests
         var file2ContentUpdated = rawBOM.Concat(Encoding.ASCII.GetBytes("updated2")).ToArray();
 
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new Job()
             {
                 Source = new()
@@ -3159,6 +3183,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
@@ -3169,6 +3194,7 @@ public class RunWorkerTests
     public async Task LineEndingsAreDetectedAndRestored()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new Job()
             {
                 Source = new()
@@ -3414,6 +3440,7 @@ public class RunWorkerTests
                     CommitMessage = TestPullRequestCommitMessage,
                     PrTitle = TestPullRequestTitle,
                     PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
                 },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
@@ -3424,6 +3451,7 @@ public class RunWorkerTests
     public async Task UnknownErrorsGenerateAllRequiredApiCalls()
     {
         await RunAsync(
+            experimentsManager: new ExperimentsManager() { UseLegacyUpdateHandler = true },
             job: new Job()
             {
                 Source = new()
@@ -3495,7 +3523,7 @@ public class RunWorkerTests
 
         var worker = new RunWorker(jobId, testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
         var repoContentsPathDirectoryInfo = new DirectoryInfo(tempDirectory.DirectoryPath);
-        var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA");
+        var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA", experimentsManager);
         var actualApiMessages = testApiHandler.ReceivedMessages
             .Select(m =>
             {
@@ -3559,6 +3587,6 @@ public class RunWorkerTests
 
     internal static string SerializeObjectAndType(object obj)
     {
-        return $"{obj.GetType().Name}:{JsonSerializer.Serialize(obj)}";
+        return $"{obj.GetType().Name}:{JsonSerializer.Serialize(obj, RunWorker.SerializerOptions)}";
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandlerTests.cs
@@ -1,0 +1,617 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class CreateSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
+{
+    [Fact]
+    public async Task GeneratesCreatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesSecurityUpdateDependencyNotFound()
+    {
+        // requested dependency doesn't exist
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["This.Dependency.Does.Not.Exist"],
+                SecurityAdvisories = [new() { DependencyName = "This.Dependency.Does.Not.Exist", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new SecurityUpdateDependencyNotFound(),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesSecurityUpdateNotNeeded()
+    {
+        // requested dependency exists, but isn't vulnerable
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new SecurityUpdateNotNeeded("Some.Dependency"),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesSecurityUpdateNotFound()
+    {
+        // dependency exists and is vulnerable, but non-vulnerable version isn't on feed
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = false,
+                    UpdatedVersion = "1.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new SecurityUpdateNotFound("Some.Dependency", "1.0.0"),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesSecurityUpdateIgnored()
+    {
+        // vulnerable dependency exists, but it is explicitly ignored
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                IgnoreConditions = [new() { DependencyName = "Some.Dependency" }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(_ => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new SecurityUpdateIgnored("Some.Dependency"),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesSecurityUpdateNotPossible()
+    {
+        // vulnerable dependency exists and update was attempted, but nothing could be done
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(input =>
+            {
+                return Task.FromResult(new UpdateOperationResult()
+                {
+                    UpdateOperations = [], // nothing could be done
+                });
+            }),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new SecurityUpdateNotPossible("Some.Dependency", "2.0.0", "2.0.0", []),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesPullRequestExistsForSecurityUpdate()
+    {
+        // everything was successful, but a PR already exists
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: CreateSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "create_security_pr",
+                    }
+                },
+                new PullRequestExistsForSecurityUpdate([new("Some.Dependency", "2.0.0", DependencyType.Unknown)]),
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
@@ -1,0 +1,484 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
+{
+    [Fact]
+    public async Task GeneratesCreatePullRequest_NoGroups()
+    {
+        // no groups specified; create 1 PR for each directory
+        await TestAsync(
+            job: new Job()
+            {
+                Source = CreateJobSource("/src", "/test"),
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+                ("test/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                }),
+                ("/test", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/test",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                var newVersion = dependencyInfo.Name switch
+                {
+                    "Some.Dependency" => "2.0.0",
+                    "Some.Other.Dependency" => "4.0.0",
+                    _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
+                };
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = newVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = dependencyName, NewVersion = NuGetVersion.Parse(newVersion), UpdatedFiles = [workspacePath] }],
+                };
+            }),
+            expectedUpdateHandler: GroupUpdateAllVersionsHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions",
+                    }
+                },
+                // for "/src"
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "4.0.0",
+                            Requirements = [
+                                new() { Requirement = "4.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "3.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                // for "/test"
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/test/project.csproj"],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "4.0.0",
+                            Requirements = [
+                                new() { Requirement = "4.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "3.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/test",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesCreatePullRequest_Grouped()
+    {
+        // single groups specified; creates 1 PR for both directories
+        await TestAsync(
+            job: new Job()
+            {
+                Source = CreateJobSource("/src", "/test"),
+                DependencyGroups = [
+                    new()
+                    {
+                        Name = "test-group",
+                        Rules = new()
+                        {
+                            ["patterns"] = new[] { "*" },
+                            ["exclude-patterns"] = new[] { "Unrelated.*" },
+                        },
+                    },
+                ],
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+                ("test/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "5.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                }),
+                ("/test", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/test",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "5.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                var newVersion = dependencyInfo.Name switch
+                {
+                    "Some.Dependency" => "2.0.0",
+                    "Some.Other.Dependency" => "4.0.0",
+                    _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
+                };
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = newVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = dependencyName, NewVersion = NuGetVersion.Parse(newVersion), UpdatedFiles = [workspacePath] }],
+                };
+            }),
+            expectedUpdateHandler: GroupUpdateAllVersionsHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions",
+                    }
+                },
+                // for "/src"
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "5.0.0",
+                            Requirements = [
+                                new() { Requirement = "5.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                // for "/test"
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "5.0.0",
+                            Requirements = [
+                                new() { Requirement = "5.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/test/project.csproj"],
+                },
+                // for both directories
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "4.0.0",
+                            Requirements = [
+                                new() { Requirement = "4.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "3.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "4.0.0",
+                            Requirements = [
+                                new() { Requirement = "4.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "3.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                        new()
+                        {
+                            Directory = "/test",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = "test-group",
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
@@ -1,0 +1,513 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class RefreshGroupUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
+{
+    // group name must match, existing pr must be found
+    // if updated_deps is empty, close(update_no_longer_possible)
+    // if updated_deps is different, close(dependencies_changed), create()
+    // else if perfect match, update()
+    // else create()
+
+    [Fact]
+    public async Task GeneratesUpdatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "test_group" }],
+                DependencyGroupToRefresh = "test_group",
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshGroupUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_group_pr",
+                    }
+                },
+                new UpdatePullRequest()
+                {
+                    DependencyNames = ["Some.Dependency"],
+                    DependencyGroup = "test_group",
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_UpdateNoLongerPossible()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "test_group" }],
+                DependencyGroupToRefresh = "test_group",
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = false,
+                    UpdatedVersion = "1.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshGroupUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_group_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "update_no_longer_possible" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task RecreatesPullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency", "Some.Other.Dependency"],
+                DependencyGroups = [new() { Name = "test_group" }],
+                DependencyGroupToRefresh = "test_group",
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") },
+                            new() { DependencyName = "Some.Other.Dependency", DependencyVersion = NuGetVersion.Parse("4.0.0") },
+                        ]
+                    },
+                ],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                var updatedVersion = dependencyInfo.Name switch
+                {
+                    "Some.Dependency" => "2.0.1",
+                    "Some.Other.Dependency" => "4.0.1",
+                    _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
+                };
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = updatedVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = dependencyName, NewVersion = NuGetVersion.Parse(newVersion), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshGroupUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_group_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency", "Some.Other.Dependency"], Reason = "dependencies_changed" },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.1",
+                            Requirements = [
+                                new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Other.Dependency",
+                            Version = "4.0.1",
+                            Requirements = [
+                                new() { Requirement = "4.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "3.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = "test_group",
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesCreatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "test_group" }],
+                DependencyGroupToRefresh = "test_group",
+                ExistingPullRequests = [
+                    new()
+                    {
+                        Dependencies = [
+                            new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") },
+                            new() { DependencyName = "Some.Other.Dependency", DependencyVersion = NuGetVersion.Parse("4.0.0") },
+                        ]
+                    },
+                ],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                var updatedVersion = dependencyInfo.Name switch
+                {
+                    "Some.Dependency" => "2.0.0",
+                    _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
+                };
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = updatedVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = dependencyName, NewVersion = NuGetVersion.Parse(newVersion), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshGroupUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_group_pr",
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = "test_group",
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
@@ -1,0 +1,668 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class RefreshSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
+{
+    [Fact]
+    public async Task GeneratesUpdatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new UpdatePullRequest()
+                {
+                    DependencyNames = ["Some.Dependency"],
+                    DependencyGroup = null,
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_DependenciesRemoved()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Unrelated.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependencies_removed" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_DependencyRemoved()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency", "Other.Dependency"],
+                ExistingPullRequests = [
+                    new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] },
+                    new() { Dependencies = [new() { DependencyName = "Other.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] },
+                ],
+                SecurityAdvisories = [
+                    new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] },
+                    new() { DependencyName = "Other.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] },
+                ],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Other.Dependency"], Reason = "dependency_removed" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_UpToDate()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")], PatchedVersions = [Requirement.Parse("2.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "up_to_date" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_UpdateNoLongerPossible()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = false,
+                    UpdatedVersion = "1.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "update_no_longer_possible" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task RecreatesPullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.1",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.1"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependencies_changed" },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.1",
+                            Requirements = [
+                                new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesCreatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Unrelated.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                SecurityAdvisories = [new() { DependencyName = "Some.Dependency", AffectedVersions = [Requirement.Parse("= 1.0.0")] }],
+                SecurityUpdatesOnly = true,
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshSecurityUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_security_pr",
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
@@ -1,0 +1,589 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class RefreshVersionUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
+{
+    [Fact]
+    public async Task GeneratesUpdatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Unrelated.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "3.0.0",
+                            Requirements = [
+                                new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new UpdatePullRequest()
+                {
+                    DependencyNames = ["Some.Dependency"],
+                    DependencyGroup = null,
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_DependenciesRemoved()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Unrelated.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Unrelated.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependencies_removed" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_DependencyRemoved()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency", "Other.Dependency"],
+                ExistingPullRequests = [
+                    new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] },
+                    new() { Dependencies = [new() { DependencyName = "Other.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] },
+                ],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Other.Dependency"], Reason = "dependency_removed" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesClosePullRequest_UpdateNoLongerPossible()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = false,
+                    UpdatedVersion = "1.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(input => throw new NotImplementedException("test shouldn't get this far")),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "update_no_longer_possible" },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task RecreatesPullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Some.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.1",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.1"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new ClosePullRequest() { DependencyNames = ["Some.Dependency"], Reason = "dependencies_changed" },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.1",
+                            Requirements = [
+                                new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task GeneratesCreatePullRequest()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                ExistingPullRequests = [new() { Dependencies = [new() { DependencyName = "Unrelated.Dependency", DependencyVersion = NuGetVersion.Parse("2.0.0") }] }],
+                Source = CreateJobSource("/src"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                if (dependencyInfo.Name != "Some.Dependency")
+                {
+                    throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}");
+                }
+
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = "Some.Dependency", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/src/project.csproj"] }],
+                };
+            }),
+            expectedUpdateHandler: RefreshVersionUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "update_version_pr",
+                    }
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        }
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        }
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = RunWorkerTests.TestPullRequestCommitMessage,
+                    PrTitle = RunWorkerTests.TestPullRequestTitle,
+                    PrBody = RunWorkerTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
@@ -1,0 +1,183 @@
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Run;
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class UpdateHandlerSelectionTests : UpdateHandlersTestsBase
+{
+    [Theory]
+    [MemberData(nameof(GetUpdateHandlerFromJobTestData))]
+    public void GetUpdateHandlerFromJob(Job job, IUpdateHandler expectedUpdateHandler)
+    {
+        var actualUpdateHandler = RunWorker.GetUpdateHandler(job);
+        Assert.Equal(expectedUpdateHandler.GetType(), actualUpdateHandler.GetType());
+    }
+
+    public static IEnumerable<object[]> GetUpdateHandlerFromJobTestData()
+    {
+        // to ensure we're not depending on any default values, _ALWAYS_ set the following properties explicitly:
+        //   Source
+        //   Dependencies
+        //   DependencyGroups
+        //   DependencyGroupToRefresh
+        //   SecurityUpdatesOnly
+        //   UpdatingAPullRequest
+
+        //
+        // group_update_all_versions
+        //
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/"),
+                Dependencies = [],
+                DependencyGroups = [],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = false,
+                UpdatingAPullRequest = false,
+            },
+            GroupUpdateAllVersionsHandler.Instance,
+        ];
+
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/"),
+                Dependencies = ["Dependency.A", "Dependency.B"],
+                DependencyGroups = [],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = false,
+            },
+            GroupUpdateAllVersionsHandler.Instance,
+        ];
+
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/"),
+                Dependencies = [],
+                DependencyGroups = [new() { Name = "some-group", AppliesTo = "security-updates" }],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = false,
+            },
+            GroupUpdateAllVersionsHandler.Instance,
+        ];
+
+        //
+        // update_version_group_pr
+        //
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/dir1", "/dir2"),
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "some-group", AppliesTo = "security-updates" }], // this
+                DependencyGroupToRefresh = "some-group",
+                SecurityUpdatesOnly = false,
+                UpdatingAPullRequest = true,
+            },
+            RefreshGroupUpdatePullRequestHandler.Instance,
+        ];
+
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Dependency.A", "Dependency.B"],
+                DependencyGroups = [new() { Name = "some-group", AppliesTo = "security-updates" }], // this
+                DependencyGroupToRefresh = "some-group",
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = true,
+            },
+            RefreshGroupUpdatePullRequestHandler.Instance,
+        ];
+
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "some-group", AppliesTo = "security-updates" }],
+                DependencyGroupToRefresh = "some-group",
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = true,
+            },
+            RefreshGroupUpdatePullRequestHandler.Instance,
+        ];
+
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [new() { Name = "some-group", AppliesTo = "security-updates" }],
+                DependencyGroupToRefresh = "some-group",
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = true,
+            },
+            RefreshGroupUpdatePullRequestHandler.Instance,
+        ];
+
+        //
+        // create_security_pr
+        //
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = false,
+            },
+            CreateSecurityUpdatePullRequestHandler.Instance,
+        ];
+
+        //
+        // update_security_pr
+        //
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = true,
+                UpdatingAPullRequest = true,
+            },
+            RefreshSecurityUpdatePullRequestHandler.Instance,
+        ];
+
+        //
+        // update_version_pr
+        //
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/src"),
+                Dependencies = ["Some.Dependency"], // must not be empty
+                DependencyGroups = [],
+                DependencyGroupToRefresh = null,
+                SecurityUpdatesOnly = false, // must be false
+                UpdatingAPullRequest = true, // must be true
+            },
+            RefreshVersionUpdatePullRequestHandler.Instance,
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlersTestsBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlersTestsBase.cs
@@ -1,0 +1,43 @@
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
+using NuGetUpdater.Core.Run;
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
+
+public class UpdateHandlersTestsBase : TestBase
+{
+    protected static JobSource CreateJobSource(string directory, params string[] additionalDirectories) => new JobSource()
+    {
+        Provider = "github",
+        Repo = "test/repo",
+        Directories = [directory, .. additionalDirectories],
+    };
+
+    protected Task TestAsync(
+        Job job,
+        IUpdateHandler expectedUpdateHandler,
+        object[] expectedApiMessages,
+        (string Name, string Contents)[] files,
+        MockNuGetPackage[]? packages = null,
+        IDiscoveryWorker? discoveryWorker = null,
+        IAnalyzeWorker? analyzeWorker = null,
+        IUpdaterWorker? updaterWorker = null,
+        ExperimentsManager? experimentsManager = null
+    )
+    {
+        // first ensure we're using the correct updater
+        var actualUpdateHandler = RunWorker.GetUpdateHandler(job);
+        Assert.Equal(actualUpdateHandler.GetType(), expectedUpdateHandler.GetType());
+
+        // the new runner doesn't report this result object so we can expect an empty one
+        var expectedResult = new RunResult()
+        {
+            Base64DependencyFiles = [],
+            BaseCommitSha = "TEST-COMMIT-SHA",
+        };
+        experimentsManager ??= new ExperimentsManager();
+        experimentsManager = experimentsManager with { UseLegacyUpdateHandler = false };
+        return RunWorkerTests.RunAsync(job, files, discoveryWorker, analyzeWorker, updaterWorker, expectedResult, expectedApiMessages, packages, experimentsManager);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -89,7 +89,7 @@ public class UpdatedDependencyListTests
                 ]
             }
         };
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, pathToContents: temp.DirectoryPath);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery);
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies =
@@ -213,7 +213,7 @@ public class UpdatedDependencyListTests
         };
 
         // act
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, pathToContents: tempDir.DirectoryPath);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery);
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MarkdownListBuilderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MarkdownListBuilderTests.cs
@@ -1,0 +1,42 @@
+using NuGetUpdater.Core.Utilities;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class MarkdownListBuilderTests
+{
+    [Theory]
+    [MemberData(nameof(ListCreationTestData))]
+    public void ListCreation(object obj, string expected)
+    {
+        expected = expected.Replace("\r", "");
+        var actual = MarkdownListBuilder.FromObject(obj).Replace("\r", "");
+        Assert.Equal(expected, actual);
+    }
+
+    public static IEnumerable<object[]> ListCreationTestData()
+    {
+        yield return
+        [
+            new Dictionary<string, object>()
+            {
+                ["key1"] = "value1",
+                ["key2"] = new[]
+                {
+                    new Dictionary<string, object>()
+                    {
+                        ["key11"] = "value11",
+                        ["key12"] = "value12"
+                    }
+                }
+            },
+            """
+            - key1: value1
+            - key2:
+              - - key11: value11
+                - key12: value12
+            """
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
@@ -9,4 +9,10 @@ public sealed record WorkspaceDiscoveryResult : NativeResult
     public ImmutableArray<ProjectDiscoveryResult> Projects { get; init; }
     public GlobalJsonDiscoveryResult? GlobalJson { get; init; }
     public DotNetToolsJsonDiscoveryResult? DotNetToolsJson { get; init; }
+
+    public ProjectDiscoveryResult? GetProjectDiscoveryFromPath(string repoPath)
+    {
+        var projectDiscovery = Projects.FirstOrDefault(p => System.IO.Path.Join(Path, p.FilePath).FullyNormalizedRootedPath().Equals(repoPath, StringComparison.OrdinalIgnoreCase));
+        return projectDiscovery;
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -10,6 +10,7 @@ public record ExperimentsManager
     public bool InstallDotnetSdks { get; init; } = false;
     public bool NativeUpdater { get; init; } = false;
     public bool UseLegacyDependencySolver { get; init; } = false;
+    public bool UseLegacyUpdateHandler { get; init; } = false;
     public bool UseDirectDiscovery { get; init; } = false;
 
     public Dictionary<string, object> ToDictionary()
@@ -19,6 +20,7 @@ public record ExperimentsManager
             ["nuget_install_dotnet_sdks"] = InstallDotnetSdks,
             ["nuget_native_updater"] = NativeUpdater,
             ["nuget_legacy_dependency_solver"] = UseLegacyDependencySolver,
+            ["nuget_use_legacy_update_handler"] = UseLegacyUpdateHandler,
             ["nuget_use_direct_discovery"] = UseDirectDiscovery,
         };
     }
@@ -30,6 +32,7 @@ public record ExperimentsManager
             InstallDotnetSdks = IsEnabled(experiments, "nuget_install_dotnet_sdks"),
             NativeUpdater = IsEnabled(experiments, "nuget_native_updater"),
             UseLegacyDependencySolver = IsEnabled(experiments, "nuget_legacy_dependency_solver"),
+            UseLegacyUpdateHandler = IsEnabled(experiments, "nuget_use_legacy_update_handler"),
             UseDirectDiscovery = IsEnabled(experiments, "nuget_use_direct_discovery"),
         };
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using NuGet.Versioning;
@@ -8,16 +9,28 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 public sealed record CreatePullRequest : MessageBase
 {
     public required ReportedDependency[] Dependencies { get; init; }
+
     [JsonPropertyName("updated-dependency-files")]
     public required DependencyFile[] UpdatedDependencyFiles { get; init; }
+
     [JsonPropertyName("base-commit-sha")]
     public required string BaseCommitSha { get; init; }
+
     [JsonPropertyName("commit-message")]
     public required string CommitMessage { get; init; }
+
     [JsonPropertyName("pr-title")]
     public required string PrTitle { get; init; }
+
     [JsonPropertyName("pr-body")]
     public required string PrBody { get; init; }
+
+    /// <summary>
+    /// This is serialized as either `null` or `{"name": "group-name"}`.
+    /// </summary>
+    [JsonPropertyName("dependency-group")]
+    [JsonConverter(typeof(DependencyGroupConverter))]
+    public required string? DependencyGroup { get; init; }
 
     public override string GetReport()
     {
@@ -34,5 +47,39 @@ public sealed record CreatePullRequest : MessageBase
         }
 
         return report.ToString().Trim();
+    }
+
+    public class DependencyGroupConverter : JsonConverter<string?>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options);
+            if (dict is not null &&
+                dict.TryGetValue("name", out var name))
+            {
+                return name;
+            }
+
+            throw new NotSupportedException("Expected an object with a `name` property.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStartObject();
+                writer.WriteString("name", value);
+                writer.WriteEndObject();
+            }
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
@@ -1,8 +1,68 @@
+using System.Collections.Immutable;
+using System.IO.Enumeration;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record DependencyGroup
 {
     public required string Name { get; init; }
     public string? AppliesTo { get; init; }
+
+    // TODO: make more strongly typed, but currently this seems to be:
+    //   "patterns" => string[] where each element is a wildcard name pattern
+    //   "exclude-patterns"=> string[] where each element is a wildcard name pattern
+    //   "dependency-type" => production|development // not used for nuget?
     public Dictionary<string, object> Rules { get; init; } = new();
+
+    public GroupMatcher GetGroupMatcher() => GroupMatcher.FromRules(Rules);
+}
+
+public class GroupMatcher
+{
+    public ImmutableArray<string> Patterns { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableArray<string> ExcludePatterns { get; init; } = ImmutableArray<string>.Empty;
+
+    public bool IsMatch(string dependencyName)
+    {
+        var isIncluded = Patterns.Any(p => FileSystemName.MatchesSimpleExpression(p, dependencyName));
+        var isExcluded = ExcludePatterns.Any(p => FileSystemName.MatchesSimpleExpression(p, dependencyName));
+        var isMatch = isIncluded && !isExcluded;
+        return isMatch;
+    }
+
+    public static GroupMatcher FromRules(Dictionary<string, object> rules)
+    {
+        string[] patterns;
+        if (rules.TryGetValue("patterns", out var patternsObject) &&
+            patternsObject is string[] patternsArray)
+        {
+            patterns = patternsArray;
+        }
+        else
+        {
+            patterns = ["*"]; // default to matching everything unless excluded below
+        }
+
+        string[] excludePatterns;
+        if (rules.TryGetValue("exclude-patterns", out var excludePatternsObject) &&
+            excludePatternsObject is string[] excludePatternsArray)
+        {
+            excludePatterns = excludePatternsArray;
+        }
+        else
+        {
+            excludePatterns = [];
+        }
+
+        return new GroupMatcher()
+        {
+            Patterns = [.. patterns],
+            ExcludePatterns = [.. excludePatterns],
+        };
+    }
+}
+
+public static class DependencyGroupExtensions
+{
+    public static bool IsSecurity(this DependencyGroup group) => group.AppliesTo == "security-updates";
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Build.Exceptions;
 
 using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
@@ -25,24 +26,9 @@ public abstract record JobErrorBase : MessageBase
     {
         var report = new StringBuilder();
         report.AppendLine($"Error type: {Type}");
-        foreach (var (key, value) in Details)
-        {
-            if (this is UnknownError && key == "error-backtrace")
-            {
-                // there's nothing meaningful in this field
-                continue;
-            }
-
-            var valueString = value.ToString();
-            if (value is IEnumerable<string> strings)
-            {
-                valueString = string.Join(", ", strings);
-            }
-
-            report.AppendLine($"- {key}: {valueString}");
-        }
-
-        return report.ToString().Trim();
+        report.Append(MarkdownListBuilder.FromObject(Details));
+        var fullReport = report.ToString().TrimEnd();
+        return fullReport;
     }
 
     public static JobErrorBase ErrorFromException(Exception ex, string jobId, string currentDirectory)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestExistsForSecurityUpdate.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequestExistsForSecurityUpdate.cs
@@ -1,0 +1,15 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PullRequestExistsForSecurityUpdate : JobErrorBase
+{
+    public PullRequestExistsForSecurityUpdate(Dependency[] dependencies)
+        : base("pull_request_exists_for_security_update")
+    {
+        Details["updated-dependencies"] = dependencies.Select(d => new Dictionary<string, object>()
+        {
+            ["dependency-name"] = d.Name,
+            ["dependency-version"] = d.Version!,
+            ["dependency-removed"] = false,
+        }).ToArray();
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateDependencyNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateDependencyNotFound.cs
@@ -1,0 +1,9 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record SecurityUpdateDependencyNotFound : JobErrorBase
+{
+    public SecurityUpdateDependencyNotFound()
+        : base("security_update_dependency_not_found")
+    {
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateIgnored.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateIgnored.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record SecurityUpdateIgnored : JobErrorBase
+{
+    public SecurityUpdateIgnored(string dependencyName)
+        : base("all_versions_ignored")
+    {
+        Details["dependency-name"] = dependencyName;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotFound.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotFound.cs
@@ -1,0 +1,11 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record SecurityUpdateNotFound : JobErrorBase
+{
+    public SecurityUpdateNotFound(string dependencyName, string dependencyVersion)
+        : base("security_update_not_found")
+    {
+        Details["dependency-name"] = dependencyName;
+        Details["dependency-version"] = dependencyVersion;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotPossible.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/SecurityUpdateNotPossible.cs
@@ -1,0 +1,13 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record SecurityUpdateNotPossible : JobErrorBase
+{
+    public SecurityUpdateNotPossible(string dependencyName, string latestResolvableVersion, string lowestNonVulnerableVersion, string[] conflictingDependencies)
+        : base("security_update_not_possible")
+    {
+        Details["dependency-name"] = dependencyName;
+        Details["latest-resolvable-version"] = latestResolvableVersion;
+        Details["lowest-non-vulnerable-version"] = lowestNonVulnerableVersion;
+        Details["conflicting-dependencies"] = conflictingDependencies;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/UpdatePullRequest.cs
@@ -2,6 +2,8 @@ using System.Collections.Immutable;
 using System.Text;
 using System.Text.Json.Serialization;
 
+using static NuGetUpdater.Core.Run.ApiModel.CreatePullRequest;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record UpdatePullRequest : MessageBase
@@ -24,7 +26,11 @@ public sealed record UpdatePullRequest : MessageBase
     [JsonPropertyName("commit-message")]
     public required string CommitMessage { get; init; }
 
+    /// <summary>
+    /// This is serialized as either `null` or `{"name": "group-name"}`.
+    /// </summary>
     [JsonPropertyName("dependency-group")]
+    [JsonConverter(typeof(DependencyGroupConverter))]
     public required string? DependencyGroup { get; init; }
 
     public override string GetReport()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -1,0 +1,151 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Utilities;
+
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+
+namespace NuGetUpdater.Core.Run;
+
+public class ModifiedFilesTracker
+{
+    public readonly DirectoryInfo RepoContentsPath;
+    private WorkspaceDiscoveryResult? _currentDiscoveryResult = null;
+
+    private readonly Dictionary<string, string> _originalDependencyFileContents = [];
+    private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
+    private readonly Dictionary<string, bool> _originalDependencyFileBOMs = [];
+    private string[] _nonProjectFiles = [];
+
+    public IReadOnlyDictionary<string, string> OriginalDependencyFileContents => _originalDependencyFileContents;
+    //public IReadOnlyDictionary<string, EOLType> OriginalDependencyFileEOFs => _originalDependencyFileEOFs;
+    public IReadOnlyDictionary<string, bool> OriginalDependencyFileBOMs => _originalDependencyFileBOMs;
+
+    public ModifiedFilesTracker(DirectoryInfo repoContentsPath)
+    {
+        RepoContentsPath = repoContentsPath;
+    }
+
+    public async Task StartTrackingAsync(WorkspaceDiscoveryResult discoveryResult)
+    {
+        if (_currentDiscoveryResult is not null)
+        {
+            throw new InvalidOperationException("Already tracking modified files.");
+        }
+
+        _currentDiscoveryResult = discoveryResult;
+
+        // track original contents for later handling
+        async Task TrackOriginalContentsAsync(string directory, string fileName)
+        {
+            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
+            var localFullPath = Path.Join(RepoContentsPath.FullName, repoFullPath);
+            var content = await File.ReadAllTextAsync(localFullPath);
+            var rawContent = await File.ReadAllBytesAsync(localFullPath);
+            _originalDependencyFileContents[repoFullPath] = content;
+            _originalDependencyFileEOFs[repoFullPath] = content.GetPredominantEOL();
+            _originalDependencyFileBOMs[repoFullPath] = rawContent.HasBOM();
+        }
+
+        foreach (var project in _currentDiscoveryResult.Projects)
+        {
+            var projectDirectory = Path.GetDirectoryName(project.FilePath);
+            await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, project.FilePath);
+            foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
+            {
+                var extraFilePath = Path.Join(projectDirectory, extraFile);
+                await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, extraFilePath);
+            }
+        }
+
+        _nonProjectFiles = new[]
+        {
+            _currentDiscoveryResult.GlobalJson?.FilePath,
+            _currentDiscoveryResult.DotNetToolsJson?.FilePath,
+        }.Where(f => f is not null).Cast<string>().ToArray();
+        foreach (var nonProjectFile in _nonProjectFiles)
+        {
+            await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, nonProjectFile);
+        }
+    }
+
+    public async Task<ImmutableArray<DependencyFile>> StopTrackingAsync()
+    {
+        if (_currentDiscoveryResult is null)
+        {
+            throw new InvalidOperationException("No discovery result to track.");
+        }
+
+        var updatedDependencyFiles = new Dictionary<string, DependencyFile>();
+        async Task AddUpdatedFileIfDifferentAsync(string directory, string fileName)
+        {
+            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
+            var localFullPath = Path.GetFullPath(Path.Join(RepoContentsPath.FullName, repoFullPath));
+            var originalContent = _originalDependencyFileContents[repoFullPath];
+            var updatedContent = await File.ReadAllTextAsync(localFullPath);
+
+            updatedContent = updatedContent.SetEOL(_originalDependencyFileEOFs[repoFullPath]);
+            var updatedRawContent = updatedContent.SetBOM(_originalDependencyFileBOMs[repoFullPath]);
+            await File.WriteAllBytesAsync(localFullPath, updatedRawContent);
+
+            if (updatedContent != originalContent)
+            {
+                var reportedContent = updatedContent;
+                var encoding = "utf-8";
+                if (_originalDependencyFileBOMs[repoFullPath])
+                {
+                    reportedContent = Convert.ToBase64String(updatedRawContent);
+                    encoding = "base64";
+                }
+
+                updatedDependencyFiles[localFullPath] = new DependencyFile()
+                {
+                    Name = Path.GetFileName(repoFullPath),
+                    Directory = Path.GetDirectoryName(repoFullPath)!.NormalizePathToUnix(),
+                    Content = reportedContent,
+                    ContentEncoding = encoding,
+                };
+            }
+        }
+
+        foreach (var project in _currentDiscoveryResult.Projects)
+        {
+            await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, project.FilePath);
+            var projectDirectory = Path.GetDirectoryName(project.FilePath);
+            foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
+            {
+                var extraFilePath = Path.Join(projectDirectory, extraFile);
+                await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, extraFilePath);
+            }
+        }
+
+        foreach (var nonProjectFile in _nonProjectFiles)
+        {
+            await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, nonProjectFile);
+        }
+
+        _currentDiscoveryResult = null;
+
+        var updatedDependencyFileList = updatedDependencyFiles
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => kvp.Value)
+            .ToImmutableArray();
+        return updatedDependencyFileList;
+    }
+
+    public static ImmutableArray<DependencyFile> MergeUpdatedFileSet(ImmutableArray<DependencyFile> setA, ImmutableArray<DependencyFile> setB)
+    {
+        static string GetFullName(DependencyFile df) => Path.Join(df.Directory, df.Name).NormalizePathToUnix();
+        var finalSet = setA.ToDictionary(GetFullName, df => df);
+        foreach (var dependencyFile in setB)
+        {
+            finalSet[GetFullName(dependencyFile)] = dependencyFile;
+        }
+
+        return finalSet
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => kvp.Value)
+            .ToImmutableArray();
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -10,10 +11,9 @@ using NuGet.Versioning;
 using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.UpdateHandlers;
 using NuGetUpdater.Core.Updater;
 using NuGetUpdater.Core.Utilities;
-
-using static NuGetUpdater.Core.Utilities.EOLHandling;
 
 namespace NuGetUpdater.Core.Run;
 
@@ -47,17 +47,73 @@ public class RunWorker
     {
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
         var jobWrapper = Deserialize(jobFileContent);
-        var result = await RunAsync(jobWrapper.Job, repoContentsPath, baseCommitSha);
-        var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
-        await File.WriteAllTextAsync(outputFilePath.FullName, resultJson);
+        var experimentsManager = ExperimentsManager.GetExperimentsManager(jobWrapper.Job.Experiments);
+        var result = await RunAsync(jobWrapper.Job, repoContentsPath, baseCommitSha, experimentsManager);
+        if (experimentsManager.UseLegacyUpdateHandler)
+        {
+            // only the legacy handler writes this file
+            var resultJson = JsonSerializer.Serialize(result, SerializerOptions);
+            await File.WriteAllTextAsync(outputFilePath.FullName, resultJson);
+        }
     }
 
-    public Task<RunResult> RunAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha)
+    public async Task<RunResult> RunAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
-        return RunWithErrorHandlingAsync(job, repoContentsPath, baseCommitSha);
+        RunResult result;
+        if (experimentsManager.UseLegacyUpdateHandler)
+        {
+            result = await RunWithErrorHandlingAsync(job, repoContentsPath, baseCommitSha, experimentsManager);
+        }
+        else
+        {
+            await RunScenarioHandlersWithErrorHandlingAsync(job, repoContentsPath, baseCommitSha, experimentsManager);
+
+            // the group updater doesn't return this, so we provide an empty object
+            result = new RunResult()
+            {
+                Base64DependencyFiles = [],
+                BaseCommitSha = baseCommitSha,
+            };
+        }
+
+        return result;
     }
 
-    private async Task<RunResult> RunWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha)
+    private static readonly ImmutableArray<IUpdateHandler> UpdateHandlers =
+    [
+        GroupUpdateAllVersionsHandler.Instance,
+        RefreshGroupUpdatePullRequestHandler.Instance,
+        CreateSecurityUpdatePullRequestHandler.Instance,
+        RefreshSecurityUpdatePullRequestHandler.Instance,
+        RefreshVersionUpdatePullRequestHandler.Instance,
+    ];
+
+    public static IUpdateHandler GetUpdateHandler(Job job) =>
+        UpdateHandlers.FirstOrDefault(h => h.CanHandle(job)) ?? throw new InvalidOperationException("Unable to find appropriate update handler.");
+
+    private async Task RunScenarioHandlersWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
+    {
+        JobErrorBase? error = null;
+
+        try
+        {
+            var handler = GetUpdateHandler(job);
+            await handler.HandleAsync(job, repoContentsPath, baseCommitSha, _discoveryWorker, _analyzeWorker, _updaterWorker, _apiHandler, experimentsManager, _logger);
+        }
+        catch (Exception ex)
+        {
+            error = JobErrorBase.ErrorFromException(ex, _jobId, repoContentsPath.FullName);
+        }
+
+        if (error is not null)
+        {
+            await _apiHandler.RecordUpdateJobError(error);
+        }
+
+        await _apiHandler.MarkAsProcessed(new(baseCommitSha));
+    }
+
+    private async Task<RunResult> RunWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
         JobErrorBase? error = null;
         var currentDirectory = repoContentsPath.FullName; // used for error reporting below
@@ -71,7 +127,6 @@ public class RunWorker
         {
             MSBuildHelper.RegisterMSBuild(repoContentsPath.FullName, repoContentsPath.FullName, _logger);
 
-            var experimentsManager = ExperimentsManager.GetExperimentsManager(job.Experiments);
             var allDependencyFiles = new Dictionary<string, DependencyFile>();
             foreach (var directory in job.GetAllDirectories())
             {
@@ -109,9 +164,7 @@ public class RunWorker
     private async Task<RunResult> RunForDirectory(Job job, DirectoryInfo repoContentsPath, string repoDirectory, string baseCommitSha, ExperimentsManager experimentsManager)
     {
         var discoveryResult = await _discoveryWorker.RunAsync(repoContentsPath.FullName, repoDirectory);
-
-        _logger.Info("Discovery JSON content:");
-        _logger.Info(JsonSerializer.Serialize(discoveryResult, DiscoveryWorker.SerializerOptions));
+        _logger.ReportDiscovery(discoveryResult);
 
         if (discoveryResult.Error is not null)
         {
@@ -125,50 +178,18 @@ public class RunWorker
         }
 
         // report dependencies
-        var discoveredUpdatedDependencies = GetUpdatedDependencyListFromDiscovery(discoveryResult, repoContentsPath.FullName);
+        var discoveredUpdatedDependencies = GetUpdatedDependencyListFromDiscovery(discoveryResult);
         await _apiHandler.UpdateDependencyList(discoveredUpdatedDependencies);
 
         var incrementMetric = GetIncrementMetric(job);
         await _apiHandler.IncrementMetric(incrementMetric);
 
         // TODO: pull out relevant dependencies, then check each for updates and track the changes
-        var originalDependencyFileContents = new Dictionary<string, string>();
-        var originalDependencyFileEOFs = new Dictionary<string, EOLType>();
-        var originalDependencyFileBOMs = new Dictionary<string, bool>();
         var actualUpdatedDependencies = new List<ReportedDependency>();
 
         // track original contents for later handling
-        async Task TrackOriginalContentsAsync(string directory, string fileName)
-        {
-            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
-            var localFullPath = Path.Join(repoContentsPath.FullName, repoFullPath);
-            var content = await File.ReadAllTextAsync(localFullPath);
-            var rawContent = await File.ReadAllBytesAsync(localFullPath);
-            originalDependencyFileContents[repoFullPath] = content;
-            originalDependencyFileEOFs[repoFullPath] = content.GetPredominantEOL();
-            originalDependencyFileBOMs[repoFullPath] = rawContent.HasBOM();
-        }
-
-        foreach (var project in discoveryResult.Projects)
-        {
-            var projectDirectory = Path.GetDirectoryName(project.FilePath);
-            await TrackOriginalContentsAsync(discoveryResult.Path, project.FilePath);
-            foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
-            {
-                var extraFilePath = Path.Join(projectDirectory, extraFile);
-                await TrackOriginalContentsAsync(discoveryResult.Path, extraFilePath);
-            }
-        }
-
-        var nonProjectFiles = new[]
-        {
-            discoveryResult.GlobalJson?.FilePath,
-            discoveryResult.DotNetToolsJson?.FilePath,
-        }.Where(f => f is not null).Cast<string>().ToArray();
-        foreach (var nonProjectFile in nonProjectFiles)
-        {
-            await TrackOriginalContentsAsync(discoveryResult.Path, nonProjectFile);
-        }
+        var tracker = new ModifiedFilesTracker(repoContentsPath);
+        await tracker.StartTrackingAsync(discoveryResult);
 
         // do update
         var updateOperationsPerformed = new List<UpdateOperationBase>();
@@ -210,8 +231,7 @@ public class RunWorker
 
             var dependencyInfo = GetDependencyInfo(job, dependency);
             var analysisResult = await _analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
-            _logger.Info("Analysis content:");
-            _logger.Info(JsonSerializer.Serialize(analysisResult, AnalyzeWorker.SerializerOptions));
+            _logger.ReportAnalysis(analysisResult);
 
             if (analysisResult.Error is not null)
             {
@@ -227,7 +247,7 @@ public class RunWorker
                         .FirstOrDefault(d => d.Name.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase));
                     if (updatedDependencyFromAnalysis is not null)
                     {
-                        var existingPullRequest = job.GetExistingPullRequestForDependency(updatedDependencyFromAnalysis);
+                        var existingPullRequest = job.GetExistingPullRequestForDependencies([updatedDependencyFromAnalysis], considerVersions: true);
                         if (existingPullRequest is not null)
                         {
                             await SendApiMessage(new PullRequestExistsForLatestVersion(dependency.Name, analysisResult.UpdatedVersion));
@@ -261,7 +281,7 @@ public class RunWorker
                     PreviousRequirements = previousDependency.Requirements,
                 };
 
-                var projectDiscovery = discoveryResult.Projects.FirstOrDefault(p => Path.Join(discoveryResult.Path, p.FilePath).FullyNormalizedRootedPath().Equals(updateOperation.ProjectPath, StringComparison.OrdinalIgnoreCase));
+                var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(updateOperation.ProjectPath);
                 var updateResult = await _updaterWorker.RunAsync(repoContentsPath.FullName, updateOperation.ProjectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, isTransitive: dependency.IsTransitive);
                 if (updateResult.Error is not null)
                 {
@@ -278,65 +298,13 @@ public class RunWorker
         }
 
         // create PR - we need to manually check file contents; we can't easily use `git status` in tests
-        var updatedDependencyFiles = new Dictionary<string, DependencyFile>();
-        async Task AddUpdatedFileIfDifferentAsync(string directory, string fileName)
-        {
-            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
-            var localFullPath = Path.GetFullPath(Path.Join(repoContentsPath.FullName, repoFullPath));
-            var originalContent = originalDependencyFileContents[repoFullPath];
-            var updatedContent = await File.ReadAllTextAsync(localFullPath);
-
-            updatedContent = updatedContent.SetEOL(originalDependencyFileEOFs[repoFullPath]);
-            var updatedRawContent = updatedContent.SetBOM(originalDependencyFileBOMs[repoFullPath]);
-            await File.WriteAllBytesAsync(localFullPath, updatedRawContent);
-
-            if (updatedContent != originalContent)
-            {
-                var reportedContent = updatedContent;
-                var encoding = "utf-8";
-                if (originalDependencyFileBOMs[repoFullPath])
-                {
-                    reportedContent = Convert.ToBase64String(updatedRawContent);
-                    encoding = "base64";
-                }
-
-                updatedDependencyFiles[localFullPath] = new DependencyFile()
-                {
-                    Name = Path.GetFileName(repoFullPath),
-                    Directory = Path.GetDirectoryName(repoFullPath)!.NormalizePathToUnix(),
-                    Content = reportedContent,
-                    ContentEncoding = encoding,
-                };
-            }
-        }
-
-        foreach (var project in discoveryResult.Projects)
-        {
-            await AddUpdatedFileIfDifferentAsync(discoveryResult.Path, project.FilePath);
-            var projectDirectory = Path.GetDirectoryName(project.FilePath);
-            foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
-            {
-                var extraFilePath = Path.Join(projectDirectory, extraFile);
-                await AddUpdatedFileIfDifferentAsync(discoveryResult.Path, extraFilePath);
-            }
-        }
-
-        foreach (var nonProjectFile in nonProjectFiles)
-        {
-            await AddUpdatedFileIfDifferentAsync(discoveryResult.Path, nonProjectFile);
-        }
-
-        var updatedDependencyFileList = updatedDependencyFiles
-            .OrderBy(kvp => kvp.Key)
-            .Select(kvp => kvp.Value)
-            .ToArray();
-
+        var updatedDependencyFiles = await tracker.StopTrackingAsync();
         var normalizedUpdateOperationsPerformed = UpdateOperationBase.NormalizeUpdateOperationCollection(repoContentsPath.FullName, updateOperationsPerformed);
         var report = UpdateOperationBase.GenerateUpdateOperationReport(normalizedUpdateOperationsPerformed);
         _logger.Info(report);
 
         var sortedUpdatedDependencies = actualUpdatedDependencies.OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase).ToArray();
-        var resultMessage = GetPullRequestApiMessage(job, updatedDependencyFileList, sortedUpdatedDependencies, normalizedUpdateOperationsPerformed, baseCommitSha);
+        var resultMessage = GetPullRequestApiMessage(job, [.. updatedDependencyFiles], sortedUpdatedDependencies, normalizedUpdateOperationsPerformed, baseCommitSha);
         switch (resultMessage)
         {
             case ClosePullRequest close:
@@ -368,11 +336,11 @@ public class RunWorker
 
         var result = new RunResult()
         {
-            Base64DependencyFiles = originalDependencyFileContents.OrderBy(kvp => kvp.Key).Select(kvp =>
+            Base64DependencyFiles = tracker.OriginalDependencyFileContents.OrderBy(kvp => kvp.Key).Select(kvp =>
             {
                 var fullPath = kvp.Key.FullyNormalizedRootedPath();
                 var rawContent = Encoding.UTF8.GetBytes(kvp.Value);
-                if (originalDependencyFileBOMs[kvp.Key])
+                if (tracker.OriginalDependencyFileBOMs[kvp.Key])
                 {
                     rawContent = Encoding.UTF8.GetPreamble().Concat(rawContent).ToArray();
                 }
@@ -390,7 +358,7 @@ public class RunWorker
         return result;
     }
 
-    private static ImmutableArray<UpdateOperationBase> PatchInOldVersions(ImmutableArray<UpdateOperationBase> updateOperations, ProjectDiscoveryResult? projectDiscovery)
+    internal static ImmutableArray<UpdateOperationBase> PatchInOldVersions(ImmutableArray<UpdateOperationBase> updateOperations, ProjectDiscoveryResult? projectDiscovery)
     {
         if (projectDiscovery is null)
         {
@@ -451,7 +419,7 @@ public class RunWorker
         if (existingPullRequest is null && updatedFiles.Length == 0)
         {
             // it's possible that we were asked to update a specific package, but it's no longer there; in that case find _that_ specific PR
-            var requestedUpdates = (job.Dependencies ?? []).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var requestedUpdates = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
             existingPullRequest = existingPullRequests.FirstOrDefault(pr => pr.Item2.Select(d => d.DependencyName).All(requestedUpdates.Contains));
         }
 
@@ -507,6 +475,7 @@ public class RunWorker
                     CommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updateOperationsPerformed, dependencyGroupName: null),
                     PrTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updateOperationsPerformed, dependencyGroupName: null),
                     PrBody = PullRequestTextGenerator.GetPullRequestBody(job, updateOperationsPerformed, dependencyGroupName: null),
+                    DependencyGroup = null,
                 };
             }
         }
@@ -656,7 +625,7 @@ public class RunWorker
                     // not vulnerable => no longer needed
                     var specificJobDependencies = job.SecurityAdvisories
                         .Select(a => a.DependencyName)
-                        .Concat(job.Dependencies ?? [])
+                        .Concat(job.Dependencies)
                         .ToHashSet(StringComparer.OrdinalIgnoreCase);
                     if (specificJobDependencies.Contains(dependency.Name))
                     {
@@ -670,7 +639,7 @@ public class RunWorker
             {
                 // not a security update, so only update if...
                 // ...we've been explicitly asked to update this
-                if ((job.Dependencies ?? []).Any(d => d.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)))
+                if (job.Dependencies.Any(d => d.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     return true;
                 }
@@ -726,7 +695,7 @@ public class RunWorker
         return dependencyInfo;
     }
 
-    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string pathToContents)
+    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult)
     {
         string GetFullRepoPath(string path)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -1,0 +1,164 @@
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
+{
+    public static IUpdateHandler Instance { get; } = new CreateSecurityUpdatePullRequestHandler();
+
+    public string TagName => "create_security_pr";
+
+    public bool CanHandle(Job job)
+    {
+        // only use this handler if we're creating a new security PR with an explicit list of dependencies
+        if (job.UpdatingAPullRequest)
+        {
+            return false;
+        }
+
+        if (job.Dependencies.Length == 0)
+        {
+            return false;
+        }
+
+        return job.SecurityUpdatesOnly;
+    }
+
+    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in job.GetAllDirectories())
+        {
+            var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+            logger.ReportDiscovery(discoveryResult);
+            if (discoveryResult.Error is not null)
+            {
+                await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                return;
+            }
+
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            await apiHandler.UpdateDependencyList(updatedDependencyList);
+            await this.ReportUpdaterStarted(apiHandler);
+
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+            var groupedUpdateOperationsToPerform = updateOperationsToPerform
+                .GroupBy(o => o.Dependency.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => jobDependencies.Contains(g.Key))
+                .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+            if (groupedUpdateOperationsToPerform.Count == 0)
+            {
+                await apiHandler.RecordUpdateJobError(new SecurityUpdateDependencyNotFound());
+                continue;
+            }
+
+            logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
+
+            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            await tracker.StartTrackingAsync(discoveryResult);
+            foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
+            {
+                var dependencyName = dependencyGroupToUpdate.Key;
+                var vulnerableDependenciesToUpdate = dependencyGroupToUpdate.Value
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Where(set => set.Item3.IsVulnerable)
+                    .ToArray();
+                if (vulnerableDependenciesToUpdate.Length == 0)
+                {
+                    await apiHandler.RecordUpdateJobError(new SecurityUpdateNotNeeded(dependencyName));
+                    continue;
+                }
+
+                foreach (var (projectPath, dependency, dependencyInfo) in vulnerableDependenciesToUpdate)
+                {
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        await apiHandler.RecordUpdateJobError(new SecurityUpdateNotFound(dependency.Name, dependency.Version!));
+                        continue;
+                    }
+
+                    if (dependencyInfo.IgnoredVersions.Any(ignored => ignored.IsSatisfiedBy(NuGetVersion.Parse(analysisResult.UpdatedVersion))) ||
+                        job.IsDependencyIgnored(dependency.Name, dependency.Version!))
+                    {
+                        logger.Error($"Cannot update {dependency.Name} for {projectPath} because all versions are ignored.");
+                        await apiHandler.RecordUpdateJobError(new SecurityUpdateIgnored(dependencyName));
+                        continue;
+                    }
+
+                    logger.Info($"Attempting update of {dependency.Name} from {dependency.Version} to {analysisResult.UpdatedVersion} for {projectPath}.");
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        logger.Error($"Error updating {dependency.Name} in {projectPath}: {updaterResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        logger.Error($"Update of {dependency.Name} in {projectPath} not possible.");
+                        await apiHandler.RecordUpdateJobError(new SecurityUpdateNotPossible(dependencyName, analysisResult.UpdatedVersion, analysisResult.UpdatedVersion, []));
+                        return;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport()}");
+                    }
+                }
+            }
+
+            var updatedDependencyFiles = await tracker.StopTrackingAsync();
+            var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
+            if (rawDependencies.Length > 0)
+            {
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                if (existingPullRequest is not null)
+                {
+                    await apiHandler.RecordUpdateJobError(new PullRequestExistsForSecurityUpdate(rawDependencies));
+                    continue;
+                }
+            }
+
+            if (updatedDependencyFiles.Length > 0)
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                await apiHandler.CreatePullRequest(new CreatePullRequest()
+                {
+                    Dependencies = [.. updatedDependencies],
+                    UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                    DependencyGroup = null,
+                });
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -1,0 +1,271 @@
+using System.Collections.Immutable;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+internal class GroupUpdateAllVersionsHandler : IUpdateHandler
+{
+    public static IUpdateHandler Instance { get; } = new GroupUpdateAllVersionsHandler();
+
+    public string TagName => "group_update_all_versions";
+
+    public bool CanHandle(Job job)
+    {
+        if (job.UpdatingAPullRequest)
+        {
+            return false;
+        }
+
+        if (job.SecurityUpdatesOnly)
+        {
+            if (job.Dependencies.Length > 1)
+            {
+                return true;
+            }
+
+            if (job.DependencyGroups.Any(g => g.IsSecurity()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        // group update, do all directories and merge
+        // ungrouped update, do each dir separate
+        await this.ReportUpdaterStarted(apiHandler);
+        if (job.DependencyGroups.Length > 0)
+        {
+            await RunGroupedDependencyUpdates(job, repoContentsPath, baseCommitSha, discoveryWorker, analyzeWorker, updaterWorker, apiHandler, experimentsManager, logger);
+        }
+        else
+        {
+            await RunUngroupedDependencyUpdates(job, repoContentsPath, baseCommitSha, discoveryWorker, analyzeWorker, updaterWorker, apiHandler, experimentsManager, logger);
+        }
+    }
+
+    private async Task RunGroupedDependencyUpdates(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        foreach (var group in job.DependencyGroups)
+        {
+            logger.Info($"Starting update for group {group.Name}");
+            var groupMatcher = group.GetGroupMatcher();
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
+            foreach (var directory in job.GetAllDirectories())
+            {
+                var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+                logger.ReportDiscovery(discoveryResult);
+                if (discoveryResult.Error is not null)
+                {
+                    await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                    return;
+                }
+
+                var tracker = new ModifiedFilesTracker(repoContentsPath);
+                await tracker.StartTrackingAsync(discoveryResult);
+
+                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+                await apiHandler.UpdateDependencyList(updatedDependencyList);
+
+                var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+                foreach (var (projectPath, dependency) in updateOperationsToPerform)
+                {
+                    if (dependency.IsTransitive)
+                    {
+                        continue;
+                    }
+
+                    if (!groupMatcher.IsMatch(dependency.Name))
+                    {
+                        continue;
+                    }
+
+                    if (job.IsDependencyIgnored(dependency.Name, dependency.Version!))
+                    {
+                        logger.Info($"Skipping ignored dependency {dependency.Name}/{dependency.Version}.");
+                        continue;
+                    }
+
+                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency);
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        continue;
+                    }
+
+                    if (dependencyInfo.IgnoredVersions.Any(ignored => ignored.IsSatisfiedBy(NuGetVersion.Parse(analysisResult.UpdatedVersion))))
+                    {
+                        logger.Info($"Cannot update {dependency.Name} for {projectPath} because all versions are ignored.");
+                        continue;
+                    }
+
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        logger.Error($"Error updating {dependency.Name} in {projectPath}: {updaterResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport()}");
+                    }
+                }
+
+                var updatedDependencyFiles = await tracker.StopTrackingAsync();
+                allUpdatedDependencyFiles = ModifiedFilesTracker.MergeUpdatedFileSet(allUpdatedDependencyFiles, updatedDependencyFiles);
+            }
+
+            if (updateOperationsPerformed.Count > 0)
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], group.Name);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], group.Name);
+                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], group.Name);
+                await apiHandler.CreatePullRequest(new CreatePullRequest()
+                {
+                    Dependencies = [.. updatedDependencies],
+                    UpdatedDependencyFiles = [.. allUpdatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                    DependencyGroup = group.Name,
+                });
+            }
+        }
+    }
+
+    private async Task RunUngroupedDependencyUpdates(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        foreach (var directory in job.GetAllDirectories())
+        {
+            var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+            logger.ReportDiscovery(discoveryResult);
+            if (discoveryResult.Error is not null)
+            {
+                await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                return;
+            }
+
+            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            await tracker.StartTrackingAsync(discoveryResult);
+
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            await apiHandler.UpdateDependencyList(updatedDependencyList);
+
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+            foreach (var (projectPath, dependency) in updateOperationsToPerform)
+            {
+                if (dependency.IsTransitive)
+                {
+                    continue;
+                }
+
+                if (job.IsDependencyIgnored(dependency.Name, dependency.Version!))
+                {
+                    logger.Info($"Skipping ignored dependency {dependency.Name}/{dependency.Version}.");
+                    continue;
+                }
+
+                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency);
+                var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                if (analysisResult.Error is not null)
+                {
+                    logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                    await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                    return;
+                }
+
+                if (!analysisResult.CanUpdate)
+                {
+                    logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                    continue;
+                }
+
+                if (dependencyInfo.IgnoredVersions.Any(ignored => ignored.IsSatisfiedBy(NuGetVersion.Parse(analysisResult.UpdatedVersion))))
+                {
+                    logger.Info($"Cannot update {dependency.Name} for {projectPath} because all versions are ignored.");
+                    continue;
+                }
+
+                var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                if (updaterResult.Error is not null)
+                {
+                    await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                    continue;
+                }
+
+                if (updaterResult.UpdateOperations.Length == 0)
+                {
+                    continue;
+                }
+
+                var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                updatedDependencies.AddRange(updatedDependenciesForThis);
+                updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                foreach (var o in patchedUpdateOperations)
+                {
+                    logger.Info($"Update operation performed: {o.GetReport()}");
+                }
+            }
+
+            var updatedDependencyFiles = await tracker.StopTrackingAsync();
+            if (updateOperationsPerformed.Count > 0)
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                await apiHandler.CreatePullRequest(new CreatePullRequest()
+                {
+                    Dependencies = [.. updatedDependencies],
+                    UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                    DependencyGroup = null,
+                });
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/IUpdateHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/IUpdateHandler.cs
@@ -1,0 +1,22 @@
+using NuGetUpdater.Core.Run.ApiModel;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+public interface IUpdateHandler
+{
+    string TagName { get; }
+    bool CanHandle(Job job);
+    Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger);
+}
+
+public static class IUpdateHandlerExtensions
+{
+    public static Task ReportUpdaterStarted(this IUpdateHandler updateHandler, IApiHandler apiHandler) => apiHandler.IncrementMetric(new IncrementMetric()
+    {
+        Metric = "updater.started",
+        Tags = new()
+        {
+            ["operation"] = updateHandler.TagName,
+        }
+    });
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -1,0 +1,196 @@
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
+{
+    public static IUpdateHandler Instance { get; } = new RefreshGroupUpdatePullRequestHandler();
+
+    public string TagName => "update_version_group_pr";
+
+    public bool CanHandle(Job job)
+    {
+        if (job.Dependencies.Length == 0)
+        {
+            return false;
+        }
+
+        if (job.DependencyGroupToRefresh is null)
+        {
+            return false;
+        }
+
+        if (job.GetAllDirectories().Length > 1)
+        {
+            return true;
+        }
+
+        if (job.SecurityUpdatesOnly)
+        {
+            if (job.Dependencies.Length > 1)
+            {
+                return true;
+            }
+
+            if (job.DependencyGroups.Any(g => g.IsSecurity()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        return job.UpdatingAPullRequest;
+    }
+
+    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        if (job.DependencyGroupToRefresh is null)
+        {
+            throw new InvalidOperationException($"{nameof(job.DependencyGroupToRefresh)} must be non-null.");
+        }
+
+        var group = job.DependencyGroups.FirstOrDefault(g => g.Name == job.DependencyGroupToRefresh);
+        if (group is null)
+        {
+            throw new InvalidOperationException($"Dependency group {job.DependencyGroupToRefresh} not found.");
+        }
+
+        logger.Info($"Starting update for group {group.Name}");
+
+        var groupMatcher = group.GetGroupMatcher();
+        var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in job.GetAllDirectories())
+        {
+            var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+            logger.ReportDiscovery(discoveryResult);
+            if (discoveryResult.Error is not null)
+            {
+                await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                return;
+            }
+
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            await apiHandler.UpdateDependencyList(updatedDependencyList);
+            await this.ReportUpdaterStarted(apiHandler);
+
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+            var groupedUpdateOperationsToPerform = updateOperationsToPerform
+                .GroupBy(o => o.Dependency.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => jobDependencies.Contains(g.Key))
+                .Where(g => groupMatcher.IsMatch(g.Key))
+                .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
+            logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
+
+            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            await tracker.StartTrackingAsync(discoveryResult);
+            foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
+            {
+                var dependencyName = dependencyGroupToUpdate.Key;
+                var relevantDependenciesToUpdate = dependencyGroupToUpdate.Value
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Where(set => !job.IsDependencyIgnored(set.Dependency.Name, set.Dependency.Version!))
+                    .ToArray();
+
+                foreach (var (projectPath, dependency, dependencyInfo) in relevantDependenciesToUpdate)
+                {
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        continue;
+                    }
+
+                    logger.Info($"Attempting update of {dependency.Name} from {dependency.Version} to {analysisResult.UpdatedVersion} for {projectPath}.");
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        logger.Error($"Error updating {dependency.Name} in {projectPath}: {updaterResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        logger.Info($"Performed no updates for {dependency.Name} in {projectPath}, but no error reported.");
+                        continue;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport()}");
+                    }
+                }
+            }
+
+            var updatedDependencyFiles = await tracker.StopTrackingAsync();
+            var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
+            if (rawDependencies.Length == 0)
+            {
+                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "update_no_longer_possible" });
+                continue;
+            }
+
+            var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+            var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+            var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+            var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+            if (existingPullRequest is not null)
+            {
+                await apiHandler.UpdatePullRequest(new UpdatePullRequest()
+                {
+                    DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                    DependencyGroup = group.Name,
+                    UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                });
+                continue;
+            }
+            else
+            {
+                var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+                if (existingPrButDifferent is not null)
+                {
+                    await apiHandler.ClosePullRequest(new ClosePullRequest()
+                    {
+                        DependencyNames = [.. rawDependencies.Select(d => d.Name)],
+                        Reason = "dependencies_changed",
+                    });
+                }
+
+                await apiHandler.CreatePullRequest(new CreatePullRequest()
+                {
+                    Dependencies = [.. updatedDependencies],
+                    UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                    DependencyGroup = group.Name,
+                });
+                continue;
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -1,0 +1,186 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
+{
+    public static IUpdateHandler Instance { get; } = new RefreshSecurityUpdatePullRequestHandler();
+
+    public string TagName => "update_security_pr";
+
+    public bool CanHandle(Job job)
+    {
+        if (!job.SecurityUpdatesOnly)
+        {
+            return false;
+        }
+
+        if (job.Dependencies.Length == 0)
+        {
+            return false;
+        }
+
+        return job.UpdatingAPullRequest;
+    }
+
+    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in job.GetAllDirectories())
+        {
+            var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+            logger.ReportDiscovery(discoveryResult);
+            if (discoveryResult.Error is not null)
+            {
+                await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                return;
+            }
+
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            await apiHandler.UpdateDependencyList(updatedDependencyList);
+            await this.ReportUpdaterStarted(apiHandler);
+
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+            var groupedUpdateOperationsToPerform = updateOperationsToPerform
+                .GroupBy(o => o.Dependency.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => jobDependencies.Contains(g.Key))
+                .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+            logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
+
+            if (groupedUpdateOperationsToPerform.Count == 0)
+            {
+                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "dependencies_removed" });
+                continue;
+            }
+
+            var missingDependencies = jobDependencies
+                .Where(d => !groupedUpdateOperationsToPerform.ContainsKey(d))
+                .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .ToImmutableArray();
+            if (missingDependencies.Length > 0)
+            {
+                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = missingDependencies, Reason = "dependency_removed" });
+                continue;
+            }
+
+            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            await tracker.StartTrackingAsync(discoveryResult);
+            foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
+            {
+                var dependencyName = dependencyGroupToUpdate.Key;
+                var vulnerableDependenciesToUpdate = dependencyGroupToUpdate.Value
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Where(set => !job.IsDependencyIgnored(set.Dependency.Name, set.Dependency.Version!))
+                    .Where(set => set.Item3.IsVulnerable)
+                    .ToArray();
+
+                if (vulnerableDependenciesToUpdate.Length < dependencyGroupToUpdate.Value.Length)
+                {
+                    await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "up_to_date" });
+                    return;
+                }
+
+                foreach (var (projectPath, dependency, dependencyInfo) in vulnerableDependenciesToUpdate)
+                {
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        return;
+                    }
+
+                    logger.Info($"Attempting update of {dependency.Name} from {dependency.Version} to {analysisResult.UpdatedVersion} for {projectPath}.");
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        logger.Error($"Error updating {dependency.Name} in {projectPath}: {updaterResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        return;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport()}");
+                    }
+                }
+            }
+
+            var updatedDependencyFiles = await tracker.StopTrackingAsync();
+            var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
+            if (rawDependencies.Length > 0)
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                if (existingPullRequest is not null)
+                {
+                    await apiHandler.UpdatePullRequest(new UpdatePullRequest()
+                    {
+                        DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                        DependencyGroup = null,
+                        UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                        BaseCommitSha = baseCommitSha,
+                        CommitMessage = commitMessage,
+                        PrTitle = prTitle,
+                        PrBody = prBody,
+                    });
+                    continue;
+                }
+                else
+                {
+                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+                    if (existingPrButDifferent is not null)
+                    {
+                        await apiHandler.ClosePullRequest(new ClosePullRequest()
+                        {
+                            DependencyNames = [.. rawDependencies.Select(d => d.Name)],
+                            Reason = "dependencies_changed",
+                        });
+                    }
+
+                    await apiHandler.CreatePullRequest(new CreatePullRequest()
+                    {
+                        Dependencies = [.. updatedDependencies],
+                        UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                        BaseCommitSha = baseCommitSha,
+                        CommitMessage = commitMessage,
+                        PrTitle = prTitle,
+                        PrBody = prBody,
+                        DependencyGroup = null,
+                    });
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -1,0 +1,179 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.UpdateHandlers;
+
+internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
+{
+    public static IUpdateHandler Instance { get; } = new RefreshVersionUpdatePullRequestHandler();
+
+    public string TagName => "update_version_pr";
+
+    public bool CanHandle(Job job)
+    {
+        if (job.SecurityUpdatesOnly)
+        {
+            return false;
+        }
+
+        if (job.Dependencies.Length == 0)
+        {
+            return false;
+        }
+
+        return job.UpdatingAPullRequest;
+    }
+
+    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    {
+        var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in job.GetAllDirectories())
+        {
+            var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
+            logger.ReportDiscovery(discoveryResult);
+            if (discoveryResult.Error is not null)
+            {
+                await apiHandler.RecordUpdateJobError(discoveryResult.Error);
+                return;
+            }
+
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            await apiHandler.UpdateDependencyList(updatedDependencyList);
+            await this.ReportUpdaterStarted(apiHandler);
+
+            var updateOperationsPerformed = new List<UpdateOperationBase>();
+            var updatedDependencies = new List<ReportedDependency>();
+            var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
+            var relevantUpdateOperationsToPerform = updateOperationsToPerform
+                .GroupBy(o => o.Dependency.Name, StringComparer.OrdinalIgnoreCase)
+                .Where(g => jobDependencies.Contains(g.Key))
+                .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+            if (relevantUpdateOperationsToPerform.Count == 0)
+            {
+                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "dependencies_removed" });
+                continue;
+            }
+
+            var missingDependencies = jobDependencies
+                .Where(d => !relevantUpdateOperationsToPerform.ContainsKey(d))
+                .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .ToImmutableArray();
+            if (missingDependencies.Length > 0)
+            {
+                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = missingDependencies, Reason = "dependency_removed" });
+                continue;
+            }
+
+            logger.Info($"Updating dependencies: {string.Join(", ", relevantUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
+
+            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            await tracker.StartTrackingAsync(discoveryResult);
+            foreach (var dependencyUpdatesToPeform in relevantUpdateOperationsToPerform)
+            {
+                var dependencyName = dependencyUpdatesToPeform.Key;
+                var dependencyInfosToUpdate = dependencyUpdatesToPeform.Value
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Where(set => !job.IsDependencyIgnored(set.Dependency.Name, set.Dependency.Version!))
+                    .ToArray();
+
+                foreach (var (projectPath, dependency, dependencyInfo) in dependencyInfosToUpdate)
+                {
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        return;
+                    }
+
+                    logger.Info($"Attempting update of {dependency.Name} from {dependency.Version} to {analysisResult.UpdatedVersion} for {projectPath}.");
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        logger.Error($"Error updating {dependency.Name} in {projectPath}: {updaterResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        return;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport()}");
+                    }
+                }
+            }
+
+            var updatedDependencyFiles = await tracker.StopTrackingAsync();
+            var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
+            if (rawDependencies.Length > 0)
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                if (existingPullRequest is not null)
+                {
+                    await apiHandler.UpdatePullRequest(new UpdatePullRequest()
+                    {
+                        DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                        DependencyGroup = null,
+                        UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                        BaseCommitSha = baseCommitSha,
+                        CommitMessage = commitMessage,
+                        PrTitle = prTitle,
+                        PrBody = prBody,
+                    });
+                    continue;
+                }
+                else
+                {
+                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+                    if (existingPrButDifferent is not null)
+                    {
+                        await apiHandler.ClosePullRequest(new ClosePullRequest()
+                        {
+                            DependencyNames = [.. rawDependencies.Select(d => d.Name)],
+                            Reason = "dependencies_changed",
+                        });
+                    }
+
+                    await apiHandler.CreatePullRequest(new CreatePullRequest()
+                    {
+                        Dependencies = [.. updatedDependencies],
+                        UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                        BaseCommitSha = baseCommitSha,
+                        CommitMessage = commitMessage,
+                        PrTitle = prTitle,
+                        PrBody = prBody,
+                        DependencyGroup = null,
+                    });
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
@@ -1,3 +1,8 @@
+using System.Text.Json;
+
+using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Discover;
+
 namespace NuGetUpdater.Core;
 
 public interface ILogger
@@ -10,6 +15,18 @@ public static class LoggerExtensions
     public static void Info(this ILogger logger, string message) => logger.LogWithLevel("INFO", message);
     public static void Warn(this ILogger logger, string message) => logger.LogWithLevel("WARN", message);
     public static void Error(this ILogger logger, string message) => logger.LogWithLevel("ERROR", message);
+
+    public static void ReportAnalysis(this ILogger logger, AnalysisResult analysisResult)
+    {
+        logger.Info("Analysis JSON content:");
+        logger.Info(JsonSerializer.Serialize(analysisResult, AnalyzeWorker.SerializerOptions));
+    }
+
+    public static void ReportDiscovery(this ILogger logger, WorkspaceDiscoveryResult discoveryResult)
+    {
+        logger.Info("Discovery JSON content:");
+        logger.Info(JsonSerializer.Serialize(discoveryResult, DiscoveryWorker.SerializerOptions));
+    }
 
     private static void LogWithLevel(this ILogger logger, string level, string message) => logger.LogRaw($"{GetCurrentTimestamp()} {level} {message}");
     private static string GetCurrentTimestamp() => DateTime.UtcNow.ToString("yyyy/MM/dd HH:mm:ss");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MarkdownListBuilder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MarkdownListBuilder.cs
@@ -1,0 +1,65 @@
+namespace NuGetUpdater.Core.Utilities;
+
+public class MarkdownListBuilder
+{
+    public static string FromObject(object obj)
+    {
+        return string.Join(Environment.NewLine, LinesFromObject(obj));
+    }
+
+    private static string[] LinesFromObject(object obj)
+    {
+        var lines = new List<string>();
+        switch (obj)
+        {
+            case IDictionary<string, object> dict:
+                // key1: value1
+                // key2: value2
+                foreach (var (key, value) in dict)
+                {
+                    if (key == "error-backtrace")
+                    {
+                        continue;
+                    }
+
+                    var childLines = LinesFromObject(value);
+                    if (childLines.Length == 1)
+                    {
+                        // display inline
+                        lines.Add($"- {key}: {childLines[0]}");
+                    }
+                    else
+                    {
+                        // display in sub-list
+                        lines.Add($"- {key}:");
+                        foreach (var childLine in childLines)
+                        {
+                            lines.Add($"  {childLine}");
+                        }
+                    }
+                }
+                break;
+            case IEnumerable<object> values:
+                // - value1
+                // - value2
+                foreach (var value in values)
+                {
+                    var valueLines = LinesFromObject(value);
+                    lines.Add($"- {valueLines[0]}");
+                    foreach (var valueLine in valueLines.Skip(1))
+                    {
+                        lines.Add($"  {valueLine}");
+                    }
+                }
+                break;
+            case bool b:
+                lines.Add(b.ToString().ToLowerInvariant());
+                break;
+            default:
+                lines.Add(obj.ToString()!);
+                break;
+        }
+
+        return [.. lines];
+    }
+}


### PR DESCRIPTION
Add new scenario update handlers for the NuGet end-to-end runner.

This PR closely mimics the existing Ruby behavior in [this directory](https://github.com/dependabot/dependabot-core/tree/main/updater/lib/dependabot/updater/operations) where a slightly different update operation runner is selected based on the shape of the job file.

The new scenario handlers are enabled by default, but a rapid rollback can be achieved by enabling the experiment flag `nuget_use_legacy_update_handler`.  The internal PR to add that flag has been created.  The only change to the legacy runner in `RunWorker.cs` was to optionally switch to the new runner, and to factor out the tracking of updated files via the new `ModifiedFilesTracker` class.

As for reviewing, I'd recommend checking the tests in `NuGetUpdater.Core.Test/Run/UpdateHandlers`.  Those tests use stubbed workers, so everything relevant to the test should be immediately visible.

The changes in this PR are to hopefully eliminate the experimental flag [`nuget_use_legacy_updater_when_updating_pr`](https://github.com/dependabot/dependabot-core/blob/3569031a5c513cac6c57a908619dd8c0f95a0270/nuget/script/run#L10) so that we can go back to testing the new runner in all cases, not just for new PRs.