### PR TITLE
Add support for `security-advisories` to `dotnet-sdk`

### DIFF
--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/package/package_details_fetcher.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/package/package_details_fetcher.rb
@@ -1,0 +1,135 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/package/package_details"
+
+require "dependabot/dotnet_sdk/version"
+
+module Dependabot
+  module DotnetSdk
+    module Package
+      class PackageDetailsFetcher
+        extend T::Sig
+
+        RELEASES_INDEX_URL = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+
+        sig do
+          params(
+            dependency: Dependabot::Dependency
+          ).void
+        end
+        def initialize(dependency:)
+          @dependency = dependency
+          @package_details = T.let(nil, T.nilable(Dependabot::Package::PackageDetails))
+        end
+
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+
+        sig do
+          returns(T.nilable(Dependabot::Package::PackageDetails))
+        end
+        def fetch
+          package_releases = releases.filter_map do |release|
+            version = release["version"]
+            release_date = release["release-date"]
+            next unless version && release_date
+
+            package_release(
+              version: version,
+              released_at: Time.parse(release_date)
+            )
+          end
+
+          package_details(package_releases)
+        end
+
+        private
+
+        sig { returns(T::Array[T::Hash[String, String]]) }
+        def releases
+          response = releases_response
+          return [] unless response.status == 200
+
+          parsed = JSON.parse(response.body)
+          parsed["releases-index"].flat_map do |release|
+            release_channel(release["releases.json"])
+          end
+        end
+
+        sig { returns(Excon::Response) }
+        def releases_response
+          Dependabot::RegistryClient.get(
+            url: RELEASES_INDEX_URL,
+            headers: { "Accept" => "application/json" }
+          )
+        end
+
+        sig { params(url: String).returns(T::Array[T::Hash[String, String]]) }
+        def release_channel(url)
+          response = release_channel_response(url)
+          return [] unless response
+
+          JSON.parse(response.body)
+              .fetch("releases", [])
+              .flat_map { |release| extract_release_versions(release) }
+        rescue JSON::ParserError
+          raise Dependabot::DependencyFileNotResolvable, "Invalid JSON response from #{url}"
+        end
+
+        sig { params(release: T::Hash[String, T.untyped]).returns(T::Array[T::Hash[String, String]]) }
+        def extract_release_versions(release)
+          release_date = release["release-date"]
+          return [] unless release_date
+
+          if release["sdks"].nil?
+            sdk_version = release.dig("sdk", "version")
+            return [] unless sdk_version
+
+            [{ "version" => sdk_version, "release-date" => release_date }]
+          else
+            release["sdks"]&.filter_map do |sdk|
+              next unless sdk["version"]
+
+              { "version" => sdk["version"], "release-date" => release_date }
+            end || []
+          end
+        end
+
+        sig { params(url: String).returns(T.nilable(Excon::Response)) }
+        def release_channel_response(url)
+          Dependabot::RegistryClient.get(
+            url: url,
+            headers: { "Accept" => "application/json" }
+          )
+        end
+
+        sig do
+          params(
+            version: String,
+            released_at: T.nilable(Time)
+          ).returns(Dependabot::Package::PackageRelease)
+        end
+        def package_release(version:, released_at:)
+          Dependabot::Package::PackageRelease.new(
+            version: DotnetSdk::Version.new(version),
+            released_at: released_at
+          )
+        end
+
+        sig do
+          params(releases: T::Array[Dependabot::Package::PackageRelease])
+            .returns(Dependabot::Package::PackageDetails)
+        end
+        def package_details(releases)
+          @package_details ||= Dependabot::Package::PackageDetails.new(
+            dependency: dependency,
+            releases: releases.reverse.uniq(&:version)
+          )
+        end
+      end
+    end
+  end
+end

--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker/latest_version_finder.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker/latest_version_finder.rb
@@ -1,138 +1,62 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "excon"
 require "sorbet-runtime"
 
-require "dependabot/dotnet_sdk/requirement"
-require "dependabot/dotnet_sdk/version"
+require "dependabot/package/package_details"
+require "dependabot/package/package_latest_version_finder"
 require "dependabot/registry_client"
 require "dependabot/update_checkers/base"
+
+require "dependabot/dotnet_sdk/package/package_details_fetcher"
+require "dependabot/dotnet_sdk/requirement"
+require "dependabot/dotnet_sdk/version"
 
 module Dependabot
   module DotnetSdk
     class UpdateChecker < Dependabot::UpdateCheckers::Base
-      class LatestVersionFinder
+      class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
 
-        RELEASES_INDEX_URL = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
-
-        sig { params(dependency: Dependabot::Dependency, ignored_versions: T::Array[String]).void }
-        def initialize(dependency:, ignored_versions:)
-          @dependency = dependency
-          @ignored_versions = ignored_versions
+        sig do
+          override.returns(T.nilable(Dependabot::Package::PackageDetails))
+        end
+        def package_details
+          @package_details ||= Package::PackageDetailsFetcher.new(dependency: dependency).fetch
         end
 
-        sig { returns(T.nilable(Dependabot::Version)) }
-        def latest_version
-          @latest_version ||= T.let(
-            fetch_latest_version,
-            T.nilable(Dependabot::Version)
-          )
+        sig do
+          override
+            .params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def latest_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
+          @latest_version ||= fetch_latest_version
         end
 
-        private
-
-        sig { returns(Dependabot::Dependency) }
-        attr_reader :dependency
-
-        sig { returns(T::Array[String]) }
-        attr_reader :ignored_versions
-
-        sig { returns(T.nilable(Dependabot::Version)) }
-        def fetch_latest_version
-          versions = available_versions
-          versions = filter_prerelease_versions(versions)
-          versions = filter_ignored_versions(versions)
-          versions.max
+        sig do
+          override
+            .params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def lowest_security_fix_version(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
+          @lowest_security_fix_version ||= fetch_lowest_security_fix_version
         end
 
-        sig { returns(T::Array[Dependabot::Version]) }
-        def available_versions
-          releases.map { |v| version_class.new(v) }
-        end
+        protected
 
-        sig { params(versions: T::Array[Dependabot::Version]).returns(T::Array[Dependabot::Version]) }
-        def filter_prerelease_versions(versions)
-          return versions if wants_prerelease?
-
-          # This isn't entirely accurate. .NET considers release candidates to NOT be pre-releases.
-          # However, we want to be conservative.
-          # See https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
-          versions.reject(&:prerelease?)
-        end
-
-        sig { params(versions: T::Array[Dependabot::Version]).returns(T::Array[Dependabot::Version]) }
-        def filter_ignored_versions(versions)
-          versions.reject do |version|
-            ignore_requirements.any? { |r| r.satisfied_by?(version) }
-          end
-        end
-
-        sig { returns(T::Array[String]) }
-        def releases
-          response = releases_response
-          return [] unless response.status == 200
-
-          parsed = JSON.parse(response.body)
-          parsed["releases-index"].flat_map do |release|
-            release_channel(release["releases.json"])
-          end
-        end
-
-        sig { returns(Excon::Response) }
-        def releases_response
-          Dependabot::RegistryClient.get(
-            url: RELEASES_INDEX_URL,
-            headers: { "Accept" => "application/json" }
-          )
-        end
-
-        sig { params(url: String).returns(T::Array[String]) }
-        def release_channel(url)
-          response = release_channel_response(url)
-          begin
-            parsed = JSON.parse(T.must(response).body)
-          rescue JSON::ParserError
-            raise Dependabot::DependencyFileNotResolvable, "Invalid JSON response from #{url}"
-          end
-
-          parsed["releases"].map do |release|
-            if release["sdks"].nil?
-              release["sdk"]["version"]
-            else
-              release["sdks"].flat_map { |sdk| sdk["version"] }
-            end
-          end
-        .flatten
-        end
-
-        sig { params(url: String).returns(T.nilable(Excon::Response)) }
-        def release_channel_response(url)
-          Dependabot::RegistryClient.get(
-            url: url,
-            headers: { "Accept" => "application/json" }
-          )
-        end
-
-        sig { returns(T::Boolean) }
+        sig { override.returns(T::Boolean) }
         def wants_prerelease?
-          dependency.metadata[:allow_prerelease]
+          !!dependency.metadata[:allow_prerelease]
         end
 
-        sig { returns(T::Array[Dependabot::Requirement]) }
-        def ignore_requirements
-          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
+        sig do
+          override
+            .params(releases: T::Array[Dependabot::Package::PackageRelease])
+            .returns(T::Array[Dependabot::Package::PackageRelease])
         end
-
-        sig { returns(T.class_of(Dependabot::Version)) }
-        def version_class
-          dependency.version_class
-        end
-
-        sig { returns(T.class_of(Dependabot::Requirement)) }
-        def requirement_class
-          dependency.requirement_class
+        def apply_post_fetch_lowest_security_fix_versions_filter(releases)
+          filter_prerelease_versions(releases)
         end
       end
     end

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/package/package_details_fetcher_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/package/package_details_fetcher_spec.rb
@@ -1,0 +1,254 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dotnet_sdk/package/package_details_fetcher"
+
+RSpec.describe Dependabot::DotnetSdk::Package::PackageDetailsFetcher do
+  subject(:fetcher) { described_class.new(dependency: dependency) }
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "dotnet-sdk",
+      version: "8.0.300",
+      requirements: [],
+      package_manager: "dotnet_sdk",
+      metadata: {
+        allow_prerelease: false
+      }
+    )
+  end
+
+  let(:releases_index_url) { Dependabot::DotnetSdk::Package::PackageDetailsFetcher::RELEASES_INDEX_URL }
+  let(:releases_index_body) { fixture("releases", "releases-index-small.json") }
+
+  before do
+    stub_request(:get, releases_index_url)
+      .with(headers: { "Accept" => "application/json" })
+      .to_return(status: 200, body: releases_index_body)
+
+    stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+      .with(headers: { "Accept" => "application/json" })
+      .to_return(status: 200, body: fixture("releases", "releases-8.0.json"))
+
+    stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/releases.json")
+      .with(headers: { "Accept" => "application/json" })
+      .to_return(status: 200, body: fixture("releases", "releases-9.0.json"))
+  end
+
+  describe "#fetch" do
+    context "when releases are successfully fetched" do
+      it "returns package details with releases" do
+        result = fetcher.fetch
+
+        expect(result).to be_a(Dependabot::Package::PackageDetails)
+        expect(result.dependency).to eq(dependency)
+        expect(result.releases).not_to be_empty
+      end
+
+      it "returns releases in descending order by version" do
+        result = fetcher.fetch
+        versions = result.releases.map { |x| x.version.to_s }
+
+        # Versions should be in descending order (latest first)
+        expect(versions).to eq(versions.sort { |a, b| Gem::Version.new(b) <=> Gem::Version.new(a) })
+      end
+
+      it "removes duplicate versions" do
+        result = fetcher.fetch
+        versions = result.releases.map { |x| x.version.to_s }
+
+        expect(versions).to eq(versions.uniq)
+      end
+
+      it "includes release dates" do
+        result = fetcher.fetch
+
+        result.releases.each do |release|
+          expect(release.released_at).to be_a(Time)
+        end
+      end
+
+      it "creates versions using DotnetSdk::Version" do
+        result = fetcher.fetch
+
+        result.releases.each do |release|
+          expect(release.version).to be_a(Dependabot::DotnetSdk::Version)
+        end
+      end
+    end
+
+    context "when releases index request fails" do
+      before do
+        stub_request(:get, releases_index_url)
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 500)
+      end
+
+      it "returns empty package details" do
+        result = fetcher.fetch
+
+        expect(result).to be_a(Dependabot::Package::PackageDetails)
+        expect(result.releases).to be_empty
+      end
+    end
+
+    context "when releases index returns invalid JSON" do
+      before do
+        stub_request(:get, releases_index_url)
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 200, body: "invalid json")
+      end
+
+      it "raises a JSON parser error" do
+        expect { fetcher.fetch }.to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "when individual release channel request fails" do
+      before do
+        stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 404, body: "")
+      end
+
+      it "raises an error due to invalid JSON" do
+        expect { fetcher.fetch }.to raise_error(
+          Dependabot::DependencyFileNotResolvable,
+          /Invalid JSON response from/
+        )
+      end
+    end
+
+    context "when individual release channel returns invalid JSON" do
+      before do
+        stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 200, body: "invalid json")
+      end
+
+      it "raises DependencyFileNotResolvable error" do
+        expect { fetcher.fetch }.to raise_error(
+          Dependabot::DependencyFileNotResolvable,
+          /Invalid JSON response from/
+        )
+      end
+    end
+
+    context "with empty releases index" do
+      let(:releases_index_body) { fixture("releases", "releases-index-empty.json") }
+
+      it "returns empty package details" do
+        result = fetcher.fetch
+
+        expect(result).to be_a(Dependabot::Package::PackageDetails)
+        expect(result.releases).to be_empty
+      end
+    end
+
+    context "with releases that have legacy SDK format" do
+      let(:legacy_release_json) do
+        {
+          "releases" => [
+            {
+              "release-date" => "2023-01-01",
+              "sdk" => {
+                "version" => "7.0.100"
+              }
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 200, body: legacy_release_json)
+      end
+
+      it "extracts SDK version from legacy format" do
+        result = fetcher.fetch
+
+        expect(result.releases.map { |x| x.version.to_s }).to include("7.0.100")
+      end
+    end
+
+    context "with releases that have modern SDKs array format" do
+      let(:modern_release_json) do
+        {
+          "releases" => [
+            {
+              "release-date" => "2023-01-01",
+              "sdks" => [
+                { "version" => "7.0.101" },
+                { "version" => "7.0.102" }
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 200, body: modern_release_json)
+      end
+
+      it "extracts all SDK versions from modern format" do
+        result = fetcher.fetch
+
+        versions = result.releases.map { |x| x.version.to_s }
+        expect(versions).to include("7.0.101", "7.0.102")
+      end
+    end
+
+    context "with releases missing required fields" do
+      let(:incomplete_release_json) do
+        {
+          "releases" => [
+            {
+              # Missing release-date
+              "sdk" => {
+                "version" => "7.0.100"
+              }
+            },
+            {
+              "release-date" => "2023-01-01"
+              # Missing SDK version
+            },
+            {
+              "release-date" => "2023-01-02",
+              "sdks" => [
+                { "version" => "7.0.103" },
+                {} # SDK without version
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
+          .with(headers: { "Accept" => "application/json" })
+          .to_return(status: 200, body: incomplete_release_json)
+      end
+
+      it "skips incomplete releases and extracts valid ones" do
+        result = fetcher.fetch
+
+        versions = result.releases.map { |x| x.version.to_s }
+        expect(versions).to include("7.0.103")
+        expect(versions).not_to include("7.0.100") # Missing release-date
+      end
+    end
+
+    context "when memoization is tested" do
+      it "returns the same instance when called multiple times" do
+        first_result = fetcher.fetch
+        second_result = fetcher.fetch
+
+        expect(first_result).to be(second_result)
+      end
+    end
+  end
+end

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker/latest_version_finder_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker/latest_version_finder_spec.rb
@@ -5,98 +5,312 @@ require "spec_helper"
 require "dependabot/dotnet_sdk/update_checker/latest_version_finder"
 
 RSpec.describe Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder do
-  before do
-    stub_request(:get, Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder::RELEASES_INDEX_URL)
-      .with(headers: { "Accept" => "application/json" })
-      .to_return(status: 200, body: releases_index_body)
-
-    stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json")
-      .with(headers: { "Accept" => "application/json" })
-      .to_return(status: 200, body: fixture("releases", "releases-8.0.json"))
-
-    stub_request(:get, "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/9.0/releases.json")
-      .with(headers: { "Accept" => "application/json" })
-      .to_return(status: 200, body: fixture("releases", "releases-9.0.json"))
+  subject(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      credentials: credentials,
+      ignored_versions: ignored_versions,
+      security_advisories: security_advisories,
+      raise_on_ignored: raise_on_ignored
+    )
   end
 
-  let(:releases_index_body) { fixture("releases", "releases-index-small.json") }
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "dotnet-sdk",
-      version: "8.0.300",
+      version: "8.0.100",
       requirements: [],
       package_manager: "dotnet_sdk",
-      metadata: {
-        allow_prerelease: false
-      }
+      metadata: metadata
     )
   end
+
+  let(:dependency_files) { [] }
+  let(:credentials) { [] }
   let(:ignored_versions) { [] }
+  let(:security_advisories) { [] }
+  let(:raise_on_ignored) { false }
+  let(:metadata) { {} }
+
+  let(:mock_package_details_fetcher) { instance_double(Dependabot::DotnetSdk::Package::PackageDetailsFetcher) }
+  let(:mock_package_details) { instance_double(Dependabot::Package::PackageDetails) }
+
+  let(:available_releases) do
+    [
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::DotnetSdk::Version.new("8.0.400"),
+        released_at: Time.parse("2024-05-15")
+      ),
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::DotnetSdk::Version.new("8.0.300"),
+        released_at: Time.parse("2024-03-15")
+      ),
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::DotnetSdk::Version.new("8.0.200"),
+        released_at: Time.parse("2024-01-15")
+      ),
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::DotnetSdk::Version.new("8.0.100"),
+        released_at: Time.parse("2023-11-15")
+      ),
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::DotnetSdk::Version.new("9.0.100-preview.1"),
+        released_at: Time.parse("2024-06-01")
+      )
+    ]
+  end
+
+  before do
+    allow(Dependabot::DotnetSdk::Package::PackageDetailsFetcher)
+      .to receive(:new)
+      .with(dependency: dependency)
+      .and_return(mock_package_details_fetcher)
+
+    allow(mock_package_details_fetcher)
+      .to receive(:fetch)
+      .and_return(mock_package_details)
+
+    allow(mock_package_details)
+      .to receive(:releases)
+      .and_return(available_releases)
+  end
+
+  describe "#package_details" do
+    it "returns package details from the fetcher" do
+      expect(finder.package_details).to eq(mock_package_details)
+    end
+
+    it "calls the PackageDetailsFetcher with the correct dependency" do
+      finder.package_details
+      expect(Dependabot::DotnetSdk::Package::PackageDetailsFetcher)
+        .to have_received(:new)
+        .with(dependency: dependency)
+    end
+
+    it "memoizes the result" do
+      2.times { finder.package_details }
+      expect(mock_package_details_fetcher).to have_received(:fetch).once
+    end
+  end
 
   describe "#latest_version" do
-    subject(:latest_version) do
-      described_class.new(dependency: dependency, ignored_versions: ignored_versions).latest_version
+    it "returns the latest stable version" do
+      expect(finder.latest_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.400"))
     end
 
-    it { is_expected.to eq(Dependabot::Version.new("8.0.402")) }
+    it "memoizes the result" do
+      2.times { finder.latest_version }
+      expect(mock_package_details_fetcher).to have_received(:fetch).once
+    end
 
-    context "when the user is on the latest version" do
+    context "when there are no releases" do
+      let(:available_releases) { [] }
+
+      it "returns nil" do
+        expect(finder.latest_version).to be_nil
+      end
+    end
+
+    context "when wants_prerelease? is true" do
+      let(:metadata) { { allow_prerelease: true } }
+
+      it "includes prerelease versions" do
+        expect(finder.latest_version).to eq(Dependabot::DotnetSdk::Version.new("9.0.100-preview.1"))
+      end
+    end
+
+    context "when wants_prerelease? is false" do
+      let(:metadata) { { allow_prerelease: false } }
+
+      it "excludes prerelease versions" do
+        expect(finder.latest_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.400"))
+      end
+    end
+
+    context "with ignored versions" do
+      let(:ignored_versions) { ["8.0.400"] }
+
+      it "excludes ignored versions" do
+        expect(finder.latest_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.300"))
+      end
+    end
+
+    context "with language_version parameter" do
+      it "accepts the parameter and returns the latest version" do
+        expect(finder.latest_version(language_version: "8.0")).to eq(Dependabot::DotnetSdk::Version.new("8.0.400"))
+      end
+    end
+  end
+
+  describe "#lowest_security_fix_version" do
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: "dotnet-sdk",
+          package_manager: "dotnet_sdk",
+          vulnerable_versions: ["<= 8.0.200"]
+        )
+      ]
+    end
+
+    it "returns the lowest version that fixes security vulnerabilities" do
+      expect(finder.lowest_security_fix_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.300"))
+    end
+
+    it "memoizes the result" do
+      2.times { finder.lowest_security_fix_version }
+      expect(mock_package_details_fetcher).to have_received(:fetch).once
+    end
+
+    context "when there are no security advisories" do
+      let(:security_advisories) { [] }
+
+      it "returns next stable version" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.200"))
+      end
+    end
+
+    context "when no versions fix the vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: "dotnet-sdk",
+            package_manager: "dotnet_sdk",
+            vulnerable_versions: [">= 1.0.0"]
+          )
+        ]
+      end
+
+      it "returns nil" do
+        expect(finder.lowest_security_fix_version).to be_nil
+      end
+    end
+
+    context "when current version is already secure" do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "dotnet-sdk",
-          version: "8.0.402",
+          version: "8.0.400",
           requirements: [],
           package_manager: "dotnet_sdk",
-          metadata: {
-            allow_prerelease: false
-          }
+          metadata: metadata
         )
       end
 
-      it { is_expected.to eq(Dependabot::Version.new("8.0.402")) }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: "dotnet-sdk",
+            package_manager: "dotnet_sdk",
+            vulnerable_versions: ["<= 8.0.200"]
+          )
+        ]
+      end
+
+      it "returns nil" do
+        expect(finder.lowest_security_fix_version).to be_nil
+      end
     end
 
-    context "when the latest version is ignored" do
-      let(:ignored_versions) { [">= 8.0.402"] }
+    context "with ignored versions" do
+      let(:ignored_versions) { ["8.0.300"] }
 
-      it { is_expected.to eq(Dependabot::Version.new("8.0.401")) }
+      it "excludes ignored versions from security fix" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.400"))
+      end
+    end
+  end
+
+  describe "#wants_prerelease?" do
+    context "when allow_prerelease is true in metadata" do
+      let(:metadata) { { allow_prerelease: true } }
+
+      it "returns true" do
+        expect(finder.send(:wants_prerelease?)).to be true
+      end
     end
 
-    context "when later versions are ignored" do
-      let(:ignored_versions) { ["> 8.0.300"] }
+    context "when allow_prerelease is false in metadata" do
+      let(:metadata) { { allow_prerelease: false } }
 
-      it { is_expected.to eq(Dependabot::Version.new("8.0.300")) }
+      it "returns false" do
+        expect(finder.send(:wants_prerelease?)).to be false
+      end
     end
 
-    context "when the latest version is a pre-release" do
+    context "when allow_prerelease is nil in metadata" do
+      let(:metadata) { { allow_prerelease: nil } }
+
+      it "returns false" do
+        expect(finder.send(:wants_prerelease?)).to be false
+      end
+    end
+
+    context "when metadata doesn't contain allow_prerelease" do
+      let(:metadata) { {} }
+
+      it "returns false" do
+        expect(finder.send(:wants_prerelease?)).to be false
+      end
+    end
+
+    context "when metadata is nil" do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "dotnet-sdk",
-          version: "8.0.300",
+          version: "8.0.100",
           requirements: [],
-          package_manager: "dotnet_sdk",
-          metadata: {
-            allow_prerelease: true
-          }
+          package_manager: "dotnet_sdk"
+          # No metadata provided
         )
       end
 
-      it { is_expected.to eq(Dependabot::Version.new("9.0.100.pre.rc.1.24452.12")) }
-
-      context "when it is ignored" do
-        let(:ignored_versions) { [">= 9.0.100.a"] }
-
-        it { is_expected.to eq(Dependabot::Version.new("8.0.402")) }
+      it "returns false" do
+        expect(finder.send(:wants_prerelease?)).to be false
       end
     end
+  end
 
-    context "when there are no available versions" do
+  describe "error handling" do
+    context "when PackageDetailsFetcher raises an error" do
       before do
-        stub_request(:get, Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder::RELEASES_INDEX_URL)
-          .to_return(status: 200, body: fixture("releases", "releases-index-empty.json"))
+        allow(mock_package_details_fetcher)
+          .to receive(:fetch)
+          .and_raise(StandardError, "Network error")
       end
 
-      it { is_expected.to be_nil }
+      it "propagates the error from package_details" do
+        expect { finder.package_details }.to raise_error(StandardError, "Network error")
+      end
+
+      it "propagates the error from latest_version" do
+        expect { finder.latest_version }.to raise_error(StandardError, "Network error")
+      end
+
+      it "propagates the error from lowest_security_fix_version" do
+        expect { finder.lowest_security_fix_version }.to raise_error(StandardError, "Network error")
+      end
+    end
+
+    context "when PackageDetailsFetcher returns nil" do
+      before do
+        allow(mock_package_details_fetcher)
+          .to receive(:fetch)
+          .and_return(nil)
+      end
+
+      it "handles nil package_details gracefully" do
+        expect(finder.package_details).to be_nil
+      end
+
+      it "returns nil for latest_version when package_details is nil" do
+        expect(finder.latest_version).to be_nil
+      end
+
+      it "returns nil for lowest_security_fix_version when package_details is nil" do
+        expect(finder.lowest_security_fix_version).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Add support for security advisories to the `dotnet-sdk` ecosystem.

Currently, if `security-advisories` are passed as a Dependabot job they are ignored, and the dotnet SDK is updated to the latest version, regardless of what the advisories say.

This change migrated `LatestVersionFinder` to use the `Dependabot::Package::PackageLatestVersionFinder` abstract class, and moves much of the API logic to `PackageDetailsFetcher`. This is the standard pattern in much of the rest of Dependabot.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I've also added a relevant smoke test in https://github.com/dependabot/smoke-tests/pull/296

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
