### PR TITLE
Bump poetry from 2.1.1 to 2.2.0 in /python/helpers in the poetry group

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -4,7 +4,7 @@ flake8==7.3.0
 hashin==1.0.5
 pipenv==2024.4.1
 plette==2.1.0
-poetry==2.1.1
+poetry==2.2.0
 # TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
 tomli==2.2.1
 


### PR DESCRIPTION
### What are you trying to accomplish?

Bump poetry version to latest release.

<!-- What issues does this affect or fix? -->

This is a patch version upgrade so it should be good

Fixes #13038 