### PR TITLE
[Experiment] Introduce DependencyFile#priority to control graph generation

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -351,11 +351,16 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def lockfile
-        @lockfile ||= T.let(
-          get_original_file("Gemfile.lock") ||
-                              get_original_file("gems.locked"),
+        return @lockfile if defined?(@lockfile)
+
+        @lockfile = T.let(
+          get_original_file("Gemfile.lock") || get_original_file("gems.locked"),
           T.nilable(Dependabot::DependencyFile)
         )
+
+        # Set the lockfile as higher priority so we know to ignore the Gemfile, etc
+        # when producing a graph.
+        @lockfile&.tap { |f| f.priority = 1 }
       end
 
       sig { returns(T.untyped) }

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -383,4 +383,23 @@ RSpec.describe Dependabot::DependencyFile do
       end
     end
   end
+
+  describe "priority" do
+    it "defaults to 0" do
+      expect(file.priority).to be_zero
+    end
+
+    it "priority may be set when created" do
+      file = described_class.new(name: "Gemfile.lock", content: "no gems here", priority: 42)
+      expect(file.priority).to be(42)
+    end
+
+    it "can be amended after creation" do
+      expect(file.priority).to be_zero
+
+      file.priority = 1
+
+      expect(file.priority).to be(1)
+    end
+  end
 end

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -138,6 +138,9 @@ module GithubApi
     sig { params(snapshot: Dependabot::DependencySnapshot).returns(T::Array[Dependabot::DependencyFile]) }
     def relevant_manifests(snapshot)
       manifests_by_directory = snapshot.dependency_files.each_with_object({}) do |file, dirs|
+        # If the file doesn't have any dependencies assigned to it, then it isn't relevant.
+        next if file.dependencies.empty?
+
         # Build up a dictionary of unique directories...
         dirs[file.directory] ||= {}
         # Add a list of files for each distinct priority...
@@ -162,7 +165,7 @@ module GithubApi
     # fill in some blanks.
     sig { params(dependency: Dependabot::Dependency).returns(String) }
     def build_purl(dependency)
-      "pkg:#{purl_pkg_for(dependency.package_manager)}/#{dependency.name}@#{dependency.version}"
+      "pkg:#{purl_pkg_for(dependency.package_manager)}/#{dependency.name}@#{dependency.version}".chomp("@")
     end
 
     sig { params(package_manager: String).returns(String) }


### PR DESCRIPTION
### What are you trying to accomplish?

The Dependabot updater needs to know about quite a lot of files to do its job, often needing information from lockfiles about dependencies in order to affect changes in manifests.

When it comes to graphing the dependencies used by a project, we generally only need to examine lockfiles for the relevant information as they will know things manifest do not provide like:
- the exact versions used
- any transitive dependencies that are pulled in by direct dependencies
- the relationships between dependencies as its ancestors decedents

#### Example

If we look at the snapshots being generated for a Ruby project by Dependency Graph's existing source-based parser for the Sinatra example in our tests, we see 28 dependencies, all of which are attributed to the Gemfile.lock:
<img width="918" height="652" alt="Screenshot 2025-08-11 at 15 03 27" src="https://github.com/user-attachments/assets/a309e406-7f6c-4b7f-aa5c-ec53c060709c" />

If we take the submission payload generated by our experiment so far we see 32 dependencies, with 4 duplicates attributed to the Gemfile:
<img width="922" height="965" alt="Screenshot 2025-08-11 at 14 30 34" src="https://github.com/user-attachments/assets/fc39c316-d5dc-44d5-8baf-7253ba7bcd7e" />

#### Which is the right approach?

The Dependency Submission API is mainly used by projects which do not have exhaustive lockfiles to fill in blanks our source-based parsing cannot cover - as a result Bundler is in a funny spot where we accept snapshots for it but until now there wasn't much real-world incentive build them so as our source-based parsing was good enough and used bundler internals in much the same way Dependabot does.

Bundler is also something of a bystander in this experiment as we're less interested in making it work fully than other ecosystems, but all things being equal it makes most sense to align with the current source-based parsing in terms of which files are submitted.

### Anything you want to highlight for special attention from reviewers?

Rather than bubble Bundler-specific knowledge up into the submission components, I've introduced a simple precedence flag on `Dependabot::DependencyFile`. When we encounter a lockfile with 1 or more dependencies, we set it to precedence of `1` so it supersedes any manifests.

This is an effort to have a simple but generic way for us to limit the files used for graphing as required within the ecosystem's file parsers.

Dependabot currently fails fast when attempting to parse Bundler projects without a Gemfile ( or gemspec ), so I haven't added tests for these scenarios and just updated our existing tests to validate that only the lockfiles make it into the submission.

### How will you know you've accomplished your goal?

When we merge this, the payloads we submit will only show 28 dependencies instead of 32, omitting the Gemfile records.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
