### PR TITLE
Re-add labeler registration for NuGet in dependabot

### DIFF
--- a/nuget/lib/dependabot/nuget.rb
+++ b/nuget/lib/dependabot/nuget.rb
@@ -7,6 +7,11 @@
 require "dependabot/nuget/requirement"
 require "dependabot/nuget/version"
 
+
+require "dependabot/pull_request_creator/labeler"
+Dependabot::PullRequestCreator::Labeler
+  .register_label_details("nuget", name: ".NET", colour: "7121c6")
+
 require "dependabot/dependency"
 Dependabot::Dependency.register_production_check(
   "nuget",


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

Adding back in the pull request label information for this ecoystem.  The file was deleted in https://github.com/dependabot/dependabot-core/commit/5d3880503b4009fe57fc4e764a2d54ad1587e148, then later re-added in https://github.com/dependabot/dependabot-core/commit/27fe9f6bb8f91890fe4c6f713f109d436a82ac12 but without the label information.

The missing label information has been causing Dependabot some issues during PR creation

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

Is there any reason this was not readded?  I think this change is safe but it could use a bit more 👀 

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Dependabot is able to more reliably create PRs for nuget changes

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
