### PR TITLE
Use prerelease info to determine unique versions

### DIFF
--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -79,7 +79,7 @@ module Dependabot
 
           Dependabot::Package::PackageDetails.new(
             dependency: dependency,
-            releases: package_releases.reverse.uniq(&:version)
+            releases: package_releases.reverse.uniq{ |v| [v.version.version, v.version.prerelease?] }
           )
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes https://github.com/dependabot/dependabot-core/issues/11846, which reported that some Python packages had their latest version incorrectly detected.

### Anything you want to highlight for special attention from reviewers?

The root cause of the bug reported in https://github.com/dependabot/dependabot-core/issues/11846 is that resolution of unique python package versions here

https://github.com/dependabot/dependabot-core/blob/1ba0d840e87014309a521da4ce9872002b63614d/python/lib/dependabot/python/package/package_details_fetcher.rb#L82

doesn't include information about a versions prerelease status. Since `uniq` uses `eql?` and `hash` to compare values, [docs](https://apidock.com/ruby/Array/uniq), and `Gem::Versions` [`eql?`](https://ruby-doc.org/stdlib-2.5.0/libdoc/rubygems/rdoc/Gem/Version.html#method-i-eql-3F) returns true if two `Version`s have the same `major.minor.patch` values, regardless of prerelease status. This means that two versions, e.g. `1.1.1` and `1.1.1.dev1` evaluate to being the same version, so `uniq` falls back choosing between the "equal" versions by hash; aka randomly. In projects that use prerelease versions frequently, this means that it's much more likely a prerelease version is chosen as the "latest" version even if a stable version has been released. This is the case with pulumi, [version history](https://pypi.org/project/pulumi/#history), referenced in the issue filed above, and also in the case where I observed the bug, with duckdb, [version history](https://pypi.org/project/duckdb/#history).

This PR addresses the issue by explicitly using prerelease info in the call to `uniq`.

```rb
releases: package_releases.reverse.uniq{ |v| [v.version.version, v.version.prerelease?] }
```

This causes more versions to be included in the release list since prerelease-ness is a new dimension uniqueness is evaluated over. While this causes the correct version to be detected, it may not be the "right" way to perform this operation (I'm not a ruby dev), or may break expectations in other parts of the codebase. I'd be happy to change the fix if either of these are the case.

### How will you know you've accomplished your goal?

I started my investigation into this bug by observing that the logs in our dependabot action for a project that uses duckdb (the package we were seeing the issue with)

```
updater | 2025/05/29 13:36:42 INFO <job_1023963999> Checking if duckdb 1.3.0 needs updating
updater | 2025/05/29 13:36:42 INFO <job_1023963999> Fetching release information from json registry at https://pypi.org/pypi/ for duckdb
  proxy | 2025/05/29 13:36:42 [381] GET https://pypi.org/pypi/duckdb/json
  proxy | 2025/05/29 13:36:42 [381] 200 https://pypi.org/pypi/duckdb/json
updater | 2025/05/29 13:36:42 INFO <job_1023963999> Filtered out 2 pre-release versions
updater | 2025/05/29 13:36:42 INFO <job_1023963999> Latest version is 1.2.2
updater | 2025/05/29 13:36:42 INFO <job_1023963999> No update needed for duckdb 1.3.0
```

Here you can see that we had manually upgraded duckdb to latest, 1.3.0, but that dependabot was getting `1.2.2` as the latest.

Following the instructions in this repo's readme for [debugging problems](https://github.com/dependabot/dependabot-core?tab=readme-ov-file#debugging-problems) I ran dependabot locally against my private repo and reproduced the issue

```
[dependabot-core-dev] ~ $ LOCAL_GITHUB_ACCESS_TOKEN=<redacted> bin/dry-run.rb pip <redacted>
=> cloning into <redacted>
I, [2025-05-30T13:18:52.068977 #11]  INFO -- : Dependabot is using Python version '3.11.11'.
🎈 Ecosystem Versions log: {:languages=>{:python=>{"raw"=>"^3.11", "max"=>"3.11"}}}
=> parsing dependency files
=> updating 3 dependencies: duckdb, pydantic, pyright

=== duckdb (1.3.0)
 => checking for updates 1/3
I, [2025-05-30T13:18:56.912933 #11]  INFO -- : Fetching release information from html registry at https://pypi.org/simple/ for duckdb
🌍 --> GET https://pypi.org/simple/duckdb/
🌍 <-- 200 https://pypi.org/simple/duckdb/
I, [2025-05-30T13:18:57.937809 #11]  INFO -- : Filtered out 2 pre-release versions
 => latest available version is 1.2.2
    (no update needed as it's already up-to-date)
```

After making the change in this PR and running locally again we see the expected version resolved.

```
[dependabot-core-dev] ~ $ LOCAL_GITHUB_ACCESS_TOKEN=<redacted> bin/dry-run.rb pip <redacted>
=> cloning into <redacted>
I, [2025-05-30T13:18:52.068977 #11]  INFO -- : Dependabot is using Python version '3.11.11'.
🎈 Ecosystem Versions log: {:languages=>{:python=>{"raw"=>"^3.11", "max"=>"3.11"}}}
=> parsing dependency files
=> updating 3 dependencies: duckdb, pydantic, pyright

=== duckdb (1.3.0)
 => checking for updates 1/3
I, [2025-05-30T13:20:01.405055 #312]  INFO -- : Fetching release information from html registry at https://pypi.org/simple/ for duckdb
🌍 --> GET https://pypi.org/simple/duckdb/
🌍 <-- 200 https://pypi.org/simple/duckdb/
I, [2025-05-30T13:20:01.819606 #312]  INFO -- : Filtered out 2 pre-release versions
 => latest available version is 1.3.0
    (no update needed as it's already up-to-date)
```

I'm happy to add a regression test but would need some pointers on where to do so.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
