### PR TITLE
[Experiment] Fix incorrect method signature when calling the Dependency Submission via Dependabot service

### DIFF
--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -170,7 +170,7 @@ module Dependabot
       Dependabot.logger.debug("Dependency submission payload:")
       Dependabot.logger.debug(JSON.pretty_generate(submission.payload))
 
-      service.create_dependency_submission(submission)
+      service.create_dependency_submission(dependency_submission: submission)
     end
   end
 end

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -469,11 +469,11 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       end
 
       it "emits a create_dependency_submission call to the Dependabot service" do
-        expect(service).to receive(:create_dependency_submission) do |dependency_submission|
-          expect(dependency_submission).to be_a(GithubApi::DependencySubmission)
+        expect(service).to receive(:create_dependency_submission) do |args|
+          expect(args[:dependency_submission]).to be_a(GithubApi::DependencySubmission)
 
-          expect(dependency_submission.job_id).to eql(job_id)
-          expect(dependency_submission.package_manager).to eql("bundler")
+          expect(args[:dependency_submission].job_id).to eql(job_id)
+          expect(args[:dependency_submission].package_manager).to eql("bundler")
         end
 
         perform_job


### PR DESCRIPTION
### What are you trying to accomplish?

**This fixes an experiment-only bug**

When testing this experimental feature, I realised there was a slip up in the in unit tests and the method signature used in the `update_files_command.rb` was that of the `api_client` and not the `service` shim that sits in between the two.

```
updater | 2025/08/05 14:43:17 ERROR <job_1069005148> wrong number of arguments (given 1, expected 0)
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.5.11952/lib/types/private/methods/signature.rb:204:in 'T::Private::Methods::Signature#each_args_value_type'
updater | 2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.5.11952/lib/types/private/methods/call_validation.rb:227:in 'T::Private::Methods::CallValidation.validate_call'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.5.11952/lib/types/private/methods/_methods.rb:277:in 'block in Dependabot::Service#_on_method_added'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:173:in 'Dependabot::UpdateFilesCommand#dependency_submission_experiment'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:43:in 'block in Dependabot::UpdateFilesCommand#perform_job'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.5.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:21:in 'Dependabot::UpdateFilesCommand#perform_job'
2025/08/05 14:43:17 ERROR <job_1069005148> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:37:in 'Dependabot::BaseCommand#run'
```

This fixes the test and method signature.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

When I run a new update for my experimental end-to-end test I will no longer see this error.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
