### PR TITLE
cleanup nuget pr body text

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -438,7 +438,6 @@ public class PullRequestTextTests
             """
             Performed the following updates:
             - Updated Some.Package from 1.0.0 to 1.2.3
-            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -79,7 +79,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
 
@@ -108,7 +108,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
 
@@ -137,7 +137,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
 
@@ -173,8 +173,8 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
-            - Updated Some.Package from 4.0.0 to 4.5.6 in b.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
+            - Updated Some.Package from 4.0.0 to 4.5.6
             """
         ];
 
@@ -229,10 +229,10 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Package.A from 0.1.0 to 1.0.0 in a1.txt
-            - Updated Package.A from 0.2.0 to 2.0.0 in a2.txt
-            - Updated Package.B from 0.3.0 to 3.0.0 in b1.txt
-            - Updated Package.B from 0.4.0 to 4.0.0 in b2.txt
+            - Updated Package.A from 0.1.0 to 1.0.0
+            - Updated Package.A from 0.2.0 to 2.0.0
+            - Updated Package.B from 0.3.0 to 3.0.0
+            - Updated Package.B from 0.4.0 to 4.0.0
             """
         ];
 
@@ -317,14 +317,14 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Package.A from 0.1.0 to 1.0.0 in a1.txt
-            - Updated Package.A from 0.2.0 to 2.0.0 in a2.txt
-            - Updated Package.B from 0.3.0 to 3.0.0 in b1.txt
-            - Updated Package.B from 0.4.0 to 4.0.0 in b2.txt
-            - Updated Package.C from 0.5.0 to 5.0.0 in c1.txt
-            - Updated Package.C from 0.6.0 to 6.0.0 in c2.txt
-            - Updated Package.D from 0.7.0 to 7.0.0 in d1.txt
-            - Updated Package.D from 0.8.0 to 8.0.0 in d2.txt
+            - Updated Package.A from 0.1.0 to 1.0.0
+            - Updated Package.A from 0.2.0 to 2.0.0
+            - Updated Package.B from 0.3.0 to 3.0.0
+            - Updated Package.B from 0.4.0 to 4.0.0
+            - Updated Package.C from 0.5.0 to 5.0.0
+            - Updated Package.C from 0.6.0 to 6.0.0
+            - Updated Package.D from 0.7.0 to 7.0.0
+            - Updated Package.D from 0.8.0 to 8.0.0
             """
         ];
 
@@ -357,7 +357,7 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
 
@@ -398,8 +398,8 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Package.A from 1.0.0 to 1.2.3 in a.txt
-            - Updated Package.B from 4.0.0 to 4.5.6 in a.txt
+            - Updated Package.A from 1.0.0 to 1.2.3
+            - Updated Package.B from 4.0.0 to 4.5.6
             """
         ];
 
@@ -437,8 +437,8 @@ public class PullRequestTextTests
             // expectedBody
             """
             Performed the following updates:
-            - Updated Some.Package from 1.0.0 to 1.2.3 in a.txt
-            - Updated Some.Package from 1.0.0 to 1.2.3 in b.txt
+            - Updated Some.Package from 1.0.0 to 1.2.3
+            - Updated Some.Package from 1.0.0 to 1.2.3
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -126,7 +126,7 @@ public class PullRequestTextGenerator
 
     public static string GetPullRequestBody(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
     {
-        var report = UpdateOperationBase.GenerateUpdateOperationReport(updateOperationsPerformed);
+        var report = UpdateOperationBase.GenerateUpdateOperationReport(updateOperationsPerformed, includeFileNames: false);
         return report;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -140,7 +140,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
-                        logger.Info($"Update operation performed: {o.GetReport()}");
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -143,7 +143,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
-                        logger.Info($"Update operation performed: {o.GetReport()}");
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
 
@@ -242,7 +242,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 updateOperationsPerformed.AddRange(patchedUpdateOperations);
                 foreach (var o in patchedUpdateOperations)
                 {
-                    logger.Info($"Update operation performed: {o.GetReport()}");
+                    logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                 }
             }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -137,7 +137,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
-                        logger.Info($"Update operation performed: {o.GetReport()}");
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -135,7 +135,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
-                        logger.Info($"Update operation performed: {o.GetReport()}");
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -125,7 +125,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
-                        logger.Info($"Update operation performed: {o.GetReport()}");
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/UpdateOperationBase.cs
@@ -62,7 +62,7 @@ public abstract record UpdateOperationBase
 
     internal static string GenerateUpdateOperationReport(IEnumerable<UpdateOperationBase> updateOperations, bool includeFileNames = true)
     {
-        var updateMessages = updateOperations.Select(u => u.GetReport(includeFileNames)).ToImmutableArray();
+        var updateMessages = updateOperations.Select(u => u.GetReport(includeFileNames)).Distinct(StringComparer.OrdinalIgnoreCase).ToImmutableArray();
         if (updateMessages.Length == 0)
         {
             return string.Empty;


### PR DESCRIPTION
Don't emit file names in a generated PR body.  It's unnecessary at that point because the user can simply look at the changed files to get the same information, but it _is_ still output to the log to make investigations easier.