### PR TITLE
improve pr title and commit message generation

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -28,7 +28,7 @@ public class PullRequestTextTests
         }
 
         var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperations], dependencyGroupName: null);
-        var expectedTitle = "Update Package1 and 9 other dependencies";
+        var expectedTitle = "Bump Package1 and 9 others";
         Assert.Equal(expectedTitle, actualTitle);
     }
 
@@ -45,10 +45,10 @@ public class PullRequestTextTests
     {
         var updateOperationsPerformedImmutable = updateOperationsPerformed.ToImmutableArray();
         var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updateOperationsPerformedImmutable, dependencyGroupName);
-        var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updateOperationsPerformedImmutable, dependencyGroupName);
-        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updateOperationsPerformedImmutable, dependencyGroupName);
+        var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updateOperationsPerformedImmutable, dependencyGroupName).Replace("\r", "");
+        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updateOperationsPerformedImmutable, dependencyGroupName).Replace("\r", "");
         Assert.Equal(expectedTitle, actualTitle);
-        Assert.Equal(expectedCommitMessage, actualCommitMessage);
+        Assert.Equal(expectedCommitMessage.Replace("\r", ""), actualCommitMessage);
         Assert.Equal(expectedBody.Replace("\r", ""), actualBody);
     }
 
@@ -65,6 +65,7 @@ public class PullRequestTextTests
                 new DirectUpdate()
                 {
                     DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
                     NewVersion = NuGetVersion.Parse("1.2.3"),
                     UpdatedFiles = ["a.txt"]
                 }
@@ -72,13 +73,13 @@ public class PullRequestTextTests
             // dependencyGroupName
             null,
             // expectedTitle
-            "Update Some.Package to 1.2.3",
+            "Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedCommitMessage
-            "Update Some.Package to 1.2.3",
+            "Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
             """
         ];
 
@@ -93,6 +94,7 @@ public class PullRequestTextTests
                 new DirectUpdate()
                 {
                     DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
                     NewVersion = NuGetVersion.Parse("1.2.3"),
                     UpdatedFiles = ["a.txt"]
                 }
@@ -100,17 +102,54 @@ public class PullRequestTextTests
             // dependencyGroupName
             null,
             // expectedTitle
-            "[SECURITY] Update Some.Package to 1.2.3",
+            "[SECURITY] Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedCommitMessage
-            "Update Some.Package to 1.2.3",
+            "Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
             """
         ];
 
-        // multiple dependencies, multiple versions
+        // single dependency, multiple versions
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("4.0.0"),
+                    NewVersion = NuGetVersion.Parse("4.5.6"),
+                    UpdatedFiles = ["b.txt"]
+                },
+            },
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "Bump Some.Package to 1.2.3, 4.5.6",
+            // expectedCommitMessage
+            "Bump Some.Package to 1.2.3, 4.5.6",
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 4.0.0 to 4.5.6 in b.txt
+            """
+        ];
+
+        // two dependencies, two versions each
         yield return
         [
             // job
@@ -121,24 +160,28 @@ public class PullRequestTextTests
                 new DirectUpdate()
                 {
                     DependencyName = "Package.A",
+                    OldVersion = NuGetVersion.Parse("0.1.0"),
                     NewVersion = NuGetVersion.Parse("1.0.0"),
                     UpdatedFiles = ["a1.txt"]
                 },
                 new DirectUpdate()
                 {
                     DependencyName = "Package.A",
+                    OldVersion = NuGetVersion.Parse("0.2.0"),
                     NewVersion = NuGetVersion.Parse("2.0.0"),
                     UpdatedFiles = ["a2.txt"]
                 },
                 new DirectUpdate()
                 {
                     DependencyName = "Package.B",
+                    OldVersion = NuGetVersion.Parse("0.3.0"),
                     NewVersion = NuGetVersion.Parse("3.0.0"),
                     UpdatedFiles = ["b1.txt"]
                 },
                 new DirectUpdate()
                 {
                     DependencyName = "Package.B",
+                    OldVersion = NuGetVersion.Parse("0.4.0"),
                     NewVersion = NuGetVersion.Parse("4.0.0"),
                     UpdatedFiles = ["b2.txt"]
                 },
@@ -146,20 +189,188 @@ public class PullRequestTextTests
             // dependencyGroupName
             null,
             // expectedTitle
-            "Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0",
+            "Bump Package.A and Package.B",
             // expectedCommitMessage
             """
-            Update:
-            - Package.A to 1.0.0, 2.0.0
-            - Package.B to 3.0.0, 4.0.0
+            Bump Package.A and Package.B
+
+            Bumps Package.A to 1.0.0, 2.0.0
+            Bumps Package.B to 3.0.0, 4.0.0
             """,
             // expectedBody
             """
             Performed the following updates:
-            - Updated Package.A to 1.0.0 in a1.txt
-            - Updated Package.A to 2.0.0 in a2.txt
-            - Updated Package.B to 3.0.0 in b1.txt
-            - Updated Package.B to 4.0.0 in b2.txt
+            - Updated Package.A from 0.1.0 to 1.0.0 in a1.txt
+            - Updated Package.A from 0.2.0 to 2.0.0 in a2.txt
+            - Updated Package.B from 0.3.0 to 3.0.0 in b1.txt
+            - Updated Package.B from 0.4.0 to 4.0.0 in b2.txt
+            """
+        ];
+
+        // four dependencies, two versions each
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.A",
+                    OldVersion = NuGetVersion.Parse("0.1.0"),
+                    NewVersion = NuGetVersion.Parse("1.0.0"),
+                    UpdatedFiles = ["a1.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.A",
+                    OldVersion = NuGetVersion.Parse("0.2.0"),
+                    NewVersion = NuGetVersion.Parse("2.0.0"),
+                    UpdatedFiles = ["a2.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.B",
+                    OldVersion = NuGetVersion.Parse("0.3.0"),
+                    NewVersion = NuGetVersion.Parse("3.0.0"),
+                    UpdatedFiles = ["b1.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.B",
+                    OldVersion = NuGetVersion.Parse("0.4.0"),
+                    NewVersion = NuGetVersion.Parse("4.0.0"),
+                    UpdatedFiles = ["b2.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.C",
+                    OldVersion = NuGetVersion.Parse("0.5.0"),
+                    NewVersion = NuGetVersion.Parse("5.0.0"),
+                    UpdatedFiles = ["c1.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.C",
+                    OldVersion = NuGetVersion.Parse("0.6.0"),
+                    NewVersion = NuGetVersion.Parse("6.0.0"),
+                    UpdatedFiles = ["c2.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.D",
+                    OldVersion = NuGetVersion.Parse("0.7.0"),
+                    NewVersion = NuGetVersion.Parse("7.0.0"),
+                    UpdatedFiles = ["d1.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.D",
+                    OldVersion = NuGetVersion.Parse("0.8.0"),
+                    NewVersion = NuGetVersion.Parse("8.0.0"),
+                    UpdatedFiles = ["d2.txt"]
+                },
+            },
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "Bump Package.A, Package.B, Package.C and Package.D",
+            // expectedCommitMessage
+            """
+            Bump Package.A, Package.B, Package.C and Package.D
+
+            Bumps Package.A to 1.0.0, 2.0.0
+            Bumps Package.B to 3.0.0, 4.0.0
+            Bumps Package.C to 5.0.0, 6.0.0
+            Bumps Package.D to 7.0.0, 8.0.0
+            """,
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Package.A from 0.1.0 to 1.0.0 in a1.txt
+            - Updated Package.A from 0.2.0 to 2.0.0 in a2.txt
+            - Updated Package.B from 0.3.0 to 3.0.0 in b1.txt
+            - Updated Package.B from 0.4.0 to 4.0.0 in b2.txt
+            - Updated Package.C from 0.5.0 to 5.0.0 in c1.txt
+            - Updated Package.C from 0.6.0 to 6.0.0 in c2.txt
+            - Updated Package.D from 0.7.0 to 7.0.0 in d1.txt
+            - Updated Package.D from 0.8.0 to 8.0.0 in d2.txt
+            """
+        ];
+
+        // group with one update
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
+                }
+            },
+            // dependencyGroupName
+            "test-group",
+            // expectedTitle
+            "Bump the test-group group with 1 update",
+            // expectedCommitMessage
+            """
+            Bump the test-group group with 1 update
+
+            Bumps Some.Package from 1.0.0 to 1.2.3
+            """,
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            """
+        ];
+
+        // group with multiple updates
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.A",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Package.B",
+                    OldVersion = NuGetVersion.Parse("4.0.0"),
+                    NewVersion = NuGetVersion.Parse("4.5.6"),
+                    UpdatedFiles = ["a.txt"]
+                }
+            },
+            // dependencyGroupName
+            "test-group",
+            // expectedTitle
+            "Bump the test-group group with 2 updates",
+            // expectedCommitMessage
+            """
+            Bump the test-group group with 2 updates
+
+            Bumps Package.A from 1.0.0 to 1.2.3
+            Bumps Package.B from 4.0.0 to 4.5.6
+            """,
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Package.A from 1.0.0 to 1.2.3 in a.txt
+            - Updated Package.B from 4.0.0 to 4.5.6 in a.txt
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
@@ -21,19 +21,28 @@ public class UpdateOperationBaseTests
                 NewVersion = NuGetVersion.Parse("1.0.0"),
                 UpdatedFiles = ["file/a.txt"]
             },
-            new PinnedUpdate()
+            new DirectUpdate()
             {
                 DependencyName = "Package.B",
+                OldVersion = NuGetVersion.Parse("0.2.0"),
                 NewVersion = NuGetVersion.Parse("2.0.0"),
                 UpdatedFiles = ["file/b.txt"]
             },
-            new ParentUpdate()
+            new PinnedUpdate()
             {
                 DependencyName = "Package.C",
+                OldVersion = NuGetVersion.Parse("0.3.0"),
                 NewVersion = NuGetVersion.Parse("3.0.0"),
-                UpdatedFiles = ["file/c.txt"],
-                ParentDependencyName = "Package.D",
-                ParentNewVersion = NuGetVersion.Parse("4.0.0"),
+                UpdatedFiles = ["file/c.txt"]
+            },
+            new ParentUpdate()
+            {
+                DependencyName = "Package.D",
+                OldVersion = NuGetVersion.Parse("0.4.0"),
+                NewVersion = NuGetVersion.Parse("4.0.0"),
+                UpdatedFiles = ["file/d.txt"],
+                ParentDependencyName = "Package.E",
+                ParentNewVersion = NuGetVersion.Parse("5.0.0"),
             },
         };
 
@@ -44,8 +53,9 @@ public class UpdateOperationBaseTests
         var expectedReport = """
             Performed the following updates:
             - Updated Package.A to 1.0.0 in file/a.txt
-            - Pinned Package.B at 2.0.0 in file/b.txt
-            - Updated Package.C to 3.0.0 indirectly via Package.D/4.0.0 in file/c.txt
+            - Updated Package.B from 0.2.0 to 2.0.0 in file/b.txt
+            - Pinned Package.C at 3.0.0 in file/c.txt
+            - Updated Package.D to 4.0.0 indirectly via Package.E/5.0.0 in file/d.txt
             """.Replace("\r", "");
         Assert.Equal(expectedReport, actualReport);
     }
@@ -60,12 +70,14 @@ public class UpdateOperationBaseTests
             new DirectUpdate()
             {
                 DependencyName = "Dependency.Direct",
+                OldVersion = NuGetVersion.Parse("0.1.0"),
                 NewVersion = NuGetVersion.Parse("1.0.0"),
                 UpdatedFiles = ["/repo/root/file/a.txt"]
             },
             new PinnedUpdate()
             {
                 DependencyName = "Dependency.Pinned",
+                OldVersion = NuGetVersion.Parse("0.2.0"),
                 NewVersion = NuGetVersion.Parse("2.0.0"),
                 UpdatedFiles = ["/repo/root/file/b.txt"]
             },
@@ -73,12 +85,14 @@ public class UpdateOperationBaseTests
             new DirectUpdate()
             {
                 DependencyName = "Dependency.Direct",
+                OldVersion = NuGetVersion.Parse("0.1.0"),
                 NewVersion = NuGetVersion.Parse("1.0.0"),
                 UpdatedFiles = ["/repo/root/file/a.txt"]
             },
             new ParentUpdate()
             {
                 DependencyName = "Dependency.Parent",
+                OldVersion = NuGetVersion.Parse("0.3.0"),
                 NewVersion = NuGetVersion.Parse("3.0.0"),
                 UpdatedFiles = ["/repo/root/file/c.txt"],
                 ParentDependencyName = "Dependency.Root",
@@ -106,12 +120,14 @@ public class UpdateOperationBaseTests
             new DirectUpdate()
             {
                 DependencyName = "Dependency.Direct",
+                OldVersion = NuGetVersion.Parse("0.1.0"),
                 NewVersion = NuGetVersion.Parse("1.0.0"),
                 UpdatedFiles = ["/repo/root/file/b.txt"]
             },
             new DirectUpdate()
             {
                 DependencyName = "Dependency.Direct",
+                OldVersion = NuGetVersion.Parse("0.1.0"),
                 NewVersion = NuGetVersion.Parse("1.0.0"),
                 UpdatedFiles = ["/repo/root/file/a.txt"]
             },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTests.Mixed.cs
@@ -54,18 +54,21 @@ public partial class UpdateWorkerTests
                     new DirectUpdate()
                     {
                         DependencyName = "Package.A",
+                        OldVersion = NuGetVersion.Parse("0.1.0"),
                         NewVersion = NuGetVersion.Parse("1.0.0"),
                         UpdatedFiles = ["a.txt"]
                     },
                     new PinnedUpdate()
                     {
                         DependencyName = "Package.B",
+                        OldVersion = NuGetVersion.Parse("0.2.0"),
                         NewVersion = NuGetVersion.Parse("2.0.0"),
                         UpdatedFiles = ["b.txt"]
                     },
                     new ParentUpdate()
                     {
                         DependencyName = "Package.C",
+                        OldVersion = NuGetVersion.Parse("0.3.0"),
                         NewVersion = NuGetVersion.Parse("3.0.0"),
                         UpdatedFiles = ["c.txt"],
                         ParentDependencyName = "Package.D",
@@ -80,6 +83,7 @@ public partial class UpdateWorkerTests
                     {
                       "Type": "DirectUpdate",
                       "DependencyName": "Package.A",
+                      "OldVersion": "0.1.0",
                       "NewVersion": "1.0.0",
                       "UpdatedFiles": [
                         "a.txt"
@@ -88,6 +92,7 @@ public partial class UpdateWorkerTests
                     {
                       "Type": "PinnedUpdate",
                       "DependencyName": "Package.B",
+                      "OldVersion": "0.2.0",
                       "NewVersion": "2.0.0",
                       "UpdatedFiles": [
                         "b.txt"
@@ -98,6 +103,7 @@ public partial class UpdateWorkerTests
                       "ParentDependencyName": "Package.D",
                       "ParentNewVersion": "4.0.0",
                       "DependencyName": "Package.C",
+                      "OldVersion": "0.3.0",
                       "NewVersion": "3.0.0",
                       "UpdatedFiles": [
                         "c.txt"

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,9 +1,10 @@
 using System.Collections.Immutable;
-
-using NuGet.Versioning;
+using System.Text;
 
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Updater;
+
+using DependencySet = (string Name, (NuGet.Versioning.NuGetVersion? OldVersion, NuGet.Versioning.NuGetVersion NewVersion)[] Versions);
 
 namespace NuGetUpdater.Core.Run;
 
@@ -13,20 +14,36 @@ public class PullRequestTextGenerator
 
     public static string GetPullRequestTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        // simple version looks like
-        //   Update Some.Package to 1.2.3
-        // if multiple packages are updated to multiple versions, result looks like:
-        //   Update Package.A to 1.0.0, 2.0.0; Package.B to 3.0.0, 4.0.0
-        var dependencySets = GetDependencySets(updateOperationsPerformed);
-        var updatedPartTitles = dependencySets
-            .Select(d => $"{d.Name} to {string.Join(", ", d.Versions.Select(v => v.ToString()))}")
-            .ToArray();
-        var title = $"{job.CommitMessageOptions?.Prefix}Update {string.Join("; ", updatedPartTitles)}";
+        var shortTitle = GetPullRequestShortTitle(job, updateOperationsPerformed, dependencyGroupName);
+        var fullTitle = $"{job.CommitMessageOptions?.Prefix}{shortTitle}";
+        return fullTitle;
+    }
 
-        // don't let the title get too long
-        if (title.Length > MaxTitleLength && updatedPartTitles.Length >= 3)
+    private static string GetPullRequestShortTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
+    {
+        string title;
+        var dependencySets = GetDependencySets(updateOperationsPerformed);
+        if (dependencyGroupName is not null)
         {
-            title = $"{job.CommitMessageOptions?.Prefix}Update {dependencySets[0].Name} and {dependencySets.Length - 1} other dependencies";
+            title = $"Bump the {dependencyGroupName} group with {dependencySets.Length} update{(dependencySets.Length > 1 ? "s" : "")}";
+        }
+        else
+        {
+            if (dependencySets.Length == 1)
+            {
+                title = GetDependencySetBumpText(dependencySets[0], isCommitMessageDetail: false);
+            }
+            else
+            {
+                var dependencyNames = dependencySets.Select(d => d.Name).Distinct().OrderBy(n => n).ToArray();
+                title = $"Bump {string.Join(", ", dependencyNames.Take(dependencyNames.Length - 1))} and {dependencyNames[^1]}";
+
+                // don't let the title get too long
+                if (title.Length > MaxTitleLength && dependencyNames.Length >= 3)
+                {
+                    title = $"Bump {dependencyNames[0]} and {dependencyNames.Length - 1} others";
+                }
+            }
         }
 
         return title;
@@ -34,28 +51,33 @@ public class PullRequestTextGenerator
 
     public static string GetPullRequestCommitMessage(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        // updating a single dependency looks like
-        //   Update Some.Package to 1.2.3
-        // if multiple packages are updated, result looks like:
-        //   Update:
-        //   - Package.A to 1.0.0
-        //   - Package.B to 2.0.0
+        var sb = new StringBuilder();
+        sb.AppendLine(GetPullRequestShortTitle(job, updateOperationsPerformed, dependencyGroupName));
         var dependencySets = GetDependencySets(updateOperationsPerformed);
-        if (dependencySets.Length == 1)
+        if (dependencySets.Length > 1 ||
+            dependencyGroupName is not null)
         {
-            var depName = dependencySets[0].Name;
-            var depVersions = dependencySets[0].Versions.Select(v => v.ToString());
-            return $"Update {dependencySets[0].Name} to {string.Join(", ", depVersions)}";
+            // multiple updates performed, enumerate them
+            sb.AppendLine();
+            foreach (var dependencySet in dependencySets)
+            {
+                sb.AppendLine(GetDependencySetBumpText(dependencySet, isCommitMessageDetail: true));
+            }
         }
 
-        var updatedParts = dependencySets
-            .Select(d => $"- {d.Name} to {string.Join(", ", d.Versions.Select(v => v.ToString()))}")
-            .ToArray();
-        var message = string.Join("\n", ["Update:", .. updatedParts]);
-        return message;
+        return sb.ToString().Replace("\r", "").TrimEnd();
     }
 
-    private static (string Name, NuGetVersion[] Versions)[] GetDependencySets(ImmutableArray<UpdateOperationBase> updateOperationsPerformed)
+    private static string GetDependencySetBumpText(DependencySet dependencySet, bool isCommitMessageDetail)
+    {
+        var bumpSuffix = isCommitMessageDetail ? "s" : string.Empty; // "Bumps" for commit message details, "Bump" otherwise
+        var fromText = dependencySet.Versions.Length == 1 && dependencySet.Versions[0].OldVersion is not null
+            ? $"from {dependencySet.Versions[0].OldVersion} "
+            : string.Empty;
+        return $"Bump{bumpSuffix} {dependencySet.Name} {fromText}to {string.Join(", ", dependencySet.Versions.Select(v => v.NewVersion.ToString()))}";
+    }
+
+    private static DependencySet[] GetDependencySets(ImmutableArray<UpdateOperationBase> updateOperationsPerformed)
     {
         var dependencySets = updateOperationsPerformed
             .GroupBy(d => d.DependencyName, StringComparer.OrdinalIgnoreCase)
@@ -64,8 +86,9 @@ public class PullRequestTextGenerator
             {
                 var name = g.Key;
                 var versions = g
-                    .Select(d => d.NewVersion)
-                    .OrderBy(v => v)
+                    .OrderBy(d => d.OldVersion)
+                    .ThenBy(d => d.NewVersion)
+                    .Select(d => (d.OldVersion, d.NewVersion))
                     .ToArray();
                 return (name, versions);
             })


### PR DESCRIPTION
Make PR title and commit messages more closely match those from other ecosystems where possible.

For the high level stuff, you should really only need to look at `PullRequestTextTests.cs`.

One thing of note: to generate the proper messages we need to know the old package version that we weren't previously tracking.  To make this easier, the generation of `DirectUpdate`, `PinnedUpdate`, and `ParentUpdate` messages always defaults to `null` for the newly added `OldVersion` property.  Then after the update was performed, the old dependency version is pulled out of the original project dependency discovery.  This way we only need to perform this mapping once.

The exact titles and commit messages couldn't be reasonably copied, especially when directory names are involved because an update operation could have started in the `src/client` directory, but the final file edit happened in `common/versions.props`.  We've had negative feedback from users in the past because the directory mentioned in the title doesn't match the file that was actually changed and given the common scenario of MSBuild navigating between several directories, reporting the directory in the messages doesn't offer anything useful.  Because of that I've avoided mentioning the update directory.

Fixes #12191.