### PR TITLE
Revert "fix: Comment out vcpkg and rust_toolchain deps in omnibus to resolve version conflicts"

### DIFF
--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -47,13 +47,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dependabot-nuget", Dependabot::VERSION
   spec.add_dependency "dependabot-pub", Dependabot::VERSION
   spec.add_dependency "dependabot-python", Dependabot::VERSION
-  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  spec.add_dependency "dependabot-rust_toolchain", "0.321.2"
+  spec.add_dependency "dependabot-rust_toolchain", Dependabot::VERSION
   spec.add_dependency "dependabot-swift", Dependabot::VERSION
   spec.add_dependency "dependabot-terraform", Dependabot::VERSION
   spec.add_dependency "dependabot-uv", Dependabot::VERSION
-  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  spec.add_dependency "dependabot-vcpkg", "0.321.2"
+  spec.add_dependency "dependabot-vcpkg", Dependabot::VERSION
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, *dep.requirement.as_list

--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -47,13 +47,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dependabot-nuget", Dependabot::VERSION
   spec.add_dependency "dependabot-pub", Dependabot::VERSION
   spec.add_dependency "dependabot-python", Dependabot::VERSION
-  # TODO: Uncomment once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  # spec.add_dependency "dependabot-rust_toolchain", Dependabot::VERSION
+  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
+  spec.add_dependency "dependabot-rust_toolchain", "0.321.2"
   spec.add_dependency "dependabot-swift", Dependabot::VERSION
   spec.add_dependency "dependabot-terraform", Dependabot::VERSION
   spec.add_dependency "dependabot-uv", Dependabot::VERSION
-  # TODO: Uncomment once https://github.com/rubygems/rubygems/issues/8836 is resolved
-  # spec.add_dependency "dependabot-vcpkg", Dependabot::VERSION
+  # TODO: Flip to `Dependabot::VERSION` once https://github.com/rubygems/rubygems/issues/8836 is resolved
+  spec.add_dependency "dependabot-vcpkg", "0.321.2"
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, *dep.requirement.as_list


### PR DESCRIPTION
Reverts the following PRs to restore dynamic versioning for dependabot-vcpkg and dependabot-rust_toolchain:

- https://github.com/dependabot/dependabot-core/pull/12701  
- https://github.com/dependabot/dependabot-core/pull/12660

We can update dependabot-api when the following RubyGems issue is resolved: 
* https://github.com/rubygems/rubygems/issues/8836