### PR TITLE
DEBUG: allow triggering releases via workflow_dispatch

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -5,6 +5,7 @@ on: # yamllint disable-line rule:truthy
     # bumping the Gem version, RubyGems will reject it with an error that the
     # version is already live.
     types: [published]
+  workflow_dispatch:
 
 jobs:
   release-gems:


### PR DESCRIPTION
this should NEVER be merged as we do not want to allow this on main otherwise changes could creep in between tagged versions.
--

For debugging:
* https://github.com/rubygems/rubygems/issues/8836