### PR TITLE
`pnpm-workspace.yaml` should not be considered a support file

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -339,14 +339,12 @@ module Dependabot
         return @pnpm_workspace_yaml if defined?(@pnpm_workspace_yaml)
 
         @pnpm_workspace_yaml = T.let(
-          fetch_support_file(PNPMPackageManager::PNPM_WS_YML_FILENAME),
+          fetch_file_if_present(PNPMPackageManager::PNPM_WS_YML_FILENAME),
           T.nilable(DependencyFile)
         )
 
         # Only fetch from parent directories if the file wasn't found initially
         @pnpm_workspace_yaml ||= fetch_file_from_parent_directories(PNPMPackageManager::PNPM_WS_YML_FILENAME)
-
-        @pnpm_workspace_yaml
       end
 
       sig { returns(T.nilable(DependencyFile)) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2092,6 +2092,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       it "parses the YAML content" do
         expect(file_fetcher.send(:parsed_pnpm_workspace_yaml)).to eq({ "packages" => ["packages/*"] })
       end
+
+      it "is not a support file" do
+        expect(file_fetcher.send(:pnpm_workspace_yaml).support_file).to be_falsey
+      end
     end
 
     context "when it's content contains valid alias" do


### PR DESCRIPTION
### What are you trying to accomplish?

Currently we are stripping out `pnpm-workspace.yaml` when are creating workspace bump pull requests,

**Attempt to fix:** https://github.com/dependabot/dependabot-core/issues/11953

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

n/a 

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Pull requests that update pnpm workspace yaml files will now be included in the bump pull request

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
