### PR TITLE
Use install instead of update when updating pnpm dependencies 

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -4,7 +4,8 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG COREPACK_VERSION=0.32.0
 
 # Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=10.11.0
+# TODO: Update to >10.11 after https://github.com/pnpm/pnpm/issues/9519 has been resolved
+ARG PNPM_VERSION=10.8.1
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
 ARG YARN_VERSION=4.7.0

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -168,8 +168,8 @@ module Dependabot
           end.join(" ")
 
           Helpers.run_pnpm_command(
-            "update #{dependency_updates}  --lockfile-only --no-save -r",
-            fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r"
+            "install #{dependency_updates} --lockfile-only -r",
+            fingerprint: "install <dependency_updates> --lockfile-only -r"
           )
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       .with(:enable_corepack_for_npm_and_yarn).and_return(enable_corepack_for_npm_and_yarn)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:avoid_duplicate_updates_package_json).and_return(true)
   end
 
   after do
@@ -712,11 +714,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           }
         end
 
-        it "uses pnpm update followed by install" do
+        it "uses pnpm install followed by install" do
           expect(Dependabot::NpmAndYarn::Helpers).not_to receive(:run_pnpm_command)
             .with(
-              "update prettier@3.3.3  --lockfile-only --no-save -r",
-              { fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r" }
+              "install prettier@3.3.3 --lockfile-only -r",
+              { fingerprint: "install <dependency_updates> --lockfile-only -r" }
             )
           expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)
             .with("install --lockfile-only")
@@ -727,11 +729,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       end
 
       context "when updating a regular package dependency" do
-        it "uses pnpm update followed by install" do
+        it "uses pnpm install followed by install" do
           expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)
             .with(
-              "update prettier@3.3.3  --lockfile-only --no-save -r",
-              { fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r" }
+              "install prettier@3.3.3 --lockfile-only -r",
+              { fingerprint: "install <dependency_updates> --lockfile-only -r" }
             )
             .ordered
           expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)


### PR DESCRIPTION
### What are you trying to accomplish?

A lot users are having issues with the latest version of pnpm. This PR downgrades pnpm to 10.8.1 to resolve these issues as this version is unaffected by this. It also switches from using `update` to `install` when updating pnpm dependencies. 

**Related issue:** https://github.com/dependabot/dependabot-core/issues/11246

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

At some point we will need to update pnpm to a version greater than 10.11.0 and possibly revert this install change. But at the moment we are going to use 10.8.1 until the issues with the latest version are resolved.

**Related bug ticket:** https://github.com/pnpm/pnpm/issues/9519

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Dependabot's pnpm updater will only update a specific dependency rather than regenerate the metadata for all packages. We don't know if this is intentional behaviour or something that will be fixed in a future release.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
