### PR TITLE
[Experiment] Log the submission payload at info level for now

### DIFF
--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -167,8 +167,9 @@ module Dependabot
         snapshot: dependency_snapshot
       )
 
-      Dependabot.logger.debug("Dependency submission payload:")
-      Dependabot.logger.debug(JSON.pretty_generate(submission.payload))
+      # TODO(brrygrdn): Drop this back down to debug logging
+      Dependabot.logger.info("Dependency submission payload:")
+      Dependabot.logger.info(JSON.pretty_generate(submission.payload))
 
       service.create_dependency_submission(dependency_submission: submission)
     end


### PR DESCRIPTION
### What are you trying to accomplish?

This branch promotes the payload logging to `info` temporarily as the backend service is designed to be unobtrusive so it's easier for us to see the payload in job logs when we see a snapshot being rejected while we're iterating.

### Anything you want to highlight for special attention from reviewers?

N/A - this is just making it a little easier for us to work transparently

### How will you know you've accomplished your goal?

I can see the generated payload in my test job logs.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
