### PR TITLE
don't assume a previous dependency could be found

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateOperationBaseTests.cs
@@ -161,6 +161,7 @@ public class UpdateOperationBaseTests
 
     public static IEnumerable<object[]> ToReportedDependencyTestData()
     {
+        // direct mapping
         yield return
         [
             // updateOperation
@@ -198,6 +199,44 @@ public class UpdateOperationBaseTests
                 PreviousVersion = "1.0.0",
                 PreviousRequirements = [
                     new() { Requirement = "1.0.0", File = "project.csproj" }
+                ],
+            },
+        ];
+
+        // updated dependency brought in new package not previously known
+        yield return
+        [
+            // updateOperation
+            new DirectUpdate()
+            {
+                DependencyName = "Transitive.Package",
+                NewVersion = NuGetVersion.Parse("3.0.0"),
+                UpdatedFiles = ["project.csproj"]
+            },
+            // previouslyReportedDependencies
+            new ReportedDependency[]
+            {
+                new()
+                {
+                    Name = "Some.Package",
+                    Version = "1.0.0",
+                    Requirements = [
+                        new() { Requirement = "1.0.0", File = "project.csproj" }
+                    ]
+                }
+            },
+            // updatedDependencies
+            new Dependency[]
+            {
+                new("Transitive.Package", "3.0.0", DependencyType.Unknown),
+            },
+            // expectedReportedDependency
+            new ReportedDependency()
+            {
+                Name = "Transitive.Package",
+                Version = "3.0.0",
+                Requirements = [
+                    new() { Requirement = "3.0.0", File = "project.csproj", Source = new() { SourceUrl = null } }
                 ],
             },
         ];

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -27,7 +27,7 @@ public abstract record UpdateOperationBase
     {
         var updatedFilesSet = UpdatedFiles.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var previousDependency = previouslyReportedDependencies
-            .Single(d => d.Name.Equals(DependencyName, StringComparison.OrdinalIgnoreCase) && PathComparer.Instance.Equals(d.Requirements.Single().File, projectPath));
+            .SingleOrDefault(d => d.Name.Equals(DependencyName, StringComparison.OrdinalIgnoreCase) && PathComparer.Instance.Equals(d.Requirements.Single().File, projectPath));
         return new ReportedDependency()
         {
             Name = DependencyName,
@@ -37,15 +37,15 @@ public abstract record UpdateOperationBase
                 {
                     File = projectPath,
                     Requirement = NewVersion.ToString(),
-                    Groups = previousDependency.Requirements.FirstOrDefault()?.Groups ?? [],
+                    Groups = previousDependency?.Requirements.FirstOrDefault()?.Groups ?? [],
                     Source = new()
                     {
                         SourceUrl = updatedDependencies.FirstOrDefault(d => d.Name.Equals(DependencyName, StringComparison.OrdinalIgnoreCase))?.InfoUrl,
                     }
                 }
             ],
-            PreviousVersion = previousDependency.Version,
-            PreviousRequirements = previousDependency.Requirements,
+            PreviousVersion = previousDependency?.Version,
+            PreviousRequirements = previousDependency?.Requirements,
         };
     }
 


### PR DESCRIPTION
Issue found during a manual scan of the logs.

The list of updates performed is matched against the initially reported dependencies so the exact update can be tracked.  If in the process of updating a package a new transitive dependency came along, there won't be a previous version of the dependency.

The fix is to change a call to `.Single()` to `.SingleOrDefault()` and add some null-safe navigation.