### PR TITLE
restore smoke test branch to 'main'

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: dev/brettfo/nuget-grouping
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restore the smoke test branch to `main`.  This is a cleanup to follow #12762.

Failing NPM smoke tests are due to https://github.com/dependabot/dependabot-core/issues/12784.
Failing Swift smoke test is due to https://github.com/dependabot/dependabot-core/issues/12647.