### PR TITLE
fix: Comment out vcpkg and rust_toolchain deps in omnibus to resolve version conflicts

### DIFF
--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -47,13 +47,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dependabot-nuget", Dependabot::VERSION
   spec.add_dependency "dependabot-pub", Dependabot::VERSION
   spec.add_dependency "dependabot-python", Dependabot::VERSION
-  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  spec.add_dependency "dependabot-rust_toolchain", "0.321.2"
+  # TODO: Uncomment once https://github.com/rubygems/rubygems/issues/8836 is resolved
+  # spec.add_dependency "dependabot-rust_toolchain", Dependabot::VERSION
   spec.add_dependency "dependabot-swift", Dependabot::VERSION
   spec.add_dependency "dependabot-terraform", Dependabot::VERSION
   spec.add_dependency "dependabot-uv", Dependabot::VERSION
-  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  spec.add_dependency "dependabot-vcpkg", "0.321.2"
+  # TODO: Uncomment once https://github.com/rubygems/rubygems/issues/8836 is resolved
+  # spec.add_dependency "dependabot-vcpkg", Dependabot::VERSION
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, *dep.requirement.as_list


### PR DESCRIPTION
### What are you trying to accomplish?

This change resolves dependency version conflicts that occur when trying to update `dependabot-omnibus` from 0.321.2 to 0.322.1. The issue stems from `dependabot-vcpkg` and `dependabot-rust_toolchain` being manually published at version 0.321.2 (which depend on `dependabot-common = 0.321.2`) while the new omnibus version depends on `dependabot-common = 0.322.1`.

The conflict prevents users from updating to the latest omnibus version with this error:
```
Because every version of dependabot-vcpkg depends on dependabot-common = 0.321.2 and dependabot-omnibus >= 0.322.1 depends on dependabot-common = 0.322.1, every version of dependabot-vcpkg is incompatible with dependabot-omnibus >= 0.322.1.
```


This affects users trying to upgrade their dependabot-omnibus dependency in projects like dependabot-api.

### Anything you want to highlight for special attention from reviewers?

I chose to comment out the dependencies rather than remove them entirely to make it easy to restore them once the underlying rubygems issue (https://github.com/rubygems/rubygems/issues/8836) is resolved. The commented lines maintain the same `Dependabot::VERSION` pattern as other ecosystems, so uncommenting them later will seamlessly integrate them back into the omnibus package.

### How will you know you've accomplished your goal?

**Success criteria:**
- Users can successfully run `bundle update dependabot-omnibus` to upgrade from 0.321.2 to 0.322.1
- No dependency resolution conflicts occur during the upgrade
- Users who need vcpkg/rust_toolchain can still install them separately at version 0.321.2

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem
