### PR TITLE
[Experiment] Transform the dependency list into a dependency submission payload 

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -121,6 +121,11 @@ module Dependabot
       client.update_dependency_list(dependency_payload, dependency_file_paths)
     end
 
+    sig { params(dependency_submission: GithubApi::DependencySubmission).void }
+    def create_dependency_submission(dependency_submission:)
+      client.create_dependency_submission(dependency_submission.payload)
+    end
+
     # This method wraps the Sentry client as the Application error tracker
     # the service uses to notice errors.
     #

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -37,7 +37,10 @@ module Dependabot
         service.update_dependency_list(dependency_snapshot: dependency_snapshot)
 
         # POC: Emit the dependency data formatted for the GitHub Dependency Submission API
-        if Dependabot::Experiments.enabled?(:enable_dependency_submission_poc)
+        #
+        # We only want to run this experiment on Version Updates as Security Updates are downstream of
+        # Dependency Submission so this could create an unhelpful feedback loop.
+        if Dependabot::Experiments.enabled?(:enable_dependency_submission_poc) && !job.security_updates_only?
           submission = GithubApi::DependencySubmission.new(
             job: job,
             snapshot: dependency_snapshot

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 # This class provides a data object that can be submitted to a repository's dependency submission
@@ -14,23 +14,34 @@ module GithubApi
     SNAPSHOT_DETECTOR_NAME = "dependabot"
     SNAPSHOT_DETECTOR_URL = "https://github.com/dependabot/dependabot-core"
 
+    sig { returns(String) }
     attr_reader :job_id
+    sig { returns(String) }
     attr_reader :ref
+    sig { returns(String) }
     attr_reader :sha
+    sig { returns(String) }
     attr_reader :directory
+    sig { returns(String) }
     attr_reader :package_manager
+    sig { returns(T::Hash[String, T.untyped]) }
     attr_reader :manifests
 
+    sig { params(job: Dependabot::Job, snapshot: Dependabot::DependencySnapshot).void }
     def initialize(job:, snapshot:)
-      @job_id = job.id.to_s
-      @ref = job.source.branch
-      @sha = snapshot.base_commit_sha
-      @directory = job.source.directory
-      @package_manager = job.package_manager
+      @job_id = T.let(job.id.to_s, String)
+      @ref = T.let(T.must(job.source.branch), String)
+      @sha = T.let(snapshot.base_commit_sha, String)
+      @directory = T.let(T.must(job.source.directory), String)
+      @package_manager = T.let(job.package_manager, String)
 
-      @manifests = build_manifests(snapshot)
+      @manifests = T.let(build_manifests(snapshot), T::Hash[String, T.untyped])
     end
 
+    # TODO: Change to a typed structure?
+    #
+    # See: https://sorbet.org/docs/tstruct
+    sig { returns(T::Hash[Symbol, T.untyped]) }
     def payload
       {
         version: SNAPSHOT_VERSION,
@@ -52,14 +63,17 @@ module GithubApi
 
     private
 
+    sig { returns(String) }
     def job_correlator
       "#{SNAPSHOT_DETECTOR_NAME}-experimental"
     end
 
+    sig { returns(String) }
     def scanned
       Time.now.utc.iso8601
     end
 
+    sig { params(snapshot: Dependabot::DependencySnapshot).returns(T::Hash[String, T.untyped]) }
     def build_manifests(snapshot)
       dependencies_by_manifest = {}
 
@@ -88,7 +102,7 @@ module GithubApi
             source_location: file_path
           },
           metadata: {
-            ecosystem: snapshot.ecosystem.name
+            ecosystem: T.must(snapshot.ecosystem).name
           },
           resolved: deps.uniq.each_with_object({}) do |dep, resolved|
             resolved[dep.name] = {
@@ -128,6 +142,7 @@ module GithubApi
     #
     # It probably makes more sense to assign this to a Dependabot::Dependency
     # when it is created so the ecosystem-specific parser can own this?
+    sig { params(dependency: Dependabot::Dependency).returns(String) }
     def build_purl(dependency)
       package_manager = dependency.package_manager
       name = dependency.name

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -130,7 +130,7 @@ module GithubApi
                 # Dependabot::Dependency objects do not include immediate dependencies,
                 # this is a capability each parser will need to have added.
               ],
-              metadata: { }
+              metadata: {}
             }
           end
         }
@@ -187,8 +187,9 @@ module GithubApi
       end
     end
 
-    def scope_for(dep)
-      if dep.production?
+    sig { params(dependency: Dependabot::Dependency).returns(String) }
+    def scope_for(dependency)
+      if dependency.production?
         "runtime"
       else
         "development"

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -1,0 +1,172 @@
+# typed: false
+# frozen_string_literal: true
+
+# This class provides a data object that can be submitted to a repository's dependency submission
+# REST API.
+#
+# See:
+#   https://docs.github.com/en/rest/dependency-graph/dependency-submission
+module GithubApi
+  class DependencySubmission
+    extend T::Sig
+
+    SNAPSHOT_VERSION = 0
+    SNAPSHOT_DETECTOR_NAME = "dependabot"
+    SNAPSHOT_DETECTOR_URL = "https://github.com/dependabot/dependabot-core"
+
+    attr_reader :job_id
+    attr_reader :ref
+    attr_reader :sha
+    attr_reader :directory
+    attr_reader :package_manager
+    attr_reader :manifests
+
+    def initialize(job:, snapshot:)
+      @job_id = job.id.to_s
+      @ref = job.source.branch
+      @sha = snapshot.base_commit_sha
+      @directory = job.source.directory
+      @package_manager = job.package_manager
+
+      @manifests = build_manifests(snapshot)
+    end
+
+    def payload
+      {
+        version: SNAPSHOT_VERSION,
+        sha: sha,
+        ref: ref,
+        job: {
+          correlator: job_correlator,
+          id: job_id
+        },
+        detector: {
+          name: SNAPSHOT_DETECTOR_NAME,
+          version: Dependabot::VERSION,
+          url: SNAPSHOT_DETECTOR_URL
+        },
+        scanned: scanned,
+        manifests: manifests
+      }
+    end
+
+    private
+
+    def job_correlator
+      "#{SNAPSHOT_DETECTOR_NAME}-experimental"
+    end
+
+    def scanned
+      Time.now.utc.iso8601
+    end
+
+    def build_manifests(snapshot)
+      dependencies_by_manifest = {}
+
+      # NOTE: This is reconstructing the manifest to dependency mapping
+      #
+      # It would require deep changes to the Dependabot::Snapshot and parsers,
+      # but it might eventually be worth retaining this information from the
+      # source files in order to avoid reconstructing it here?
+      snapshot.dependencies.each do |dependency|
+        dependency.requirements.each do |requirement|
+          dependencies_by_manifest[requirement[:file]] ||= []
+          dependencies_by_manifest[requirement[:file]] << dependency
+        end
+      end
+
+      dependencies_by_manifest.each_with_object({}) do |(file, deps), manifests|
+        # TODO: This approach won't work properly with multi-directory job definitions
+        #
+        # For now it is tolerable to omit this and limit our testing accordingly, but we
+        # should behave sensibly in a multi-directory context as well
+        file_path = File.join(directory, file).gsub(%r{^/}, "")
+
+        manifests[file] = {
+          name: file,
+          file: {
+            source_location: file_path
+          },
+          metadata: {
+            ecosystem: snapshot.ecosystem.name
+          },
+          resolved: deps.uniq.each_with_object({}) do |dep, resolved|
+            resolved[dep.name] = {
+              package_url: build_purl(dep),
+              # TODO: Replace relationship placeholder
+              #
+              # Dependabot has a bias towards operating on **declared dependencies**, so
+              # we need to close gaps on transitive dependencies in a few places.
+              #
+              # This should be set in the parsers when we add capabilities to track immediate
+              # dependencies.
+              relationship: "direct",
+              # TODO: Replace scope placeholder
+              #
+              # Dependabot::Dependency objects do include the `groups` a dependency is included in
+              # that we could derive this from, but since group conventions vary by ecosystem
+              # we should probably determine this in the parser and set the scope there.
+              scope: "runtime",
+              dependencies: [
+                # TODO: Populate direct child dependencies
+                #
+                # Dependabot::Dependency objects do not include immediate dependencies,
+                # this is a capability each parser will need to have added.
+              ],
+              metadata: {
+                groups: dep.requirements.map { |r| r[:groups] }.flatten.join(", ")
+              }
+            }
+          end
+        }
+      end
+    end
+
+    # Helper function to create a Package URL (purl)
+    #
+    # TODO: Move out of this class?
+    #
+    # It probably makes more sense to assign this to a Dependabot::Dependency
+    # when it is created so the ecosystem-specific parser can own this?
+    def build_purl(dependency)
+      package_manager = dependency.package_manager
+      name = dependency.name
+      version = dependency.version
+
+      case package_manager
+      when "bundler"
+        "pkg:gem/#{name}@#{version}"
+      when "npm_and_yarn", "bun"
+        "pkg:npm/#{name}@#{version}"
+      when "maven", "gradle"
+        "pkg:maven/#{name}@#{version}"
+      when "pip", "uv"
+        "pkg:pypi/#{name}@#{version}"
+      when "cargo"
+        "pkg:cargo/#{name}@#{version}"
+      when "hex"
+        "pkg:hex/#{name}@#{version}"
+      when "composer"
+        "pkg:composer/#{name}@#{version}"
+      when "nuget"
+        "pkg:nuget/#{name}@#{version}"
+      when "go_modules"
+        "pkg:golang/#{name}@#{version}"
+      when "docker"
+        "pkg:docker/#{name}@#{version}"
+      when "github_actions"
+        "pkg:github/#{name}@#{version}"
+      when "terraform"
+        "pkg:terraform/#{name}@#{version}"
+      when "pub"
+        "pkg:pub/#{name}@#{version}"
+      when "elm"
+        "pkg:elm/#{name}@#{version}"
+      when "submodules"                 # TODO: Verify this is correct
+        "pkg:github/#{name}@#{version}" # Use github format for submodules
+      else
+        "pkg:generic/#{name}@#{version}"
+      end
+    end
+  end
+end

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -123,21 +123,14 @@ module GithubApi
               # This should be set in the parsers when we add capabilities to track immediate
               # dependencies.
               relationship: "direct",
-              # TODO: Replace scope placeholder
-              #
-              # Dependabot::Dependency objects do include the `groups` a dependency is included in
-              # that we could derive this from, but since group conventions vary by ecosystem
-              # we should probably determine this in the parser and set the scope there.
-              scope: "runtime",
+              scope: scope_for(dep),
               dependencies: [
                 # TODO: Populate direct child dependencies
                 #
                 # Dependabot::Dependency objects do not include immediate dependencies,
                 # this is a capability each parser will need to have added.
               ],
-              metadata: {
-                groups: dep.requirements.map { |r| r[:groups] }.flatten.join(", ")
-              }
+              metadata: { }
             }
           end
         }
@@ -191,6 +184,14 @@ module GithubApi
         "elm"
       else
         "generic"
+      end
+    end
+
+    def scope_for(dep)
+      if dep.production?
+        "runtime"
+      else
+        "development"
       end
     end
   end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Dependabot::Service do
       close_pull_request: nil,
       record_update_job_error: nil,
       record_update_job_unknown_error: nil,
-      record_update_job_warning: nil
+      record_update_job_warning: nil,
+      create_dependency_submission: nil
     })
     allow(api_client).to receive(:is_a?).with(Dependabot::ApiClient).and_return(true)
     api_client
@@ -525,6 +526,30 @@ RSpec.describe Dependabot::Service do
       expect(mock_client).to receive(:update_dependency_list).with(expected_dependency_payload, expected_file_paths)
 
       service.update_dependency_list(dependency_snapshot: dependency_snapshot)
+    end
+  end
+
+  describe "#create_dependency_submission" do
+    let(:mock_payload) do
+      {
+        detector: {
+          name: "mock-detector"
+        }
+      }
+    end
+
+    let(:dependency_submission) do
+      instance_double(
+        GithubApi::DependencySubmission,
+        payload: mock_payload
+      )
+    end
+
+    it "delegates to @client with the dependency submission payload" do
+      service.create_dependency_submission(dependency_submission: dependency_submission)
+
+      expect(mock_client)
+        .to have_received(:create_dependency_submission).with(mock_payload)
     end
   end
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -456,8 +456,8 @@ RSpec.describe Dependabot::UpdateFilesCommand do
   #
   # This functionality should ideally be a separate binary, we are attaching it
   # to existing updates during POC work
-  context "experiment: enable_dependency_submission_poc" do
-    describe "#perform_job when it is enabled" do
+  describe "experiment: enable_dependency_submission_poc" do
+    context "when it is enabled" do
       subject(:perform_job) { job.perform_job }
 
       before do
@@ -489,7 +489,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       end
     end
 
-    describe "#perform_job when it is disabled" do
+    context "when it is disabled" do
       subject(:perform_job) { job.perform_job }
 
       before do

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -478,6 +478,15 @@ RSpec.describe Dependabot::UpdateFilesCommand do
 
         perform_job
       end
+
+      it "does not emit a create_dependency_submission call if the job is a Security update" do
+        job_definition["job"]["security_updates_only"] = true
+        job_definition["job"]["dependencies"] = ["octokit"]
+
+        expect(service).not_to receive(:create_dependency_submission)
+
+        perform_job
+      end
     end
 
     describe "#perform_job when it is disabled" do

--- a/updater/spec/fixtures/bundler_sinatra_app/original/Gemfile
+++ b/updater/spec/fixtures/bundler_sinatra_app/original/Gemfile
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "sinatra", "4.1.1"
+
+group :development do
+  gem "pry"
+end
+
+group :test do
+  gem "rspec"
+end
+
+group :development, :test do
+  gem "capybara"
+end

--- a/updater/spec/fixtures/bundler_sinatra_app/original/Gemfile.lock
+++ b/updater/spec/fixtures/bundler_sinatra_app/original/Gemfile.lock
@@ -1,0 +1,77 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    logger (1.7.0)
+    matrix (0.4.3)
+    method_source (1.1.0)
+    mini_mime (1.1.5)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (6.0.2)
+    racc (1.8.1)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    regexp_parser (2.10.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    ruby2_keywords (0.0.5)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.6.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+
+PLATFORMS
+  arm64-darwin-24
+
+DEPENDENCIES
+  capybara
+  pry
+  rspec
+  sinatra (= 4.1.1)
+
+BUNDLED WITH
+   2.6.9

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe GithubApi::DependencySubmission do
       # Resolved dependencies are correct
       expect(gemfile[:resolved].length).to eq(2)
 
-      dependency_1 = gemfile[:resolved]["dummy-pkg-a"]
-      dependency_2 = gemfile[:resolved]["dummy-pkg-b"]
+      dependency1 = gemfile[:resolved]["dummy-pkg-a"]
+      dependency2 = gemfile[:resolved]["dummy-pkg-b"]
 
-      expect(dependency_1[:package_url]).to eql("pkg:gem/dummy-pkg-a@2.0.0")
+      expect(dependency1[:package_url]).to eql("pkg:gem/dummy-pkg-a@2.0.0")
 
-      expect(dependency_2[:package_url]).to eql("pkg:gem/dummy-pkg-b@1.1.0")
+      expect(dependency2[:package_url]).to eql("pkg:gem/dummy-pkg-b@1.1.0")
     end
   end
 

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -1,0 +1,170 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/dependency_file_helpers"
+
+require "dependabot/bundler"
+require "dependabot/dependency_file"
+require "dependabot/dependency_snapshot"
+require "dependabot/job"
+
+require "github_api/dependency_submission"
+
+RSpec.describe GithubApi::DependencySubmission do
+  include DependencyFileHelpers
+
+  subject(:dependency_submission) do
+    described_class.new(
+      job: job,
+      snapshot: dependabot_snapshot
+    )
+  end
+
+  let(:repo) { "dependabot-fixtures/dependabot-test-ruby-package" }
+  let(:branch) { "main" }
+  let(:sha) { "fake-sha" }
+
+  let(:directory) { "/" }
+  let(:directories) { nil }
+
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "github",
+      repo: repo,
+      directory: "/",
+      branch: branch
+    )
+  end
+
+  let(:job) do
+    instance_double(
+      Dependabot::Job,
+      id: 9999,
+      source: source,
+      package_manager: "bundler",
+      repo_contents_path: nil,
+      credentials: [],
+      reject_external_code?: false,
+      experiments: {},
+      dependency_groups: [],
+      security_updates_only?: false,
+      allowed_update?: true
+    )
+  end
+
+  let(:job_definition) do
+    {
+      "base_commit_sha" => sha,
+      "base64_dependency_files" => encode_dependency_files(dependency_files)
+    }
+  end
+
+  let(:dependabot_snapshot) do
+    Dependabot::DependencySnapshot.create_from_job_definition(
+      job: job,
+      job_definition: job_definition
+    )
+  end
+
+  context "with a basic Gemfile project" do
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler/original/Gemfile"),
+          directory: directory
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler/original/Gemfile.lock"),
+          directory: directory
+        )
+      ]
+    end
+
+    it "generates submission metadata correctly" do
+      payload = dependency_submission.payload
+
+      # Check metadata
+      expect(payload[:version]).to eq(described_class::SNAPSHOT_VERSION)
+      expect(payload[:detector][:name]).to eq(described_class::SNAPSHOT_DETECTOR_NAME)
+      expect(payload[:detector][:url]).to eq(described_class::SNAPSHOT_DETECTOR_URL)
+      expect(payload[:detector][:version]).to eq(Dependabot::VERSION)
+      expect(payload[:job][:correlator]).to eq("dependabot-experimental")
+      expect(payload[:job][:id]).to eq("9999")
+
+      # And check we have an iso8601 timestamp
+      expect(payload[:scanned]).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+    end
+
+    it "generates a valid manifest list" do
+      payload = dependency_submission.payload
+
+      expect(payload[:manifests].length).to eq(1)
+
+      # File data is correct
+      gemfile = payload[:manifests].fetch("Gemfile")
+      expect(gemfile[:name]).to eq("Gemfile")
+      expect(gemfile[:file][:source_location]).to eq("Gemfile")
+
+      # Resolved dependencies are correct
+      expect(gemfile[:resolved].length).to eq(2)
+
+      dependency_1 = gemfile[:resolved]["dummy-pkg-a"]
+      dependency_2 = gemfile[:resolved]["dummy-pkg-b"]
+
+      expect(dependency_1[:package_url]).to eql("pkg:gem/dummy-pkg-a@2.0.0")
+
+      expect(dependency_2[:package_url]).to eql("pkg:gem/dummy-pkg-b@1.1.0")
+    end
+  end
+
+  context "with a small sinatra app" do
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler_sinatra_app/original/Gemfile"),
+          directory: directory
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler_sinatra_app/original/Gemfile.lock"),
+          directory: directory
+        )
+      ]
+    end
+
+    it "generates a valid manifest list" do
+      payload = dependency_submission.payload
+
+      expect(payload[:manifests].length).to eq(1)
+
+      # File data is correct
+      gemfile = payload[:manifests].fetch("Gemfile")
+      expect(gemfile[:name]).to eq("Gemfile")
+      expect(gemfile[:file][:source_location]).to eq("Gemfile")
+
+      # Resolved dependencies are correct
+      expect(gemfile[:resolved].length).to eq(4)
+
+      # NOTE: For bundler, we only surface top-level dependencies for now
+      sinatra = gemfile[:resolved]["sinatra"]
+      pry = gemfile[:resolved]["pry"]
+      rspec = gemfile[:resolved]["rspec"]
+      capybara = gemfile[:resolved]["capybara"]
+
+      expect(sinatra[:package_url]).to eql("pkg:gem/sinatra@4.1.1")
+      expect(pry[:package_url]).to eql("pkg:gem/pry@0.15.2")
+      expect(rspec[:package_url]).to eql("pkg:gem/rspec@3.13.1")
+      expect(capybara[:package_url]).to eql("pkg:gem/capybara@3.40.0")
+
+      # Check we are surfacing any groups assigned as metadata
+      expect(sinatra[:metadata][:groups]).to eq("default")
+      expect(pry[:metadata][:groups]).to eq("development")
+      expect(rspec[:metadata][:groups]).to eq("test")
+      expect(capybara[:metadata][:groups]).to eq("development, test")
+    end
+  end
+end

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -160,11 +160,11 @@ RSpec.describe GithubApi::DependencySubmission do
       expect(rspec[:package_url]).to eql("pkg:gem/rspec@3.13.1")
       expect(capybara[:package_url]).to eql("pkg:gem/capybara@3.40.0")
 
-      # Check we are surfacing any groups assigned as metadata
-      expect(sinatra[:metadata][:groups]).to eq("default")
-      expect(pry[:metadata][:groups]).to eq("development")
-      expect(rspec[:metadata][:groups]).to eq("test")
-      expect(capybara[:metadata][:groups]).to eq("development, test")
+      # Check we are surfacing groups as runtime/development scope
+      expect(sinatra[:scope]).to eq("runtime")
+      expect(pry[:scope]).to eq("development")
+      expect(rspec[:scope]).to eq("development")
+      expect(capybara[:scope]).to eq("development")
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This pull request introduces an experiment to emit the dependency data available in an Dependabot Update job to the repository as a payload for the [Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission).

The payload is proxied via the Dependabot backend to the GitHub API using the existing job token Authentication pattern rather than submitted directly.

### Anything you want to highlight for special attention from reviewers?

This experiment is being used to gather examples of the data available to Dependabot jobs for some internal testing right now, we do not plan to make this available as a feature in the short-term so the implementation has been limited to the updater component rather than `dependabot-core` for more general purpose use.

The client API will raise on errors, however the backend implementation is expected to act permissively and return a 204 on any call that isn't related to network layer problems.

### How will you know you've accomplished your goal?

We are able to trigger snapshot submission when a scheduled Dependabot job runs on our test repositories that have the experiment enabled.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
