### PR TITLE
Fix Gradle lockfile support against Gradle's version catalog (Fix #12557)

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
@@ -31,11 +31,11 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do |temp_dir|
             populate_temp_directory(temp_dir)
             cwd = File.join(temp_dir, build_file.directory, build_file.name)
-            if build_file.path.end_with?("/gradle/libs.versions.toml")
-              cwd = File.dirname(cwd, 2)
-            else
-              cwd = File.dirname(cwd)
-            end
+            cwd = if build_file.path.end_with?("/gradle/libs.versions.toml")
+                    File.dirname(cwd, 2)
+                  else
+                    File.dirname(cwd)
+                  end
 
             # Create gradle.properties file with proxy settings
             # Would prefer to use command line arguments, but they don't work.


### PR DESCRIPTION
### What are you trying to accomplish?

Trying to fix #12557 -- a bug in Gradle lockfile support (which is introduced in #12287) against Gradle version catalog (`/gradle/libs.versions.toml`).

Before this fix, Gradle lockfile has not been updated when the versions are managed in Gradle version catalog (`/gradle/libs.versions.toml`), not in build file (`build.gradle(.kts)`). (See #12557 for the bug details.)

The issue came from how `lockfile_updater.rb` determined `cwd`. `cwd` should be where `build.gradle(.kts)` exists.

It determined `cwd` by `File.dirname(build_file)` (in short). However, it does not work for the version catalog file (`build_file` = `/gradle/libs.versions.toml`) because `File.dirname("/gradle/libs.versions.toml")` would be `/gradle`, not `/`.

Against `/gradle/libs.versions.toml`, `cwd` should be `/`.

### Anything you want to highlight for special attention from reviewers?

I tried this so that it would be a minimum fix for the Gradle version catalog issue.

### How will you know you've accomplished your goal?

I confirmed this fix by :

```
$ bin/dry-run.rb gradle dmikurube/dependabot-catalog
```

When adding `--info` and `--stacktrace` in the Gradle commandline below,

https://github.com/dependabot/dependabot-core/blob/58212ab85ead42b51a147a5e05ea30ca4d827ef2/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb#L41-L46

an error message could be observed.

```
Project directory 'dependabot_tmp_dir/gradle' is not part of the build defined by settings file 'dependabot_tmp_dir/settings.gradle'. If this is an unrelated build, it must have its own settings file.
```

After this fix, the error message has gone, and `gradle.lockfile` is updated.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
