### PR TITLE
Track local dependencies from uv tool sources

### DIFF
--- a/uv/helpers/lib/parser.py
+++ b/uv/helpers/lib/parser.py
@@ -86,6 +86,23 @@ def parse_pep621_dependencies(pyproject_path):
             )
             dependencies.extend(build_system_dependencies)
 
+    # Parse UV sources for path dependencies
+    if 'tool' in project_toml and 'uv' in project_toml['tool'] and 'sources' in project_toml['tool']['uv']:
+        uv_sources = project_toml['tool']['uv']['sources']
+        for dep_name, source_config in uv_sources.items():
+            if isinstance(source_config, dict) and 'path' in source_config:
+                # Add path dependency info (but don't parse as regular dependency)
+                dependencies.append({
+                    "name": dep_name,
+                    "version": None,
+                    "markers": None,
+                    "file": pyproject_path,
+                    "requirement": None,
+                    "extras": [],
+                    "path_dependency": True,
+                    "path": source_config['path']
+                })
+
     return json.dumps({"result": dependencies})
 
 

--- a/uv/spec/dependabot/uv/file_fetcher_spec.rb
+++ b/uv/spec/dependabot/uv/file_fetcher_spec.rb
@@ -797,5 +797,72 @@ RSpec.describe Dependabot::Uv::FileFetcher do
           .to raise_error(Dependabot::DependencyFileNotFound)
       end
     end
+
+    context "with UV sources path dependencies" do
+      describe "#uv_sources_path_dependencies" do
+        let(:pyproject_content) { fixture("pyproject_files", "uv_path_dependencies.toml") }
+        let(:pyproject_file) do
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: pyproject_content
+          )
+        end
+
+        before do
+          allow(file_fetcher_instance).to receive(:pyproject).and_return(pyproject_file)
+        end
+
+        it "detects UV sources path dependencies" do
+          path_deps = file_fetcher_instance.send(:uv_sources_path_dependencies)
+          expect(path_deps).to contain_exactly(
+            { name: "protos", path: "../protos", file: "pyproject.toml" },
+            { name: "another-local", path: "local-lib", file: "pyproject.toml" }
+          )
+        end
+
+        it "includes UV sources in path_dependencies method" do
+          # Mock other path dependency methods to return empty arrays for isolation
+          allow(file_fetcher_instance).to receive(:requirement_txt_path_dependencies).and_return([])
+          allow(file_fetcher_instance).to receive(:requirement_in_path_dependencies).and_return([])
+
+          all_path_deps = file_fetcher_instance.send(:path_dependencies)
+          expect(all_path_deps).to contain_exactly(
+            { name: "protos", path: "../protos", file: "pyproject.toml" },
+            { name: "another-local", path: "./local-lib", file: "pyproject.toml" }
+          )
+        end
+
+        context "when pyproject.toml has no UV sources" do
+          let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
+
+          it "returns empty array for UV sources path dependencies" do
+            path_deps = file_fetcher_instance.send(:uv_sources_path_dependencies)
+            expect(path_deps).to be_empty
+          end
+        end
+
+        context "when UV sources contain non-path dependencies" do
+          let(:pyproject_content) { fixture("pyproject_files", "uv_mixed_sources.toml") }
+
+          it "only detects path-based UV sources" do
+            path_deps = file_fetcher_instance.send(:uv_sources_path_dependencies)
+            expect(path_deps).to contain_exactly(
+              { name: "local-package", path: "./local-package", file: "pyproject.toml" }
+            )
+          end
+        end
+
+        context "when pyproject.toml is nil" do
+          before do
+            allow(file_fetcher_instance).to receive(:pyproject).and_return(nil)
+          end
+
+          it "returns empty array" do
+            path_deps = file_fetcher_instance.send(:uv_sources_path_dependencies)
+            expect(path_deps).to be_empty
+          end
+        end
+      end
+    end
   end
 end

--- a/uv/spec/fixtures/pyproject_files/uv_mixed_sources.toml
+++ b/uv/spec/fixtures/pyproject_files/uv_mixed_sources.toml
@@ -1,0 +1,28 @@
+[project]
+name = "mixed-sources-project"
+version = "0.1.0"
+description = "Test UV mixed source types"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0",
+    "local-package",
+    "git-package",
+    "registry-package",
+]
+
+[tool.uv.sources]
+# Path dependency - should be detected
+local-package = { path = "./local-package" }
+
+# Git dependency - should NOT be detected as path dependency
+git-package = { git = "https://github.com/example/package.git" }
+
+# Registry dependency with custom index - should NOT be detected as path dependency
+registry-package = { index = "https://custom-pypi.example.com/simple" }
+
+# URL dependency - should NOT be detected as path dependency
+url-package = { url = "https://example.com/package.whl" }
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/uv/spec/fixtures/pyproject_files/uv_path_dependencies.toml
+++ b/uv/spec/fixtures/pyproject_files/uv_path_dependencies.toml
@@ -1,0 +1,17 @@
+[project]
+name = "my-project"
+version = "0.1.0"
+description = "Test UV path dependencies"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0",
+    "protos",
+]
+
+[tool.uv.sources]
+protos = { path = "../protos" }
+another-local = { path = "local-lib", editable = true }
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### What are you trying to accomplish?

I have repositories that are in a monorepo that rely on some locally built python packages like protos. So I want dependabot to be able to correctly install the project with these local dependencies when doing version bumps. Right now dependabot is not aware of uv tool sources so it will not copy this local directory when doing the `uv sync`. 

### Anything you want to highlight for special attention from reviewers?

Let me know if the parsing of the toml looks correct I took a shot at it based on some of the other references

### How will you know you've accomplished your goal?

Wrote some tests based on some examples that I ran into when testing this issue.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
