### PR TITLE
Remove deprecated cooldown feature flag for Python ecosystems: python, uv

### DIFF
--- a/python/lib/dependabot/python/package/package_details_fetcher.rb
+++ b/python/lib/dependabot/python/package/package_details_fetcher.rb
@@ -90,13 +90,11 @@ module Dependabot
             .returns(T.nilable(T::Array[Dependabot::Package::PackageRelease]))
         end
         def fetch_from_registry(index_url)
-          if Dependabot::Experiments.enabled?(:enable_cooldown_for_python)
-            metadata = fetch_from_json_registry(index_url)
+          metadata = fetch_from_json_registry(index_url)
 
-            return metadata if metadata&.any?
+          return metadata if metadata&.any?
 
-            Dependabot.logger.warn("No valid versions found via JSON API. Falling back to HTML.")
-          end
+          Dependabot.logger.warn("No valid versions found via JSON API. Falling back to HTML.")
           fetch_from_html_registry(index_url)
         rescue StandardError => e
           Dependabot.logger.warn("Unexpected error in JSON fetch: #{e.message}. Falling back to HTML.")

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -35,7 +35,7 @@ module Dependabot
 
         sig { override.returns(T::Boolean) }
         def cooldown_enabled?
-          Dependabot::Experiments.enabled?(:enable_cooldown_for_python)
+          true
         end
       end
     end

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -77,16 +77,12 @@ RSpec.describe Dependabot::Python::UpdateChecker do
   end
   let(:pypi_response) { fixture("pypi", "pypi_simple_response.html") }
   let(:pypi_url) { "https://pypi.org/simple/luigi/" }
-  let(:enable_cooldown_for_python) { false }
 
   before do
     stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_file_parser_python_local)
       .and_return(false)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_cooldown_for_python)
-      .and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout)
       .and_return(true)

--- a/uv/lib/dependabot/uv/package/package_details_fetcher.rb
+++ b/uv/lib/dependabot/uv/package/package_details_fetcher.rb
@@ -90,13 +90,11 @@ module Dependabot
             .returns(T.nilable(T::Array[Dependabot::Package::PackageRelease]))
         end
         def fetch_from_registry(index_url)
-          if Dependabot::Experiments.enabled?(:enable_cooldown_for_uv)
-            metadata = fetch_from_json_registry(index_url)
+          metadata = fetch_from_json_registry(index_url)
 
-            return metadata if metadata&.any?
+          return metadata if metadata&.any?
 
-            Dependabot.logger.warn("No valid versions found via JSON API. Falling back to HTML.")
-          end
+          Dependabot.logger.warn("No valid versions found via JSON API. Falling back to HTML.")
           fetch_from_html_registry(index_url)
         rescue StandardError => e
           Dependabot.logger.warn("Unexpected error in JSON fetch: #{e.message}. Falling back to HTML.")

--- a/uv/lib/dependabot/uv/update_checker/latest_version_finder.rb
+++ b/uv/lib/dependabot/uv/update_checker/latest_version_finder.rb
@@ -35,7 +35,7 @@ module Dependabot
 
         sig { override.returns(T::Boolean) }
         def cooldown_enabled?
-          Dependabot::Experiments.enabled?(:enable_cooldown_for_uv)
+          true
         end
       end
     end

--- a/uv/spec/dependabot/uv/package/package_details_fetcher_spec.rb
+++ b/uv/spec/dependabot/uv/package/package_details_fetcher_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Dependabot::Uv::Package::PackageDetailsFetcher do
   let(:json_url) { "https://pypi.org/pypi/#{dependency_name}/json" }
 
   let(:expected_versions) { ["2.32.3", "2.27.0"] }
-  let(:enable_cooldown_for_uv) { false }
 
   let(:expected_releases) do
     [
@@ -74,74 +73,42 @@ RSpec.describe Dependabot::Uv::Package::PackageDetailsFetcher do
     ]
   end
 
-  before do
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_cooldown_for_uv)
-      .and_return(enable_cooldown_for_uv)
-  end
-
-  after do
-    Dependabot::Experiments.reset!
-  end
-
   describe "#fetch" do
     subject(:fetch) { fetcher.fetch }
 
-    context "when enable_cooldown_for_uv is enabled" do
-      let(:enable_cooldown_for_uv) { true }
-
-      context "with a valid JSON response" do
-        before do
-          stub_request(:get, json_url).to_return(status: 200,
-                                                 body: fixture("releases_api", "pypi", "pypi_json_response.json"))
-          stub_request(:get, registry_url).to_return(status: 200,
-                                                     body: fixture("releases_api", "simple", "simple_index.html"))
-        end
-
-        it "fetches data from JSON registry first and returns correct package releases" do
-          result = fetch
-
-          expect(result.releases).not_to be_empty
-          expect(a_request(:get, json_url)).to have_been_made.once
-          expect(a_request(:get, registry_url)).not_to have_been_made
-
-          expect(result.releases.map(&:version)).to match_array(expected_releases.map(&:version))
-        end
+    context "with a valid JSON response" do
+      before do
+        stub_request(:get, json_url).to_return(status: 200,
+                                               body: fixture("releases_api", "pypi", "pypi_json_response.json"))
+        stub_request(:get, registry_url).to_return(status: 200,
+                                                   body: fixture("releases_api", "simple", "simple_index.html"))
       end
 
-      context "when JSON response is empty" do
-        before do
-          stub_request(:get, json_url).to_return(status: 200,
-                                                 body: fixture("releases_api", "pypi", "pypi_json_response_empty.json"))
-          stub_request(:get, registry_url).to_return(status: 200,
-                                                     body: fixture("releases_api", "simple", "simple_index.html"))
-        end
-
-        it "falls back to HTML registry and fetches versions correctly" do
-          result = fetch
-
-          expect(result.releases).not_to be_empty
-          expect(a_request(:get, json_url)).to have_been_made.once
-          expect(a_request(:get, registry_url)).to have_been_made.once
-
-          expect(result.releases.map(&:version)).to match_array(expected_releases.map(&:version))
-        end
-      end
-    end
-
-    context "when enable_cooldown_for_uv is disabled" do
-      let(:enable_cooldown_for_uv) { false }
-
-      it "fetches data from the HTML registry and returns package releases" do
-        stub_request(:get, registry_url).to_return(
-          status: 200, body: fixture("releases_api", "simple", "simple_index.html")
-        )
-
+      it "fetches data from JSON registry first and returns correct package releases" do
         result = fetch
 
         expect(result.releases).not_to be_empty
+        expect(a_request(:get, json_url)).to have_been_made.once
+        expect(a_request(:get, registry_url)).not_to have_been_made
+
+        expect(result.releases.map(&:version)).to match_array(expected_releases.map(&:version))
+      end
+    end
+
+    context "when JSON response is empty" do
+      before do
+        stub_request(:get, json_url).to_return(status: 200,
+                                               body: fixture("releases_api", "pypi", "pypi_json_response_empty.json"))
+        stub_request(:get, registry_url).to_return(status: 200,
+                                                   body: fixture("releases_api", "simple", "simple_index.html"))
+      end
+
+      it "falls back to HTML registry and fetches versions correctly" do
+        result = fetch
+
+        expect(result.releases).not_to be_empty
+        expect(a_request(:get, json_url)).to have_been_made.once
         expect(a_request(:get, registry_url)).to have_been_made.once
-        expect(a_request(:get, json_url)).not_to have_been_made
 
         expect(result.releases.map(&:version)).to match_array(expected_releases.map(&:version))
       end

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -70,13 +70,9 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
   end
   let(:pypi_response) { fixture("pypi", "pypi_simple_response.html") }
   let(:pypi_url) { "https://pypi.org/simple/luigi/" }
-  let(:enable_cooldown_for_uv) { false }
 
   before do
     stub_request(:get, pypi_url).to_return(status: 200, body: pypi_response)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:enable_cooldown_for_uv)
-      .and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_shared_helpers_command_timeout)
       .and_return(true)


### PR DESCRIPTION
### What are you trying to accomplish?

This PR removes the deprecated cooldown feature flag usage across the Python ecosystems: "python" and "uv".

The feature flag was originally used to control behavior related to dependency resolution cooldowns. Now that the cooldown logic is permanently enabled and stable across all Python package managers (pip, poetry, pipenv, pip-tools, uv), the flag and associated conditional logic are no longer needed.

This cleanup helps simplify the codebase, reduce configuration complexity, and eliminate dead code specific to Python package management.

### Anything you want to highlight for special attention from reviewers?

The Python ecosystems had consistent patterns for how the flag was used. In each case, I ensured the removal preserved the current behavior (i.e., as if the flag were always enabled).

Key changes:
- `python` ecosystem: Removed `Dependabot::Experiments.enabled?(:enable_cooldown_for_python)` checks
- `uv` ecosystem: Removed `Dependabot::Experiments.enabled?(:enable_cooldown_for_uv)` checks
- All cooldown functionality now defaults to enabled behavior

Please double-check that the removals in each Python ecosystem (especially any subtle branching logic) are safe and do not impact functionality.

### How will you know you've accomplished your goal?

The goal will be met when:
- The feature flag and its references are fully removed from both Python ecosystems (python, uv)
- All tests pass without needing the flag
- No existing behavior related to dependency resolution cooldowns is altered
- Python package managers (pip, poetry, pipenv, pip-tools, uv) continue to function with cooldown logic enabled by default

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.