### PR TITLE
Use normalised_name when fetching json response from python registry

### DIFF
--- a/uv/lib/dependabot/uv/package/package_details_fetcher.rb
+++ b/uv/lib/dependabot/uv/package/package_details_fetcher.rb
@@ -385,7 +385,7 @@ module Dependabot
 
         sig { params(json_url: String).returns(Excon::Response) }
         def registry_json_response_for_dependency(json_url)
-          url = "#{json_url.chomp('/')}/#{@dependency.name}/json"
+          url = "#{json_url.chomp('/')}/#{normalised_name}/json"
           Dependabot::RegistryClient.get(
             url: url,
             headers: { "Accept" => APPLICATION_JSON }


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot uses incorrect URLs to fetch details from JSON registry when dependencies have extras (see 3rd line):

```
 updater | 2025/08/22 07:50:08 INFO <job_1081779337> Checking if celery[redis] 5.5.3 needs updating
updater | 2025/08/22 07:50:08 INFO <job_1081779337> Fetching release information from json registry at https://pypi.org/pypi/ for celery[redis]
updater | 2025/08/22 07:50:08 WARN <job_1081779337> Unexpected error in JSON fetch: bad URI (is not URI?): "https://pypi.org/pypi/celery[redis]/json". Falling back to HTML.
2025/08/22 07:50:08 INFO <job_1081779337> Fetching release information from html registry at https://pypi.org/simple/ for celery[redis]
  proxy | 2025/08/22 07:50:08 [302] GET https://pypi.org/simple/celery/
  proxy | 2025/08/22 07:50:08 [302] 200 https://pypi.org/simple/celery/
```

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

HTML URL already uses normalized name and JSON endpoints follow a similar convention.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
