### PR TITLE
Fix cooldown filtering for latest distribution tags in npm/yarn and bun

### DIFF
--- a/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -95,7 +95,7 @@ module Dependabot
           with_custom_registry_rescue do
             return unless valid_npm_details?
 
-            tag_release = version_from_dist_tags
+            tag_release = version_from_dist_tags(cooldown: true)
             return tag_release.version if tag_release
 
             return if specified_dist_tag_requirement?
@@ -113,7 +113,7 @@ module Dependabot
         def fetch_latest_version_with_no_unlock(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           with_custom_registry_rescue do
             return unless valid_npm_details?
-            return version_from_dist_tags&.version if specified_dist_tag_requirement?
+            return version_from_dist_tags(cooldown: true)&.version if specified_dist_tag_requirement?
 
             filtered_releases = filter_by_cooldown(possible_releases)
 
@@ -272,8 +272,11 @@ module Dependabot
           !!package_details&.releases&.any?
         end
 
-        sig { returns(T.nilable(Dependabot::Package::PackageRelease)) }
-        def version_from_dist_tags # rubocop:disable Metrics/PerceivedComplexity
+        sig do
+          params(cooldown: T::Boolean)
+            .returns(T.nilable(Dependabot::Package::PackageRelease))
+        end
+        def version_from_dist_tags(cooldown: false) # rubocop:disable Metrics/PerceivedComplexity
           dist_tags = package_details&.dist_tags
           return nil unless dist_tags
 
@@ -284,7 +287,7 @@ module Dependabot
           # For cooldown filtering, use filtered releases
           releases = available_versions
 
-          releases = filter_by_cooldown(releases) if releases
+          releases = filter_by_cooldown(releases) if cooldown && releases
 
           if dist_tag_req
             release = find_dist_tag_release(dist_tag_req, releases)
@@ -297,7 +300,9 @@ module Dependabot
 
           if wants_latest_dist_tag?(latest_version)
             # Find the release object for this version, even if deprecated
-            return possible_previous_releases.find { |r| r.version == latest_version }
+            releases = possible_previous_releases
+            releases = filter_by_cooldown(releases) if cooldown
+            return releases.find { |r| r.version == latest_version }
           end
 
           nil

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -95,7 +95,7 @@ module Dependabot
           with_custom_registry_rescue do
             return unless valid_npm_details?
 
-            tag_release = version_from_dist_tags
+            tag_release = version_from_dist_tags(cooldown: true)
             return tag_release.version if tag_release
 
             return if specified_dist_tag_requirement?
@@ -113,7 +113,7 @@ module Dependabot
         def fetch_latest_version_with_no_unlock(language_version: nil) # rubocop:disable Lint/UnusedMethodArgument
           with_custom_registry_rescue do
             return unless valid_npm_details?
-            return version_from_dist_tags&.version if specified_dist_tag_requirement?
+            return version_from_dist_tags(cooldown: true)&.version if specified_dist_tag_requirement?
 
             filtered_releases = filter_by_cooldown(possible_releases)
 
@@ -272,8 +272,11 @@ module Dependabot
           !!package_details&.releases&.any?
         end
 
-        sig { returns(T.nilable(Dependabot::Package::PackageRelease)) }
-        def version_from_dist_tags # rubocop:disable Metrics/PerceivedComplexity
+        sig do
+          params(cooldown: T::Boolean)
+            .returns(T.nilable(Dependabot::Package::PackageRelease))
+        end
+        def version_from_dist_tags(cooldown: false) # rubocop:disable Metrics/PerceivedComplexity
           dist_tags = package_details&.dist_tags
           return nil unless dist_tags
 
@@ -284,7 +287,7 @@ module Dependabot
           # For cooldown filtering, use filtered releases
           releases = available_versions
 
-          releases = filter_by_cooldown(releases) if releases
+          releases = filter_by_cooldown(releases) if cooldown && releases
 
           if dist_tag_req
             release = find_dist_tag_release(dist_tag_req, releases)
@@ -297,7 +300,9 @@ module Dependabot
 
           if wants_latest_dist_tag?(latest_version)
             # Find the release object for this version, even if deprecated
-            return possible_previous_releases.find { |r| r.version == latest_version }
+            releases = possible_previous_releases
+            releases = filter_by_cooldown(releases) if cooldown
+            return releases.find { |r| r.version == latest_version }
           end
 
           nil


### PR DESCRIPTION
### What are you trying to accomplish?

Fix cooldown filtering for distribution tag versions (like `latest`, `next`, `beta`) in npm/yarn and bun ecosystems. Currently, when cooldown periods are configured, distribution tag versions bypass cooldown filtering and can update to versions that should be blocked.

### Anything you want to highlight for special attention from reviewers?

Added a `cooldown` parameter to `version_from_dist_tags` method and apply cooldown filtering when `cooldown: true` is passed. This ensures distribution tag versions respect the same cooldown rules as regular releases.

### How will you know you've accomplished your goal?

- Distribution tag versions will be filtered by cooldown settings when enabled
- Dependencies with cooldown configurations won't update to versions within the cooldown period, even if tagged as `latest`
- Cooldown functionality works consistently across npm/yarn and bun ecosystems

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to