### PR TITLE
NPM error found on release PR is fixed here

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -516,18 +516,17 @@ module Dependabot
           if (error_message.include?("No matching vers") ||
              error_message.include?("404 Not Found") ||
              error_message.include?("Non-registry package missing package") ||
-             error_message.include?("Invalid tag name")) &&
+             error_message.include?("Invalid tag name") ||
+             error_message.match?(NPM6_MISSING_GIT_REF) ||
+             error_message.match?(NPM8_MISSING_GIT_REF)) &&
              !resolvable_before_update?
             raise_resolvability_error(error_message)
           end
 
-          # Handle missing git reference errors separately. npm can error with
-          # greppable messages like "did not match any file(s) known to git".
-          # These are best surfaced as GitDependenciesNotReachable so callers
-          # can treat them as unreachable git dependencies (Yarn can sometimes
-          # silently succeed where npm fails).
-          if error_message.match?(NPM6_MISSING_GIT_REF) || error_message.match?(NPM8_MISSING_GIT_REF)
-            raise Dependabot::GitDependenciesNotReachable
+          # NOTE: This check was introduced in npm8/arborist
+          if error_message.include?("must provide string spec")
+            msg = "Error parsing your package.json manifest: the version requirement must be a string."
+            raise Dependabot::DependencyFileNotParseable, msg
           end
 
           if error_message.match?(PREMATURE_CLOSE)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
       it "raises a helpful error" do
         expect { updated_npm_lock_content }
-          .to raise_error(Dependabot::DependencyFileNotParseable)
+          .to raise_error(Dependabot::DependencyFileNotResolvable)
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
 
       it "raises a helpful error" do
         expect { updated_npm_lock_content }
-          .to raise_error(Dependabot::GitDependenciesNotReachable)
+          .to raise_error(Dependabot::DependencyFileNotParseable)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixing the npm error on the gem release PR
PR: https://github.com/dependabot/dependabot-core/pull/12900
Failing CI: https://github.com/dependabot/dependabot-core/actions/runs/17136748425/job/48614480727?pr=12900


### Anything you want to highlight for special attention from reviewers?

Related PR updates: https://github.com/dependabot/dependabot-core/commit/35e0d994d28b0370f6a3edfa3a64f5f5cb19a358#diff-3bef8da3dc328cdacd3164c9818a8d9dd8a0969def3d06e5230cd3aa64f32f18R427

### How will you know you've accomplished your goal?

Ran rspec in local ensured no errors

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
