### PR TITLE
Fix: Terminate NPM processes early on peer dependency conflicts using OutputObserver

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -443,7 +443,7 @@ module Dependabot
         output_observer: CommandHelpers::OutputObserver
       ).returns(String)
     end
-    def self.run_shell_command(command, # rubocop:disable Metrics/MethodLength
+    def self.run_shell_command(command,
                                allow_unsafe_shell_command: false,
                                cwd: nil,
                                env: {},
@@ -467,17 +467,9 @@ module Dependabot
         }
         kwargs[:output_observer] = output_observer if output_observer
 
-        CommandHelpers.capture3_with_timeout(
-          env_cmd,
-          **kwargs
-        )
-
-        # If the command is a string, we need to convert it to an array
         stdout, stderr, process = CommandHelpers.capture3_with_timeout(
           env_cmd,
-          stderr_to_stdout: stderr_to_stdout,
-          timeout: timeout,
-          output_observer: output_observer
+          **kwargs
         )
       elsif stderr_to_stdout
         stdout, process = Open3.capture2e(env || {}, cmd, opts)


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a bug where Dependabot gets stuck during `npm install` when `ERESOLVE` peer dependency conflicts occur. In affected cases, the process remains active without producing output, causing jobs to hang for extended periods or indefinitely.

This change introduces support for early termination by observing command output using the `OutputObserver` interface. When a known ERESOLVE pattern is detected (e.g., invalid peer dependency resolution loops), we gracefully stop the process and propagate the failure early.

This affects:
- dependabot-core command execution logic (`CommandHelpers.capture3_with_timeout`)
- npm command wrapper to utilize output observation and early exit

Fixes:
- https://github.com/github/dependabot-updates/issues/9872
- githubcustomers/Morgan-Stanley#699

### Anything you want to highlight for special attention from reviewers?

We now use an `OutputObserver` to monitor live output for known error states such as:
- infinite resolution loops triggered by peer dependency mismatches
- long hangs without clear terminal conditions

Once a matching signal is observed, the observer triggers a `gracefully_stop` signal to exit early and report the problem with a meaningful reason.

### How will you know you've accomplished your goal?

- The previously hanging NPM job now exits early with a clear log message.
- The job no longer runs indefinitely after the last line of output.
- Observed hang at Morgan Stanley can now be reproduced and automatically avoided using the observer logic.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
