### PR TITLE
Improves PHP_CS_FIXER compatibility with PHP8.4 

### DIFF
--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -22,10 +22,6 @@ cp -r \
 
 cd "$install_dir"
 
-# We are skipping the PHP-CS-Fixer compatibility check as support for php 8.4+ is not available in latest version.
-# Once PHP-CS-Fixer supports 8.4+ we can remove this line - https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/milestone/173
-export PHP_CS_FIXER_IGNORE_ENV=1
-
 composer validate --no-check-publish
 composer install
 composer run lint -- --dry-run


### PR DESCRIPTION
### What are you trying to accomplish?

This pull request removes an environment variable and associated comment from the `composer/helpers/v2/build` script. The change eliminates the `PHP_CS_FIXER_IGNORE_ENV` variable, which was previously used to bypass PHP-CS-Fixer compatibility checks for PHP 8.4+. The removal suggests that PHP-CS-Fixer may now support PHP 8.4+, making the workaround unnecessary.

There was initial incompatibility that has been resolved. For more info [see](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/milestone/173?closed=1)

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
