### PR TITLE
Update XML parser to manually format newly added elements.

### DIFF
--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -395,6 +395,47 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         end
       end
 
+      context "with a new transitive dependency that is consistently formatted with tabs" do
+        let(:pom_body) do
+          fixture("poms", "transitive_dependency_pom_version_not_defined_with_tabs.xml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.apache.zookeeper:zookeeper",
+            version: "3.7.2",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "3.7.2",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            previous_requirements: [{
+              file: "pom.xml",
+              requirement: "3.4.6",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            package_manager: "maven"
+          )
+        end
+
+        its(:content) do
+          is_expected.to include(
+            "	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.zookeeper</groupId>
+				<artifactId>zookeeper</artifactId>
+				<version>3.7.2</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>"
+          )
+        end
+      end
+
       context "with a repeated dependency" do
         let(:pom_body) { fixture("poms", "repeated_pom.xml") }
         let(:dependency) do

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         its(:content) { is_expected.to include("<version>0.7.9</version>") }
       end
 
-      context "with a transitive dependency not added to dependencyManagement" do
+      context "with a transitive dependency not added to dependencyManagement with indentation 2" do
         let(:pom_body) do
           fixture("poms", "transitive_dependency_pom_version_not_defined.xml")
         end
@@ -251,9 +251,58 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         end
 
         its(:content) do
-          is_expected.to include("<dependencyManagement>")
-          is_expected.to include("</dependencyManagement>")
-          is_expected.to include("<version>3.7.2</version>")
+          is_expected.to include(
+            "  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>3.7.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>"
+          )
+        end
+      end
+
+      context "with a transitive dependency not in dependencyManagement and pom file doesn't have XML namespace" do
+        let(:pom_body) do
+          fixture("poms", "transitive_dependency_pom_version_not_defined_no_namespace.xml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.apache.zookeeper:zookeeper",
+            version: "3.7.2",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "3.7.2",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            previous_requirements: [{
+              file: "pom.xml",
+              requirement: "3.4.6",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            package_manager: "maven"
+          )
+        end
+
+        its(:content) do
+          is_expected.to include(
+            "    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.7.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>"
+          )
         end
       end
 
@@ -284,7 +333,65 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         end
 
         its(:content) do
-          is_expected.to include("<version>3.7.2</version>")
+          is_expected.to include(
+            "    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.7.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>"
+          )
+        end
+      end
+
+      context "with a new transitive dependency in existing dependencyManagement that is consistently formatted" do
+        let(:pom_body) do
+          fixture("poms", "transitive_dependency_pom_dep_management_exist.xml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.apache.zookeeper:zookeeper",
+            version: "3.7.2",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "3.7.2",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            previous_requirements: [{
+              file: "pom.xml",
+              requirement: "3.4.6",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            package_manager: "maven"
+          )
+        end
+
+        its(:content) do
+          is_expected.to include(
+            "  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>3.7.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>"
+          )
         end
       end
 

--- a/maven/spec/fixtures/poms/transitive_dependency_pom_dep_management_exist.xml
+++ b/maven/spec/fixtures/poms/transitive_dependency_pom_dep_management_exist.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Plugin POM</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.11.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.11.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_no_namespace.xml
+++ b/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_no_namespace.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dependabot</groupId>
@@ -8,27 +6,7 @@
     <version>0.0.1-RELEASE</version>
     <name>Dependabot Plugin POM</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>3.4.6</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>

--- a/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_with_tabs.xml
+++ b/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_with_tabs.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.dependabot</groupId>
+	<artifactId>basic-pom</artifactId>
+	<version>0.0.1-RELEASE</version>
+	<name>Dependabot Plugin POM</name>
+
+	<dependencies>
+	<dependency>
+		<groupId>org.junit.jupiter</groupId>
+		<artifactId>junit-jupiter-api</artifactId>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.junit.jupiter</groupId>
+		<artifactId>junit-jupiter-params</artifactId>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.scala-lang</groupId>
+		<artifactId>scala-library</artifactId>
+		<version>2.11.12</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.spark</groupId>
+		<artifactId>spark-core_2.11</artifactId>
+		<version>2.4.0</version>
+		<scope>provided</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.spark</groupId>
+		<artifactId>spark-sql_2.11</artifactId>
+		<version>2.4.0</version>
+		<scope>provided</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.spark</groupId>
+		<artifactId>spark-hive_2.11</artifactId>
+		<version>2.4.0</version>
+		<scope>provided</scope>
+	</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

This PR updates the XML parser that is used to add new elements to the `pom.xml` file. Previous approach was using Nokogiri formatter that removed blank lines and makes some unrelated changes to directly adding dependency entries. REXML provides more flexibility in modifying the XML structure and allows to manually format added elements.

New logic also includes manual indentation work. `file_updater` attempts to determine indentation size by looking at children of `<project>` element and construct indentation relatively for all children that are being created. This produces changes that include much less unrelated changes to the file.

Unit tests are updated to also validate that indentation is correct and test cases are exist for 2 space indentation, 4 space indentation, and tabs.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

PRs for transitive dependencies in Maven should no longer produce unrelated changes, like removed blank lines.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
