### PR TITLE
ensure project is supported file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1591,4 +1591,30 @@ public class XmlFileWriterTests : FileWriterTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task NoChangesForUnsupportedInitialFile()
+    {
+        // the extension `.xyproj` is not supported by the file writer; it is immediately rejected
+        await TestNoChangeAsync(
+            files: [
+                ("unsupported.xyproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="$(SomePackageVersion)" />
+                      </ItemGroup>
+                    </Project
+                    """),
+                ("versions.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <SomePackageVersion>1.0.0</SomePackageVersion>
+                      </PropertyGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Package/1.0.0"],
+            requiredDependencyStrings: ["Some.Package/2.0.0"]
+        );
+    }
 }


### PR DESCRIPTION
Part of the ongoing `nuget_use_new_file_updater` experiment work.

Explicitly restrict the allowed project extension to `.csproj`, `.vbproj`, and `.fsproj` and the allowed additional files to be the same plus `.props` and `.targets`.

Found during a manual scan of the telemetry.