### PR TITLE
allow custom hostname for github repos

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -51,6 +51,20 @@ public class CloneWorkerTests
     }
 
     [Fact]
+    public void GheOnPremCloneCommandsAreGenerated()
+    {
+        TestCommands(
+            provider: "github",
+            hostname: "ghe-onprem-url.example.com",
+            repoMoniker: "OwnerName/RepoName",
+            expectedCommands:
+            [
+                (["clone", "--no-tags", "--depth", "1", "--recurse-submodules", "--shallow-submodules", "https://ghe-onprem-url.example.com/OwnerName/RepoName", TestRepoPath], null)
+            ]
+        );
+    }
+
+    [Fact]
     public void CloneCommandsAreGeneratedWhenBranchIsSpecified()
     {
         TestCommands(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -170,7 +170,7 @@ public class CloneWorker
     {
         return job.Source.Provider switch
         {
-            "azure" when !string.IsNullOrWhiteSpace(job.Source.Hostname) => $"https://{job.Source.Hostname}/{job.Source.Repo}",
+            "azure" or "github" when !string.IsNullOrWhiteSpace(job.Source.Hostname) => $"https://{job.Source.Hostname}/{job.Source.Repo}",
             "azure" => $"https://dev.azure.com/{job.Source.Repo}",
             "github" => $"https://github.com/{job.Source.Repo}",
             _ => throw new ArgumentException($"Unknown provider: {job.Source.Provider}")


### PR DESCRIPTION
Adds a scenario that we already had for Azure DevOps.

Since ADO and GitHub on-prem use similar repo schemes, the switch expression was simply expanded.