### PR TITLE
filter out non-version tags in Helm update checker

### DIFF
--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -235,6 +235,14 @@ module Dependabot
         oci_registry = repo_url.gsub("oci://", "")
 
         release_tags = Helpers.fetch_oci_tags("#{oci_registry}/#{chart_name}").split("\n")
+        # Filter out tags that are not valid versions (e.g., SHA256 hashes, .sig, .att, .metadata files)
+        release_tags = release_tags.select do |tag|
+          # Skip tags that start with "sha256-" or end with .sig, .att, or .metadata
+          next false if tag.start_with?("sha256-") || tag.end_with?(".sig", ".att", ".metadata")
+
+          # Use Version.correct? to check if the tag is a valid version
+          version_class.correct?(tag)
+        end
         release_tags.map { |tag| tag.tr("_", "+") }
       end
 

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -118,6 +118,28 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
           Dependabot::Helm::Version.new("1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238")
         )
       end
+
+      context "when tags include non-version tags like SHA256 hashes and metadata files" do
+        before do
+          allow(Dependabot::Helm::Helpers).to receive(:fetch_oci_tags)
+            .with("registry.sweet.security/helm/frontierchart")
+            .and_return(
+              "1.0.119807+c2277fddd003556d4982b86ef4e77fc84a41ed79\n" \
+              "1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238\n" \
+              "sha256-bbccb29e4f20037bc6c3319199138172c044d29c514431a11f0f2bfd9b694d6d\n" \
+              "sha256-bbccb29e4f20037bc6c3319199138172c044d29c514431a11f0f2bfd9b694d6d.att\n" \
+              "sha256-bbccb29e4f20037bc6c3319199138172c044d29c514431a11f0f2bfd9b694d6d.sig\n" \
+              "sha256-bbccb29e4f20037bc6c3319199138172c044d29c514431a11f0f2bfd9b694d6d.metadata\n" \
+              "1.1.0"
+            )
+        end
+
+        it "filters out non-version tags and returns the latest valid version" do
+          expect(checker.latest_version).to eq(
+            Dependabot::Helm::Version.new("1.1.0")
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves: #12423

### What are you trying to accomplish?

**What:** This PR fixes an issue in the Helm update checker where non-version tags (such as SHA256 hashes, signature files, attestation files, and metadata files) were being incorrectly processed as version tags when fetching OCI registry tags.

**Why:** The Helm update checker was failing to properly identify the latest valid version because it was attempting to parse non-version tags like `sha256-*` hashes and files ending with `.sig`, `.att`, and `.metadata` as version numbers. This caused incorrect version comparisons and potentially prevented proper dependency updates.

<details>
<summary><b>GitHub Action Run Log</b></summary>
<p>

```
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Checking if postgresql 16.7.6 needs updating
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Attempting to search for postgresql using helm CLI
2025/07/11 10:08:14 INFO <job_1051265558> Fetching releases for Helm chart: postgresql
2025/07/11 10:08:14 INFO <job_1051265558> Adding Helm repository: oci---registry-1-docker-io-bitnamicharts (oci://registry-1.docker.io/bitnamicharts)
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Started process PID: 1312 with command: {} helm repo add oci---registry-1-docker-io-bitnamicharts oci://registry-1.docker.io/bitnamicharts {}
  proxy | 2025/07/11 10:08:14 [024] HEAD https://registry-1.docker.io:443/v2/bitnamicharts/index.yaml/manifests/@
2025/07/11 10:08:14 [024] * authenticating docker registry request (host: registry-1.docker.io)
  proxy | 2025/07/11 10:08:14 [024] 404 https://registry-1.docker.io:443/v2/bitnamicharts/index.yaml/manifests/@
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Process PID: 1312 completed with status: pid 1312 exit 1
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Total execution time: 0.72 seconds
2025/07/11 10:08:14 ERROR <job_1051265558> Error adding/updating Helm repository: Error: looks like "oci://registry-1.docker.io/bitnamicharts" is not a valid chart repository or cannot be reached: registry-1.docker.io/bitnamicharts/index.yaml@: not found
2025/07/11 10:08:14 INFO <job_1051265558> Searching for: oci---registry-1-docker-io-bitnamicharts/postgresql
2025/07/11 10:08:14 INFO <job_1051265558> Searching Helm repository for: oci---registry-1-docker-io-bitnamicharts/postgresql
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Started process PID: 1318 with command: {} helm search repo oci---registry-1-docker-io-bitnamicharts/postgresql --versions --output\=json {}
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Process PID: 1318 completed with status: pid 1318 exit 1
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Total execution time: 0.07 seconds
2025/07/11 10:08:14 ERROR <job_1051265558> Error fetching chart releases: Error: no repositories configured
2025/07/11 10:08:14 INFO <job_1051265558> Fetching OCI tags for oci://registry-1.docker.io/bitnamicharts
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Searching OCI tags for: registry-1.docker.io/bitnamicharts/postgresql
updater | 2025/07/11 10:08:14 INFO <job_1051265558> Started process PID: 1325 with command: {} oras repo tags registry-1.docker.io/bitnamicharts/postgresql {}
  proxy | 2025/07/11 10:08:14 [026] GET https://registry-1.docker.io:443/v2/bitnamicharts/postgresql/tags/list
  proxy | 2025/07/11 10:08:14 [026] * authenticating docker registry request (host: registry-1.docker.io)
  proxy | 2025/07/11 10:08:15 [026] 200 https://registry-1.docker.io:443/v2/bitnamicharts/postgresql/tags/list
updater | 2025/07/11 10:08:15 INFO <job_1051265558> Process PID: 1325 completed with status: pid 1325 exit 0
updater | 2025/07/11 10:08:15 INFO <job_1051265558> Total execution time: 0.35 seconds
  proxy | 2025/07/11 10:08:15 [030] POST /update_jobs/1051265558/record_update_job_unknown_error
  proxy | 2025/07/11 10:08:15 [030] 204 /update_jobs/1051265558/record_update_job_unknown_error
  proxy | 2025/07/11 10:08:15 [032] POST /update_jobs/1051265558/record_update_job_error
  proxy | 2025/07/11 10:08:15 [032] 204 /update_jobs/1051265558/record_update_job_error
  proxy | 2025/07/11 10:08:15 [034] POST /update_jobs/1051265558/increment_metric
  proxy | 2025/07/11 10:08:15 [034] 204 /update_jobs/1051265558/increment_metric
  proxy | 2025/07/11 10:08:15 [036] POST /update_jobs/1051265558/record_update_job_unknown_error
  proxy | 2025/07/11 10:08:15 [036] 204 /update_jobs/1051265558/record_update_job_unknown_error
updater | 2025/07/11 10:08:15 ERROR <job_1051265558> Error processing postgresql (TypeError)
2025/07/11 10:08:15 ERROR <job_1051265558> Passed `nil` into T.must
updater | 2025/07/11 10:08:15 ERROR <job_1051265558> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.5.11952/lib/types/_types.rb:222:in 'T.must'
```

</p>
</details>

**What issues does this affect or fix:** Resolves issue #12423

### Anything you want to highlight for special attention from reviewers?

The solution adds filtering logic to the `fetch_oci_tags_for_chart` method that:
1. Excludes tags starting with "sha256-" (SHA256 hash identifiers)
2. Excludes tags ending with ".sig", ".att", or ".metadata" (signature, attestation, and metadata files)
3. Uses `version_class.correct?` to validate that remaining tags are valid version strings

This approach ensures we only process actual version tags while maintaining compatibility with existing version parsing logic. The filtering happens before version comparison, so it's efficient and doesn't affect the core version selection algorithm.

### How will you know you've accomplished your goal?

- **Test Coverage:** Added comprehensive test case that simulates the problematic scenario with mixed version tags and non-version tags (SHA256 hashes, .sig, .att, .metadata files)
- **Expected Behavior:** The test verifies that the latest valid version (1.1.0) is correctly identified while filtering out all non-version tags
- **Regression Testing:** Existing tests continue to pass, ensuring backward compatibility with current functionality

The test case demonstrates that when given a mix of valid versions and non-version tags, the system now correctly identifies and returns the latest valid version.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.