### PR TITLE
Improve error handling in docker yaml file parsing

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -106,8 +106,9 @@ module Dependabot
         end
 
         dependency_set
-      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias => e
+        Dependabot.logger.error("Failed to parse file #{file.path}: #{e.message}")
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
 
       sig { params(json_obj: T.anything).returns(T::Array[String]) }


### PR DESCRIPTION
Improve error handling in `docker` yaml file parsing by logging the error message and passing the message to `DependencyFileNotParseable`

### What are you trying to accomplish?

Improve debugging experience for when a yaml file fails to parse in the `docker` ecosystem.

### How will you know you've accomplished your goal?

Errors when parsing yaml files in the `docker` ecosystem are logged in the output, and sent with the error as the message.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
