### PR TITLE
Engines package.json: support special characters >=, ~, ^ (npm_and_yarn)

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -399,6 +399,10 @@ module Dependabot
       sig { params(name: String, version: String).void }
       def raise_if_unsupported!(name, version)
         return unless name == PNPMPackageManager::NAME
+
+        # Remove common leading version specifiers (^, ~, >=)
+        version = version.gsub(/^(?:\^|~|>=|>)/, "")
+
         return unless Version.new(version) < Version.new("7")
 
         raise ToolVersionNotSupported.new(PNPMPackageManager::NAME.upcase, version, "7.*, 8.*, 9.*")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb
@@ -44,7 +44,15 @@ module Dependabot
             )
           end
         else
-          versions = engine_versions.select do |engine, value|
+          cleaned_versions = {}
+          engine_versions.each do |engine, value|
+            next unless engine.to_s.match(name)
+
+            # Handle common leading version specifiers (^, ~, >=) in engine constraints
+            cleaned_value = value.to_s.strip.gsub(/^(?:\^|~|>=|>)/, "")
+            cleaned_versions[engine] = cleaned_value
+          end
+          versions = cleaned_versions.select do |engine, value|
             engine.to_s.match(name) && valid_extracted_version?(value)
           end
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -347,6 +347,48 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
     end
   end
 
+  describe "#raise_if_unsupported!" do
+    let(:helper) { described_class.new({}, {}, {}, []) }
+
+    context "when version contains special characters (^) (~) (>=)" do
+      it "doesn't raise for supported pnpm version with caret" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "^7") }
+          .not_to raise_error
+      end
+
+      it "doesn't raise for supported pnpm version with tilde" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "~7") }
+          .not_to raise_error
+      end
+
+      it "raises for unsupported pnpm version with >=" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", ">=6") }
+          .to raise_error(Dependabot::ToolVersionNotSupported)
+      end
+
+      it "doesn't raise for supported pnpm version with >=" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", ">=7") }
+          .not_to raise_error
+      end
+
+      it "handles major-only versions" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "6") }
+          .to raise_error(Dependabot::ToolVersionNotSupported)
+
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "7") }
+          .not_to raise_error
+      end
+
+      it "handles major.minor versions" do
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "6.9") }
+          .to raise_error(Dependabot::ToolVersionNotSupported)
+
+        expect { helper.send(:raise_if_unsupported!, "pnpm", "7.1") }
+          .not_to raise_error
+      end
+    end
+  end
+
   describe "#installed_version" do
     before do
       allow(Dependabot::NpmAndYarn::Helpers).to receive_messages(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/version_selector_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/version_selector_spec.rb
@@ -1,0 +1,21 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/version_selector"
+
+RSpec.describe Dependabot::NpmAndYarn::VersionSelector do
+  describe "#setup" do
+    let(:manifest_json) { { "engines" => engines } }
+    let(:name) { "pnpm" }
+    let(:selector) { described_class.new }
+
+    context "with versions containing special characters" do
+      it "strips special characters from version strings" do
+        # Test with a caret version
+        engines = { "pnpm" => "^10.2.3" }
+        expect(selector.setup({ "engines" => engines }, "pnpm")).to eq({ "pnpm" => "10.2.3" })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
The following syntax from the `engines` field in the `package.json` are not supported: `>=`, `~`, `^`, and they are valid.
```json
  "engines": {
    "pnpm": ">=10",
    "node": "~22.0.0"
    "npm": "^9.0.0"
  },
``` 

### How will you know you've accomplished your goal?

This will solve the issue: https://github.com/dependabot/dependabot-core/issues/12643

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
