### PR TITLE
reset smoke test branch to main

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: dev/brettfo/nuget-no-sdk-version
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR #12638 had to temporarily redirect the smoke test branch but that work is now done so the branch can be restored to `main`.

Composer failure is addressed in dependabot/smoke-tests#311
Swift failure is tracked in #12647