### PR TITLE
ensure padding after prefix

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -104,7 +104,7 @@ public class PullRequestTextTests
             // expectedTitle
             "[SECURITY] Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedCommitMessage
-            "Bump Some.Package from 1.0.0 to 1.2.3",
+            "[SECURITY] Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedBody
             """
             Performed the following updates:
@@ -133,7 +133,7 @@ public class PullRequestTextTests
             // expectedTitle
             "chore(deps): Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedCommitMessage
-            "Bump Some.Package from 1.0.0 to 1.2.3",
+            "chore(deps): Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedBody
             """
             Performed the following updates:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -83,7 +83,7 @@ public class PullRequestTextTests
             """
         ];
 
-        // single dependency, prefix given
+        // single dependency, prefix given, ends with space
         yield return
         [
             // job
@@ -103,6 +103,35 @@ public class PullRequestTextTests
             null,
             // expectedTitle
             "[SECURITY] Bump Some.Package from 1.0.0 to 1.2.3",
+            // expectedCommitMessage
+            "Bump Some.Package from 1.0.0 to 1.2.3",
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            """
+        ];
+
+        // single dependency, prefix given, ends with character or bracket
+        yield return
+        [
+            // job
+            FromCommitOptions(new(){ Prefix = "chore(deps)" }),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
+                }
+            },
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "chore(deps): Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedCommitMessage
             "Bump Some.Package from 1.0.0 to 1.2.3",
             // expectedBody

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -75,7 +75,7 @@ public class PullRequestTextGenerator
     public static string GetPullRequestCommitMessage(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(GetPullRequestShortTitle(job, updateOperationsPerformed, dependencyGroupName));
+        sb.AppendLine(GetPullRequestTitle(job, updateOperationsPerformed, dependencyGroupName));
         var dependencySets = GetDependencySets(updateOperationsPerformed);
         if (dependencySets.Length > 1 ||
             dependencyGroupName is not null)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Updater;
@@ -15,8 +16,30 @@ public class PullRequestTextGenerator
     public static string GetPullRequestTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
         var shortTitle = GetPullRequestShortTitle(job, updateOperationsPerformed, dependencyGroupName);
-        var fullTitle = $"{job.CommitMessageOptions?.Prefix}{shortTitle}";
+        var titlePrefix = GetPullRequestTitlePrefix(job);
+        var fullTitle = $"{titlePrefix}{shortTitle}";
         return fullTitle;
+    }
+
+    private static string GetPullRequestTitlePrefix(Job job)
+    {
+        if (string.IsNullOrEmpty(job.CommitMessageOptions?.Prefix))
+        {
+            return string.Empty;
+        }
+
+        var prefix = job.CommitMessageOptions?.Prefix ?? string.Empty;
+        if (Regex.IsMatch(prefix, @"[a-z0-9\)\]]$", RegexOptions.IgnoreCase))
+        {
+            prefix += ":";
+        }
+
+        if (!prefix.EndsWith(" "))
+        {
+            prefix += " ";
+        }
+
+        return prefix;
     }
 
     private static string GetPullRequestShortTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)


### PR DESCRIPTION
PR #12343 missed a scenario where the PR prefix is separated from the rest of the title.  Thanks to @samtrion for finding this so quickly after yesterday's merge.  Implementation inspired by `pr_name_prefixer.rb` line 106.