### PR TITLE
Allow specifying a hostname in dry-run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -10,7 +10,7 @@
 # should always be up-to-date.
 #
 # Usage:
-#   ruby bin/dry-run.rb [OPTIONS] PACKAGE_MANAGER GITHUB_REPO
+#   bin/dry-run.rb [OPTIONS] PACKAGE_MANAGER GITHUB_REPO
 #
 # ! You'll need to have a GitHub access token (a personal access token is
 # ! fine) available as the environment variable LOCAL_GITHUB_ACCESS_TOKEN.
@@ -157,6 +157,7 @@ $options = {
   vendor_dependencies: false,
   ignore_conditions: [],
   pull_request: false,
+  hostname: nil,
   cooldown: nil
 }
 
@@ -321,6 +322,11 @@ option_parse = OptionParser.new do |opts|
   rescue JSON::ParserError
     puts "Invalid JSON format for cooldown parameter. Please provide a valid JSON string."
     exit 1
+  end
+
+  opts.on("--ghes-hostname HOSTNAME", "Custom hostname for the provider") do |value|
+    $options[:ghes_hostname] = value
+    $options[:api_endpoint] = File.join(value, "api", "v3")
   end
 end
 # rubocop:enable Metrics/BlockLength
@@ -575,13 +581,20 @@ begin
     end
   end
 
-  $source = Dependabot::Source.new(
+  source_options = {
     provider: $options[:provider],
     repo: $repo_name,
     directory: $options[:directory],
     branch: $options[:branch],
     commit: $options[:commit]
-  )
+  }
+
+  if $options[:ghes_hostname]
+    source_options[:hostname] = $options[:ghes_hostname]
+    source_options[:api_endpoint] = $options[:api_endpoint]
+  end
+
+  $source = Dependabot::Source.new(**source_options)
 
   $repo_contents_path = File.expand_path(File.join("tmp", $repo_name.split("/")))
 


### PR DESCRIPTION
### What are you trying to accomplish?

When running against a GHES instance, we need to be able to specify the hostname of that instance.

Usage would look like this:

```
bin/dry-run --ghes-hostname git.myghes.com go_modules <org>/<repo>
```

### Anything you want to highlight for special attention from reviewers?

I've hardcoded this to assume GHES, since for that we can determine the api endpoint, and I think there's not really a reason to try and make it generic for other providers.

### How will you know you've accomplished your goal?

Local testing

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
