### PR TITLE
Remove byte-order marks from all dependency files

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -84,7 +84,8 @@ module Dependabot
                    content_encoding: ContentEncoding::UTF_8, deleted: false,
                    operation: Operation::UPDATE, mode: nil)
       @name = name
-      @content = content
+      # Remove UTF-8 BOM if present
+      @content = content.delete_prefix("\uFEFF")
       @directory = T.let(clean_directory(directory), String)
       @symlink_target = symlink_target
       @support_file = support_file

--- a/docker/lib/dependabot/shared/shared_file_fetcher.rb
+++ b/docker/lib/dependabot/shared/shared_file_fetcher.rb
@@ -80,7 +80,7 @@ module Dependabot
               fetched = fetch_file_from_host(f.name)
               # The YAML parser used doesn't properly handle a byte-order-mark (BOM) and it can cause failures in
               # unexpected ways.  That BOM is removed here to allow regular updates to proceed.
-              fetched.content = T.must(fetched.content)[1..-1] if fetched.content&.start_with?("\uFEFF")
+              fetched.content = T.must(fetched.content).delete_prefix("\uFEFF")
               fetched
             end,
           T.nilable(T::Array[DependencyFile])

--- a/docker/spec/fixtures/docker/dockerfiles/byte_order_mark
+++ b/docker/spec/fixtures/docker/dockerfiles/byte_order_mark
@@ -1,0 +1,19 @@
+﻿FROM ubuntu@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005
+
+### SYSTEM DEPENDENCIES
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      dirmngr \
+      git \
+
+
+### RUBY
+
+# Install Ruby 2.4
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
+    && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu zesty main" > /etc/apt/sources.list.d/brightbox.list \
+    && apt-get update
+RUN apt-get install -y ruby2.4 ruby2.4-dev

--- a/docker/spec/fixtures/kubernetes/yaml/with_bom.yaml
+++ b/docker/spec/fixtures/kubernetes/yaml/with_bom.yaml
@@ -1,0 +1,10 @@
+﻿apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
@@ -46,9 +46,7 @@ module Dependabot
         return unless dependency_file.content
 
         begin
-          # Remove UTF-8 BOM if present
-          content = T.must(dependency_file.content).delete_prefix("\uFEFF")
-          contents = JSON.parse(content)
+          contents = JSON.parse(dependency_file.content)
         rescue JSON::ParserError
           raise Dependabot::DependencyFileNotParseable, T.must(dependency_files.first).path
         end
@@ -103,9 +101,7 @@ module Dependabot
       def sdk_version
         @sdk_version ||= T.let(
           config_dependency_files.filter_map do |dependency_file|
-            # Remove UTF-8 BOM if present
-            content = T.must(dependency_file.content).delete_prefix("\uFEFF")
-            contents = JSON.parse(content)
+            contents = JSON.parse(dependency_file.content)
             contents.dig("sdk", "version")
           rescue JSON::ParserError
             raise Dependabot::DependencyFileNotParseable, dependency_file.path


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
We are now removing the byte-order mark prefix (`"\uFEFF"`) if it exists at the beginning of the `dependency_file` content.
<!-- What issues does this affect or fix? -->
This fixes inconsistencies where some files were saved with BOM but aren't able to be parsed by certain ecosystems.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
