### PR TITLE
bump to Go 1.25

### DIFF
--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.5-bookworm AS go
+FROM docker.io/library/golang:1.25.0-bookworm AS go
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
@@ -18,13 +18,3 @@ USER dependabot
 COPY --chown=dependabot:dependabot go_modules $DEPENDABOT_HOME/go_modules
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
-
-# Put binaries installed with `go install` in the PATH
-ENV PATH=$DEPENDABOT_HOME/go/bin:$PATH
-
-# Temporarily install https://go.dev/cl/657178 for new toolchain behavior.
-# TODO: Switch to Go 1.25 when it is released.
-RUN go install golang.org/dl/gotip@latest \
-    && echo y | gotip download 657178 \
-    && gotip version \
-    && ln -sf "$(which gotip)" $DEPENDABOT_HOME/go/bin/go

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -8,7 +8,7 @@ module Dependabot
     module ResolvabilityErrors
       extend T::Sig
 
-      GITHUB_REPO_REGEX = %r{github.com/[^:@]*}
+      GITHUB_REPO_REGEX = %r{github.com/[^:@ ]*}
 
       sig { params(message: String, goprivate: T.untyped).void }
       def self.handle(message, goprivate:)

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
       it "returns the correct package manager" do
         expect(package_manager.name).to eq "go_modules"
         expect(package_manager.requirement).to be_nil
-        expect(package_manager.version.to_s).to eq "1.25-12"
+        expect(package_manager.version.to_s).to eq "1.25.0"
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Bumps Go to 1.25 which allows us to revert the change in #12230 where we manually download a CL to avoid undesirable toolchain changes.

### Anything you want to highlight for special attention from reviewers?

Feel free to read the reason why this was added over in #12230. 

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Tests continue to pass. 

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
