### PR TITLE
Fix issues with multi-version dependency changes when refreshing security update PRs

### DIFF
--- a/updater/lib/dependabot/pull_request.rb
+++ b/updater/lib/dependabot/pull_request.rb
@@ -87,11 +87,10 @@ module Dependabot
     sig { params(other: PullRequest).returns(T::Boolean) }
     def ==(other)
       if using_directory? && other.using_directory?
-        dependencies.map(&:to_h).difference(other.dependencies.map(&:to_h)).none?
+        dependencies.to_set(&:to_h) == other.dependencies.to_set(&:to_h)
       else
-        dependencies.map { |dep| dep.to_h.except(:directory) }.difference(
-          other.dependencies.map { |dep| dep.to_h.except(:directory) }
-        ).none?
+        dependencies.to_set { |dep| dep.to_h.except(:directory) } ==
+          other.dependencies.to_set { |dep| dep.to_h.except(:directory) }
       end
     end
 

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -92,7 +92,7 @@ module Dependabot
         sig { params(dependencies: T::Array[Dependabot::Dependency]).void }
         def check_and_update_pull_request(dependencies)
           # If the job dependencies are empty, then we should close the PR
-          job_dependencies = job.dependencies.uniq
+          job_dependencies = job.dependencies&.uniq
           unless job_dependencies
             Dependabot.logger.info("No dependencies to update")
             close_pull_request(reason: :dependencies_removed)

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -92,7 +92,7 @@ module Dependabot
         sig { params(dependencies: T::Array[Dependabot::Dependency]).void }
         def check_and_update_pull_request(dependencies)
           # If the job dependencies are empty, then we should close the PR
-          job_dependencies = job.dependencies
+          job_dependencies = job.dependencies.uniq
           unless job_dependencies
             Dependabot.logger.info("No dependencies to update")
             close_pull_request(reason: :dependencies_removed)
@@ -103,6 +103,9 @@ module Dependabot
             # If the job dependencies mismatch the parsed dependencies, then
             # we should close the PR as at least one thing we changed has been
             # removed from the project.
+            Dependabot.logger.info("Job dependencies do not match parsed dependencies. " \
+                                   "Job dependencies: #{job_dependencies}, " \
+                                   "Parsed dependencies: #{dependencies.map(&:name)}")
             close_pull_request(reason: :dependency_removed)
             return
           end
@@ -194,8 +197,11 @@ module Dependabot
           # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
           # and the dependency name in the security advisory often doesn't match
           # what users have specified in their manifest.
-          job_dependencies = job_dependencies.map(&:downcase)
-          changed_dependencies = dependency_change.updated_dependencies.map { |x| x.name.downcase }
+          job_dependencies = job_dependencies.map(&:downcase).uniq
+          changed_dependencies = dependency_change.updated_dependencies.map { |x| x.name.downcase }.uniq
+
+          Dependabot.logger.info("Job Dependencies (current): #{job_dependencies}, " \
+                                 "Changed Dependencies (new): #{changed_dependencies}")
 
           if changed_dependencies.sort_by(&:downcase) != job_dependencies.sort_by(&:downcase)
             # The dependencies being updated have changed. Close the existing

--- a/updater/spec/dependabot/pull_request_spec.rb
+++ b/updater/spec/dependabot/pull_request_spec.rb
@@ -113,5 +113,55 @@ RSpec.describe Dependabot::PullRequest do
 
       expect(pr1).not_to eq(pr2)
     end
+
+    it "is false when the left has more dependencies" do
+      pr1 = described_class.new(
+        [
+          Dependabot::PullRequest::Dependency.new(
+            name: "foo",
+            version: "1.0.0"
+          ),
+          Dependabot::PullRequest::Dependency.new(
+            name: "bar",
+            version: "2.0.0"
+          )
+        ]
+      )
+      pr2 = described_class.new(
+        [
+          Dependabot::PullRequest::Dependency.new(
+            name: "foo",
+            version: "1.0.0"
+          )
+        ]
+      )
+
+      expect(pr1).not_to eq(pr2)
+    end
+
+    it "is false when the right has more dependencies" do
+      pr1 = described_class.new(
+        [
+          Dependabot::PullRequest::Dependency.new(
+            name: "foo",
+            version: "1.0.0"
+          )
+        ]
+      )
+      pr2 = described_class.new(
+        [
+          Dependabot::PullRequest::Dependency.new(
+            name: "foo",
+            version: "1.0.0"
+          ),
+          Dependabot::PullRequest::Dependency.new(
+            name: "bar",
+            version: "2.0.0"
+          )
+        ]
+      )
+
+      expect(pr1).not_to eq(pr2)
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

#12821 contained a fix which allows the npm updater to update a package to multiple versions within a security update, as this is sometimes the best and only way to resolve a security vulnerability. Unfortunately, refreshing a PR that updates a single package to multiple versions is not handled properly and this PR has a fix.

The core issue is that the code to refresh a security update PR did not properly deduplicate the list of modified dependencies when comparing it to the dependencies associated with the job. This causes the updater to close the PR instead of updating it. Here's an example: https://github.com/jasonpaulos/test-dependency-repo/actions/runs/17105333309/job/48512654569

Additionally, I found that the equality code for PullRequest objects was not correct, especially when a PR with multiple dependencies was being compared.

### Anything you want to highlight for special attention from reviewers?

No

### How will you know you've accomplished your goal?

Added regression tests and performed extensive local testing

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
