### PR TITLE
add pattern for unparseable NuGet.Config

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -1924,6 +1924,17 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new DependencyFileNotParseable("/path/to/packages.config", "Some error message."),
         ];
+
+        yield return
+        [
+            // output
+            """
+            NuGet.Config is not valid XML. Path: '/path/to/NuGet.Config'.
+              Some error message.
+            """,
+            // expectedError
+            new DependencyFileNotParseable("/path/to/NuGet.Config", "Some error message."),
+        ];
     }
 
     public static IEnumerable<object[]> GetTopLevelPackageDependencyInfosTestData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -1080,6 +1080,7 @@ internal static partial class MSBuildHelper
         var patterns = new[]
         {
             new Regex(@"\nAn error occurred while reading file '(?<FilePath>[^']+)': (?<Message>[^\n]*)\n"),
+            new Regex(@"NuGet\.Config is not valid XML\. Path: '(?<FilePath>[^']+)'\.\n\s*(?<Message>[^\n]*)(\n|$)"),
         };
         var match = patterns.Select(p => p.Match(output)).Where(m => m.Success).FirstOrDefault();
         if (match is not null)


### PR DESCRIPTION
A manual audit of internal logs found an instance of a `NuGet.Config` file that couldn't be parsed by `nuget.exe`.  Instead of turning this into `unknown_error`, this can be transformed into `dependency_file_not_parseable`.