### PR TITLE
Pin dependency plugin version when running dependency tree in Maven

### DIFF
--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -8,6 +8,7 @@ module Dependabot
   module Maven
     module NativeHelpers
       extend T::Sig
+      DEPENDENCY_PLUGIN_VERSION = "3.7.0"
 
       sig do
         params(file_name: String).void
@@ -17,7 +18,7 @@ module Dependabot
         stdout, _, status = Open3.capture3(
           { "PROXY_HOST" => proxy_url.host },
           "mvn",
-          "dependency:tree",
+          "dependency:#{DEPENDENCY_PLUGIN_VERSION}:tree",
           "-DoutputFile=#{file_name}",
           "-DoutputType=json",
           "-e"


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes the issue where pom.xml file might override `maven-dependency-plugin` version to a lower version where `json` as output format is not supported. This change pins version of the plugin to call when running tree scanning.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

Bug was causing updater to throw `JSONError` exception, because it was attempting to parse non-json dependency tree. `JSONError` in Maven updater should disappear after this change.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
