### PR TITLE
generate detailed pr body

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
@@ -1,0 +1,498 @@
+using System.Collections.Immutable;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+using NuGetUpdater.Core.Updater;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.PullRequestBodyGenerator;
+
+public class DetailedPullRequestBodyGeneratorTests
+{
+    [Fact]
+    public async Task GeneratePrBody_Azure()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://dev.azure.com/Some.Organization/Some.Owner/_git/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated [Some.Dependency](https://dev.azure.com/Some.Organization/Some.Owner/_git/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://dev.azure.com/Some.Organization/Some.Owner/_git/Some.Dependency/tags">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://dev.azure.com/Some.Organization/Some.Owner/_git/Some.Dependency/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_Azure_VisualStudioDomain()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://example-org.visualstudio.com/Some.Owner/_git/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated [Some.Dependency](https://example-org.visualstudio.com/Some.Owner/_git/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://example-org.visualstudio.com/Some.Owner/_git/Some.Dependency/tags">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://example-org.visualstudio.com/Some.Owner/_git/Some.Dependency/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitHub()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://github.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://api.github.com/repos/Some.Owner/Some.Dependency/releases?per_page=100", """
+                    [
+                      {
+                        "name": "2.0.0",
+                        "tag_name": "2.0.0",
+                        "body": "* point 5\n* point 6"
+                      },
+                      {
+                        "name": "1.0.1",
+                        "tag_name": "1.0.1",
+                        "body": "* point 3\n* point 4"
+                      },
+                      {
+                        "name": "1.0.0",
+                        "tag_name": "1.0.0",
+                        "body": "* point 1\n* point 2"
+                      }
+                    ]
+                    """)
+            ],
+            expectedBody: """
+                Updated [Some.Dependency](https://github.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://github.com/Some.Owner/Some.Dependency/releases">Some.Dependency's releases</a>.</em>
+                <h2>2.0.0</h2>
+
+                * point 5
+                * point 6
+
+                <h2>1.0.1</h2>
+
+                * point 3
+                * point 4
+
+                Commits viewable in <a href="https://github.com/Some.Owner/Some.Dependency/compare/1.0.0...2.0.0">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitHub_EmptyApiResponses()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://github.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated [Some.Dependency](https://github.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://github.com/Some.Owner/Some.Dependency/releases">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://github.com/Some.Owner/Some.Dependency/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitHub_NonJsonResponse()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://github.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://api.github.com/repos/Some.Owner/Some.Dependency/releases?per_page=100", """
+                    this is not JSON
+                    """)
+            ],
+            expectedBody: """
+                Updated [Some.Dependency](https://github.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://github.com/Some.Owner/Some.Dependency/releases">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://github.com/Some.Owner/Some.Dependency/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitLab()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://gitlab.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://gitlab.com/api/v4/projects/Some.Owner%2FSome.Dependency/repository/tags", """
+                    [
+                      {
+                        "name": "2.0.0",
+                        "release": {
+                          "tag_name": "2.0.0",
+                          "description": "* point 5\n* point 6"
+                        }
+                      },
+                      {
+                        "name": "1.0.1",
+                        "release": null
+                      },
+                      {
+                        "name": "1.0.0",
+                        "release": null
+                      }
+                    ]
+                    """)
+            ],
+            expectedBody: """
+                Updated [Some.Dependency](https://gitlab.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/releases">Some.Dependency's releases</a>.</em>
+                <h2>2.0.0</h2>
+
+                * point 5
+                * point 6
+
+                <h2>1.0.1</h2>
+
+                Commits viewable in <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/compare/1.0.0...2.0.0">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitLab_EmptyApiResponses()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://gitlab.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated [Some.Dependency](https://gitlab.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/releases">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitLab_NonJsonResponse()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://gitlab.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://gitlab.com/api/v4/projects/Some.Owner%2FSome.Dependency/repository/tags", """
+                    this is not JSON
+                    """)
+            ],
+            expectedBody: """
+                Updated [Some.Dependency](https://gitlab.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+                <em>Sourced from <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/releases">Some.Dependency's releases</a>.</em>
+
+                No release notes found for this version range.
+
+                Commits viewable in <a href="https://gitlab.com/Some.Owner/Some.Dependency/-/commits">compare view</a>.
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_NoSource()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated Some.Dependency from 1.0.0 to 2.0.0.
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_UnsupportedSource()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://example.com/git/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [],
+            expectedBody: """
+                Updated [Some.Dependency](https://example.com/git/Some.Dependency) from 1.0.0 to 2.0.0.
+                """
+        );
+    }
+
+    private static async Task TestAsync(
+        ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
+        ImmutableArray<ReportedDependency> updatedDependencies,
+        (string Url, string Body)[] httpResponses,
+        string expectedBody
+    )
+    {
+        // arrange
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "test/repo",
+            }
+        };
+
+        // act
+        var responses = httpResponses.ToDictionary(x => x.Url, x => x.Body);
+        var httpFetcher = new TestHttpFetcher(responses);
+        var generator = new DetailedPullRequestBodyGenerator(httpFetcher);
+        var actualBody = await generator.GeneratePullRequestBodyTextAsync(job, updateOperationsPerformed, updatedDependencies);
+
+        // assert
+        Assert.Equal(expectedBody.Replace("\r", ""), actualBody.Replace("\r", ""));
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
@@ -1,0 +1,28 @@
+using NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.PullRequestBodyGenerator;
+
+public class IPackageDetailFinderTests
+{
+    [Theory]
+    [InlineData("1.0.0", "1.0.0", "1.0.0")]
+    [InlineData("one.zero.zero", "1.0.0", "1.0.0")]
+    [InlineData("version-one.zero.zero", "v1.0.0", "1.0.0")]
+    [InlineData("v-one.zero.zero", "v-one.zero.zero", null)]
+    [InlineData("Stable", "version-1.0.0", "1.0.0")]
+    public void GetVersionFromNames(string releaseName, string tagName, string? expectedVersion)
+    {
+        var actualVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+        if (expectedVersion is null)
+        {
+            Assert.Null(actualVersion);
+        }
+        else
+        {
+            Assert.NotNull(actualVersion);
+            Assert.Equal(expectedVersion, actualVersion.ToString());
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestHttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestHttpFetcher.cs
@@ -1,0 +1,23 @@
+using NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+namespace NuGetUpdater.Core.Test.Run.PullRequestBodyGenerator;
+
+internal class TestHttpFetcher : IHttpFetcher
+{
+    private readonly Dictionary<string, string> _responses;
+
+    public TestHttpFetcher(Dictionary<string, string> responses)
+    {
+        _responses = responses;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public Task<string?> GetStringAsync(string url)
+    {
+        _responses.TryGetValue(url, out var response);
+        return Task.FromResult(response);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestMessageTests.cs
@@ -12,9 +12,9 @@ public class PullRequestMessageTests
 {
     [Theory]
     [MemberData(nameof(GetPullRequestApiMessageData))]
-    public void GetPullRequestApiMessage(Job job, DependencyFile[] updatedFiles, ReportedDependency[] updatedDependencies, UpdateOperationBase[] updateOperationsPerformed, MessageBase expectedMessage)
+    public async Task GetPullRequestApiMessage(Job job, DependencyFile[] updatedFiles, ReportedDependency[] updatedDependencies, UpdateOperationBase[] updateOperationsPerformed, MessageBase expectedMessage)
     {
-        var actualMessage = RunWorker.GetPullRequestApiMessage(job, updatedFiles, updatedDependencies, [.. updateOperationsPerformed], "TEST-COMMIT-SHA");
+        var actualMessage = await RunWorker.GetPullRequestApiMessageAsync(job, updatedFiles, updatedDependencies, [.. updateOperationsPerformed], "TEST-COMMIT-SHA", new ExperimentsManager());
         Assert.NotNull(actualMessage);
         actualMessage = actualMessage switch
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -34,7 +34,7 @@ public class PullRequestTextTests
 
     [Theory]
     [MemberData(nameof(GetPullRequestTextTestData))]
-    public void PullRequestText(
+    public async Task PullRequestText(
         Job job,
         UpdateOperationBase[] updateOperationsPerformed,
         string? dependencyGroupName,
@@ -43,10 +43,11 @@ public class PullRequestTextTests
         string expectedBody
     )
     {
+        var experimentsManager = new ExperimentsManager() { GenerateSimplePrBody = true };
         var updateOperationsPerformedImmutable = updateOperationsPerformed.ToImmutableArray();
         var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, updateOperationsPerformedImmutable, dependencyGroupName);
         var actualCommitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, updateOperationsPerformedImmutable, dependencyGroupName).Replace("\r", "");
-        var actualBody = PullRequestTextGenerator.GetPullRequestBody(job, updateOperationsPerformedImmutable, dependencyGroupName).Replace("\r", "");
+        var actualBody = (await PullRequestTextGenerator.GetPullRequestBodyAsync(job, updateOperationsPerformedImmutable, [], experimentsManager)).Replace("\r", "");
         Assert.Equal(expectedTitle, actualTitle);
         Assert.Equal(expectedCommitMessage.Replace("\r", ""), actualCommitMessage);
         Assert.Equal(expectedBody.Replace("\r", ""), actualBody);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -7,6 +7,7 @@ namespace NuGetUpdater.Core;
 
 public record ExperimentsManager
 {
+    public bool GenerateSimplePrBody { get; init; } = false;
     public bool InstallDotnetSdks { get; init; } = false;
     public bool NativeUpdater { get; init; } = false;
     public bool UseLegacyDependencySolver { get; init; } = false;
@@ -18,6 +19,7 @@ public record ExperimentsManager
     {
         return new()
         {
+            ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
             ["nuget_install_dotnet_sdks"] = InstallDotnetSdks,
             ["nuget_native_updater"] = NativeUpdater,
             ["nuget_legacy_dependency_solver"] = UseLegacyDependencySolver,
@@ -31,6 +33,7 @@ public record ExperimentsManager
     {
         return new ExperimentsManager()
         {
+            GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
             InstallDotnetSdks = IsEnabled(experiments, "nuget_install_dotnet_sdks"),
             NativeUpdater = IsEnabled(experiments, "nuget_native_updater"),
             UseLegacyDependencySolver = IsEnabled(experiments, "nuget_legacy_dependency_solver"),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/AzurePackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/AzurePackageDetailFinder.cs
@@ -1,0 +1,30 @@
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class AzurePackageDetailFinder : IPackageDetailFinder
+{
+    public string GetCompareUrlPath(string? oldTag, string? newTag)
+    {
+        // azure devops doesn't support direct tag listing so both parameters are likely to be null, but just in case, this is the correct url format
+        if (oldTag is not null && newTag is not null)
+        {
+            return $"branchCompare?baseVersion=GT{oldTag}&targetVersion=GT{newTag}";
+        }
+
+        if (newTag is not null)
+        {
+            return $"commits?itemVersion=GT{newTag}";
+        }
+
+        return "commits";
+    }
+
+    public Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    {
+        // azure devops doesn't support direct tag listing
+        return Task.FromResult(new Dictionary<NuGetVersion, (string TagName, string? Details)>());
+    }
+
+    public string GetReleasesUrlPath() => "tags";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGenerator.cs
@@ -1,0 +1,131 @@
+using System.Collections.Immutable;
+using System.Text;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class DetailedPullRequestBodyGenerator : IPullRequestBodyGenerator, IDisposable
+{
+    private readonly IHttpFetcher _httpFetcher;
+
+    public DetailedPullRequestBodyGenerator(IHttpFetcher httpFetcher)
+    {
+        _httpFetcher = httpFetcher;
+    }
+
+    public void Dispose()
+    {
+        _httpFetcher.Dispose();
+    }
+
+    public async Task<string> GeneratePullRequestBodyTextAsync(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, ImmutableArray<ReportedDependency> updatedDependencies)
+    {
+        var sb = new StringBuilder();
+        foreach (var updateOperation in updateOperationsPerformed)
+        {
+            var reportText = $"{updateOperation.GetReport(includeFileNames: false)}.";
+            var updatedDependency = updatedDependencies
+                .Where(d => d.Name.Equals(updateOperation.DependencyName, StringComparison.OrdinalIgnoreCase))
+                .Where(d => NuGetVersion.TryParse(d.Version, out var version) && version == updateOperation.NewVersion)
+                .FirstOrDefault();
+            var sourceUrl = (updatedDependency?.Requirements ?? [])
+                .Select(r => r.Source?.SourceUrl)
+                .FirstOrDefault(u => u is not null);
+            if (sourceUrl is null)
+            {
+                // no source url, just append the report text
+                sb.AppendLine(reportText);
+            }
+            else
+            {
+                // build detailed report
+                var packageNameIndex = reportText.IndexOf(updateOperation.DependencyName, StringComparison.OrdinalIgnoreCase);
+                if (packageNameIndex >= 0)
+                {
+                    // link the package name
+                    sb.AppendLine($"{reportText[..packageNameIndex]}[{updateOperation.DependencyName}]({sourceUrl}){reportText[(packageNameIndex + updateOperation.DependencyName.Length)..]}");
+                }
+                else
+                {
+                    sb.AppendLine(reportText);
+                }
+
+                // more details
+                if (Uri.TryCreate(sourceUrl, UriKind.Absolute, out var uri))
+                {
+                    IPackageDetailFinder? packageDetailFinder = uri.Host.ToLowerInvariant() switch
+                    {
+                        "dev.azure.com" => new AzurePackageDetailFinder(),
+                        "github.com" => new GitHubPackageDetailFinder(_httpFetcher),
+                        "gitlab.com" => new GitLabPackageDetailFinder(_httpFetcher),
+                        var host when host.EndsWith(".visualstudio.com") => new AzurePackageDetailFinder(),
+                        _ => null,
+                    };
+
+                    if (packageDetailFinder is not null &&
+                        updateOperation.OldVersion is not null)
+                    {
+                        var repoName = uri.LocalPath.TrimStart('/');
+                        var versionsAndDetails = await packageDetailFinder.GetReleaseDataForVersionsAsync(repoName, updateOperation.OldVersion, updateOperation.NewVersion);
+                        var ordered = versionsAndDetails
+                            .Where(kv => kv.Key != updateOperation.OldVersion)
+                            .OrderByDescending(kv => kv.Key)
+                            .ToList();
+
+                        sb.AppendLine();
+                        sb.AppendLine("<details>");
+                        sb.AppendLine("<summary>Release notes</summary>");
+
+                        var releasesUrlPath = packageDetailFinder.GetReleasesUrlPath();
+                        if (releasesUrlPath is not null)
+                        {
+                            sb.AppendLine($"<em>Sourced from <a href=\"{sourceUrl}/{releasesUrlPath}\">{updateOperation.DependencyName}'s releases</a>.</em>");
+                        }
+
+                        foreach (var (version, (tagName, body)) in ordered)
+                        {
+                            sb.AppendLine($"<h2>{version}</h2>");
+                            if (body is not null)
+                            {
+                                sb.AppendLine();
+                                sb.AppendLine(body);
+                            }
+
+                            sb.AppendLine();
+                        }
+
+                        if (ordered.Count == 0)
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine("No release notes found for this version range.");
+                            sb.AppendLine();
+                        }
+
+                        string? oldTag = null;
+                        if (versionsAndDetails.TryGetValue(updateOperation.OldVersion, out var oldVersionDetails))
+                        {
+                            oldTag = oldVersionDetails.TagName;
+                        }
+
+                        string? newTag = null;
+                        if (versionsAndDetails.TryGetValue(updateOperation.NewVersion, out var newVersionDetails))
+                        {
+                            newTag = newVersionDetails.TagName;
+                        }
+
+                        var compareUrlPath = packageDetailFinder.GetCompareUrlPath(oldTag, newTag);
+                        sb.AppendLine($"Commits viewable in <a href=\"{sourceUrl}/{compareUrlPath}\">compare view</a>.");
+                        sb.AppendLine("</details>");
+                    }
+                }
+            }
+        }
+
+        var prBody = sb.ToString().Replace("\r", "").TrimEnd();
+        return prBody;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class GitHubPackageDetailFinder : IPackageDetailFinder
+{
+    private readonly IHttpFetcher _httpFetcher;
+
+    public GitHubPackageDetailFinder(IHttpFetcher httpFetcher)
+    {
+        _httpFetcher = httpFetcher;
+    }
+
+    public string GetCompareUrlPath(string? oldTag, string? newTag)
+    {
+        if (oldTag is not null && newTag is not null)
+        {
+            return $"compare/{oldTag}...{newTag}";
+        }
+
+        if (newTag is not null)
+        {
+            return $"commits/{newTag}";
+        }
+
+        return "commits";
+    }
+
+    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    {
+        var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var url = $"https://api.github.com/repos/{repoName}/releases?per_page=100";
+        var jsonString = await _httpFetcher.GetStringAsync(url);
+        if (jsonString is null)
+        {
+            return result;
+        }
+
+        JsonElement json;
+        try
+        {
+            json = JsonSerializer.Deserialize<JsonElement>(jsonString);
+        }
+        catch (JsonException)
+        {
+            return result;
+        }
+
+        if (json.ValueKind != JsonValueKind.Array)
+        {
+            return result;
+        }
+
+        if (json.GetArrayLength() == 0)
+        {
+            return result;
+        }
+
+        foreach (var releaseObject in json.EnumerateArray())
+        {
+            if (releaseObject.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            // get release name
+            if (!releaseObject.TryGetProperty("name", out var releasenameElement) ||
+                releasenameElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var releaseName = releasenameElement.GetString()!;
+
+            // get tag name
+            if (!releaseObject.TryGetProperty("tag_name", out var tagNameElement) ||
+                tagNameElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var tagName = tagNameElement.GetString()!;
+
+            // find matching version
+            var correspondingVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            if (correspondingVersion is null)
+            {
+                continue;
+            }
+
+            if (correspondingVersion >= oldVersion && correspondingVersion <= newVersion)
+            {
+                if (!releaseObject.TryGetProperty("body", out var bodyElement) ||
+                bodyElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var body = bodyElement.GetString()!;
+                result[correspondingVersion] = (tagName, body);
+            }
+        }
+
+        return result;
+    }
+
+    public string GetReleasesUrlPath() => "releases";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class GitLabPackageDetailFinder : IPackageDetailFinder
+{
+    private readonly IHttpFetcher _httpFetcher;
+
+    public GitLabPackageDetailFinder(IHttpFetcher httpFetcher)
+    {
+        _httpFetcher = httpFetcher;
+    }
+
+    public string GetCompareUrlPath(string? oldTag, string? newTag)
+    {
+        if (oldTag is not null && newTag is not null)
+        {
+            return $"-/compare/{oldTag}...{newTag}";
+        }
+
+        if (newTag is not null)
+        {
+            return $"-/commits/{newTag}";
+        }
+
+        return "-/commits";
+    }
+
+    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    {
+        var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var url = $"https://gitlab.com/api/v4/projects/{Uri.EscapeDataString(repoName)}/repository/tags";
+        var jsonString = await _httpFetcher.GetStringAsync(url);
+        if (jsonString is null)
+        {
+            return result;
+        }
+
+        JsonElement json;
+        try
+        {
+            json = JsonSerializer.Deserialize<JsonElement>(jsonString);
+        }
+        catch (JsonException)
+        {
+            return result;
+        }
+
+        if (json.ValueKind != JsonValueKind.Array)
+        {
+            return result;
+        }
+
+        if (json.GetArrayLength() == 0)
+        {
+            return result;
+        }
+
+        foreach (var responseObject in json.EnumerateArray())
+        {
+            if (responseObject.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            // get release name
+            if (!responseObject.TryGetProperty("name", out var releaseNameElement) ||
+                releaseNameElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var releaseName = releaseNameElement.GetString()!;
+
+            // get release info
+            string? tagName = null;
+            string? description = null;
+            if (responseObject.TryGetProperty("release", out var releaseObject) &&
+                releaseObject.ValueKind == JsonValueKind.Object)
+            {
+                if (releaseObject.TryGetProperty("tag_name", out var tagNameElement) &&
+                    tagNameElement.ValueKind == JsonValueKind.String)
+                {
+                    tagName = tagNameElement.GetString()!;
+                }
+
+                if (releaseObject.TryGetProperty("description", out var descriptionElement) &&
+                    descriptionElement.ValueKind == JsonValueKind.String)
+                {
+                    description = descriptionElement.GetString();
+                }
+            }
+
+            // find matching version
+            var correspondingVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            if (correspondingVersion is null)
+            {
+                continue;
+            }
+
+            var resultTag = tagName ?? releaseName;
+            if (resultTag is not null &&
+                correspondingVersion >= oldVersion &&
+                correspondingVersion <= newVersion)
+            {
+                result[correspondingVersion] = (resultTag, description);
+            }
+        }
+
+        return result;
+    }
+
+    public string GetReleasesUrlPath() => "-/releases";
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/HttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/HttpFetcher.cs
@@ -1,0 +1,32 @@
+using System.Net.Http.Headers;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class HttpFetcher : IHttpFetcher
+{
+    private readonly HttpClient _httpClient;
+
+    public HttpFetcher()
+    {
+        _httpClient = new HttpClient();
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    public async Task<string?> GetStringAsync(string url)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("dependabot-core", null));
+        var response = await _httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var result = await response.Content.ReadAsStringAsync();
+        return result;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IHttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IHttpFetcher.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal interface IHttpFetcher : IDisposable
+{
+    Task<string?> GetStringAsync(string url);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
@@ -1,0 +1,47 @@
+using NuGet.Versioning;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal interface IPackageDetailFinder
+{
+    string GetReleasesUrlPath();
+    string GetCompareUrlPath(string? oldTag, string? newTag);
+    Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion);
+
+    internal static NuGetVersion? GetVersionFromNames(string? releaseName, string? tagName)
+    {
+        var prefixesToTrim = new[]
+        {
+            "version-",
+            "version.",
+            "version ",
+            "version",
+            "v-",
+            "v.",
+            "v ",
+            "v",
+        };
+        foreach (var candidateName in new[] { releaseName, tagName }.Where(n => n is not null).Cast<string>())
+        {
+            foreach (var prefix in prefixesToTrim)
+            {
+                if (candidateName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var trimmedCandidateName = candidateName[prefix.Length..];
+                    if (NuGetVersion.TryParse(trimmedCandidateName, out var versionFromTrimmed))
+                    {
+                        return versionFromTrimmed;
+                    }
+                }
+            }
+
+            // no prefix match, try the whole string
+            if (NuGetVersion.TryParse(candidateName, out var versionFromWhole))
+            {
+                return versionFromWhole;
+            }
+        }
+
+        return null;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPullRequestBodyGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPullRequestBodyGenerator.cs
@@ -1,0 +1,11 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+public interface IPullRequestBodyGenerator
+{
+    public Task<string> GeneratePullRequestBodyTextAsync(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, ImmutableArray<ReportedDependency> updatedDependencies);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/SimplePullRequestBodyGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/SimplePullRequestBodyGenerator.cs
@@ -1,0 +1,15 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Updater;
+
+namespace NuGetUpdater.Core.Run.PullRequestBodyGenerator;
+
+internal class SimplePullRequestBodyGenerator : IPullRequestBodyGenerator
+{
+    public Task<string> GeneratePullRequestBodyTextAsync(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, ImmutableArray<ReportedDependency> updatedDependencies)
+    {
+        var prBody = UpdateOperationBase.GenerateUpdateOperationReport(updateOperationsPerformed, includeFileNames: false);
+        return Task.FromResult(prBody);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 
 using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Run.PullRequestBodyGenerator;
 using NuGetUpdater.Core.Updater;
 
 using DependencySet = (string Name, (NuGet.Versioning.NuGetVersion? OldVersion, NuGet.Versioning.NuGetVersion NewVersion)[] Versions);
@@ -124,9 +125,12 @@ public class PullRequestTextGenerator
         return dependencySets;
     }
 
-    public static string GetPullRequestBody(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
+    public static async Task<string> GetPullRequestBodyAsync(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, ImmutableArray<ReportedDependency> updatedDependencies, ExperimentsManager experimentsManager)
     {
-        var report = UpdateOperationBase.GenerateUpdateOperationReport(updateOperationsPerformed, includeFileNames: false);
-        return report;
+        var bodyGenerator = experimentsManager.GenerateSimplePrBody
+            ? (IPullRequestBodyGenerator)new SimplePullRequestBodyGenerator()
+            : new DetailedPullRequestBodyGenerator(new HttpFetcher());
+        var prBody = await bodyGenerator.GeneratePullRequestBodyTextAsync(job, updateOperationsPerformed, updatedDependencies);
+        return prBody;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -161,7 +161,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
             {
                 var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                 await apiHandler.CreatePullRequest(new CreatePullRequest()
                 {
                     Dependencies = [.. updatedDependencies],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -155,7 +155,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             {
                 var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], group.Name);
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], group.Name);
-                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], group.Name);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                 await apiHandler.CreatePullRequest(new CreatePullRequest()
                 {
                     Dependencies = [.. updatedDependencies],
@@ -251,7 +251,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             {
                 var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                 await apiHandler.CreatePullRequest(new CreatePullRequest()
                 {
                     Dependencies = [.. updatedDependencies],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -154,7 +154,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
 
             var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
             var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-            var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+            var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
             var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
             if (existingPullRequest is not null)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -161,7 +161,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
             {
                 var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
 
                 var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
                 if (existingPullRequest is not null)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -151,7 +151,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
             {
                 var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-                var prBody = PullRequestTextGenerator.GetPullRequestBody(job, [.. updateOperationsPerformed], null);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
 
                 var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
                 if (existingPullRequest is not null)


### PR DESCRIPTION
This PR restores most of the old PR body generation behavior so it contains links to GitHub releases, etc.

Once merged, this behavior is live and will generate the more detailed PR descriptions; the experiment flag is only being used to keep the smoke tests stable until the churn of this feature has calmed down because it's very involved to update the smoke tests.

For GitHub and GitLab, special classes were added to query their APIs to get releases and tags and try to map those to package version numbers.

`IPackageDetailFinder.cs` contains a static method that takes a release and tag name and tries removing various common prefixes like `version-` and `v` and parsing the remainder as a version number.  This is really just a heuristic and can be tuned over time.

To make unit testing faster and more deterministic, an interface `IHttpFetcher` was added.  The production version is really just a wrapper around `HttpClient.GetString` and the one used in unit tests is just a `Dictionary<string, string>` mapping URLs to the expected response string.  Manual tests were run locally with the real fetcher and once this feature is more stable, we'll get real world use from the smoke tests.