### PR TITLE
Removing helm and oras login command

### DIFF
--- a/helm/lib/dependabot/helm/helpers.rb
+++ b/helm/lib/dependabot/helm/helpers.rb
@@ -52,36 +52,6 @@ module Dependabot
         )
       end
 
-      sig { params(username: String, password: String, repository_url: String).returns(String) }
-      def self.registry_login(username, password, repository_url)
-        Dependabot.logger.info("Logging into Helm registry \"#{repository_url}\"")
-
-        Dependabot::SharedHelpers.run_shell_command(
-          "helm registry login --username #{username} --password #{password} #{repository_url}",
-          fingerprint: "helm registry login --username <username> --password <password> <repository_url>"
-        )
-      rescue StandardError => e
-        Dependabot.logger.error(
-          "Failed to authenticate for #{repository_url}: #{e.message}"
-        )
-        raise
-      end
-
-      sig { params(username: String, password: String, repository_url: String).returns(String) }
-      def self.oci_registry_login(username, password, repository_url)
-        Dependabot.logger.info("Logging into OCI registry \"#{repository_url}\"")
-
-        Dependabot::SharedHelpers.run_shell_command(
-          "oras login --username #{username} --password #{password} #{repository_url}",
-          fingerprint: "oras login --username <username> --password <password> <repository_url>"
-        )
-      rescue StandardError => e
-        Dependabot.logger.error(
-          "Failed to authenticate for #{repository_url}: #{e.message}"
-        )
-        raise
-      end
-
       sig { params(name: String).returns(String) }
       def self.fetch_oci_tags(name)
         Dependabot.logger.info("Searching OCI tags for: #{name}")

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -167,7 +167,6 @@ module Dependabot
         Dependabot.logger.info("Fetching releases for Helm chart: #{chart_name}")
 
         if repo_name && repo_url
-          authenticate_registry_source(repo_url)
           begin
             Helpers.add_repo(repo_name, repo_url)
             Helpers.update_repo
@@ -190,32 +189,6 @@ module Dependabot
           Dependabot.logger.error("Error fetching chart releases: #{e.message}")
           nil
         end
-      end
-
-      sig { params(repo_url: T.nilable(String)).returns(T.nilable(String)) }
-      def authenticate_registry_source(repo_url)
-        return unless repo_url
-
-        repo_creds = Shared::Utils::CredentialsFinder.new(@credentials, private_repository_type: "helm_registry")
-                                                     .credentials_for_registry(repo_url)
-        return unless repo_creds
-
-        Helpers.registry_login(T.must(repo_creds["username"]), T.must(repo_creds["password"]), repo_url)
-      rescue StandardError
-        raise PrivateSourceAuthenticationFailure, repo_url
-      end
-
-      sig { params(repo_url: T.nilable(String)).returns(T.nilable(String)) }
-      def authenticate_oci_registry_source(repo_url)
-        return unless repo_url
-
-        repo_creds = Shared::Utils::CredentialsFinder.new(@credentials, private_repository_type: "helm_registry")
-                                                     .credentials_for_registry(repo_url)
-        return unless repo_creds
-
-        Helpers.oci_registry_login(T.must(repo_creds["username"]), T.must(repo_creds["password"]), repo_url)
-      rescue StandardError
-        raise PrivateSourceAuthenticationFailure, repo_url
       end
 
       sig { returns(T.nilable(Gem::Version)) }
@@ -260,7 +233,6 @@ module Dependabot
       def fetch_oci_tags(chart_name, repo_url)
         Dependabot.logger.info("Fetching OCI tags for #{repo_url}")
         oci_registry = repo_url.gsub("oci://", "")
-        authenticate_oci_registry_source(repo_url)
 
         release_tags = Helpers.fetch_oci_tags("#{oci_registry}/#{chart_name}").split("\n")
         release_tags.map { |tag| tag.tr("_", "+") }

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -69,42 +69,6 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
 
     it { is_expected.to eq(Dependabot::Helm::Version.new("20.11.3")) }
 
-    context "when using a private repository" do
-      before do
-        allow(Dependabot::Helm::Helpers).to receive(:registry_login)
-          .with(username, password, repo_url)
-          .and_return("Login successful")
-
-        allow(Dependabot::Helm::Helpers).to receive(:search_releases)
-          .with("oci---localhost-5000/#{dependency_name}")
-          .and_return(repo_tags)
-      end
-
-      let(:version) { "1.0.0" }
-      let(:repo_url) { "oci://localhost:5000" }
-      let(:repo_fixture_name) { "my_chart.json" }
-      let(:dependency_name) { "my_chart" }
-      let(:source) { { tag: version, registry: repo_url } }
-
-      it { is_expected.to eq(Dependabot::Helm::Version.new("1.1.0")) }
-
-      context "when authentication fails" do
-        before do
-          allow(Dependabot::Helm::Helpers).to receive(:registry_login)
-            .with(username, password, repo_url)
-            .and_raise(StandardError)
-        end
-
-        it "raises a to PrivateSourceAuthenticationFailure error" do
-          error_class = Dependabot::PrivateSourceAuthenticationFailure
-          expect { latest_version }
-            .to raise_error(error_class) do |error|
-            expect(error.source).to eq("oci://localhost:5000")
-          end
-        end
-      end
-    end
-
     context "when dependency is a docker image" do
       let(:dependency_type) { { type: :docker_image } }
       let(:repo_fixture_name) { "ubuntu_no_latest.json" }
@@ -153,43 +117,6 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
         expect(checker.latest_version).to eq(
           Dependabot::Helm::Version.new("1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238")
         )
-      end
-
-      context "with private registry" do
-        before do
-          allow(Dependabot::Helm::Helpers).to receive(:oci_registry_login)
-            .with(username, password, repo_url)
-            .and_return("Login successful")
-        end
-
-        let(:credentials) do
-          [Dependabot::Credential.new({
-            "type" => "helm_registry",
-            "registry" => repo_url,
-            "username" => username,
-            "password" => password
-          })]
-        end
-
-        it "returns the latest version" do
-          expect(checker.latest_version).to eq(
-            Dependabot::Helm::Version.new("1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238")
-          )
-        end
-
-        context "with invalid login" do
-          before do
-            allow(Dependabot::Helm::Helpers).to receive(:oci_registry_login)
-              .with(username, password, repo_url)
-              .and_raise(StandardError)
-          end
-
-          it "raises a to PrivateSourceAuthenticationFailure error" do
-            error_class = Dependabot::PrivateSourceAuthenticationFailure
-            expect { latest_version }
-              .to raise_error(error_class)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Core currently handles private registry authentication directly, but it doesn't have proper access to credentials and violates our architecture where authentication should happen at the proxy layer. This change aligns Helm/ORAS with other package managers and enables proper proxy-based authentication.

Fixes authentication failures with private Helm registries and prepares for implementing basic auth in the proxy.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

I am completely removing all places where helm login/oras login were called, there will be a follow up pr replacing this implementation 

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

 All `helm login` and `oras login` CLI calls removed

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
