### PR TITLE
scrub github name and issue mentions

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
@@ -772,6 +772,75 @@ public class DetailedPullRequestBodyGeneratorTests
         );
     }
 
+    [Fact]
+    public async Task GeneratePrBody_LinksAndMentionsAreScrubbed()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "Some.Dependency",
+                    PreviousVersion = "1.0.0",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "2.0.0",
+                            Source = new()
+                            {
+                                SourceUrl = "https://github.com/Some.Owner/Some.Dependency",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://api.github.com/repos/Some.Owner/Some.Dependency/releases?per_page=100", """
+                    [
+                      {
+                        "name": "2.0.0",
+                        "tag_name": "2.0.0",
+                        "body": "Direct mention of @example user on @team/example."
+                      },
+                      {
+                        "name": "1.0.1",
+                        "tag_name": "1.0.1",
+                        "body": "Issue #123 as well as owner/repo#456."
+                      },
+                      {
+                        "name": "1.0.0",
+                        "tag_name": "1.0.0",
+                        "body": "* point 1\n* point 2"
+                      }
+                    ]
+                    """)
+            ],
+            expectedBody: $"""
+                Updated [Some.Dependency](https://github.com/Some.Owner/Some.Dependency) from 1.0.0 to 2.0.0.
+
+                <details>
+                <summary>Release notes</summary>
+
+                _Sourced from [Some.Dependency's releases](https://github.com/Some.Owner/Some.Dependency/releases)._
+
+                ## 2.0.0
+
+                Direct mention of @{"\u200B"}example user on @{"\u200B"}team/example.
+
+                ## 1.0.1
+
+                Issue #{"\u200B"}123 as well as owner/repo#{"\u200B"}456.
+
+                Commits viewable in [compare view](https://github.com/Some.Owner/Some.Dependency/compare/1.0.0...2.0.0).
+                </details>
+                """
+        );
+    }
+
     private static async Task TestAsync(
         ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
         ImmutableArray<ReportedDependency> updatedDependencies,


### PR DESCRIPTION
Scrubs GitHub username and issue/PR mentions from the generated PR body text.

Inserts a zero-width space `\u200B` after the `@` or `#` characters.

Fixes #12683