### PR TITLE
classify additional error shapes

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
@@ -61,6 +61,13 @@ public class JobErrorBaseTests : TestBase
             new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
         ];
 
+        // service returned corrupt package
+        yield return
+        [
+            new InvalidDataException("Central Directory corrupt."),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+        ];
+
         // top-level exception turns into private_source_authentication_failure
         yield return
         [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -837,6 +837,14 @@ public class MSBuildHelperTests : TestBase
         yield return
         [
             // output
+            "Unable to resolve dependency 'Some.Package'. Source(s) used: 'nuget.org'.",
+            // expectedError
+            new DependencyNotFound("Some.Package"),
+        ];
+
+        yield return
+        [
+            // output
             "Unable to resolve dependencies. 'Some.Package 1.2.3' is not compatible with",
             // expectedError
             new UpdateNotPossible(["Some.Package.1.2.3"]),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -70,6 +70,8 @@ public abstract record JobErrorBase : MessageBase
 
                         return new UnknownError(ex, jobId);
                 }
+            case InvalidDataException invalidData when invalidData.Message == "Central Directory corrupt.":
+                return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory));
             case InvalidProjectFileException invalidProjectFile:
                 return new DependencyFileNotParseable(invalidProjectFile.ProjectFile);
             case MissingFileException missingFile:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -1057,6 +1057,7 @@ internal static partial class MSBuildHelper
             new Regex(@"Unable to find package (?<PackageName>[^ ]+)\. No packages exist with this id in source\(s\): (?<PackageSource>.*)$", RegexOptions.Multiline),
             new Regex(@"Unable to find package (?<PackageName>[^ ]+) with version \((?<PackageVersion>[^)]+)\)"),
             new Regex(@"Unable to find package '(?<PackageName>[^ ]+)'\."),
+            new Regex(@"Unable to resolve dependency '(?<PackageName>[^']+)'\. Source\(s\) used"),
             new Regex(@"Could not resolve SDK ""(?<PackageName>[^ ]+)""\."),
             new Regex(@"Failed to fetch results from V2 feed at '.*FindPackagesById\(\)\?id='(?<PackageName>[^']+)'&semVerLevel=2\.0\.0' with following message : Response status code does not indicate success: 404\."),
         };


### PR DESCRIPTION
Sometimes a NuGet feed will return a corrupt `.nupkg`.  This PR catches the relevant exception and turns it into a `private_source_bad_response` instead of surfacing it as `unknown_error`.

Example stack trace:

```
System.IO.InvalidDataException: Central Directory corrupt.
 ---> System.IO.IOException: Invalid argument : '/home/dependabot/.nuget/packages/fluentassertions/8.5.0/fluentassertions.8.5.0.nupkg'
   at System.IO.Strategies.FileStreamHelpers.ThrowInvalidArgument(SafeFileHandle handle)
   at System.IO.Strategies.BufferedFileStreamStrategy.Seek(Int64 offset, SeekOrigin origin)
   at System.IO.Compression.ZipArchive.ReadEndOfCentralDirectory()
   --- End of inner exception stack trace ---
   at System.IO.Compression.ZipArchive.ReadEndOfCentralDirectory()
   at System.IO.Compression.ZipArchive..ctor(Stream stream, ZipArchiveMode mode, Boolean leaveOpen, Encoding entryNameEncoding)
   at NuGetUpdater.Core.Analyze.CompatibilityChecker.GetPackageReadersAsync(PackageIdentity package, NuGetContext nugetContext, CancellationToken cancellationToken) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs:line 84
   at NuGetUpdater.Core.Analyze.CompatibilityChecker.GetPackageInfoAsync(PackageIdentity package, NuGetContext nugetContext, CancellationToken cancellationToken) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs:line 95
   at NuGetUpdater.Core.Analyze.CompatibilityChecker.CheckAsync(PackageIdentity package, ImmutableArray`1 projectFrameworks, NuGetContext nugetContext, ILogger logger, CancellationToken cancellationToken) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs:line 27
   at NuGetUpdater.Core.Analyze.VersionFinder.GetVersionsAsync(ImmutableArray`1 projectTfms, String packageId, NuGetVersion currentVersion, Func`2 versionFilter, NuGetContext nugetContext, ILogger logger, CancellationToken cancellationToken) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs:line 127
   at NuGetUpdater.Core.Analyze.AnalyzeWorker.FindUpdatedVersionAsync(String startingDirectory, DependencyInfo dependencyInfo, ImmutableHashSet`1 packageIds, ImmutableArray`1 projectFrameworks, NuGetContext nugetContext, ILogger logger, CancellationToken cancellationToken) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs:line 238
   at NuGetUpdater.Core.Analyze.AnalyzeWorker.RunAsync(String repoRoot, WorkspaceDiscoveryResult discovery, DependencyInfo dependencyInfo) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs:line 124
   at NuGetUpdater.Core.Run.UpdateHandlers.GroupUpdateAllVersionsHandler.RunUngroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo caseInsensitiveRepoContentsPath, String baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs:line 209
   at NuGetUpdater.Core.Run.UpdateHandlers.GroupUpdateAllVersionsHandler.HandleAsync(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo caseInsensitiveRepoContentsPath, String baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs:line 52
   at NuGetUpdater.Core.Run.RunWorker.RunScenarioHandlersWithErrorHandlingAsync(Job job, DirectoryInfo repoContentsPath, DirectoryInfo caseInsensitiveRepoContentsPath, String baseCommitSha, ExperimentsManager experimentsManager) in /opt/nuget/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs:line 103
```

Also classify another output shape for a missing package when using `packages.config`.

Found during a manual scan of telemetry.