### PR TITLE
Use tag name corresponding to vcpkg commit

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -8,18 +8,20 @@ module Dependabot
   class Dependency
     extend T::Sig
 
-    @production_checks = T.let(
+    # rubocop:disable Style/ClassVars
+    @@production_checks = T.let(
       {},
       T::Hash[String, T.proc.params(arg0: T::Array[T.untyped]).returns(T::Boolean)]
     )
-    @display_name_builders = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
-    @name_normalisers = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
+    @@display_name_builders = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
+    @@name_normalisers = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
+    # rubocop:enable Style/ClassVars
 
     sig do
       params(package_manager: String).returns(T.proc.params(arg0: T::Array[T.untyped]).returns(T::Boolean))
     end
     def self.production_check_for_package_manager(package_manager)
-      production_check = @production_checks[package_manager]
+      production_check = @@production_checks[package_manager]
       return production_check if production_check
 
       raise "Unsupported package_manager #{package_manager}"
@@ -33,22 +35,22 @@ module Dependabot
         .returns(T.proc.params(arg0: T::Array[T.untyped]).returns(T::Boolean))
     end
     def self.register_production_check(package_manager, production_check)
-      @production_checks[package_manager] = production_check
+      @@production_checks[package_manager] = production_check
     end
 
     sig { params(package_manager: String).returns(T.nilable(T.proc.params(arg0: String).returns(String))) }
     def self.display_name_builder_for_package_manager(package_manager)
-      @display_name_builders[package_manager]
+      @@display_name_builders[package_manager]
     end
 
     sig { params(package_manager: String, name_builder: T.proc.params(arg0: String).returns(String)).void }
     def self.register_display_name_builder(package_manager, name_builder)
-      @display_name_builders[package_manager] = name_builder
+      @@display_name_builders[package_manager] = name_builder
     end
 
     sig { params(package_manager: String).returns(T.nilable(T.proc.params(arg0: String).returns(String))) }
     def self.name_normaliser_for_package_manager(package_manager)
-      @name_normalisers[package_manager] || ->(name) { name }
+      @@name_normalisers[package_manager] || ->(name) { name }
     end
 
     sig do
@@ -58,7 +60,7 @@ module Dependabot
       ).void
     end
     def self.register_name_normaliser(package_manager, name_builder)
-      @name_normalisers[package_manager] = name_builder
+      @@name_normalisers[package_manager] = name_builder
     end
 
     sig { returns(String) }
@@ -202,7 +204,7 @@ module Dependabot
       display_name_builder.call(name)
     end
 
-    sig { returns(T.nilable(String)) }
+    sig { overridable.returns(T.nilable(String)) }
     def humanized_previous_version
       # If we don't have a previous version, we *may* still be able to figure
       # one out if a ref was provided and has been changed (in which case the
@@ -224,7 +226,7 @@ module Dependabot
       end
     end
 
-    sig { returns(T.nilable(String)) }
+    sig { overridable.returns(T.nilable(String)) }
     def humanized_version
       return "removed" if removed?
 

--- a/vcpkg/lib/dependabot/vcpkg.rb
+++ b/vcpkg/lib/dependabot/vcpkg.rb
@@ -17,8 +17,8 @@ require "dependabot/pull_request_creator/labeler"
 Dependabot::PullRequestCreator::Labeler
   .register_label_details("vcpkg", name: "vcpkg_package_manager", colour: "512BD4")
 
-require "dependabot/dependency"
-Dependabot::Dependency.register_production_check("vcpkg", ->(_) { true })
+require "dependabot/vcpkg/dependency"
+Dependabot::Vcpkg::Dependency.register_production_check("vcpkg", ->(_) { true })
 
 module Dependabot
   module Vcpkg

--- a/vcpkg/lib/dependabot/vcpkg/dependency.rb
+++ b/vcpkg/lib/dependabot/vcpkg/dependency.rb
@@ -1,0 +1,75 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency"
+require "dependabot/git_commit_checker"
+
+require "dependabot/vcpkg"
+
+module Dependabot
+  module Vcpkg
+    class Dependency < Dependabot::Dependency
+      extend T::Sig
+
+      sig { override.returns(T.nilable(String)) }
+      def humanized_previous_version
+        git_sha?(previous_version) ? humanized_git_version(previous_version) : super
+      end
+
+      sig { override.returns(T.nilable(String)) }
+      def humanized_version
+        git_sha?(version) ? humanized_git_version(version) : super
+      end
+
+      private
+
+      sig { params(value: T.nilable(String)).returns(T::Boolean) }
+      def git_sha?(value)
+        !value.nil? && value.match?(/^[0-9a-f]{40}/)
+      end
+
+      sig { params(sha: T.nilable(String)).returns(T.nilable(String)) }
+      def humanized_git_version(sha)
+        return nil unless sha
+        return "`#{sha[0..6]}`" unless git_source?
+
+        tag_name = tag_name_for_sha(sha)
+        tag_name || "`#{sha[0..6]}`"
+      end
+
+      sig { returns(T::Boolean) }
+      def git_source?
+        requirements.any? { _1.dig(:source, :type) == "git" }
+      end
+
+      sig { params(sha: String).returns(T.nilable(String)) }
+      def tag_name_for_sha(sha)
+        @tag_name_cache = T.let(@tag_name_cache, T.nilable(T::Hash[String, T.nilable(String)]))
+        (@tag_name_cache ||= {}).fetch(sha) do |key|
+          @tag_name_cache[key] = fetch_tag_name_for_sha(key)
+        end
+      end
+
+      sig { params(sha: String).returns(T.nilable(String)) }
+      def fetch_tag_name_for_sha(sha)
+        git_commit_checker = GitCommitChecker.new(
+          dependency: self,
+          credentials: []
+        )
+
+        # Get all tags and find one that points to this commit
+        tags = git_commit_checker.local_tags_for_allowed_versions
+        tags.find { |tag_info| sha_matches_tag?(sha, tag_info) }&.dig(:tag)
+      rescue Dependabot::GitDependenciesNotReachable
+        nil
+      end
+
+      sig { params(sha: String, tag_info: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def sha_matches_tag?(sha, tag_info)
+        tag_info[:commit_sha] == sha || tag_info[:tag_sha] == sha
+      end
+    end
+  end
+end

--- a/vcpkg/lib/dependabot/vcpkg/file_parser.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_parser.rb
@@ -3,11 +3,11 @@
 
 require "sorbet-runtime"
 
-require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 
 require "dependabot/vcpkg"
+require "dependabot/vcpkg/dependency"
 require "dependabot/vcpkg/language"
 require "dependabot/vcpkg/package_manager"
 
@@ -74,7 +74,7 @@ module Dependabot
 
       sig { params(baseline: String, file: Dependabot::DependencyFile).returns(Dependabot::Dependency) }
       def build_baseline_dependency(baseline:, file:)
-        Dependabot::Dependency.new(
+        Dependabot::Vcpkg::Dependency.new(
           name: VCPKG_DEFAULT_BASELINE_DEPENDENCY_NAME,
           version: baseline,
           package_manager: "vcpkg",

--- a/vcpkg/spec/dependabot/vcpkg/dependency_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/dependency_spec.rb
@@ -1,0 +1,192 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/vcpkg/dependency"
+
+RSpec.describe Dependabot::Vcpkg::Dependency do
+  let(:dependency) do
+    described_class.new(
+      name: "github.com/microsoft/vcpkg",
+      version: version,
+      previous_version: previous_version,
+      requirements: requirements,
+      package_manager: "vcpkg"
+    )
+  end
+
+  let(:version) { "abc123def456789012345678901234567890abcd" }
+  let(:previous_version) { "def789abc123456789012345678901234567890def" }
+  let(:requirements) do
+    [{
+      requirement: nil,
+      groups: [],
+      source: {
+        type: "git",
+        url: "https://github.com/microsoft/vcpkg.git",
+        ref: version
+      },
+      file: "vcpkg.json"
+    }]
+  end
+
+  let(:git_commit_checker) { instance_double(Dependabot::GitCommitChecker) }
+  let(:mock_tags) { [] }
+
+  before do
+    allow(Dependabot::GitCommitChecker).to receive(:new)
+      .with(dependency: dependency, credentials: [])
+      .and_return(git_commit_checker)
+    allow(git_commit_checker).to receive(:local_tags_for_allowed_versions)
+      .and_return(mock_tags)
+  end
+
+  describe "#humanized_version" do
+    context "when version is not a 40-character SHA" do
+      let(:version) { "1.2.3" }
+
+      it "delegates to parent class" do
+        expect(dependency.humanized_version).to eq("1.2.3")
+      end
+    end
+
+    context "when version is a 40-character SHA" do
+      context "with a matching git tag" do
+        let(:mock_tags) do
+          [{
+            tag: "2025.06.13",
+            commit_sha: version,
+            tag_sha: "def456789012345678901234567890abcdef123"
+          }]
+        end
+
+        it "returns the tag name" do
+          expect(dependency.humanized_version).to eq("2025.06.13")
+        end
+      end
+
+      context "with a matching tag SHA" do
+        let(:mock_tags) do
+          [{
+            tag: "2025.06.13",
+            commit_sha: "def456789012345678901234567890abcdef123",
+            tag_sha: version
+          }]
+        end
+
+        it "returns the tag name" do
+          expect(dependency.humanized_version).to eq("2025.06.13")
+        end
+      end
+
+      context "with no matching tag" do
+        let(:mock_tags) do
+          [{
+            tag: "2025.06.13",
+            commit_sha: "different_sha_123456789012345678901234567890",
+            tag_sha: "another_sha_456789012345678901234567890123"
+          }]
+        end
+
+        it "returns first 6 characters of SHA with backticks" do
+          expect(dependency.humanized_version).to eq("`abc123d`")
+        end
+      end
+
+      context "when git repository is not reachable" do
+        before do
+          allow(git_commit_checker).to receive(:local_tags_for_allowed_versions)
+            .and_raise(Dependabot::GitDependenciesNotReachable.new(["https://github.com/microsoft/vcpkg.git"]))
+        end
+
+        it "returns first 6 characters of SHA with backticks" do
+          expect(dependency.humanized_version).to eq("`abc123d`")
+        end
+      end
+    end
+
+    context "when dependency has no git source" do
+      let(:requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          source: nil,
+          file: "vcpkg.json"
+        }]
+      end
+
+      it "returns first 6 characters of SHA with backticks" do
+        expect(dependency.humanized_version).to eq("`abc123d`")
+      end
+    end
+  end
+
+  describe "#humanized_previous_version" do
+    context "when previous_version is not a 40-character SHA" do
+      let(:previous_version) { "1.2.2" }
+
+      it "delegates to parent class" do
+        expect(dependency.humanized_previous_version).to eq("1.2.2")
+      end
+    end
+
+    context "when previous_version is a 40-character SHA" do
+      context "with a matching git tag" do
+        let(:mock_tags) do
+          [{
+            tag: "2025.04.09",
+            commit_sha: previous_version,
+            tag_sha: "def456789012345678901234567890abcdef123"
+          }]
+        end
+
+        it "returns the tag name" do
+          expect(dependency.humanized_previous_version).to eq("2025.04.09")
+        end
+      end
+
+      context "with no matching tag" do
+        let(:mock_tags) do
+          [{
+            tag: "2025.06.13",
+            commit_sha: "different_sha_123456789012345678901234567890",
+            tag_sha: "another_sha_456789012345678901234567890123"
+          }]
+        end
+
+        it "returns first 6 characters of SHA with backticks" do
+          expect(dependency.humanized_previous_version).to eq("`def789a`")
+        end
+      end
+    end
+
+    context "when previous_version is nil" do
+      let(:previous_version) { nil }
+
+      it "delegates to parent class" do
+        expect(dependency.humanized_previous_version).to be_nil
+      end
+    end
+  end
+
+  describe "caching behavior" do
+    let(:mock_tags) do
+      [{
+        tag: "2025.06.13",
+        commit_sha: version,
+        tag_sha: "def456789012345678901234567890abcdef123"
+      }]
+    end
+
+    it "caches tag lookup results" do
+      # First call should fetch from git
+      expect(dependency.humanized_version).to eq("2025.06.13")
+
+      # Second call should use cached result
+      expect(dependency.humanized_version).to eq("2025.06.13")
+
+      # Should only have called git_commit_checker once
+      expect(git_commit_checker).to have_received(:local_tags_for_allowed_versions).once
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
The current PR titles created for VCPKG are something like

> Bump github.com/microsoft/vcpkg from master to ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0 in /vcpkg/builtin-baseline

That is a little too verbose. Ideally I'd like to use the underlying git tag name (if one exists) and truncate the commit hash to 7 characters (like all other ecosystems). That would look a little something like:

> Bump github.com/microsoft/vcpkg from `fe1cde6` to 2025.06.13 in /vcpkg/builtin-baseline

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
