### PR TITLE
only close with `up_to_date` if there are no operations to perform

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -86,7 +86,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                     .Where(set => set.Item3.IsVulnerable)
                     .ToArray();
 
-                if (vulnerableDependenciesToUpdate.Length < dependencyGroupToUpdate.Value.Length)
+                if (vulnerableDependenciesToUpdate.Length == 0)
                 {
                     var close = ClosePullRequest.WithUpToDate(job);
                     logger.Info(close.GetReport());


### PR DESCRIPTION
The NuGet updater was doing a less-than check for vulnerable dependencies by name vs. total dependencies by name, but that doesn't account for the possibility that a scan could return a certain dependency for two projects, one where it's actually up to date and another where it's vulnerable and needs to be processed.

The fix is to do a zero check instead of less-than before closing an existing pull request and declaring it up-do-date.

Issue found from manual log scan.