### PR TITLE
fix incorrect cast when adding child xml element

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1233,6 +1233,30 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
+    public async Task SingleDependency_SingleFile_TransitiveIsPinnedInNewElement()
+    {
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Transitive.Dependency/2.0.0"],
+            requiredDependencyStrings: ["Transitive.Dependency/3.0.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Transitive.Dependency" Version="3.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
     public async Task SingleDependency_CentralPackageManagement_TransitiveIsPinned_ExistingPackageVersionElement_AlreadyCorrect()
     {
         await TestAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/XmlExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/XmlExtensions.cs
@@ -83,16 +83,16 @@ public static class XmlExtensions
         return CreateOpenCloseXmlElementSyntax(name, new SyntaxList<SyntaxNode>(leadingTrivia));
     }
 
-    public static XmlElementSyntax CreateOpenCloseXmlElementSyntax(string name, SyntaxList<SyntaxNode> leadingTrivia)
+    public static XmlElementSyntax CreateOpenCloseXmlElementSyntax(string name, SyntaxList<SyntaxNode> leadingTrivia, bool insertIntermediateNewline = true)
     {
-        var newlineTrivia = SyntaxFactory.WhitespaceTrivia(Environment.NewLine);
+        var newlineTrivia = SyntaxFactory.EndOfLineTrivia(Environment.NewLine);
 
         return SyntaxFactory.XmlElement(
             SyntaxFactory.XmlElementStartTag(
                 SyntaxFactory.Punctuation(SyntaxKind.LessThanToken, "<", leadingTrivia, default),
                 SyntaxFactory.XmlName(null, SyntaxFactory.XmlNameToken(name, null, null)),
                 new SyntaxList<XmlAttributeSyntax>(),
-                SyntaxFactory.Punctuation(SyntaxKind.GreaterThanToken, ">", null, newlineTrivia)),
+                SyntaxFactory.Punctuation(SyntaxKind.GreaterThanToken, ">", null, insertIntermediateNewline ? newlineTrivia : null)),
             new SyntaxList<SyntaxNode>(),
             SyntaxFactory.XmlElementEndTag(
                 SyntaxFactory.Punctuation(SyntaxKind.LessThanSlashToken, "</", leadingTrivia, default),


### PR DESCRIPTION
This PR fixes an error found during a manual scan of the error logs.

When it's necessary to add an `<ItemGroup>` element to a project, don't cast the root object to `IXmlElementSyntax`.  Instead use the `RootSyntax` property which has everything we need.

This also required an update to make the newlines configurable in an existing helper function.