### PR TITLE
implement package update cooldown feature for nuget

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/CooldownTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/CooldownTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Immutable;
+
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run.ApiModel;
+
+public class CooldownTests
+{
+    [Theory]
+    [InlineData("2025-07-04T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "2.0.0", true)] // 3 days later - major allowed
+    [InlineData("2025-07-04T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.1.0", true)] // 3 days later - minor allowed
+    [InlineData("2025-07-04T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.0.1", true)] // 3 days later - patch allowed
+    [InlineData("2025-07-03T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "2.0.0", false)] // 2 days later - major not allowed
+    [InlineData("2025-07-03T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.1.0", true)] // 2 days later - minor allowed
+    [InlineData("2025-07-03T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.0.1", true)] // 2 days later - patch allowed
+    [InlineData("2025-07-02T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "2.0.0", false)] // 1 day later - major not allowed
+    [InlineData("2025-07-02T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.1.0", false)] // 1 day later - minor not allowed
+    [InlineData("2025-07-02T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.0.1", true)] // 1 day later - patch allowed
+    [InlineData("2025-07-01T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "2.0.0", false)] // same day - major not allowed
+    [InlineData("2025-07-01T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.1.0", false)] // same day - minor not allowed
+    [InlineData("2025-07-01T00:00:00Z", "2025-07-01T00:00:00Z", "1.0.0", "1.0.1", false)] // same day - patch not allowed
+    [InlineData("2025-07-01T00:00:00Z", null, "1.0.0", "2.0.0", true)] // no publish date - major allowed
+    [InlineData("2025-07-01T00:00:00Z", null, "1.0.0", "1.1.0", true)] // no publish date - minor allowed
+    [InlineData("2025-07-01T00:00:00Z", null, "1.0.0", "1.0.1", true)] // no publish date - patch allowed
+    public void Cooldown(string currentTimeString, string? packagePublishTimeString, string currentVersionString, string candidateVersionString, bool expectedIsUpdateAllowed)
+    {
+        // all scenarios use the same configuration
+        var cooldown = new Cooldown()
+        {
+            DefaultDays = 4,
+            SemVerMajorDays = 3,
+            SemVerMinorDays = 2,
+            SemVerPatchDays = 1,
+        };
+        var currentTime = DateTimeOffset.Parse(currentTimeString);
+        var packagePublishTime = packagePublishTimeString is null ? (DateTimeOffset?)null : DateTimeOffset.Parse(packagePublishTimeString);
+        var currentVersion = NuGetVersion.Parse(currentVersionString);
+        var candidateVersion = NuGetVersion.Parse(candidateVersionString);
+        var actualIsUpdateAllowed = cooldown.IsVersionUpdateAllowed(currentTime, packagePublishTime, currentVersion, candidateVersion);
+        Assert.Equal(expectedIsUpdateAllowed, actualIsUpdateAllowed);
+    }
+
+    [Theory]
+    [InlineData(4, 3, 2, 1, "1.0.0", "2.0.0", 3)] // major update allowed after 3 days
+    [InlineData(4, 3, 2, 1, "1.0.0", "1.1.0", 2)] // minor update allowed after 2 days
+    [InlineData(4, 3, 2, 1, "1.0.0", "1.0.1", 1)] // patch update allowed after 1 day
+    [InlineData(4, 0, 0, 0, "1.0.0", "2.0.0", 4)] // major update allowed after default days
+    [InlineData(4, 0, 0, 0, "1.0.0", "1.1.0", 4)] // minor update allowed after default days
+    [InlineData(4, 0, 0, 0, "1.0.0", "1.0.1", 4)] // patch update allowed after default day
+    [InlineData(4, 3, 2, 1, "1.0.0-beta1", "1.0.0-beta2", 4)] // default update allowed after 4 days
+    public void GetCooldownDays(int defaultDays, int semverMajorDays, int semverMinorDays, int semverPatchDays, string currentVersionString, string candidateUpdateVersioString, int expectedDaysDelay)
+    {
+        var cooldown = new Cooldown()
+        {
+            DefaultDays = defaultDays,
+            SemVerMajorDays = semverMajorDays,
+            SemVerMinorDays = semverMinorDays,
+            SemVerPatchDays = semverPatchDays,
+        };
+        var currentVersion = NuGetVersion.Parse(currentVersionString);
+        var candidateUpdateVersion = NuGetVersion.Parse(candidateUpdateVersioString);
+        var actualDaysDelay = cooldown.GetCooldownDays(currentVersion, candidateUpdateVersion);
+        Assert.Equal(expectedDaysDelay, actualDaysDelay);
+    }
+
+    [Theory]
+    [InlineData(null, null, "Some.Package", true)] // no include, no exclude - always applies
+    [InlineData("", null, "Some.Package", true)] // empty include, no exclude - always applies
+    [InlineData("*", null, "Some.Package", true)] // wildcard include, no exclude - always applies
+    [InlineData(null, "", "Some.Package", true)] // no include, empty exclude - always applies
+    [InlineData("", "", "Some.Package", true)] // empty include, empty exclude - always applies
+    [InlineData("*", "", "Some.Package", true)] // wildcard include, empty exclude - always applies
+    [InlineData(null, "*", "Some.Package", false)] // no include, wildcard exclude - never applies
+    [InlineData("", "*", "Some.Package", false)] // empty include, wildcard exclude - never applies
+    [InlineData(null, "Some.*", "Some.Package", false)] // no include, exclude pattern match - doesn't apply
+    [InlineData("", "Some.*", "Some.Package", false)] // empty include, exclude pattern match - doesn't apply
+    [InlineData("*", "Some.*", "Some.Package", false)] // wildcard include, exclude pattern match - doesn't apply
+    [InlineData("*", "Some.*", "Other.Package", true)] // wildcard include, exclude doesn't match - applies
+    [InlineData("Some.*", null, "Some.Package", true)] // include pattern match, no exclude - applies
+    [InlineData("Some.*", "", "Some.Package", true)] // include pattern match, empty exclude - applies
+    [InlineData("Some.*", null, "Other.Package", false)] // include pattern doesn't match, no exclude - doesn't apply
+    [InlineData("Some.*", "", "Other.Package", false)] // include pattern doesn't match, empty exclude - doesn't apply
+    [InlineData("Some.*", "Some.Other.*", "Some.Package", true)] // include pattern match, exclude pattern doesn't match - applies
+    [InlineData("Some.*", "Some.Other.*", "Some.Other.Package", false)] // include pattern match, exclude pattern match - doesn't apply
+    public void CooldownAppliesToPackage(string? includeString, string? excludeString, string packageName, bool expectedResult)
+    {
+        var cooldown = new Cooldown()
+        {
+            Include = includeString?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToImmutableArray(),
+            Exclude = excludeString?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToImmutableArray(),
+        };
+        var actualResult = cooldown.AppliesToPackage(packageName);
+        Assert.Equal(expectedResult, actualResult);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -17,8 +17,7 @@ public class JobTests
     [MemberData(nameof(IsUpdatePermittedTestData))]
     public void IsUpdatePermitted(Job job, Dependency dependency, bool expectedResult)
     {
-        var experimentsManager = new ExperimentsManager() { EnableCooldown = false }; // not tested here
-        var actualResult = job.IsUpdatePermitted(dependency, experimentsManager);
+        var actualResult = job.IsUpdatePermitted(dependency);
         Assert.Equal(expectedResult, actualResult);
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -17,7 +17,8 @@ public class JobTests
     [MemberData(nameof(IsUpdatePermittedTestData))]
     public void IsUpdatePermitted(Job job, Dependency dependency, bool expectedResult)
     {
-        var actualResult = job.IsUpdatePermitted(dependency);
+        var experimentsManager = new ExperimentsManager() { EnableCooldown = false }; // not tested here
+        var actualResult = job.IsUpdatePermitted(dependency, experimentsManager);
         Assert.Equal(expectedResult, actualResult);
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -517,8 +517,7 @@ public class MiscellaneousTests
     [MemberData(nameof(DependencyInfoFromJobData))]
     public void DependencyInfoFromJob(Job job, Dependency dependency, bool enableCooldown, DependencyInfo expectedDependencyInfo)
     {
-        var experimentsManager = new ExperimentsManager() { EnableCooldown = enableCooldown };
-        var actualDependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
+        var actualDependencyInfo = RunWorker.GetDependencyInfo(job, dependency, enableCooldown);
         var expectedString = JsonSerializer.Serialize(expectedDependencyInfo, AnalyzeWorker.SerializerOptions);
         var actualString = JsonSerializer.Serialize(actualDependencyInfo, AnalyzeWorker.SerializerOptions);
         Assert.Equal(expectedString, actualString);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -515,9 +515,10 @@ public class MiscellaneousTests
 
     [Theory]
     [MemberData(nameof(DependencyInfoFromJobData))]
-    public void DependencyInfoFromJob(Job job, Dependency dependency, DependencyInfo expectedDependencyInfo)
+    public void DependencyInfoFromJob(Job job, Dependency dependency, bool enableCooldown, DependencyInfo expectedDependencyInfo)
     {
-        var actualDependencyInfo = RunWorker.GetDependencyInfo(job, dependency);
+        var experimentsManager = new ExperimentsManager() { EnableCooldown = enableCooldown };
+        var actualDependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
         var expectedString = JsonSerializer.Serialize(expectedDependencyInfo, AnalyzeWorker.SerializerOptions);
         var actualString = JsonSerializer.Serialize(actualDependencyInfo, AnalyzeWorker.SerializerOptions);
         Assert.Equal(expectedString, actualString);
@@ -634,6 +635,8 @@ public class MiscellaneousTests
             },
             // dependency
             new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            true,
             // expectedDependencyInfo
             new DependencyInfo()
             {
@@ -651,7 +654,7 @@ public class MiscellaneousTests
                     }
                 ],
                 IgnoredUpdateTypes = [],
-            }
+            },
         ];
 
         yield return
@@ -679,6 +682,8 @@ public class MiscellaneousTests
             },
             // dependency
             new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            true,
             // expectedDependencyInfo
             new DependencyInfo()
             {
@@ -688,7 +693,167 @@ public class MiscellaneousTests
                 IgnoredVersions = [],
                 Vulnerabilities = [],
                 IgnoredUpdateTypes = [ConditionUpdateType.SemVerMajor],
-            }
+            },
+        ];
+
+        // with cooldown object when `include` and `exclude` are empty
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "some/repo",
+                },
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                }
+            },
+            // dependency
+            new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            true,
+            // expectedDependencyInfo
+            new DependencyInfo()
+            {
+                Name = "Some.Dependency",
+                Version = "1.0.0",
+                IsVulnerable = false,
+                IgnoredVersions = [],
+                Vulnerabilities = [],
+                IgnoredUpdateTypes = [],
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                }
+            },
+        ];
+
+        // with cooldown object when `include` matches and `exclude` is empty
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "some/repo",
+                },
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                    Include = ["Some.*"],
+                }
+            },
+            // dependency
+            new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            true,
+            // expectedDependencyInfo
+            new DependencyInfo()
+            {
+                Name = "Some.Dependency",
+                Version = "1.0.0",
+                IsVulnerable = false,
+                IgnoredVersions = [],
+                Vulnerabilities = [],
+                IgnoredUpdateTypes = [],
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                    Include = ["Some.*"],
+                }
+            },
+        ];
+
+        // without cooldown object `exclude` matches
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "some/repo",
+                },
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                    Exclude = ["Some.*"],
+                }
+            },
+            // dependency
+            new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            true,
+            // expectedDependencyInfo
+            new DependencyInfo()
+            {
+                Name = "Some.Dependency",
+                Version = "1.0.0",
+                IsVulnerable = false,
+                IgnoredVersions = [],
+                Vulnerabilities = [],
+                IgnoredUpdateTypes = [],
+                Cooldown = null,
+            },
+        ];
+
+        // with cooldown object when `include` matches but experiment flag is false
+        yield return
+        [
+            // job
+            new Job()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "some/repo",
+                },
+                Cooldown = new()
+                {
+                    DefaultDays = 4,
+                    SemVerMajorDays = 3,
+                    SemVerMinorDays = 2,
+                    SemVerPatchDays = 1,
+                    Include = ["Some.*"],
+                }
+            },
+            // dependency
+            new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference),
+            // enableCooldown
+            false,
+            // expectedDependencyInfo
+            new DependencyInfo()
+            {
+                Name = "Some.Dependency",
+                Version = "1.0.0",
+                IsVulnerable = false,
+                IgnoredVersions = [],
+                Vulnerabilities = [],
+                IgnoredUpdateTypes = [],
+                Cooldown = null
+            },
         ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -238,6 +238,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         var versionResult = await VersionFinder.GetVersionsAsync(
             projectFrameworks,
             dependencyInfo,
+            DateTimeOffset.UtcNow,
             nugetContext,
             logger,
             cancellationToken);
@@ -248,34 +249,6 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             versionResult,
             projectFrameworks,
             findLowestVersion: dependencyInfo.IsVulnerable,
-            nugetContext,
-            logger,
-            cancellationToken);
-    }
-
-    internal static async Task<NuGetVersion?> FindUpdatedVersionAsync(
-        ImmutableHashSet<string> packageIds,
-        ImmutableArray<NuGetFramework> projectFrameworks,
-        NuGetVersion version,
-        bool findLowestVersion,
-        NuGetContext nugetContext,
-        ILogger logger,
-        CancellationToken cancellationToken)
-    {
-        var versionResult = await VersionFinder.GetVersionsAsync(
-            projectFrameworks,
-            packageIds.First(),
-            version,
-            nugetContext,
-            logger,
-            cancellationToken);
-
-        return await FindUpdatedVersionAsync(
-            packageIds,
-            version.ToNormalizedString(),
-            versionResult,
-            projectFrameworks,
-            findLowestVersion,
             nugetContext,
             logger,
             cancellationToken);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/DependencyInfo.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/DependencyInfo.cs
@@ -12,4 +12,5 @@ public sealed record DependencyInfo
     public ImmutableArray<Requirement> IgnoredVersions { get; init; }
     public ImmutableArray<SecurityVulnerability> Vulnerabilities { get; init; }
     public ImmutableArray<ConditionUpdateType> IgnoredUpdateTypes { get; init; } = [];
+    public Cooldown? Cooldown { get; init; } = null;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -7,6 +7,7 @@ namespace NuGetUpdater.Core;
 
 public record ExperimentsManager
 {
+    public bool EnableCooldown { get; init; } = false;
     public bool GenerateSimplePrBody { get; init; } = false;
     public bool InstallDotnetSdks { get; init; } = false;
     public bool NativeUpdater { get; init; } = false;
@@ -15,6 +16,7 @@ public record ExperimentsManager
     {
         return new()
         {
+            ["enable_cooldown_for_nuget"] = EnableCooldown,
             ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
             ["nuget_install_dotnet_sdks"] = InstallDotnetSdks,
             ["nuget_native_updater"] = NativeUpdater,
@@ -25,6 +27,7 @@ public record ExperimentsManager
     {
         return new ExperimentsManager()
         {
+            EnableCooldown = IsEnabled(experiments, "enable_cooldown_for_nuget"),
             GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
             InstallDotnetSdks = IsEnabled(experiments, "nuget_install_dotnet_sdks"),
             NativeUpdater = IsEnabled(experiments, "nuget_native_updater"),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Cooldown.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Cooldown.cs
@@ -1,0 +1,25 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record Cooldown
+{
+    [JsonPropertyName("default-days")]
+    public int DefaultDays { get; init; } = 0;
+
+    [JsonPropertyName("semver-major-days")]
+    public int SemVerMajorDays { get; init; } = 0;
+
+    [JsonPropertyName("semver-minor-days")]
+    public int SemVerMinorDays { get; init; } = 0;
+
+    [JsonPropertyName("semver-patch-days")]
+    public int SemVerPatchDays { get; init; } = 0;
+
+    [JsonPropertyName("include")]
+    public ImmutableArray<string>? Include { get; init; } = null;
+
+    [JsonPropertyName("exclude")]
+    public ImmutableArray<string>? Exclude { get; init; } = null;
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -112,7 +112,7 @@ public sealed record Job
         return isIgnored;
     }
 
-    public bool IsUpdatePermitted(Dependency dependency, ExperimentsManager experimentsManager)
+    public bool IsUpdatePermitted(Dependency dependency)
     {
         if (dependency.Version is null)
         {
@@ -121,7 +121,7 @@ public sealed record Job
         }
 
         var version = NuGetVersion.Parse(dependency.Version);
-        var dependencyInfo = RunWorker.GetDependencyInfo(this, dependency, experimentsManager);
+        var dependencyInfo = RunWorker.GetDependencyInfo(this, dependency, allowCooldown: false);
         var isVulnerable = dependencyInfo.Vulnerabilities.Any(v => v.IsVulnerable(version));
 
         bool IsAllowed(AllowedUpdate allowedUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -40,6 +40,7 @@ public sealed record Job
     public CommitOptions? CommitMessageOptions { get; init; } = null;
     public ImmutableArray<Dictionary<string, object>>? CredentialsMetadata { get; init; } = null;
     public int MaxUpdaterRunTime { get; init; } = 0;
+    public Cooldown? Cooldown { get; init; } = null;
 
     public ImmutableArray<string> GetAllDirectories()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -112,7 +112,7 @@ public sealed record Job
         return isIgnored;
     }
 
-    public bool IsUpdatePermitted(Dependency dependency)
+    public bool IsUpdatePermitted(Dependency dependency, ExperimentsManager experimentsManager)
     {
         if (dependency.Version is null)
         {
@@ -121,7 +121,7 @@ public sealed record Job
         }
 
         var version = NuGetVersion.Parse(dependency.Version);
-        var dependencyInfo = RunWorker.GetDependencyInfo(this, dependency);
+        var dependencyInfo = RunWorker.GetDependencyInfo(this, dependency, experimentsManager);
         var isVulnerable = dependencyInfo.Vulnerabilities.Any(v => v.IsVulnerable(version));
 
         bool IsAllowed(AllowedUpdate allowedUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -152,7 +152,7 @@ public class RunWorker
         }
     }
 
-    internal static DependencyInfo GetDependencyInfo(Job job, Dependency dependency, ExperimentsManager experimentsManager)
+    internal static DependencyInfo GetDependencyInfo(Job job, Dependency dependency, bool allowCooldown)
     {
         var dependencyVersion = NuGetVersion.Parse(dependency.Version!);
         var securityAdvisories = job.SecurityAdvisories.Where(s => s.DependencyName.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)).ToArray();
@@ -178,7 +178,7 @@ public class RunWorker
 
         // while it would be nice to lift the cooldown options into the IgnoredUpdateTypes field, we don't know the
         // publish date of the packages, so we have to pass along the whole object for the version finder to sort out
-        var includeCooldown = experimentsManager.EnableCooldown &&
+        var includeCooldown = allowCooldown &&
             job.Cooldown is not null &&
             job.Cooldown.AppliesToPackage(dependency.Name);
         var dependencyInfo = new DependencyInfo()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -152,7 +152,7 @@ public class RunWorker
         }
     }
 
-    internal static DependencyInfo GetDependencyInfo(Job job, Dependency dependency)
+    internal static DependencyInfo GetDependencyInfo(Job job, Dependency dependency, ExperimentsManager experimentsManager)
     {
         var dependencyVersion = NuGetVersion.Parse(dependency.Version!);
         var securityAdvisories = job.SecurityAdvisories.Where(s => s.DependencyName.Equals(dependency.Name, StringComparison.OrdinalIgnoreCase)).ToArray();
@@ -175,6 +175,12 @@ public class RunWorker
             .SelectMany(c => c.UpdateTypes ?? [])
             .Distinct()
             .ToImmutableArray();
+
+        // while it would be nice to lift the cooldown options into the IgnoredUpdateTypes field, we don't know the
+        // publish date of the packages, so we have to pass along the whole object for the version finder to sort out
+        var includeCooldown = experimentsManager.EnableCooldown &&
+            job.Cooldown is not null &&
+            job.Cooldown.AppliesToPackage(dependency.Name);
         var dependencyInfo = new DependencyInfo()
         {
             Name = dependency.Name,
@@ -183,6 +189,7 @@ public class RunWorker
             IgnoredVersions = ignoredVersions,
             Vulnerabilities = vulnerabilities,
             IgnoredUpdateTypes = ignoredUpdateTypes,
+            Cooldown = includeCooldown ? job.Cooldown : null,
         };
         return dependencyInfo;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -67,7 +67,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
             {
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var vulnerableCandidateDependenciesToUpdate = dependencyGroupToUpdate.Value
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, allowCooldown: false)))
                     .Where(set => set.Item3.IsVulnerable)
                     .ToArray();
                 var vulnerableDependenciesToUpdate = vulnerableCandidateDependenciesToUpdate

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -67,7 +67,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
             {
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var vulnerableCandidateDependenciesToUpdate = dependencyGroupToUpdate.Value
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
                     .Where(set => set.Item3.IsVulnerable)
                     .ToArray();
                 var vulnerableDependenciesToUpdate = vulnerableCandidateDependenciesToUpdate

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -89,7 +89,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
                 foreach (var (projectPath, dependency) in updateOperationsToPerform)
                 {
-                    if (!job.IsUpdatePermitted(dependency))
+                    if (!job.IsUpdatePermitted(dependency, experimentsManager))
                     {
                         continue;
                     }
@@ -105,7 +105,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         continue;
                     }
 
-                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency);
+                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
                     var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
                     if (analysisResult.Error is not null)
                     {
@@ -194,7 +194,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
             foreach (var (projectPath, dependency) in updateOperationsToPerform)
             {
-                if (!job.IsUpdatePermitted(dependency))
+                if (!job.IsUpdatePermitted(dependency, experimentsManager))
                 {
                     continue;
                 }
@@ -205,7 +205,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     continue;
                 }
 
-                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency);
+                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
                 var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
                 if (analysisResult.Error is not null)
                 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -89,7 +89,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
                 foreach (var (projectPath, dependency) in updateOperationsToPerform)
                 {
-                    if (!job.IsUpdatePermitted(dependency, experimentsManager))
+                    if (!job.IsUpdatePermitted(dependency))
                     {
                         continue;
                     }
@@ -105,7 +105,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         continue;
                     }
 
-                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
+                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, allowCooldown: false);
                     var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
                     if (analysisResult.Error is not null)
                     {
@@ -194,7 +194,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
             foreach (var (projectPath, dependency) in updateOperationsToPerform)
             {
-                if (!job.IsUpdatePermitted(dependency, experimentsManager))
+                if (!job.IsUpdatePermitted(dependency))
                 {
                     continue;
                 }
@@ -205,7 +205,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     continue;
                 }
 
-                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, experimentsManager);
+                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, allowCooldown: experimentsManager.EnableCooldown);
                 var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
                 if (analysisResult.Error is not null)
                 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -93,7 +93,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var relevantDependenciesToUpdate = dependencyGroupToUpdate.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, allowCooldown: false)))
                     .ToArray();
 
                 foreach (var (projectPath, dependency, dependencyInfo) in relevantDependenciesToUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -93,7 +93,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var relevantDependenciesToUpdate = dependencyGroupToUpdate.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
                     .ToArray();
 
                 foreach (var (projectPath, dependency, dependencyInfo) in relevantDependenciesToUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -82,7 +82,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var vulnerableDependenciesToUpdate = dependencyGroupToUpdate.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
                     .Where(set => set.Item3.IsVulnerable)
                     .ToArray();
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -82,7 +82,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyGroupToUpdate.Key;
                 var vulnerableDependenciesToUpdate = dependencyGroupToUpdate.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, allowCooldown: false)))
                     .Where(set => set.Item3.IsVulnerable)
                     .ToArray();
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -81,7 +81,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyUpdatesToPerform.Key;
                 var dependencyInfosToUpdate = dependencyUpdatesToPerform.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
                     .ToArray();
 
                 foreach (var (projectPath, dependency, dependencyInfo) in dependencyInfosToUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -81,7 +81,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 var dependencyName = dependencyUpdatesToPerform.Key;
                 var dependencyInfosToUpdate = dependencyUpdatesToPerform.Value
                     .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
-                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, experimentsManager)))
+                    .Select(o => (o.ProjectPath, o.Dependency, RunWorker.GetDependencyInfo(job, o.Dependency, allowCooldown: experimentsManager.EnableCooldown)))
                     .ToArray();
 
                 foreach (var (projectPath, dependency, dependencyInfo) in dependencyInfosToUpdate)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
@@ -460,7 +460,7 @@ public class PackageManager
                             string currentVersionString = parent.CurrentVersion;
                             NuGetVersion currentVersionParent = NuGetVersion.Parse(currentVersionString);
 
-                            var result = await VersionFinder.GetVersionsAsync([projectFramework], parent.PackageName, currentVersionParent, nugetContext, logger, CancellationToken.None);
+                            var result = await VersionFinder.GetVersionsByNameAsync([projectFramework], parent.PackageName, currentVersionParent, nugetContext, logger, CancellationToken.None);
                             var versions = result.GetVersions();
                             NuGetVersion latestVersion = versions.Where(v => !v.IsPrerelease).Max();
 
@@ -550,7 +550,7 @@ public class PackageManager
         NuGetContext nugetContext = new NuGetContext(Path.GetDirectoryName(projectPath));
         var projectFramework = NuGetFramework.Parse(targetFramework);
 
-        var result = await VersionFinder.GetVersionsAsync([projectFramework], possibleParent.PackageName, CurrentVersion, nugetContext, logger, CancellationToken.None);
+        var result = await VersionFinder.GetVersionsByNameAsync([projectFramework], possibleParent.PackageName, CurrentVersion, nugetContext, logger, CancellationToken.None);
         var versions = result.GetVersions();
 
         // If there are no versions


### PR DESCRIPTION
This PR implements the package update cooldown feature for NuGet and is behind the new experiment flag `enable_cooldown_for_nuget`.  Separate internal PR will be submitted adding that flag.

The new `cooldown` property was added to the job file and is parsed based on the [common ruby parser](https://github.com/dependabot/dependabot-core/blob/39105f4b8bc2f09066730ae52590245be2d45afb/updater/lib/dependabot/job.rb#L476).

The `AnalyzeWorker` class checks all available package versions and returns the appropriate set, so the high-level work is done there by checking the package metadata for a publish date and passing the appropriate info to the `Cooldown.IsVersionUpdateAllowed` method.  The function `RunWorker.GetDependencyInfo` will include the cooldown object if appropriate and that dependency info is what eventually is fed into the analyze worker.

Other helper methods were added to the cooldown object to determine if it applies by name and what the appropriate cooldown days delay is.

Manually verified locally in end-to-end smoke test, but due to the ever progressing march of time, a real smoke test can't be added for this.