### PR TITLE
check output for timeouts

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -149,6 +149,7 @@ public class HttpApiHandlerTests
         yield return [new JobRepoNotFound("unused"), "record_update_job_error"];
         yield return [new PrivateSourceAuthenticationFailure(["unused"]), "record_update_job_error"];
         yield return [new PrivateSourceBadResponse(["unused"]), "record_update_job_error"];
+        yield return [new PrivateSourceTimedOut("unused"), "record_update_job_error"];
         yield return [new PullRequestExistsForLatestVersion("unused", "unused"), "record_update_job_error"];
         yield return [new PullRequestExistsForSecurityUpdate([]), "record_update_job_error"];
         yield return [new SecurityUpdateDependencyNotFound(), "record_update_job_error"];

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -163,6 +163,17 @@ public class MessageReportTests
         yield return
         [
             // message
+            new PrivateSourceTimedOut("url"),
+            // expected
+            """
+            Error type: private_source_timed_out
+            - source: url
+            """
+        ];
+
+        yield return
+        [
+            // message
             new PullRequestExistsForLatestVersion("Some.Dependency", "1.2.3"),
             // expected
             """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -709,6 +709,14 @@ public class SerializationTests : TestBase
 
         yield return
         [
+            new PrivateSourceTimedOut("url"),
+            """
+            {"data":{"error-type":"private_source_timed_out","error-details":{"source":"url"}}}
+            """
+        ];
+
+        yield return
+        [
             new PullRequestExistsForLatestVersion("dep", "ver"),
             """
             {"data":{"error-type":"pull_request_exists_for_latest_version","error-details":{"dependency-name":"dep","dependency-version":"ver"}}}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -781,6 +781,14 @@ public class MSBuildHelperTests : TestBase
         yield return
         [
             // output
+            "  The HTTP request to 'GET some-source' has timed out after 100000ms.",
+            // expectedError
+            new PrivateSourceTimedOut("some-source"),
+        ];
+
+        yield return
+        [
+            // output
             "The imported file \"some.file\" does not exist",
             // expectedError
             new DependencyFileNotFound("some.file", "test message"),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/PrivateSourceTimedOutException.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/PrivateSourceTimedOutException.cs
@@ -1,0 +1,12 @@
+namespace NuGetUpdater.Core;
+
+internal class PrivateSourceTimedOutException : Exception
+{
+    public string Url { get; }
+
+    public PrivateSourceTimedOutException(string url)
+        : base($"The request to source {url} has timed out.")
+    {
+        Url = url;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -74,6 +74,8 @@ public abstract record JobErrorBase : MessageBase
                 return new DependencyFileNotParseable(invalidProjectFile.ProjectFile);
             case MissingFileException missingFile:
                 return new DependencyFileNotFound(missingFile.FilePath, missingFile.Message);
+            case PrivateSourceTimedOutException timeout:
+                return new PrivateSourceTimedOut(timeout.Url);
             case UnparseableFileException unparseableFile:
                 return new DependencyFileNotParseable(unparseableFile.FilePath, unparseableFile.Message);
             case UpdateNotPossibleException updateNotPossible:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceTimedOut.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceTimedOut.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record PrivateSourceTimedOut : JobErrorBase
+{
+    public PrivateSourceTimedOut(string url)
+        : base("private_source_timed_out")
+    {
+        Details["source"] = url;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -976,6 +976,7 @@ internal static partial class MSBuildHelper
         ThrowOnMissingPackages(output);
         ThrowOnUpdateNotPossible(output);
         ThrowOnRateLimitExceeded(output);
+        ThrowOnTimeout(output);
         ThrowOnBadResponse(output);
         ThrowOnUnparseableFile(output);
     }
@@ -1006,6 +1007,19 @@ internal static partial class MSBuildHelper
         if (rateLimitMessageSnippets.Any(stdout.Contains))
         {
             throw new HttpRequestException(message: stdout, inner: null, statusCode: System.Net.HttpStatusCode.TooManyRequests);
+        }
+    }
+
+    private static void ThrowOnTimeout(string stdout)
+    {
+        var patterns = new[]
+        {
+            new Regex(@"The HTTP request to 'GET (?<Source>[^']+)' has timed out after \d+ms"),
+        };
+        var match = patterns.Select(p => p.Match(stdout)).Where(m => m.Success).FirstOrDefault();
+        if (match is not null)
+        {
+            throw new PrivateSourceTimedOutException(match.Groups["Source"].Value);
         }
     }
 


### PR DESCRIPTION
Report a timeout exception instead of letting it get turned into an `unknown_error`.

From a manual scan of the telemetry.