### PR TITLE
properly deserialize group rules

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -114,6 +114,46 @@ public class MiscellaneousTests
         ];
     }
 
+    [Fact]
+    public void DeserializeDependencyGroup()
+    {
+        var json = """
+            {
+              "name": "test-group",
+              "rules": {
+                "patterns": ["Test.*"],
+                "exclude-patterns": ["Dependency.*"]
+              }
+            }
+            """;
+        var group = JsonSerializer.Deserialize<DependencyGroup>(json, RunWorker.SerializerOptions);
+        Assert.NotNull(group);
+        Assert.Equal("test-group", group.Name);
+        var matcher = group.GetGroupMatcher();
+        Assert.Equal(["Test.*"], matcher.Patterns);
+        Assert.Equal(["Dependency.*"], matcher.ExcludePatterns);
+    }
+
+    [Fact]
+    public void DeserializeDependencyGroup_UnexpectedShape()
+    {
+        var json = """
+            {
+              "name": "test-group",
+              "rules": {
+                "patterns": { "unexpected": 1 },
+                "exclude-patterns": { "unexpected": 2 }
+              }
+            }
+            """;
+        var group = JsonSerializer.Deserialize<DependencyGroup>(json, RunWorker.SerializerOptions);
+        Assert.NotNull(group);
+        Assert.Equal("test-group", group.Name);
+        var matcher = group.GetGroupMatcher();
+        Assert.Equal([], matcher.Patterns);
+        Assert.Equal([], matcher.ExcludePatterns);
+    }
+
     [Theory]
     [MemberData(nameof(DependencyGroup_IsMatchTestData))]
     public void DependencyGroup_IsMatch(string[]? patterns, string[]? excludePatterns, string dependencyName, bool expectedMatch)


### PR DESCRIPTION
When deserializing dependency group rules, we incorrectly assumed the `pattern` and `exclude-pattern` properties would come in as a string array when they really come in as a `JsonElement` bypassing the type check and defaulting to `["*"]` and `[]` respectively.

This PR fixes that assumption and properly deserializes the array.

Fixes #12322 and #12448.