### PR TITLE
Bump `google-protobuf` from `4.28.2` to `4.31.1` to fix GCC 15 incompatibility

### DIFF
--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -208,10 +208,16 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.2.2)
     citrus (3.0.2)
     commonmarker (2.3.1)
       rb_sys (~> 0.9)
+    commonmarker (2.3.1-aarch64-linux)
+    commonmarker (2.3.1-aarch64-linux-musl)
+    commonmarker (2.3.1-arm64-darwin)
+    commonmarker (2.3.1-x86_64-darwin)
+    commonmarker (2.3.1-x86_64-linux)
+    commonmarker (2.3.1-x86_64-linux-musl)
     concurrent-ruby (1.2.3)
     crack (1.0.0)
       bigdecimal
@@ -244,10 +250,34 @@ GEM
       base64 (~> 0.2.0)
       httparty (~> 0.20)
       terminal-table (>= 1.5.1)
-    google-protobuf (4.28.2)
+    google-protobuf (4.31.1)
       bigdecimal
       rake (>= 13)
-    googleapis-common-protos-types (1.16.0)
+    google-protobuf (4.31.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.31.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
     gpgme (2.0.24)
       mini_portile2 (~> 2.7)
@@ -286,6 +316,22 @@ GEM
     netrc (0.11.0)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.8-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (7.2.0)
       faraday (>= 1, < 3)
@@ -346,14 +392,14 @@ GEM
       opentelemetry-api (~> 1.1)
       opentelemetry-metrics-api (~> 0.2)
       opentelemetry-sdk (~> 1.2)
-    opentelemetry-registry (0.3.0)
+    opentelemetry-registry (0.4.0)
       opentelemetry-api (~> 1.1)
     opentelemetry-sdk (1.8.0)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.10.0)
+    opentelemetry-semantic_conventions (1.11.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -368,7 +414,7 @@ GEM
     public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     rake-compiler-dock (1.9.1)
     rb_sys (0.9.116)
       rake-compiler-dock (= 1.9.1)
@@ -472,7 +518,19 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   debug (~> 1.9)
@@ -545,9 +603,15 @@ CHECKSUMS
   aws-sdk-ecr (1.68.0) sha256=86763b7291170dc6dbbf827f35d4142683622e68d7dff6719eeb98b13b677e80
   aws-sigv4 (1.8.0) sha256=84dd99768b91b93b63d1d8e53ee837cfd06ab402812772a7899a78f9f9117cbc
   base64 (0.2.0) sha256=0f25e9b21a02a0cc0cea8ef92b2041035d39350946e8789c562b2d1a3da01507
-  bigdecimal (3.1.8) sha256=a89467ed5a44f8ae01824af49cbc575871fa078332e8f77ea425725c1ffe27be
+  bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
   citrus (3.0.2) sha256=4ec2412fc389ad186735f4baee1460f7900a8e130ffe3f216b30d4f9c684f650
   commonmarker (2.3.1) sha256=8943ef0731a4205765b1ab8f25a7a9b9f62acb28b0054c7d60f06720a23cadc7
+  commonmarker (2.3.1-aarch64-linux) sha256=43b940cb5a4d59378c68d1dcf4480b4223817aaf53acebe262467eca8dd14807
+  commonmarker (2.3.1-aarch64-linux-musl) sha256=57971a5429973823f315a861210883640c864182cd622e3691b3d71321c9b3aa
+  commonmarker (2.3.1-arm64-darwin) sha256=e1c8991b92ea971b8933621124f6461ef06ea64c031429d8b8ebd297dab790dc
+  commonmarker (2.3.1-x86_64-darwin) sha256=75475606be508f0e3dbae03612516e89e8cbf8d0913c172729b53d0c30853d5e
+  commonmarker (2.3.1-x86_64-linux) sha256=afa0df3f64076f0fe996120783db6af28b6d634019ff3a954155884d409caf2a
+  commonmarker (2.3.1-x86_64-linux-musl) sha256=70556fce0bc3f67026e5a20ea9881080755cae80d165374c88498402ba9536a5
   concurrent-ruby (1.2.3) sha256=82fdd3f8a0816e28d513e637bb2b90a45d7b982bdf4f3a0511722d2e495801e2
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   csv (3.3.0) sha256=0bbd1defdc31134abefed027a639b3723c2753862150f4c3ee61cab71b20d67d
@@ -591,8 +655,16 @@ CHECKSUMS
   ffi-compiler (1.0.1) sha256=019f389b078a2fec9de7f4f65771095f80a447e34436b4588bcb629e2a564c30
   flamegraph (0.9.5) sha256=a683020637ffa0e14a72640fa41babf14d926bfeaed87e31907cfd06ab2de8dc
   gitlab (5.1.0) sha256=021c27807a98f379c0cfeda459327c026d3756dbd6531dc1479f0e3df03572c7
-  google-protobuf (4.28.2) sha256=6841bb4566bc33fc2d59b4dd28bfd9308fc528545f21722e9f6e6fa566289c29
-  googleapis-common-protos-types (1.16.0) sha256=94655d1aeb9f3cb2da6b58affb131562851a8d89b69273fac84570f505b3d1f7
+  google-protobuf (4.31.1) sha256=022bc82931a0860a7f2ace41bd48e904c8e65032c1d5eefc33294b5edf9741f8
+  google-protobuf (4.31.1-aarch64-linux-gnu) sha256=d5b8268b2e07776b15a73ed96ca416eab771821b162b239dbdbfb2c85e2d17e5
+  google-protobuf (4.31.1-aarch64-linux-musl) sha256=fcd5b79ac4048e89e44c4c64fb432fa6400ec3c2f0344a7effa95fbc6895d24a
+  google-protobuf (4.31.1-arm64-darwin) sha256=177ca61d254e4516d42997aa9d3127fd5e04ffc60c4ad333b1515ded6d7af89d
+  google-protobuf (4.31.1-x86-linux-gnu) sha256=88fbe376846cd2eb16f538f56c987ec389b932316f40a4db53c317543e0c978e
+  google-protobuf (4.31.1-x86-linux-musl) sha256=8f91a6046bf9c94cf5dfe70a3415c38931f60851cfedefc059c2bda13d758256
+  google-protobuf (4.31.1-x86_64-darwin) sha256=bdf067d1456167275ca7ce269922a99d24fcb9071d86429289cd73f0cf536ae4
+  google-protobuf (4.31.1-x86_64-linux-gnu) sha256=7def6dbf996dab289dd541a3ee8b201e2c3e35911c274325ad9b483ebffb6dcd
+  google-protobuf (4.31.1-x86_64-linux-musl) sha256=7d99d7728d9d7a6fda36130acac2a9947b868e28fe3f4aec4131cebce0d420f9
+  googleapis-common-protos-types (1.20.0) sha256=5e374b06bcfc7e13556e7c0d87b99f1fa3d42de6396a1de3d8fc13aefb4dd07f
   gpgme (2.0.24) sha256=53eccd7042abb4fd5c78f30bc9ed075b1325e6450eab207f2f6a1e7e28ae3b64
   hashdiff (1.1.1) sha256=c7966316726e0ceefe9f5c6aef107ebc3ccfef8b6db55fe3934f046b2cf0936a
   http (5.1.1) sha256=fcaec14a4f82de6d2f9cb978c07326814c6c2b42b8974f6ec166ff19c645ebaf
@@ -614,6 +686,14 @@ CHECKSUMS
   multi_xml (0.7.1) sha256=4fce100c68af588ff91b8ba90a0bb3f0466f06c909f21a32f4962059140ba61b
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
   nokogiri (1.18.8) sha256=8c7464875d9ca7f71080c24c0db7bcaa3940e8be3c6fc4bcebccf8b9a0016365
+  nokogiri (1.18.8-aarch64-linux-gnu) sha256=36badd2eb281fca6214a5188e24a34399b15d89730639a068d12931e2adc210e
+  nokogiri (1.18.8-aarch64-linux-musl) sha256=664e0f9a77a7122a66d6c03abba7641ca610769a4728db55ee1706a0838b78a2
+  nokogiri (1.18.8-arm-linux-gnu) sha256=17de01ca3adf9f8e187883ed73c672344d3dbb3c260f88ffa1008e8dc255a28e
+  nokogiri (1.18.8-arm-linux-musl) sha256=6e6d7e71fc39572bd613a82d528cf54392c3de1ba5ce974f05c832b8187a040b
+  nokogiri (1.18.8-arm64-darwin) sha256=483b5b9fb33653f6f05cbe00d09ea315f268f0e707cfc809aa39b62993008212
+  nokogiri (1.18.8-x86_64-darwin) sha256=024cdfe7d9ae3466bba6c06f348fb2a8395d9426b66a3c82f1961b907945cc0c
+  nokogiri (1.18.8-x86_64-linux-gnu) sha256=4a747875db873d18a2985ee2c320a6070c4a414ad629da625fbc58d1a20e5ecc
+  nokogiri (1.18.8-x86_64-linux-musl) sha256=ddd735fba49475a395b9ea793bb6474e3a3125b89960339604d08a5397de1165
   octokit (7.2.0) sha256=7032d968d03177ee7a29e3bd4782fc078215cca4743db0dfc66a49feb9411907
   opentelemetry-api (1.5.0) sha256=8dcc33e7aba70b1da630065ce0db3d6f50cb8ebd2017383209739439025ea997
   opentelemetry-common (0.22.0) sha256=ce5e96a0f838d67eb70a1d32e02bdbe7b8f41767bc71994d73b299a8b0c5878d
@@ -629,9 +709,9 @@ CHECKSUMS
   opentelemetry-logs-sdk (0.2.0) sha256=5911963a80e8852d07bf0e4acf630dac4177af178a0fc0287a1878114c81c640
   opentelemetry-metrics-api (0.3.0) sha256=29f4b82cd5c5992884f4dc68d279a2cc114560f433c431bf9ef6f42d8d0f10b1
   opentelemetry-metrics-sdk (0.6.0) sha256=8cf629c8e533d01e21675eef55fe9e824e67a2d8d21bb708d4931d62c8cdc065
-  opentelemetry-registry (0.3.0) sha256=116ab6114a706340900718298c126f720e50b1ef3cfdbe5997611ff232fe6822
+  opentelemetry-registry (0.4.0) sha256=903fa6bfaa29eac1c1d73a4fdd29b850977b5353b84b8cdff11222c00ad2968f
   opentelemetry-sdk (1.8.0) sha256=fad979b4a6c7ad5b2f9f2bfde77ab5c0c6a9b81d5a6458becf5957e3fa371df7
-  opentelemetry-semantic_conventions (1.10.0) sha256=13d24c1071736004a6c09113ee9fe163a25daa0defe6ab279a42cac7b92b1b76
+  opentelemetry-semantic_conventions (1.11.0) sha256=89f209f588d48a8e38ca2205c24c6b4a35f3d2622c2f1854bd476c56290afdcb
   ostruct (0.6.1) sha256=09a3fb7ecc1fa4039f25418cc05ae9c82bd520472c5c6a6f515f03e4988cb817
   parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
   parallel_tests (4.7.1) sha256=98ad977f5e5a28df77c0364504bdea21f0a2a9ea86eae238668fdfec341ab860
@@ -641,7 +721,7 @@ CHECKSUMS
   public_suffix (6.0.1) sha256=61d44e1cab5cbbbe5b31068481cf16976dd0dc1b6b07bd95617ef8c5e3e00c6f
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
+  rake (13.3.0) sha256=96f5092d786ff412c62fde76f793cc0541bd84d2eb579caa529aa8a059934493
   rake-compiler-dock (1.9.1) sha256=e73720a29aba9c114728ce39cc0d8eef69ba61d88e7978c57bac171724cd4d53
   rb_sys (0.9.116) sha256=c879891018535d4362455197065ea580541b10ffdfa940bec512ec1dd9a7def4
   rdoc (6.6.3.1) sha256=39f7b749229ab5ad9d21c81586151c1dd7a549fa8be4070ee09b524f9c656345


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

This resolves build failures with GCC 15. Related to #12508 and #12545

Before this change, running `bundle install` resulted in the following build failure

<details>
<summary>Details</summary>

```
current directory: /home/jamie/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/google-protobuf-4.28.2/ext/google/protobuf_c
/home/jamie/.local/share/mise/installs/ruby/3.4.4/bin/ruby extconf.rb
creating Makefile

current directory: /home/jamie/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/google-protobuf-4.28.2/ext/google/protobuf_c
make DESTDIR\= sitearchdir\=./.gem.20250705-2604-o0ps3o sitelibdir\=./.gem.20250705-2604-o0ps3o clean

current directory: /home/jamie/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/google-protobuf-4.28.2/ext/google/protobuf_c
make DESTDIR\= sitearchdir\=./.gem.20250705-2604-o0ps3o sitelibdir\=./.gem.20250705-2604-o0ps3o
compiling protobuf.c
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/long.h:42,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/int.h:26,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/char.h:23,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic.h:24,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:28,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby.h:38,
                 from protobuf.h:13,
                 from protobuf.c:8:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:137:15: error: unknown type name ‘bool’
  137 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:31:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   30 | #include "ruby/internal/attr/enum_extensibility.h"
  +++ |+#include <stdbool.h>
   31 | #include "ruby/internal/stdbool.h"
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:172:15: error: unknown type name ‘bool’
  172 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:172:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:188:15: error: unknown type name ‘bool’
  188 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:188:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:205:15: error: unknown type name ‘bool’
  205 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:205:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:246:15: error: unknown type name ‘bool’
  246 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:246:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:266:15: error: unknown type name ‘bool’
  266 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:266:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:287:15: error: unknown type name ‘bool’
  287 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:287:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:310:15: error: unknown type name ‘bool’
  310 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:310:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:326:15: error: unknown type name ‘bool’
  326 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/special_consts.h:326:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/long.h:215:15: error: unknown type name ‘bool’
  215 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/long.h:43:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   42 | #include "ruby/internal/special_consts.h"      /* FIXNUM_FLAG */
  +++ |+#include <stdbool.h>
   43 | #include "ruby/internal/value.h"
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:38,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rstring.h:30,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/arithmetic/char.h:29:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:203:15: error: unknown type name ‘bool’
  203 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:34:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   33 | #include "ruby/internal/error.h"
  +++ |+#include <stdbool.h>
   34 | #include "ruby/internal/has/builtin.h"
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: In function ‘rb_integer_type_p’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:207:16: error: ‘true’ undeclared (first use in this function)
  207 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:207:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:207:16: note: each undeclared identifier is reported only once for each function it appears in
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:210:16: error: ‘false’ undeclared (first use in this function)
  210 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:210:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:263:15: error: unknown type name ‘bool’
  263 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:263:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: In function ‘RB_FLOAT_TYPE_P’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:267:16: error: ‘true’ undeclared (first use in this function)
  267 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:267:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:270:16: error: ‘false’ undeclared (first use in this function)
  270 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:270:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:286:15: error: unknown type name ‘bool’
  286 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:286:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: In function ‘RB_DYNAMIC_SYM_P’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:290:16: error: ‘false’ undeclared (first use in this function)
  290 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:290:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:306:15: error: unknown type name ‘bool’
  306 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:306:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:325:8: error: unknown type name ‘bool’
  325 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:325:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: In function ‘rbimpl_RB_TYPE_P_fastpath’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:350:16: error: ‘false’ undeclared (first use in this function)
  350 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:350:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:353:16: error: ‘true’ undeclared (first use in this function)
  353 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:353:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:375:15: error: unknown type name ‘bool’
  375 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:375:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:419:15: error: unknown type name ‘bool’
  419 | static inline bool rbimpl_rtypeddata_p(VALUE obj);
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/value_type.h:419:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:443:8: error: unknown type name ‘bool’
  443 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:41:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   40 | #include "ruby/defines.h"
  +++ |+#include <stdbool.h>
   41 | 
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: In function ‘RB_FL_ABLE’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:447:16: error: ‘false’ undeclared (first use in this function)
  447 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:447:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:453:16: error: ‘true’ undeclared (first use in this function)
  453 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:453:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:517:15: error: unknown type name ‘bool’
  517 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:517:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:533:15: error: unknown type name ‘bool’
  533 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:533:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:551:15: error: unknown type name ‘bool’
  551 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:551:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:567:15: error: unknown type name ‘bool’
  567 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:567:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:755:15: error: unknown type name ‘bool’
  755 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:755:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTABLE’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:759:12: error: ‘false’ undeclared (first use in this function)
  759 |     return false;
      |            ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:759:12: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTED_RAW’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:777:12: error: ‘false’ undeclared (first use in this function)
  777 |     return false;
      |            ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:777:12: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:791:15: error: unknown type name ‘bool’
  791 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:791:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_TAINTED’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:795:12: error: ‘false’ undeclared (first use in this function)
  795 |     return false;
      |            ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:795:12: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:897:15: error: unknown type name ‘bool’
  897 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:897:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h: In function ‘RB_OBJ_FROZEN’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:901:16: error: ‘true’ undeclared (first use in this function)
  901 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/fl_type.h:901:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rarray.h:32,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core.h:23,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:29:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:705:15: error: unknown type name ‘bool’
  705 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:27:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   26 | # include <stddef.h>                       /* size_t */
  +++ |+#include <stdbool.h>
   27 | #endif
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:725:15: error: unknown type name ‘bool’
  725 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:725:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h: In function ‘RB_OBJ_PROMOTED’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:729:16: error: ‘false’ undeclared (first use in this function)
  729 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/gc.h:729:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core.h:25:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rbignum.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rbignum.h:60:15: error: unknown type name ‘bool’
   60 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rbignum.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef RBIMPL_RBIGNUM_H                             /*-*-C++-*-vi:se ft=cpp:*/
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rbignum.h:73:15: error: unknown type name ‘bool’
   73 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rbignum.h:73:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core.h:34:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:518:15: error: unknown type name ‘bool’
  518 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:27:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   26 | # include <stddef.h>
  +++ |+#include <stdbool.h>
   27 | #endif
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:561:15: error: unknown type name ‘bool’
  561 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:561:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:578:15: error: unknown type name ‘bool’
  578 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rtypeddata.h:578:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:42:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/memory.h:420:5: error: unknown type name ‘bool’
  420 |     bool left;                  /**< Whether overflow happened or not. */
      |     ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/memory.h:65:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   64 | #include "ruby/internal/stdckdint.h"
  +++ |+#include <stdbool.h>
   65 | #include "ruby/internal/xmalloc.h"
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/memory.h: In function ‘rbimpl_size_mul_overflow’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/memory.h:574:49: error: ‘false’ undeclared (first use in this function)
  574 |     struct rbimpl_size_mul_overflow_tag ret = { false,  0, };
      |                                                 ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/memory.h:574:49: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:46:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:252:15: error: unknown type name ‘bool’
  252 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:39:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   38 | #include "ruby/internal/intern/proc.h"  /* rb_block_proc */
  +++ |+#include <stdbool.h>
   39 | #include "ruby/internal/iterator.h"     /* rb_block_given_p / rb_keyword_given_p */
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h: In function ‘rb_scan_args_keyword_p’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:259:16: error: ‘true’ undeclared (first use in this function)
  259 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:259:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:263:16: error: ‘false’ undeclared (first use in this function)
  263 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:263:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:268:8: error: unknown type name ‘bool’
  268 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:268:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:282:8: error: unknown type name ‘bool’
  282 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:282:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:303:8: error: unknown type name ‘bool’
  303 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:303:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:334:8: error: unknown type name ‘bool’
  334 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:334:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:349:8: error: unknown type name ‘bool’
  349 | static bool
      |        ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:349:8: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:18: error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                  ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:18: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:30: error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                              ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:30: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:43: error: unknown type name ‘bool’
  390 |                  bool f_var, bool f_hash, bool f_block,
      |                                           ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/scan_args.h:390:43: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/intern.h:41,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:194:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/intern/load.h:234:25: error: unknown type name ‘bool’
  234 | void rb_ext_ractor_safe(bool flag);
      |                         ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/intern/load.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef  RBIMPL_INTERN_LOAD_H                        /*-*-C++-*-vi:se ft=cpp:*/
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/encoding.h:21,
                 from protobuf.h:26:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/coderange.h:79:15: error: unknown type name ‘bool’
   79 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/coderange.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef RUBY_INTERNAL_ENCODING_CODERANGE_H           /*-*-C++-*-vi:se ft=cpp:*/
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/coderange.h:113:15: error: unknown type name ‘bool’
  113 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/coderange.h:113:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:27,
                 from /home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/encoding.h:22:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:767:15: error: unknown type name ‘bool’
  767 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:25:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   24 | #include "ruby/oniguruma.h"
  +++ |+#include <stdbool.h>
   25 | #include "ruby/internal/attr/const.h"
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h: In function ‘rb_enc_asciicompat’:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:771:16: error: ‘false’ undeclared (first use in this function)
  771 |         return false;
      |                ^~~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:771:16: note: ‘false’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:777:16: error: ‘true’ undeclared (first use in this function)
  777 |         return true;
      |                ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:777:16: note: ‘true’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h: At top level:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:788:15: error: unknown type name ‘bool’
  788 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:788:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:926:15: error: unknown type name ‘bool’
  926 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/encoding.h:926:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:42:15: error: unknown type name ‘bool’
   42 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:28:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
   27 | #include "ruby/internal/encoding/encoding.h"
  +++ |+#include <stdbool.h>
   28 | #include "ruby/internal/value.h"
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:62:15: error: unknown type name ‘bool’
   62 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:62:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:81:15: error: unknown type name ‘bool’
   81 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:81:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:95:15: error: unknown type name ‘bool’
   95 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:95:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:109:15: error: unknown type name ‘bool’
  109 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:109:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:123:15: error: unknown type name ‘bool’
  123 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:123:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:137:15: error: unknown type name ‘bool’
  137 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:137:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:151:15: error: unknown type name ‘bool’
  151 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:151:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:165:15: error: unknown type name ‘bool’
  165 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:165:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:179:15: error: unknown type name ‘bool’
  179 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:179:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:193:15: error: unknown type name ‘bool’
  193 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:193:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:207:15: error: unknown type name ‘bool’
  207 | static inline bool
      |               ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/encoding/ctype.h:207:15: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
In file included from protobuf.h:27:
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/vm.h:57:1: error: unknown type name ‘bool’
   57 | bool ruby_free_at_exit_p(void);
      | ^~~~
/home/jamie/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/vm.h:1:1: note: ‘bool’ is defined in header ‘<stdbool.h>’; this is probably fixable by adding ‘#include <stdbool.h>’
  +++ |+#include <stdbool.h>
    1 | #ifndef RUBY_VM_H                                    /*-*-C++-*-vi:se ft=cpp:*/
In file included from defs.h:12,
                 from protobuf.h:29:
ruby-upb.h: In function ‘_upb_vsnprintf’:
ruby-upb.h:13230:3: warning: function ‘_upb_vsnprintf’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
13230 |   return vsnprintf(buf, size, fmt, ap);
      |   ^~~~~~
protobuf.c: In function ‘StringBuilder_New’:
protobuf.c:46:16: warning: old-style function definition [-Wold-style-definition]
   46 | StringBuilder *StringBuilder_New() {
      |                ^~~~~~~~~~~~~~~~~
protobuf.c: In function ‘StringBuilder_Printf’:
protobuf.c:66:3: warning: function ‘StringBuilder_Printf’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
   66 |   n = vsnprintf(&b->data[b->size], have, fmt, args);
      |   ^
protobuf.c:76:5: warning: function ‘StringBuilder_Printf’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
   76 |     n = vsnprintf(&b->data[b->size], have, fmt, args);
      |     ^
protobuf.c: In function ‘Arena_new’:
protobuf.c:222:7: warning: old-style function definition [-Wold-style-definition]
  222 | VALUE Arena_new() { return Arena_alloc(cArena); }
      |       ^~~~~~~~~
protobuf.c: In function ‘Init_protobuf_c’:
protobuf.c:327:45: warning: old-style function definition [-Wold-style-definition]
  327 | __attribute__((visibility("default"))) void Init_protobuf_c() {
      |                                             ^~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
make: *** [Makefile:251: protobuf.o] Error 1

make failed, exit code 2
```

</details>

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I haven't been able to identify the exact commit that fixed the issue in [the upstream repository](https://github.com/protocolbuffers/protobuf), but `bundle install` does now work.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
