### PR TITLE
Enhance nuget updater to support ADO OnPrem URLs

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -11,6 +11,33 @@ public class CloneWorkerTests
     private const string TestRepoPath = "TEST/REPO/PATH";
 
     [Fact]
+    public void AdoCloneCommandsAreGenerated()
+    {
+        TestCommands(
+            provider: "azure",
+            repoMoniker: "OrganizationName/ProjectName/_git/RepositoryName",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "https://dev.azure.com/OrganizationName/ProjectName/_git/RepositoryName", TestRepoPath], null)
+            ]
+        );
+    }
+
+    [Fact]
+    public void AdoOnPremCloneCommandsAreGenerated()
+    {
+        TestCommands(
+            provider: "azure",
+            hostname: "azure-onprem-url.domain.org",
+            repoMoniker: "CollectionName/ProjectName/_git/RepositoryName",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "https://azure-onprem-url.domain.org/CollectionName/ProjectName/_git/RepositoryName", TestRepoPath], null)
+            ]
+        );
+    }
+
+    [Fact]
     public void CloneCommandsAreGenerated()
     {
         TestCommands(
@@ -172,13 +199,14 @@ public class CloneWorkerTests
         }
     }
 
-    private static void TestCommands(string provider, string repoMoniker, (string[] Args, string? WorkingDirectory)[] expectedCommands, string? branch = null, string? commit = null)
+    private static void TestCommands(string provider, string repoMoniker, (string[] Args, string? WorkingDirectory)[] expectedCommands, string? branch = null, string? commit = null, string? hostname = null)
     {
         var job = new Job()
         {
             Source = new()
             {
                 Provider = provider,
+                Hostname = hostname,
                 Repo = repoMoniker,
                 Branch = branch,
                 Commit = commit,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -168,6 +168,7 @@ public class CloneWorker
     {
         return job.Source.Provider switch
         {
+            "azure" when !string.IsNullOrWhiteSpace(job.Source.Hostname) => $"https://{job.Source.Hostname}/{job.Source.Repo}",
             "azure" => $"https://dev.azure.com/{job.Source.Repo}",
             "github" => $"https://github.com/{job.Source.Repo}",
             _ => throw new ArgumentException($"Unknown provider: {job.Source.Provider}")


### PR DESCRIPTION
### What are you trying to accomplish?
The nuget native updater does currently only support `github` and **hosted** `azure` repository for update
but no OnPrem ADO, with a private ADO (not `dev.azure.com`) url.

See also https://github.com/tinglesoftware/dependabot-azure-devops/issues/1720#issuecomment-2899340259

calling the CLI 
```bash
dependabot update --file /tmp/dependabot-jobs/job.yaml --output /tmp/dependabot-jobs/scenario.yaml --provider azure
```

with this job configuration (shortened)
```json
{
  "package-manager": "nuget",
  "allowed-updates": [
    {
      "dependency-type": "direct",
      "update-type": "all"
    }
  ],
  "debug": false,
  "dependency-groups": [],
  "dependencies": null,
  "dependency-group-to-refresh": null,
  "existing-pull-requests": [],
  "existing-group-pull-requests": [],
  "experiments": {
// snip
    "nuget-install-dotnet-sdks": true,
    "nuget-native-analysis": true,
    "nuget-native-updater": true,
    "nuget-use-direct-discovery": true,
    "nuget-use-legacy-updater-when-updating-pr": true,
// snip
  },
  "ignore-conditions": [],
  "lockfile-only": false,
  "requirements-update-strategy": null,
  "security-advisories": [],
  "security-updates-only": false,
  "source": {
    "provider": "azure",
    "repo": "tfs/CollectionName/ProjectName/_git/RepositoryName",
    "directory": "/",
    "hostname": "azure-onprem-url.domain.org",
    "api-endpoint": "https://azure-onprem-url.domain.org:/tfs/"
  },
  "update-subdependencies": false,
  "updating-a-pull-request": false,
  "vendor-dependencies": false,
  "reject-external-code": false,
  "repo-private": false,
  "commit-message-options": null,
  "credentials-metadata": [
    {
      "host": "azure-onprem-url.domain.org",
      "type": "git_source"
    }
  ],
  "max-updater-run-time": 2700
}
```

results in this call:
```
Running command: git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://dev.azure.com/tfs/CollectionName/ProjectName/_git/RepositoryName /home/dependabot/dependabot-updater/repo
```

which results in a call to 
```
GET https://dev.azure.com:443/tfs/CollectionName/ProjectName/_git/RepositoryName/info/refs?service=git-upload-pack
404 https://dev.azure.com:443/tfs/CollectionName/ProjectName/_git/RepositoryName/info/refs?service=git-upload-pack
```

 _see also [#3620](https://github.com/dependabot/dependabot-core/issues/3620#issuecomment-1443514961) from some older discussions_


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
