### PR TITLE
fix incorrect PR grouping

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
@@ -15,7 +15,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
     [Fact]
     public async Task GeneratesCreatePullRequest_NoGroups()
     {
-        // no groups specified; create 1 PR for each directory
+        // no groups specified; create 1 PR for each directory for each dependency
         await TestAsync(
             job: new Job()
             {
@@ -34,8 +34,8 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         {
                             FilePath = "project.csproj",
                             Dependencies = [
-                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
-                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Production.Dependency.1", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Production.Dependency.2", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
                             ],
                             ImportedFiles = [],
                             AdditionalFiles = [],
@@ -50,8 +50,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         {
                             FilePath = "project.csproj",
                             Dependencies = [
-                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
-                                new("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Test.Dependency", "5.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
                             ],
                             ImportedFiles = [],
                             AdditionalFiles = [],
@@ -66,8 +65,9 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                 var dependencyInfo = input.Item3;
                 var newVersion = dependencyInfo.Name switch
                 {
-                    "Some.Dependency" => "2.0.0",
-                    "Some.Other.Dependency" => "4.0.0",
+                    "Production.Dependency.1" => "2.0.0",
+                    "Production.Dependency.2" => "4.0.0",
+                    "Test.Dependency" => "6.0.0",
                     _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
                 };
                 return Task.FromResult(new AnalysisResult()
@@ -109,7 +109,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                     Dependencies = [
                         new()
                         {
-                            Name = "Some.Dependency",
+                            Name = "Production.Dependency.1",
                             Version = "1.0.0",
                             Requirements = [
                                 new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
@@ -117,7 +117,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         },
                         new()
                         {
-                            Name = "Some.Other.Dependency",
+                            Name = "Production.Dependency.2",
                             Version = "3.0.0",
                             Requirements = [
                                 new() { Requirement = "3.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
@@ -126,12 +126,13 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                     ],
                     DependencyFiles = ["/src/project.csproj"],
                 },
+                // for "/src" and Production.Dependency.1
                 new CreatePullRequest()
                 {
                     Dependencies = [
                         new()
                         {
-                            Name = "Some.Dependency",
+                            Name = "Production.Dependency.1",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -141,9 +142,28 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                                 new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
                             ],
                         },
+                    ],
+                    UpdatedDependencyFiles = [
                         new()
                         {
-                            Name = "Some.Other.Dependency",
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                // for "/src" and Production.Dependency.2
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Production.Dependency.2",
                             Version = "4.0.0",
                             Requirements = [
                                 new() { Requirement = "4.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -174,18 +194,10 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                     Dependencies = [
                         new()
                         {
-                            Name = "Some.Dependency",
-                            Version = "1.0.0",
+                            Name = "Test.Dependency",
+                            Version = "5.0.0",
                             Requirements = [
-                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
-                            ],
-                        },
-                        new()
-                        {
-                            Name = "Some.Other.Dependency",
-                            Version = "3.0.0",
-                            Requirements = [
-                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                                new() { Requirement = "5.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
                             ],
                         },
                     ],
@@ -196,26 +208,14 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                     Dependencies = [
                         new()
                         {
-                            Name = "Some.Dependency",
-                            Version = "2.0.0",
+                            Name = "Test.Dependency",
+                            Version = "6.0.0",
                             Requirements = [
-                                new() { Requirement = "2.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                                new() { Requirement = "6.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
                             ],
-                            PreviousVersion = "1.0.0",
+                            PreviousVersion = "5.0.0",
                             PreviousRequirements = [
-                                new() { Requirement = "1.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
-                            ],
-                        },
-                        new()
-                        {
-                            Name = "Some.Other.Dependency",
-                            Version = "4.0.0",
-                            Requirements = [
-                                new() { Requirement = "4.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
-                            ],
-                            PreviousVersion = "3.0.0",
-                            PreviousRequirements = [
-                                new() { Requirement = "3.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
+                                new() { Requirement = "5.0.0", File = "/test/project.csproj", Groups = ["dependencies"] },
                             ],
                         },
                     ],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -72,7 +72,7 @@ public class ModifiedFilesTracker
         }
     }
 
-    public async Task<ImmutableArray<DependencyFile>> StopTrackingAsync()
+    public async Task<ImmutableArray<DependencyFile>> StopTrackingAsync(bool restoreOriginalContents = false)
     {
         if (_currentDiscoveryResult is null)
         {
@@ -108,6 +108,14 @@ public class ModifiedFilesTracker
                     Content = reportedContent,
                     ContentEncoding = encoding,
                 };
+            }
+
+            if (restoreOriginalContents)
+            {
+                var originalRawContent = originalContent
+                    .SetEOL(_originalDependencyFileEOFs[repoFullPath])
+                    .SetBOM(_originalDependencyFileBOMs[repoFullPath]);
+                await File.WriteAllBytesAsync(localFullPath, originalRawContent);
             }
         }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -183,85 +183,91 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 return;
             }
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
-            await tracker.StartTrackingAsync(discoveryResult);
-
             var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsPerformed = new List<UpdateOperationBase>();
-            var updatedDependencies = new List<ReportedDependency>();
             var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
-            foreach (var (projectPath, dependency) in updateOperationsToPerform)
+            var updateOperationsToPerformByDependency = updateOperationsToPerform
+                .GroupBy(o => o.Dependency);
+            foreach (var sameDependencySet in updateOperationsToPerformByDependency)
             {
-                if (!job.IsUpdatePermitted(dependency))
+                logger.Info($"Starting dependency update for {sameDependencySet.Key.Name}/{sameDependencySet.Key.Version}");
+                foreach (var (projectPath, dependency) in sameDependencySet)
                 {
-                    continue;
+                    if (!job.IsUpdatePermitted(dependency))
+                    {
+                        continue;
+                    }
+
+                    if (job.IsDependencyIgnoredByNameOnly(dependency.Name))
+                    {
+                        logger.Info($"Skipping ignored dependency {dependency.Name}.");
+                        continue;
+                    }
+
+                    var updatedDependencies = new List<ReportedDependency>();
+                    var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+                    await tracker.StartTrackingAsync(discoveryResult);
+
+                    var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, allowCooldown: experimentsManager.EnableCooldown);
+                    var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
+                    if (analysisResult.Error is not null)
+                    {
+                        logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
+                        await apiHandler.RecordUpdateJobError(analysisResult.Error, logger);
+                        return;
+                    }
+
+                    if (!analysisResult.CanUpdate)
+                    {
+                        logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        continue;
+                    }
+
+                    var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
+                    var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
+                    if (updaterResult.Error is not null)
+                    {
+                        await apiHandler.RecordUpdateJobError(updaterResult.Error, logger);
+                        continue;
+                    }
+
+                    if (updaterResult.UpdateOperations.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
+                    var updatedDependenciesForThis = patchedUpdateOperations
+                        .Select(o => o.ToReportedDependency(projectPath, updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
+                        .ToArray();
+
+                    updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    foreach (var o in patchedUpdateOperations)
+                    {
+                        logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
+                    }
+
+                    var updatedDependencyFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
+                    if (updateOperationsPerformed.Count > 0)
+                    {
+                        var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
+                        var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+                        var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
+                        await apiHandler.CreatePullRequest(new CreatePullRequest()
+                        {
+                            Dependencies = [.. updatedDependencies],
+                            UpdatedDependencyFiles = [.. updatedDependencyFiles],
+                            BaseCommitSha = baseCommitSha,
+                            CommitMessage = commitMessage,
+                            PrTitle = prTitle,
+                            PrBody = prBody,
+                            DependencyGroup = null,
+                        });
+                    }
                 }
-
-                if (job.IsDependencyIgnoredByNameOnly(dependency.Name))
-                {
-                    logger.Info($"Skipping ignored dependency {dependency.Name}.");
-                    continue;
-                }
-
-                var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, allowCooldown: experimentsManager.EnableCooldown);
-                var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
-                if (analysisResult.Error is not null)
-                {
-                    logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
-                    await apiHandler.RecordUpdateJobError(analysisResult.Error, logger);
-                    return;
-                }
-
-                if (!analysisResult.CanUpdate)
-                {
-                    logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
-                    continue;
-                }
-
-                var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
-                var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
-                if (updaterResult.Error is not null)
-                {
-                    await apiHandler.RecordUpdateJobError(updaterResult.Error, logger);
-                    continue;
-                }
-
-                if (updaterResult.UpdateOperations.Length == 0)
-                {
-                    continue;
-                }
-
-                var patchedUpdateOperations = RunWorker.PatchInOldVersions(updaterResult.UpdateOperations, projectDiscovery);
-                var updatedDependenciesForThis = patchedUpdateOperations
-                    .Select(o => o.ToReportedDependency(projectPath, updatedDependencyList.Dependencies, analysisResult.UpdatedDependencies))
-                    .ToArray();
-
-                updatedDependencies.AddRange(updatedDependenciesForThis);
-                updateOperationsPerformed.AddRange(patchedUpdateOperations);
-                foreach (var o in patchedUpdateOperations)
-                {
-                    logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
-                }
-            }
-
-            var updatedDependencyFiles = await tracker.StopTrackingAsync();
-            if (updateOperationsPerformed.Count > 0)
-            {
-                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
-                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
-                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
-                await apiHandler.CreatePullRequest(new CreatePullRequest()
-                {
-                    Dependencies = [.. updatedDependencies],
-                    UpdatedDependencyFiles = [.. updatedDependencyFiles],
-                    BaseCommitSha = baseCommitSha,
-                    CommitMessage = commitMessage,
-                    PrTitle = prTitle,
-                    PrBody = prBody,
-                    DependencyGroup = null,
-                });
             }
         }
     }


### PR DESCRIPTION
NuGet PRs were incorrectly grouped on the directory when they should have also been split out per dependency.

E.g., the old, but wrong, behavior was this:

``` csharp
foreach (var directory in job.GetDirectories())
{
    StartPrTracking();
    foreach (var dependency in dependenciesInThisDirectory)
    {
        // ... do update things ...
    }
    EndPrTracking();
}
```

But the correct behavior is to move the PR tracking inside that second loop:

``` csharp
foreach (var directory in job.GetDirectories())
{
    foreach (var dependency in dependenciesInThisDirectory)
    {
        StartPrTracking();
        // ... do update things ...
        EndPrTracking();
    }
}
```

[This comment](https://github.com/dependabot/dependabot-core/issues/12401#issuecomment-3111511203) explains the fix.

Most of this PR is whitespace, so I'd recommend reviewing by ignoring the whitespace changes, but I did also have to add the ability for the updater to reset file contents at the end of a loop iteration so each PR is self-contained.  That code change should be unsurprising.

Fixes #12401.