### PR TITLE
[Experiment] Populate child dependencies for Go graphs

### DIFF
--- a/go_modules/spec/fixtures/projects/graphing_dependencies/go.mod
+++ b/go_modules/spec/fixtures/projects/graphing_dependencies/go.mod
@@ -1,0 +1,17 @@
+module github.com/dependabot/core-test
+
+go 1.23.0
+
+require (
+	github.com/fatih/color v1.18.0
+	rsc.io/qr v0.2.0
+	rsc.io/quote v1.5.2
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+)

--- a/go_modules/spec/fixtures/projects/graphing_dependencies/go.sum
+++ b/go_modules/spec/fixtures/projects/graphing_dependencies/go.sum
@@ -1,0 +1,17 @@
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go_modules/spec/fixtures/projects/graphing_dependencies/main.go
+++ b/go_modules/spec/fixtures/projects/graphing_dependencies/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	_ "github.com/fatih/color"
+	_ "rsc.io/qr"
+	_ "rsc.io/quote"
+)
+
+func main() {
+}


### PR DESCRIPTION
### What are you trying to accomplish?

This PR can ship separately but in order for the child dependencies to be relayed to the snapshot, it depends on some changes from this:
- https://github.com/dependabot/dependabot-core/pull/12818

In the Bundler module, we already have access to the child dependencies in the `FileParser`, but for go we need to run an extra native command - `go mod graph` - to get a dictionary of parent > child relationships we can use to populate it.

Since this 1/ increases the runtime of the file parser and 2/ introduces some new risk of failure when parsing go, we do not want to make this baseline behaviour of the file parser.

For now, we check if the experiment is enabled and only gather this data if it is - which will limit the child dependency fetches to repositories with the feature enabled.

Our next step will be introducing a new parameter to `FileParsers` which allows us to pass in a flag to indicate whether we want a verbose parse for a graph command or the default behaviour to make this extensible and allow us to start to bed down the `UpdateGraphCommand` entry point.

### Anything you want to highlight for special attention from reviewers?

Mainly that the use of the native command looks sensible.

### How will you know you've accomplished your goal?

Once this merges, along with #12818, child dependencies will be populated in our experimental repositories.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
