### PR TITLE
Add support for `OnPrem` Azure DevOps in `Dependabot.Source`

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -194,7 +194,14 @@ module Dependabot
 
     sig { returns(String) }
     def organization
-      T.must(repo.split("/").first)
+      case provider
+      when "azure"
+        prefix = T.must(repo.split("/#{project}/").first)
+        parts = prefix.split("/")
+        repo.end_with?(project) ? T.must(parts.first) : T.must(parts.last)
+      else
+        T.must(repo.split("/").first)
+      end
     end
 
     sig { returns(String) }
@@ -202,7 +209,7 @@ module Dependabot
       raise "Project is an Azure DevOps concept only" unless provider == "azure"
 
       parts = repo.split("/_git/")
-      return T.must(T.must(parts.first).split("/").last) if parts.first&.split("/")&.count == 2
+      return T.must(T.must(parts.first).split("/").last) if parts.first&.split("/")&.count&.>=(2)
 
       T.must(parts.last)
     end

--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -196,9 +196,8 @@ module Dependabot
     def organization
       case provider
       when "azure"
-        prefix = T.must(repo.split("/#{project}/").first)
-        parts = prefix.split("/")
-        repo.end_with?(project) ? T.must(parts.first) : T.must(parts.last)
+        parts = repo.split("/_git/")
+        T.must(T.must(parts.first).split("/").last(2).first)
       else
         T.must(repo.split("/").first)
       end

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Dependabot::Source do
 
       specify { expect { source }.to raise_error(/hostname and api_endpoint/) }
     end
+
+    context "with an OnPrem Azure DevOps" do
+      let(:attrs) do
+        {
+          provider: "azure",
+          repo: "tfs/CollectionName/ProjectName/_git/RepositoryName",
+          hostname: "azure-onprem-url.domain.org",
+          api_endpoint: "https://azure-onprem-url.domain.org:/tfs/"
+        }
+      end
+
+      its(:url) { is_expected.to eq("https://azure-onprem-url.domain.org/tfs/CollectionName/ProjectName/_git/RepositoryName") }
+      its(:unscoped_repo) { is_expected.to eq("RepositoryName") }
+      its(:organization) { is_expected.to eq("CollectionName") }
+      its(:project) { is_expected.to eq("ProjectName") }
+    end
   end
 
   describe ".from_url" do


### PR DESCRIPTION
### What are you trying to accomplish?
Add support for **OnPrem** Azure DevOps repository URLs (currently only Hosted Azure DevOps urls are supported: `https://dev.azure.com`)

Enhance `organization` and `project` methods in `source.rb` to correctly extract organization and project names.
Add tests in `source_spec.rb` to validate behavior for On-Prem Azure DevOps configurations.

See also: #12364

current implementation, executed with this source configuration (using dependabot cli)

```yaml
  "source": {
    "provider": "azure",
    "repo": "tfs/CollectionName/ProjectName/_git/RepositoryName",
    "directory": "/",
    "hostname": "azure-onprem-url.domain.org",
    "api-endpoint": "https://azure-onprem-url.domain.org:/tfs/"
  },
```

results in a bad repository url:
```
##updater | INFO <job_update_0_nuget_all> Submitting CsvHelper pull request for creation
##[debug]proxy | GET https://azure-onprem-url.domain.org/tfs/tfs/RepositoryName/_apis/git/repositories/RepositoryName/commits
##[debug]proxy | * authenticating git server request (host: azure-onprem-url.domain.org)
##[debug]proxy | 401 https://azure-onprem-url.domain.org/tfs/tfs/RepositoryName/_apis/git/repositories/RepositoryName/commits
##[debug]proxy | GET https://azure-onprem-url.domain.org/tfs/tfs/RepositoryName/_apis/git/repositories/RepositoryName/commits
##[debug]proxy | 401 https://azure-onprem-url.domain.org/tfs/tfs/RepositoryName/_apis/git/repositories/RepositoryName/commits
##[debug]proxy | * auth'd git request previously retried, won't retry again.
##updater | ERROR <job_update_0_nuget_all> Error while generating PR name: Dependabot::Clients::Azure::Unauthorized
##updater | ERROR <job_update_0_nuget_all> /home/dependabot/common/lib/dependabot/clients/azure.rb:351:in `get'
```

currently the values are
```ruby
api_endpoint = "https://azure-onprem-url.domain.org/tfs/"
organization = "tfs"
project = "RepositoryName"
unscoped_repo = "RepositoryName"
```

but should be 
```ruby
api_endpoint = "https://azure-onprem-url.domain.org/tfs/"
organization = "CollectionName"
project = "ProjectName"
unscoped_repo = "RepositoryName"
```



### Anything you want to highlight for special attention from reviewers?

I'm not a Ruby developer, but I've done my best to implement it. I'm open to suggestions for improvements or feedback.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
