### PR TITLE
mount the SSH_AUTH_SOCK socket for ssh-agent

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -109,6 +109,16 @@ if [ "$#" -gt "1" ]; then
   CONTAINER_ARGS=("${@:2}")
 fi
 
+# Use Docker Desktop's special SSH agent path
+export SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+
+# for Mac with Docker Desktop or Rancher Desktop, use:Add commentMore actions
+# SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock ./bin/docker-dev-shell go_modules -r
+if [ -n "$SSH_AUTH_SOCK" ]; then
+  DOCKER_OPTS+=("-v" "$SSH_AUTH_SOCK:/tmp/ssh-auth.sock")
+  DOCKER_OPTS+=("-e" "SSH_AUTH_SOCK=/tmp/ssh-auth.sock")
+fi
+
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot"
 touch .core-bash_history # allow bash history to persist across invocations


### PR DESCRIPTION
### What are you trying to accomplish?

Please refer to the description [here in this PR](https://github.com/dependabot/dependabot-core/pull/11683) generated by @dmitris 

Above PR has been reverted: https://github.com/dependabot/dependabot-core/pull/11818
Reason provided in above PR description.

This PR fixes the issue by 

Instead of relying on the full macOS path to the socket (which lives in a temporary directory like /private/tmp/...), Docker Desktop provides a special path to access host services safely:

`/run/host-services/ssh-auth.sock` is Docker Desktop’s mapped socket, which avoids the issues of directly accessing macOS paths like `/private/tmp/....`


### Anything you want to highlight for special attention from reviewers?

Ran in the Local and ensured the error mentioned by @robaiken is fixed by this changes

```
docker: Error response from daemon: error while creating mount source path '/host_mnt/private/tmp/com.apple.launchd.Q3NRTvcke4/Listeners': mkdir /host_mnt/private/tmp/com.apple.launchd.Q3NRTvcke4/Listeners: operation not supported```
```

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
