### PR TITLE
prevent mislabeling Go issues

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -26,7 +26,7 @@
     - '(actions)'
 
 "L: go:modules":
-    - '(go|gomod)'
+    - '(golang|gomod)'
 
 "L: javascript":
     - '(javascript|npm|pnpm|yarn|bun)'


### PR DESCRIPTION
### What are you trying to accomplish?

- fixes #12669

Anytime anyone used `go` in their post, it would get labelled with the Go ecosystem label. So every Cargo issue was also a Go issue since `go` is in `cargo`. 

We probably need a better system for customers to select the ecosystem but this is an improvement for now.
