### PR TITLE
don't repeat the same version number in pr title

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -402,6 +402,45 @@ public class PullRequestTextTests
             - Updated Package.B from 4.0.0 to 4.5.6 in a.txt
             """
         ];
+
+        // multiple updates to the same dependency
+        yield return
+        [
+            // job
+            FromCommitOptions(null),
+            // updateOperationsPerformed
+            new UpdateOperationBase[]
+            {
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["a.txt"]
+                },
+                new DirectUpdate()
+                {
+                    DependencyName = "Some.Package",
+                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    NewVersion = NuGetVersion.Parse("1.2.3"),
+                    UpdatedFiles = ["b.txt"]
+                }
+            },
+            // dependencyGroupName
+            null,
+            // expectedTitle
+            "Bump Some.Package to 1.2.3",
+            // expectedCommitMessage
+            """
+            Bump Some.Package to 1.2.3
+            """,
+            // expectedBody
+            """
+            Performed the following updates:
+            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3 in b.txt
+            """
+        ];
     }
 
     private static Job FromCommitOptions(CommitOptions? commitOptions)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -97,7 +97,12 @@ public class PullRequestTextGenerator
         var fromText = dependencySet.Versions.Length == 1 && dependencySet.Versions[0].OldVersion is not null
             ? $"from {dependencySet.Versions[0].OldVersion} "
             : string.Empty;
-        return $"Bump{bumpSuffix} {dependencySet.Name} {fromText}to {string.Join(", ", dependencySet.Versions.Select(v => v.NewVersion.ToString()))}";
+        var newVersions = dependencySet.Versions
+            .Select(v => v.NewVersion)
+            .Distinct()
+            .OrderBy(v => v)
+            .ToArray();
+        return $"Bump{bumpSuffix} {dependencySet.Name} {fromText}to {string.Join(", ", newVersions.Select(v => v.ToString()))}";
     }
 
     private static DependencySet[] GetDependencySets(ImmutableArray<UpdateOperationBase> updateOperationsPerformed)


### PR DESCRIPTION
The PR title is created from all package version updates that occurred, but if the same update was performed in multiple locations, we can collapse the versions so that instead of getting this:

```
Bump Some.Package to 1.2.3, 1.2.3
```

We get a single:

```
Bump Some.Package to 1.2.3
```