### PR TITLE
[Experiment] Populate child dependencies for Bundler graphs

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -207,6 +207,9 @@ module Dependabot
             version: dependency_version(dependency.name)&.to_s,
             requirements: [],
             package_manager: "bundler",
+            metadata: {
+              depends_on: dependency.dependencies.map(&:name)
+            },
             subdependency_metadata: [{
               production: production_dep_names.include?(dependency.name)
             }],

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -120,12 +120,7 @@ module GithubApi
               package_url: build_purl(dep),
               relationship: relationship_for(dep),
               scope: scope_for(dep),
-              dependencies: [
-                # TODO: Populate direct child dependencies
-                #
-                # Dependabot::Dependency objects do not include immediate dependencies,
-                # this is a capability each parser will need to have added.
-              ],
+              dependencies: dep.metadata.fetch(:depends_on, []),
               metadata: {}
             }
           end


### PR DESCRIPTION
### What are you trying to accomplish?

When we process a lockfile, we iterate over the file's `Bundler::LazySpecification` [objects](https://ruby-doc.org/3.4.1/stdlibs/bundler/Bundler/LazySpecification.html) which knows the direct descendants of that package but we don't currently attach this to the `Dependabot::Dependency` object we return.

This PR establishes the pattern of using `metadata[:depends_on]` key to return a list of dependent names that we can use when we are building graphs for the project.

### Anything you want to highlight for special attention from reviewers?

I elected not to add a new attribute to `Dependabot::Dependency` or its constructor and just use the `metadata` hash as this is, well, metadata.

We might decide to promote this later, but I'd rather revisit that after doing a few ecosystems so we have a better idea of what logic we want to push into base classes, etc with a few examples under our belt.

### How will you know you've accomplished your goal?

We start seeing dependency relationships reflected in Dependency Insights when we use our experiment to submit a snapshot, and we're also able to see transitive paths in Dependabot Alerts when a vulnerable version is involved.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
