### PR TITLE
Fix npm security fix version selection to pick lowest instead of highest version

### DIFF
--- a/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -200,11 +200,8 @@ module Dependabot
             secure_versions = filter_ignored_versions(secure_versions)
             secure_versions = filter_lower_versions(secure_versions)
 
-            # Apply lazy filtering for yanked versions (min or max logic)
-            secure_versions = lazy_filter_yanked_versions_by_min_max(secure_versions, check_max: false)
-
             # Return the lowest non-yanked version
-            secure_versions.max_by(&:version)&.version
+            secure_versions.sort_by(&:version).find { |release| !yanked_version?(release.version) }&.version
           end
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes a bug in the npm_and_yarn package manager where the security fix version selection was incorrectly picking the highest secure version instead of the lowest

### Anything you want to highlight for special attention from reviewers?

The fix replaces the `lazy_filter_yanked_versions_by_min_max` approach with a simpler, more direct method that:
1. Sorts all secure versions by version number (ascending)
2. Finds the first (lowest) non-yanked version
3. Returns that version

This approach is more straightforward and matches the expected behavior from the old implementation. The lazy filtering was designed for finding the latest version efficiently, but for security fixes we specifically need the lowest version, so a simple sort + find is more appropriate.

### How will you know you've accomplished your goal?

Need update smoke test

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.