### PR TITLE
[Experiment] Correctly convert the Dependabot job's branch attribute into a full ref

### DIFF
--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -169,7 +169,7 @@ module Dependabot
 
       # TODO(brrygrdn): Drop this back down to debug logging
       Dependabot.logger.info("Dependency submission payload:")
-      Dependabot.logger.info(JSON.pretty_generate(submission.payload))
+      Dependabot.logger.info("\n" + JSON.pretty_generate(submission.payload))
 
       service.create_dependency_submission(dependency_submission: submission)
     end

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -17,7 +17,7 @@ module GithubApi
     sig { returns(String) }
     attr_reader :job_id
     sig { returns(String) }
-    attr_reader :ref
+    attr_reader :branch
     sig { returns(String) }
     attr_reader :sha
     sig { returns(String) }
@@ -34,7 +34,7 @@ module GithubApi
       #
       # For purposes of the POC, we'll assume the default branch of `main`
       # if this is nil, but this isn't a sustainable approach
-      @ref = T.let(job.source.branch || "main", String)
+      @branch = T.let(job.source.branch || "main", String)
       @sha = T.let(snapshot.base_commit_sha, String)
       # TODO: Ensure that directory is always set for analysis runs
       #
@@ -54,7 +54,7 @@ module GithubApi
       {
         version: SNAPSHOT_VERSION,
         sha: sha,
-        ref: ref,
+        ref: symbolic_ref,
         job: {
           correlator: job_correlator,
           id: job_id
@@ -79,6 +79,13 @@ module GithubApi
     sig { returns(String) }
     def scanned
       Time.now.utc.iso8601
+    end
+
+    sig { returns(String) }
+    def symbolic_ref
+      return branch.gsub(%r{^/}, "") if branch.start_with?(%r{/?ref})
+
+      "refs/heads/#{branch}"
     end
 
     sig { params(snapshot: Dependabot::DependencySnapshot).returns(T::Hash[String, T.untyped]) }

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -98,6 +98,35 @@ RSpec.describe GithubApi::DependencySubmission do
       expect(payload[:scanned]).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
     end
 
+    it "generates git attributes correctly" do
+      payload = dependency_submission.payload
+
+      expect(payload[:sha]).to eq(sha)
+      expect(payload[:ref]).to eql("refs/heads/main")
+    end
+
+    context "when given a symbolic reference for the job's branch" do
+      let(:branch) { "refs/heads/release" }
+
+      it "does not add an additional refs/heads/ prefix" do
+        payload = dependency_submission.payload
+
+        expect(payload[:sha]).to eq(sha)
+        expect(payload[:ref]).to eql("refs/heads/release")
+      end
+    end
+
+    context "when given a symbolic reference for the job's branch with a leading /" do
+      let(:branch) { "/refs/heads/release" }
+
+      it "removes the leading slash" do
+        payload = dependency_submission.payload
+
+        expect(payload[:sha]).to eq(sha)
+        expect(payload[:ref]).to eql("refs/heads/release")
+      end
+    end
+
     it "generates a valid manifest list" do
       payload = dependency_submission.payload
 


### PR DESCRIPTION
### What are you trying to accomplish?

Payloads generated with the current version encounter a 422 error from Dependency Submission as we expect the branch name to be of the form `refs/heads/main`.

This adds logic to the serialiser to prefix the branch appropriately unless it is already prefixed.

### Anything you want to highlight for special attention from reviewers?

I decided not to try to detect and handle SHA-as-references since it would be irregular for us to pass this into a job as a `branch` name even though it might work in some circumstances - we would never be able to submit this to the Dependency Submission API.

It might be worth eventually raising if we get a SHA-like branch name, but I've opted not to be defensive on this for now.

### How will you know you've accomplished your goal?

I will see the results from my experimental jobs appear in the DS-API database as well as logs.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
