### PR TITLE
[Do not merge] Test latest CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,4 @@ jobs:
         run: |
           cd silent/tests
           go test ./...
+


### PR DESCRIPTION
I'm seeing some unrelated failures on https://github.com/dependabot/dependabot-core/pull/12316 that I don't understand, so I'm checking the state of CI on main