### PR TITLE
enable case-insensitive file operations

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
@@ -11,6 +11,7 @@ internal static class RunCommand
 {
     internal static readonly Option<FileInfo> JobPathOption = new("--job-path") { IsRequired = true };
     internal static readonly Option<DirectoryInfo> RepoContentsPathOption = new("--repo-contents-path") { IsRequired = true };
+    internal static readonly Option<DirectoryInfo?> CaseInsensitiveRepoContentsPathOption = new("--case-insensitive-repo-contents-path") { IsRequired = false };
     internal static readonly Option<Uri> ApiUrlOption = new("--api-url") { IsRequired = true };
     internal static readonly Option<string> JobIdOption = new("--job-id") { IsRequired = true };
     internal static readonly Option<FileInfo> OutputPathOption = new("--output-path") { IsRequired = true };
@@ -22,6 +23,7 @@ internal static class RunCommand
         {
             JobPathOption,
             RepoContentsPathOption,
+            CaseInsensitiveRepoContentsPathOption,
             ApiUrlOption,
             JobIdOption,
             OutputPathOption,
@@ -30,7 +32,7 @@ internal static class RunCommand
 
         command.TreatUnmatchedTokensAsErrors = true;
 
-        command.SetHandler(async (jobPath, repoContentsPath, apiUrl, jobId, outputPath, baseCommitSha) =>
+        command.SetHandler(async (jobPath, repoContentsPath, caseInsensitiveRepoContentsPath, apiUrl, jobId, outputPath, baseCommitSha) =>
         {
             var apiHandler = new HttpApiHandler(apiUrl.ToString(), jobId);
             var (experimentsManager, _errorResult) = await ExperimentsManager.FromJobFileAsync(jobId, jobPath.FullName);
@@ -39,8 +41,8 @@ internal static class RunCommand
             var analyzeWorker = new AnalyzeWorker(jobId, experimentsManager, logger);
             var updateWorker = new UpdaterWorker(jobId, experimentsManager, logger);
             var worker = new RunWorker(jobId, apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
-            await worker.RunAsync(jobPath, repoContentsPath, baseCommitSha, outputPath);
-        }, JobPathOption, RepoContentsPathOption, ApiUrlOption, JobIdOption, OutputPathOption, BaseCommitShaOption);
+            await worker.RunAsync(jobPath, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, outputPath);
+        }, JobPathOption, RepoContentsPathOption, CaseInsensitiveRepoContentsPathOption, ApiUrlOption, JobIdOption, OutputPathOption, BaseCommitShaOption);
 
         return command;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -561,6 +561,16 @@ public class MiscellaneousTests
         Assert.Equal(expectedUpdateOperations, actualUpdateOperations);
     }
 
+    [Theory]
+    [InlineData("/src/project.csproj", "/src/project.csproj")] // correct casing
+    [InlineData("/src/project.csproj", "/SRC/PROJECT.csproj")] // incorrect casing
+    public async Task EnsureCorrectFileCasing(string filePathOnDisk, string candidatePath)
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((filePathOnDisk, "contents unimportant"));
+        var actualRepoRelativePath = RunWorker.EnsureCorrectFileCasing(candidatePath, tempDir.DirectoryPath);
+        Assert.Equal(filePathOnDisk, actualRepoRelativePath);
+    }
+
     public static IEnumerable<object[]> GetUpdateOperationsData()
     {
         static ProjectDiscoveryResult GetProjectDiscovery(string filePath, params string[] dependencyNames)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -567,7 +567,7 @@ public class MiscellaneousTests
     public async Task EnsureCorrectFileCasing(string filePathOnDisk, string candidatePath)
     {
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((filePathOnDisk, "contents unimportant"));
-        var actualRepoRelativePath = RunWorker.EnsureCorrectFileCasing(candidatePath, tempDir.DirectoryPath);
+        var actualRepoRelativePath = RunWorker.EnsureCorrectFileCasing(candidatePath, tempDir.DirectoryPath, new TestLogger());
         Assert.Equal(filePathOnDisk, actualRepoRelativePath);
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -3523,7 +3523,7 @@ public class RunWorkerTests
 
         var worker = new RunWorker(jobId, testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
         var repoContentsPathDirectoryInfo = new DirectoryInfo(tempDirectory.DirectoryPath);
-        var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA", experimentsManager);
+        var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA", experimentsManager);
         var actualApiMessages = testApiHandler.ReceivedMessages
             .Select(m =>
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -89,7 +89,7 @@ public class UpdatedDependencyListTests
                 ]
             }
         };
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath);
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies =
@@ -213,7 +213,7 @@ public class UpdatedDependencyListTests
         };
 
         // act
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath);
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -89,7 +89,7 @@ public class UpdatedDependencyListTests
                 ]
             }
         };
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath, new TestLogger());
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies =
@@ -213,7 +213,7 @@ public class UpdatedDependencyListTests
         };
 
         // act
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath);
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath, new TestLogger());
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryDirectory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TemporaryDirectory.cs
@@ -29,7 +29,13 @@ public sealed class TemporaryDirectory : IDisposable
     public void Dispose()
     {
         _environment.Dispose();
-        Directory.Delete(_rootDirectory, true);
+        try
+        {
+            Directory.Delete(_rootDirectory, true);
+        }
+        catch
+        {
+        }
     }
 
     public async Task<TestFile[]> ReadFileContentsAsync(HashSet<string> filePaths)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -39,7 +39,7 @@ public class ModifiedFilesTracker
         // track original contents for later handling
         async Task TrackOriginalContentsAsync(string directory, string fileName)
         {
-            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
+            var repoFullPath = CorrectRepoRelativePathCasing(directory, fileName);
             var localFullPath = Path.Join(RepoContentsPath.FullName, repoFullPath);
             var content = await File.ReadAllTextAsync(localFullPath);
             var rawContent = await File.ReadAllBytesAsync(localFullPath);
@@ -80,7 +80,7 @@ public class ModifiedFilesTracker
         var updatedDependencyFiles = new Dictionary<string, DependencyFile>();
         async Task AddUpdatedFileIfDifferentAsync(string directory, string fileName)
         {
-            var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
+            var repoFullPath = CorrectRepoRelativePathCasing(directory, fileName);
             var localFullPath = Path.GetFullPath(Path.Join(RepoContentsPath.FullName, repoFullPath));
             var originalContent = _originalDependencyFileContents[repoFullPath];
             var updatedContent = await File.ReadAllTextAsync(localFullPath);
@@ -132,6 +132,13 @@ public class ModifiedFilesTracker
             .Select(kvp => kvp.Value)
             .ToImmutableArray();
         return updatedDependencyFileList;
+    }
+
+    private string CorrectRepoRelativePathCasing(string directory, string fileName)
+    {
+        var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
+        var correctedRepoFullPath = RunWorker.EnsureCorrectFileCasing(repoFullPath, RepoContentsPath.FullName);
+        return correctedRepoFullPath;
     }
 
     public static ImmutableArray<DependencyFile> MergeUpdatedFileSet(ImmutableArray<DependencyFile> setA, ImmutableArray<DependencyFile> setB)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -12,6 +12,7 @@ public class ModifiedFilesTracker
 {
     public readonly DirectoryInfo RepoContentsPath;
     private WorkspaceDiscoveryResult? _currentDiscoveryResult = null;
+    private readonly ILogger _logger;
 
     private readonly Dictionary<string, string> _originalDependencyFileContents = [];
     private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
@@ -22,9 +23,10 @@ public class ModifiedFilesTracker
     //public IReadOnlyDictionary<string, EOLType> OriginalDependencyFileEOFs => _originalDependencyFileEOFs;
     public IReadOnlyDictionary<string, bool> OriginalDependencyFileBOMs => _originalDependencyFileBOMs;
 
-    public ModifiedFilesTracker(DirectoryInfo repoContentsPath)
+    public ModifiedFilesTracker(DirectoryInfo repoContentsPath, ILogger logger)
     {
         RepoContentsPath = repoContentsPath;
+        _logger = logger;
     }
 
     public async Task StartTrackingAsync(WorkspaceDiscoveryResult discoveryResult)
@@ -137,7 +139,7 @@ public class ModifiedFilesTracker
     private string CorrectRepoRelativePathCasing(string directory, string fileName)
     {
         var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
-        var correctedRepoFullPath = RunWorker.EnsureCorrectFileCasing(repoFullPath, RepoContentsPath.FullName);
+        var correctedRepoFullPath = RunWorker.EnsureCorrectFileCasing(repoFullPath, RepoContentsPath.FullName, _logger);
         return correctedRepoFullPath;
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -44,12 +44,12 @@ public class RunWorker
         _updaterWorker = updateWorker;
     }
 
-    public async Task RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, string baseCommitSha, FileInfo outputFilePath)
+    public async Task RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, FileInfo outputFilePath)
     {
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
         var jobWrapper = Deserialize(jobFileContent);
         var experimentsManager = ExperimentsManager.GetExperimentsManager(jobWrapper.Job.Experiments);
-        var result = await RunAsync(jobWrapper.Job, repoContentsPath, baseCommitSha, experimentsManager);
+        var result = await RunAsync(jobWrapper.Job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, experimentsManager);
         if (experimentsManager.UseLegacyUpdateHandler)
         {
             // only the legacy handler writes this file
@@ -58,16 +58,16 @@ public class RunWorker
         }
     }
 
-    public async Task<RunResult> RunAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
+    public async Task<RunResult> RunAsync(Job job, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
         RunResult result;
         if (experimentsManager.UseLegacyUpdateHandler)
         {
-            result = await RunWithErrorHandlingAsync(job, repoContentsPath, baseCommitSha, experimentsManager);
+            result = await RunWithErrorHandlingAsync(job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, experimentsManager);
         }
         else
         {
-            await RunScenarioHandlersWithErrorHandlingAsync(job, repoContentsPath, baseCommitSha, experimentsManager);
+            await RunScenarioHandlersWithErrorHandlingAsync(job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, experimentsManager);
 
             // the group updater doesn't return this, so we provide an empty object
             result = new RunResult()
@@ -92,7 +92,7 @@ public class RunWorker
     public static IUpdateHandler GetUpdateHandler(Job job) =>
         UpdateHandlers.FirstOrDefault(h => h.CanHandle(job)) ?? throw new InvalidOperationException("Unable to find appropriate update handler.");
 
-    private async Task RunScenarioHandlersWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
+    private async Task RunScenarioHandlersWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
         JobErrorBase? error = null;
 
@@ -100,7 +100,7 @@ public class RunWorker
         {
             var handler = GetUpdateHandler(job);
             _logger.Info($"Starting update job of type {handler.TagName}");
-            await handler.HandleAsync(job, repoContentsPath, baseCommitSha, _discoveryWorker, _analyzeWorker, _updaterWorker, _apiHandler, experimentsManager, _logger);
+            await handler.HandleAsync(job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, _discoveryWorker, _analyzeWorker, _updaterWorker, _apiHandler, experimentsManager, _logger);
         }
         catch (Exception ex)
         {
@@ -115,7 +115,7 @@ public class RunWorker
         await _apiHandler.MarkAsProcessed(new(baseCommitSha));
     }
 
-    private async Task<RunResult> RunWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
+    private async Task<RunResult> RunWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
         JobErrorBase? error = null;
         var currentDirectory = repoContentsPath.FullName; // used for error reporting below
@@ -134,7 +134,7 @@ public class RunWorker
             {
                 var localPath = PathHelper.JoinPath(repoContentsPath.FullName, directory);
                 currentDirectory = localPath;
-                var result = await RunForDirectory(job, repoContentsPath, directory, baseCommitSha, experimentsManager);
+                var result = await RunForDirectory(job, repoContentsPath, caseInsensitiveRepoContentsPath, directory, baseCommitSha, experimentsManager);
                 foreach (var dependencyFile in result.Base64DependencyFiles)
                 {
                     var uniqueKey = Path.GetFullPath(Path.Join(dependencyFile.Directory, dependencyFile.Name)).NormalizePathToUnix().EnsurePrefix("/");
@@ -163,8 +163,9 @@ public class RunWorker
         return runResult;
     }
 
-    private async Task<RunResult> RunForDirectory(Job job, DirectoryInfo repoContentsPath, string repoDirectory, string baseCommitSha, ExperimentsManager experimentsManager)
+    private async Task<RunResult> RunForDirectory(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string repoDirectory, string baseCommitSha, ExperimentsManager experimentsManager)
     {
+        var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var discoveryResult = await _discoveryWorker.RunAsync(repoContentsPath.FullName, repoDirectory);
         _logger.ReportDiscovery(discoveryResult);
 
@@ -180,7 +181,7 @@ public class RunWorker
         }
 
         // report dependencies
-        var discoveredUpdatedDependencies = GetUpdatedDependencyListFromDiscovery(discoveryResult);
+        var discoveredUpdatedDependencies = GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
         await _apiHandler.UpdateDependencyList(discoveredUpdatedDependencies);
 
         var incrementMetric = GetIncrementMetric(job);
@@ -190,7 +191,7 @@ public class RunWorker
         var actualUpdatedDependencies = new List<ReportedDependency>();
 
         // track original contents for later handling
-        var tracker = new ModifiedFilesTracker(repoContentsPath);
+        var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
         await tracker.StartTrackingAsync(discoveryResult);
 
         // do update
@@ -708,7 +709,20 @@ public class RunWorker
         return dependencyInfo;
     }
 
-    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult)
+    internal static string EnsureCorrectFileCasing(string repoRelativePath, string repoRoot)
+    {
+        var fullPath = Path.Join(repoRoot, repoRelativePath);
+        var resolvedName = PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(fullPath, repoRoot)?.FirstOrDefault();
+        if (resolvedName is null)
+        {
+            return repoRelativePath;
+        }
+
+        var relativeResolvedName = Path.GetRelativePath(repoRoot, resolvedName).FullyNormalizedRootedPath();
+        return relativeResolvedName;
+    }
+
+    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string repoRoot)
     {
         string GetFullRepoPath(string path)
         {
@@ -793,6 +807,7 @@ public class RunWorker
         var dependencyFiles = discoveryResult.Projects
             .Select(p => GetFullRepoPath(p.FilePath))
             .Concat(auxiliaryFiles)
+            .Select(p => EnsureCorrectFileCasing(p, repoRoot))
             .Distinct()
             .OrderBy(p => p)
             .ToArray();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -41,7 +41,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -61,7 +61,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -80,10 +80,10 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     return;
                 }
 
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
                 await tracker.StartTrackingAsync(discoveryResult);
 
-                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
                 await apiHandler.UpdateDependencyList(updatedDependencyList);
 
                 var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
@@ -183,10 +183,10 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 return;
             }
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
             await tracker.StartTrackingAsync(discoveryResult);
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsPerformed = new List<UpdateOperationBase>();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/IUpdateHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/IUpdateHandler.cs
@@ -6,7 +6,7 @@ public interface IUpdateHandler
 {
     string TagName { get; }
     bool CanHandle(Job job);
-    Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger);
+    Task HandleAsync(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger);
 }
 
 public static class IUpdateHandlerExtensions

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -72,7 +72,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -86,7 +86,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -44,8 +44,9 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         return job.UpdatingAPullRequest;
     }
 
-    public async Task HandleAsync(Job job, DirectoryInfo repoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
+    public async Task HandleAsync(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
     {
+        var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         if (job.DependencyGroupToRefresh is null)
         {
             throw new InvalidOperationException($"{nameof(job.DependencyGroupToRefresh)} must be non-null.");
@@ -71,7 +72,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -85,7 +86,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(repoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -41,7 +41,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -75,7 +75,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 continue;
             }
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -40,7 +40,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -74,7 +74,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", relevantUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyUpdatesToPerform in relevantUpdateOperationsToPerform)
             {

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -29,8 +29,8 @@ function Get-Files {
         $script:operationExitCode = $LASTEXITCODE
     }
 
-    if ($script:operationExitCode -eq 0) {
-        # this only makes sense if the native clone operation succeeded
+    if ($script:operationExitCode -eq 0 && "$env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH" -eq "") {
+        # this only makes sense if the native clone operation succeeded and we're not running in case-insensitive mode
         Repair-FileCasing
     }
 }
@@ -49,14 +49,33 @@ function Update-Files {
     Push-Location $env:DEPENDABOT_REPO_CONTENTS_PATH
     $baseCommitSha = git rev-parse HEAD
     Pop-Location
+    Write-Host "Base commit SHA: $baseCommitSha"
 
-    & $updaterTool run `
-        --job-path $env:DEPENDABOT_JOB_PATH `
-        --repo-contents-path $env:DEPENDABOT_REPO_CONTENTS_PATH `
-        --api-url $env:DEPENDABOT_API_URL `
-        --job-id $env:DEPENDABOT_JOB_ID `
-        --output-path $env:DEPENDABOT_OUTPUT_PATH `
-        --base-commit-sha $baseCommitSha
+    $arguments = @()
+    $arguments += "--job-path `"$env:DEPENDABOT_JOB_PATH`""
+    $arguments += "--repo-contents-path `"$env:DEPENDABOT_REPO_CONTENTS_PATH`""
+    $arguments += "--api-url `"$env:DEPENDABOT_API_URL`""
+    $arguments += "--job-id `"$env:DEPENDABOT_JOB_ID`""
+    $arguments += "--output-path `"$env:DEPENDABOT_OUTPUT_PATH`""
+    $arguments += "--base-commit-sha `"$baseCommitSha`""
+    if ("$env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH" -ne "") {
+        # ensure the updater gets this optional path
+        $arguments += "--case-insensitive-repo-contents-path `"$env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH`""
+
+        # redirect the local package cache to the case-insensitive path
+        $caseInsensitiveRoot = Join-Path $env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH ".."
+        $env:NUGET_PACKAGES = "$caseInsensitiveRoot/.nuget/packages"
+        $env:NUGET_HTTP_CACHE_PATH = "$caseInsensitiveRoot/.nuget/http-cache"
+        $env:NUGET_SCRATCH = "$caseInsensitiveRoot/.nuget/scratch"
+        $env:NUGET_PLUGINS_CACHE_PATH = "$caseInsensitiveRoot/.nuget/plugins-cache"
+
+        # migrate local package cache from the local image
+        Write-Host "Copying NuGet packages to case-inseensitive cache path: $env:NUGET_PACKAGES"
+        New-Item -ItemType Directory -Path $env:NUGET_PACKAGES | Out-Null
+        Copy-Item -Path "$env:DEPENDABOT_HOME/.nuget/packages/*" -Destination $env:NUGET_PACKAGES -Recurse -Force
+    }
+
+    Invoke-Expression -Command "$updaterTool run $arguments"
     $script:operationExitCode = $LASTEXITCODE
 }
 

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -62,17 +62,15 @@ function Update-Files {
         # ensure the updater gets this optional path
         $arguments += "--case-insensitive-repo-contents-path `"$env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH`""
 
-        # redirect the local package cache to the case-insensitive path
+        # redirect the local package cache to the case-insensitive path...
         $caseInsensitiveRoot = Join-Path $env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH ".."
         $env:NUGET_PACKAGES = "$caseInsensitiveRoot/.nuget/packages"
         $env:NUGET_HTTP_CACHE_PATH = "$caseInsensitiveRoot/.nuget/http-cache"
         $env:NUGET_SCRATCH = "$caseInsensitiveRoot/.nuget/scratch"
         $env:NUGET_PLUGINS_CACHE_PATH = "$caseInsensitiveRoot/.nuget/plugins-cache"
 
-        # migrate local package cache from the local image
-        Write-Host "Copying NuGet packages to case-inseensitive cache path: $env:NUGET_PACKAGES"
-        New-Item -ItemType Directory -Path $env:NUGET_PACKAGES | Out-Null
-        Copy-Item -Path "$env:DEPENDABOT_HOME/.nuget/packages/*" -Destination $env:NUGET_PACKAGES -Recurse -Force
+        # ...but still allow read access to the pre-populated packages
+        $env:NUGET_FALLBACK_PACKAGES = "$env:DEPENDABOT_HOME/.nuget/packages"
     }
 
     Invoke-Expression -Command "$updaterTool run $arguments"


### PR DESCRIPTION
Mature .NET repos with NuGet packages are often built only on Windows with a case-insensitive filesystem.  This can cause issues with the NuGet updater because it does much of its work by calling the external tool `dotnet` and `MSBuild`.  Since we can't intercept their filesystem access, this can cause a problem if a `.csproj` contains the line `<Import Project="build/versions.props" />` but the file in the repo and on disk is named `build/Versions.props` (note the upper-case `V`).

The fix is to allow the updater access to two paths: `$DEPENDABOT_REPO_CONTENTS_PATH` as before and a new `$DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH` which is a layer over the same storage, but with a case-insensitive filter on top.  (More on that later.)

Most of the changes in this PR are plumbing through this additional path where the real work is the new helper function `EnsureCorrectFileCasing()` in `RunWorker.cs`.  This function is called right before file path information is returned to the service via `update_dependency_list`, `create_pull_request`, or `update_pull_request`.

The work for the new case-insensitive filesystem layer is in dependabot/cli#472 and the changes in this PR will have no effect until that is also used.

Note that currently the dependabot CLI isn't used by the GitHub dependabot runner, so this new behavior will only surface where the CLI is directly invoked.