### PR TITLE
Fix Maven Regex that detects `pom.xml` indentation.

### DIFF
--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -333,8 +333,8 @@ module Dependabot
       sig { params(project: REXML::Element).returns(T::Hash[Symbol, T.untyped]) }
       def detect_indentation_config(project)
         sample_indent = project.children.find do |child|
-          child.to_s.match?(/\n[\t\s]+/)
-        end&.to_s&.match(/\n([\t\s]+)/)&.[](1)
+          child.to_s.match?(/\n(\t+| +)$/)
+        end&.to_s&.match(/\n(\t+| +)$/)&.[](1)
 
         base_indent = sample_indent || "  "
 

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -265,6 +265,47 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         end
       end
 
+      context "with a transitive dependency not added to dependencyManagement with mixed indentation" do
+        let(:pom_body) do
+          fixture("poms", "transitive_dependency_pom_version_not_defined_mixed_indentation.xml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.apache.zookeeper:zookeeper",
+            version: "3.7.2",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "3.7.2",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            previous_requirements: [{
+              file: "pom.xml",
+              requirement: "3.4.6",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            package_manager: "maven"
+          )
+        end
+
+        its(:content) do
+          is_expected.to include(
+            "  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>3.7.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>"
+          )
+        end
+      end
+
       context "with a transitive dependency not in dependencyManagement and pom file doesn't have XML namespace" do
         let(:pom_body) do
           fixture("poms", "transitive_dependency_pom_version_not_defined_no_namespace.xml")

--- a/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_mixed_indentation.xml
+++ b/maven/spec/fixtures/poms/transitive_dependency_pom_version_not_defined_mixed_indentation.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+							               
+  	<modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Plugin POM</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.11.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes a bug where indentation might not be correctly detected if a first blank line in <project> contains spaces and tabs or mix of those. Regex is updated to look at the whitespace that's last before the tag and also filters to match either only tabs or spaces, ignoring lines with mixed indentation.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
