### PR TITLE
Fix pip latest version detection when final releases follow prereleases

### DIFF
--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -79,7 +79,7 @@ module Dependabot
 
           Dependabot::Package::PackageDetails.new(
             dependency: dependency,
-            releases: package_releases.reverse.uniq { |r| r.version.to_s }
+            releases: package_releases
           )
         end
 

--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -79,7 +79,7 @@ module Dependabot
 
           Dependabot::Package::PackageDetails.new(
             dependency: dependency,
-            releases: package_releases.reverse.uniq(&:version)
+            releases: package_releases.reverse.uniq { |r| r.version.to_s }
           )
         end
 

--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -79,7 +79,7 @@ module Dependabot
 
           Dependabot::Package::PackageDetails.new(
             dependency: dependency,
-            releases: package_releases
+            releases: package_releases.reverse
           )
         end
 

--- a/uv/lib/dependabot/uv/package/package_details_fetcher.rb
+++ b/uv/lib/dependabot/uv/package/package_details_fetcher.rb
@@ -79,7 +79,7 @@ module Dependabot
 
           Dependabot::Package::PackageDetails.new(
             dependency: dependency,
-            releases: package_releases.reverse.uniq(&:version)
+            releases: package_releases.reverse
           )
         end
 


### PR DESCRIPTION
**Related Issue:** 

- https://github.com/dependabot/dependabot-core/issues/11902

### What are you trying to accomplish?

Fix a bug where Dependabot fails to detect the correct latest version of a pip package when a final release (e.g. `0.45.0`) follows one or more pre-releases (e.g. `0.45.0a1`, `0.45.0rc1`).
In https://github.com/dependabot/dependabot-core/pull/11630, we introduced a `uniq` check for versions, which unintentionally caused final releases to be filtered out when preceded by pre-releases.

This PR reverts that change by removing the `uniq` check, restoring the previous behavior where pre-releases and final releases are treated as distinct entries.

---

### Anything you want to highlight for special attention from reviewers?

The regression was introduced in https://github.com/dependabot/dependabot-core/pull/11630 as part of the cooldown implementation. The added `uniq` version filtering was not part of the original release resolution logic and led to incorrect latest version detection.

Also you can see smoke test change here:
- https://github.com/dependabot/smoke-tests/pull/297

---

### How will you know you've accomplished your goal?

* The test cases from the original issue now pass.
* Dependabot correctly identifies the final release (e.g. `0.45.0`) as the latest version even when pre-releases exist.

---

### Checklist

* [x] I have run the complete test suite and ensured all linters pass.
* [ ] I have added or updated tests to validate the fix.
* [x] I have written clear and descriptive commit messages.
* [x] I have explained the problem and the fix clearly in this PR description.
* [x] The code is well-documented and easy to understand.