### PR TITLE
add portable profiles to framework compatibility checks

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using NuGet.Frameworks;
 
 using NuGetUpdater.Core.FrameworkChecker;
@@ -64,17 +60,18 @@ public class FrameworkCompatibilityServiceFacts
     }
 
     [Theory]
-    [InlineData("portable-net45+sl4+win8+wp7")]
-    [InlineData("portable-net40+sl4")]
-    [InlineData("portable-net45+sl5+win8+wpa81+wp8")]
-    public void PCLPackageFrameworksReturnsEmptySet(string pclFrameworkName)
+    [InlineData("portable-net45+win8+wpa81", "net48", true)] // profile 111, compatible
+    [InlineData("portable-net45+win8+wpa81", "net40", false)] // profile 111, incompatible
+    [InlineData("portable-net45+win8+wp8+wpa81", "net48", true)] // profile 259, compatible
+    public void PCLPackageFrameworksReportCompatibility(string pclFrameworkName, string projectFrameworkName, bool expectedCompatible)
     {
         var portableFramework = NuGetFramework.Parse(pclFrameworkName);
+        var projectFramework = NuGetFramework.Parse(projectFrameworkName);
 
-        var result = _service.GetCompatibleFrameworks([portableFramework]);
+        var compatible = _service.GetCompatibleFrameworks([portableFramework]);
 
-        Assert.True(portableFramework.IsPCL);
-        Assert.Empty(result);
+        var actualCompatible = compatible.Contains(projectFramework);
+        Assert.Equal(expectedCompatible, actualCompatible);
     }
 
     [Theory]


### PR DESCRIPTION
Before target frameworks like `netstandard2.0` existed, cross-platform and TFM compatibility was accomplished via portable class libraries (PCL).

Package compatibility checks previously returned false if `IsPCL` was `true`, but this PR fixes that by iterating through all PCL profiles in NuGet, determining if a "regular" TFM is compatible with it, then checking each other TFM for compatibility with _that_.  If found, the final framework is marked as being compatible with the PCL.

The reason for the double-lookup is because the NuGet source only defines compatible TFM ranges for the portable profiles.  E.g., PCL Profile 111 `portable-net45+win8+wpa81` reports as supporting the range of `netstandard1.0` through `netstandard1.1`, but a project targeting `netstandard2.0` can absolutely reference a library of `netstandard1.0`, hence the check that `netstandard1.0` is compatible with Profile 111 and `netstandard2.0` is compatible with `netstandard1.0`, therefore Profile 111 is compatible with `netstandard2.0`.