### PR TITLE
use initial project directory when computing updated file paths from project discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -3522,7 +3522,7 @@ public class RunWorkerTests
         updaterWorker ??= new UpdaterWorker(jobId, experimentsManager, logger);
 
         var worker = new RunWorker(jobId, testApiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
-        var repoContentsPathDirectoryInfo = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var repoContentsPathDirectoryInfo = new DirectoryInfo(repoContentsPath);
         var actualResult = await worker.RunAsync(job, repoContentsPathDirectoryInfo, repoContentsPathDirectoryInfo, "TEST-COMMIT-SHA", experimentsManager);
         var actualApiMessages = testApiHandler.ReceivedMessages
             .Select(m =>


### PR DESCRIPTION
From a manual scan of the telemetry from the recent `nuget_use_new_file_updater` experiment.

When calculating file paths to watch for possible edits, use the initial project's starting directory, since that's where the workspace discovery object came from.  Previously each individual project directory was used, which is incorrect because workspace discovery is all relative to the first directory scanned.