### PR TITLE
Add support for goproxy_server and go.env files

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -62,8 +62,7 @@ module Dependabot
       def go_env
         return @go_env if defined?(@go_env)
 
-        @go_env = T.let(fetch_file_if_present("go.env"), T.nilable(Dependabot::DependencyFile))
-        @go_env.support_file = true if @go_env
+        @go_env = T.let(fetch_support_file("go.env"), T.nilable(Dependabot::DependencyFile))
         @go_env
       end
     end

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -41,6 +41,7 @@ module Dependabot
           fetched_files = go_mod ? [go_mod] : []
           # Fetch the (optional) go.sum
           fetched_files << T.must(go_sum) if go_sum
+          fetched_files << T.must(go_env) if go_env
           fetched_files
         end
       end
@@ -55,6 +56,15 @@ module Dependabot
       sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def go_sum
         @go_sum ||= T.let(fetch_file_if_present("go.sum"), T.nilable(Dependabot::DependencyFile))
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def go_env
+        return @go_env if defined?(@go_env)
+
+        @go_env = T.let(fetch_file_if_present("go.env"), T.nilable(Dependabot::DependencyFile))
+        @go_env.support_file = true if @go_env
+        @go_env
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -29,7 +29,6 @@ module Dependabot
       def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path: nil, options: {})
         super
 
-        @goprivate = T.let(options.fetch(:goprivate, "*"), String)
         use_repo_contents_stub if repo_contents_path.nil?
       end
 
@@ -149,7 +148,7 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: T.must(directory),
-            options: { tidy: tidy?, vendor: vendor?, goprivate: @goprivate }
+            options: { tidy: tidy?, vendor: vendor? }
           ),
           T.nilable(Dependabot::GoModules::FileUpdater::GoModUpdater)
         )

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -10,8 +10,8 @@ module Dependabot
 
       GITHUB_REPO_REGEX = %r{github.com/[^:@ ]*}
 
-      sig { params(message: String, goprivate: T.untyped).void }
-      def self.handle(message, goprivate:)
+      sig { params(message: String).void }
+      def self.handle(message)
         mod_path = message.scan(GITHUB_REPO_REGEX).last
         unless mod_path && message.include?("If this is a private repository")
           raise Dependabot::DependencyFileNotResolvable, message
@@ -30,8 +30,7 @@ module Dependabot
                         mod_path
                       end
 
-          env = { "GOPRIVATE" => goprivate }
-          _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go list -m -versions #{repo_path}"))
+          _, _, status = Open3.capture3(SharedHelpers.escape_command("go list -m -versions #{repo_path}"))
           raise Dependabot::DependencyFileNotResolvable, message if status.success?
 
           raise Dependabot::GitDependenciesNotReachable, [repo_path]

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -66,8 +66,7 @@ module Dependabot
             ignored_versions: ignored_versions,
             security_advisories: security_advisories,
             raise_on_ignored: raise_on_ignored,
-            cooldown_options: update_cooldown,
-            goprivate: options.fetch(:goprivate, "*")
+            cooldown_options: update_cooldown
           ),
           T.nilable(Dependabot::GoModules::UpdateChecker::LatestVersionFinder)
         )

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     end
   end
 
+  context "with a go.env file" do
+    let(:branch) { "with-go-env" }
+
+    it "fetches the go.env file" do
+      expect(file_fetcher_instance.files.map(&:name)).to include("go.env")
+    end
+  end
+
   context "when directory is missing" do
     let(:directory) { "/missing" }
 

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe Dependabot::GoModules::FileParser do
       described_class.new(dependency_files: [go_mod, go_env], source: source)
       expect(`go env GOPROXY`.strip).to eq("https://proxy.example.com")
     end
+
+    it "does not set the GOPRIVATE environment variable if a goproxy_server credential is passed" do
+      credentials = [
+        Dependabot::Credential.new({
+          "type" => "goproxy_server",
+          "url" => "https://proxy.example.com"
+        })
+      ]
+      described_class.new(dependency_files: [go_mod], source: source, credentials: credentials,
+                          options: { goprivate: "*" })
+      expect(`go env GOPRIVATE`.strip).to be_empty
+    end
   end
 
   describe "parse" do

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
     # Reset the environment variable after each test to avoid side effects
     ENV.delete("GOENV")
     ENV.delete("GOPROXY")
+    ENV.delete("GOPRIVATE")
   end
 
   it_behaves_like "a dependency file parser"

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       before do
         exit_status = double(success?: false)
         allow(Open3).to receive(:capture3).and_call_original
-        allow(Open3).to receive(:capture3).with(anything, "go get").and_return(["", stderr, exit_status])
+        allow(Open3).to receive(:capture3).with("go get").and_return(["", stderr, exit_status])
       end
 
       it "raises a helpful error" do
@@ -229,7 +229,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
             credentials: anything,
             repo_contents_path: anything,
             directory: anything,
-            options: { tidy: false, vendor: false, goprivate: "*" }
+            options: { tidy: false, vendor: false }
           ).and_return(double)
 
         updater.updated_dependency_files

--- a/go_modules/spec/dependabot/go_modules/package/package_details_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/package/package_details_fetcher_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Dependabot::GoModules::Package::PackageDetailsFetcher do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: credentials,
-      goprivate: "*"
+      credentials: credentials
     )
   end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -8,6 +8,14 @@ require "dependabot/go_modules/update_checker"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::GoModules::UpdateChecker do
+  before do
+    ENV["GOPRIVATE"] = "*"
+  end
+
+  after do
+    ENV.delete("GOPRIVATE")
+  end
+
   let(:dependency_files) do
     [
       Dependabot::DependencyFile.new(


### PR DESCRIPTION
### What are you trying to accomplish?

In order for customers to leverage go proxy servers and/or to configure environment variables used by go to determine how to resolve dependencies, we'll now do two things:

- If a `go.env` file is present at the root of the repository, we'll pull it in and tell the Go toolchain to use it.
- If a credential for a goproxy_server is passed in, and no `go.env` exists, we export the URLs from the credentials as `GOPROXY`, allowing the toolchain to use it. By default we also append `direct` so that direct access to dependencies is still possible.

This should give customers all the flexibility they need to configure how go mod accesses dependencies for their projects, with nice defaults.

### Anything you want to highlight for special attention from reviewers?

The approach I've taken here is to export these values at the file fetching step, from here on the toolchain should use them.

Since every job runs in its own container, once the job finished the environment is wiped when done.

### How will you know you've accomplished your goal?

Tests and manual verification

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
