### PR TITLE
Fix gems-bump-version workflow by removing sorbet-runtime

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
-# typed: strict
+# typed: true
 # frozen_string_literal: true
-
-require "sorbet-runtime"
 
 unless %w(minor patch).include?(ARGV[0])
   puts "usage: bin/bump-version.rb minor|patch"
@@ -32,14 +30,14 @@ File.write(version_path, new_version_contents)
 `cd updater/ && bundle lock`
 unless $?.success?
   puts "Failed to update `updater/Gemfile.lock`"
-  exit T.must($?).exitstatus
+  exit $?.exitstatus
 end
 
 # Bump the root's Gemfile.lock with the new version
 `bundle lock`
 unless $?.success?
   puts "Failed to update `Gemfile.lock`"
-  exit T.must($?).exitstatus
+  exit $?.exitstatus
 end
 
 puts new_version


### PR DESCRIPTION
Fixes LoadError: `cannot load such file -- sorbet-runtime`, by reverting changes to `bin/bump-version.rb` in #12490

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
A sorbet typing [PR](https://github.com/dependabot/dependabot-core/pull/12490) has introduced an error when running `bin/bump-version.rb`:

```
Run NEW_VERSION=$(bin/bump-version.rb patch)
  NEW_VERSION=$(bin/bump-version.rb patch)
  echo "New version is: $NEW_VERSION"
  echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
<internal:/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- sorbet-runtime (LoadError)
	from <internal:/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from bin/bump-version.rb:5:in '<main>'
```

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
The bump-version.rb script was updated to require sorbet-runtime, but the workflow wasn't installing gems. We enabled bundler-cache in ruby/setup-ruby to automatically run bundle install and make dependencies available. However, the same error was thrown during testing.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
