### PR TITLE
always report the same dependency set when closing or updating

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
@@ -263,7 +263,7 @@ public class RefreshSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsB
                         ["operation"] = "update_security_pr",
                     }
                 },
-                new ClosePullRequest() { DependencyNames = ["Other.Dependency"], Reason = "dependency_removed" },
+                new ClosePullRequest() { DependencyNames = ["Other.Dependency", "Some.Dependency"], Reason = "dependency_removed" },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
         );

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
@@ -254,7 +254,7 @@ public class RefreshVersionUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         ["operation"] = "update_version_pr",
                     }
                 },
-                new ClosePullRequest() { DependencyNames = ["Other.Dependency"], Reason = "dependency_removed" },
+                new ClosePullRequest() { DependencyNames = ["Other.Dependency", "Some.Dependency"], Reason = "dependency_removed" },
                 new MarkAsProcessed("TEST-COMMIT-SHA"),
             ]
         );

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ClosePullRequest.cs
@@ -22,4 +22,19 @@ public sealed record ClosePullRequest : MessageBase
 
         return report.ToString().Trim();
     }
+
+    public static ClosePullRequest WithDependenciesChanged(Job job) => CloseWithReason(job, "dependencies_changed");
+    public static ClosePullRequest WithDependenciesRemoved(Job job) => CloseWithReason(job, "dependencies_removed");
+    public static ClosePullRequest WithDependencyRemoved(Job job) => CloseWithReason(job, "dependency_removed");
+    public static ClosePullRequest WithUpdateNoLongerPossible(Job job) => CloseWithReason(job, "update_no_longer_possible");
+    public static ClosePullRequest WithUpToDate(Job job) => CloseWithReason(job, "up_to_date");
+
+    private static ClosePullRequest CloseWithReason(Job job, string reason)
+    {
+        return new ClosePullRequest()
+        {
+            DependencyNames = [.. job.Dependencies.Distinct().OrderBy(n => n, StringComparer.OrdinalIgnoreCase)],
+            Reason = reason,
+        };
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -145,7 +145,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
             var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
             if (rawDependencies.Length == 0)
             {
-                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "update_no_longer_possible" });
+                await apiHandler.ClosePullRequest(ClosePullRequest.WithUpdateNoLongerPossible(job));
                 continue;
             }
 
@@ -157,7 +157,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
             {
                 await apiHandler.UpdatePullRequest(new UpdatePullRequest()
                 {
-                    DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                    DependencyNames = [.. jobDependencies.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)],
                     DependencyGroup = group.Name,
                     UpdatedDependencyFiles = [.. updatedDependencyFiles],
                     BaseCommitSha = baseCommitSha,
@@ -172,11 +172,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
                 if (existingPrButDifferent is not null)
                 {
-                    await apiHandler.ClosePullRequest(new ClosePullRequest()
-                    {
-                        DependencyNames = [.. rawDependencies.Select(d => d.Name)],
-                        Reason = "dependencies_changed",
-                    });
+                    await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
                 }
 
                 await apiHandler.CreatePullRequest(new CreatePullRequest()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -55,7 +55,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
 
             if (groupedUpdateOperationsToPerform.Count == 0)
             {
-                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "dependencies_removed" });
+                await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesRemoved(job));
                 continue;
             }
 
@@ -65,7 +65,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 .ToImmutableArray();
             if (missingDependencies.Length > 0)
             {
-                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = missingDependencies, Reason = "dependency_removed" });
+                await apiHandler.ClosePullRequest(ClosePullRequest.WithDependencyRemoved(job));
                 continue;
             }
 
@@ -82,7 +82,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
 
                 if (vulnerableDependenciesToUpdate.Length < dependencyGroupToUpdate.Value.Length)
                 {
-                    await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "up_to_date" });
+                    await apiHandler.ClosePullRequest(ClosePullRequest.WithUpToDate(job));
                     return;
                 }
 
@@ -99,7 +99,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                     if (!analysisResult.CanUpdate)
                     {
                         logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
-                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithUpdateNoLongerPossible(job));
                         return;
                     }
 
@@ -115,7 +115,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
 
                     if (updaterResult.UpdateOperations.Length == 0)
                     {
-                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithUpdateNoLongerPossible(job));
                         return;
                     }
 
@@ -146,7 +146,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 {
                     await apiHandler.UpdatePullRequest(new UpdatePullRequest()
                     {
-                        DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                        DependencyNames = [.. jobDependencies.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)],
                         DependencyGroup = null,
                         UpdatedDependencyFiles = [.. updatedDependencyFiles],
                         BaseCommitSha = baseCommitSha,
@@ -161,11 +161,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                     var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
                     if (existingPrButDifferent is not null)
                     {
-                        await apiHandler.ClosePullRequest(new ClosePullRequest()
-                        {
-                            DependencyNames = [.. rawDependencies.Select(d => d.Name)],
-                            Reason = "dependencies_changed",
-                        });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
                     }
 
                     await apiHandler.CreatePullRequest(new CreatePullRequest()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -53,7 +53,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
             if (relevantUpdateOperationsToPerform.Count == 0)
             {
-                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = job.Dependencies, Reason = "dependencies_removed" });
+                await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesRemoved(job));
                 continue;
             }
 
@@ -63,7 +63,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 .ToImmutableArray();
             if (missingDependencies.Length > 0)
             {
-                await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = missingDependencies, Reason = "dependency_removed" });
+                await apiHandler.ClosePullRequest(ClosePullRequest.WithDependencyRemoved(job));
                 continue;
             }
 
@@ -92,7 +92,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                     if (!analysisResult.CanUpdate)
                     {
                         logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
-                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithUpdateNoLongerPossible(job));
                         return;
                     }
 
@@ -108,7 +108,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
                     if (updaterResult.UpdateOperations.Length == 0)
                     {
-                        await apiHandler.ClosePullRequest(new ClosePullRequest() { DependencyNames = [dependencyName], Reason = "update_no_longer_possible" });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithUpdateNoLongerPossible(job));
                         return;
                     }
 
@@ -139,7 +139,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 {
                     await apiHandler.UpdatePullRequest(new UpdatePullRequest()
                     {
-                        DependencyNames = [.. updatedDependencies.Select(d => d.Name)],
+                        DependencyNames = [.. jobDependencies.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)],
                         DependencyGroup = null,
                         UpdatedDependencyFiles = [.. updatedDependencyFiles],
                         BaseCommitSha = baseCommitSha,
@@ -154,11 +154,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                     var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
                     if (existingPrButDifferent is not null)
                     {
-                        await apiHandler.ClosePullRequest(new ClosePullRequest()
-                        {
-                            DependencyNames = [.. rawDependencies.Select(d => d.Name)],
-                            Reason = "dependencies_changed",
-                        });
+                        await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
                     }
 
                     await apiHandler.CreatePullRequest(new CreatePullRequest()


### PR DESCRIPTION
Reviewing some internal logs, the service will sometimes return a `400` when trying to call `close_pull_request` or `update_pull_request`.  Examining the service code reports that the body of those requests is expected to contain the same set of dependency names that started the job, not just reporting the offending dependencies.

To make this easier to use going forward, the numerous calls to `close_pull_request` were replaced with a helper that takes the actual job so the dependency names can be correctly constructed.

The calls to `update_pull_request` are more complicated and were patched in-place.