### PR TITLE
Fix Go modules vanity import SSH URL failures by configuring git rewrite rules

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -251,7 +251,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Configure git rewrite rules for vanity import hosts by actually resolving them
               # This prevents SSH URL failures when Go toolchain discovers git hosts from vanity imports
-              UpdaterHelper.configure_git_vanity_imports(dependencies)
+              UpdaterHelper.configure_git_vanity_imports(dependencies, credentials)
 
               yield
             end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -253,7 +253,7 @@ module Dependabot
               # This prevents SSH URL failures when Go toolchain discovers git hosts from vanity imports
               UpdaterHelper.configure_git_vanity_imports(dependencies)
 
-              block.call
+              yield
             end
           end
         end

--- a/go_modules/lib/dependabot/go_modules/file_updater/updater_helper.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/updater_helper.rb
@@ -8,33 +8,34 @@ require "dependabot/go_modules/vanity_import_resolver"
 
 module Dependabot
   module GoModules
-    class FileUpdater
-      module UpdaterHelper
-        extend T::Sig
+    module UpdaterHelper
+      extend T::Sig
 
-        # Configure git rewrite rules for vanity import hosts
-        # This prevents SSH URL failures when Go toolchain discovers git hosts from vanity imports
-        sig { params(dependencies: T::Array[Dependabot::Dependency]).void }
-        def self.configure_git_vanity_imports(dependencies)
-          return unless dependencies.any?
+      # Configure git rewrite rules for vanity import hosts
+      # This prevents SSH URL failures when Go toolchain discovers git hosts from vanity imports
+      sig { params(dependencies: T::Array[Dependabot::Dependency], credentials: T::Array[Dependabot::Credential]).void }
+      def self.configure_git_vanity_imports(dependencies, credentials)
+        return unless dependencies.any?
 
-          resolver = Dependabot::GoModules::VanityImportResolver.new(dependencies: dependencies)
-          return unless resolver.has_vanity_imports?
+        resolver = Dependabot::GoModules::VanityImportResolver.new(
+          dependencies: dependencies,
+          credentials: credentials
+        )
+        return unless resolver.vanity_imports?
 
-          begin
-            git_hosts = resolver.resolve_git_hosts
+        begin
+          git_hosts = resolver.resolve_git_hosts
 
-            if git_hosts.any?
-              git_hosts.each do |host|
-                SharedHelpers.configure_git_to_use_https(host)
-              end
-              Dependabot.logger.info("Configured git rewrite rules for #{git_hosts.length} vanity import host(s)")
+          if git_hosts.any?
+            git_hosts.each do |host|
+              SharedHelpers.configure_git_to_use_https(host)
             end
-          rescue => e
-            # Log the error but don't fail the entire update process
-            # Vanity import resolution is an optimization, not a requirement
-            Dependabot.logger.warn("Failed to configure vanity git hosts: #{e.message}")
+            Dependabot.logger.info("Configured git rewrite rules for #{git_hosts.length} vanity import host(s)")
           end
+        rescue StandardError => e
+          # Log the error but don't fail the entire update process
+          # Vanity import resolution is an optimization, not a requirement
+          Dependabot.logger.warn("Failed to configure vanity git hosts: #{e.message}")
         end
       end
     end

--- a/go_modules/lib/dependabot/go_modules/file_updater/updater_helper.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/updater_helper.rb
@@ -1,0 +1,42 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/logger"
+require "dependabot/shared_helpers"
+require "dependabot/go_modules/vanity_import_resolver"
+
+module Dependabot
+  module GoModules
+    class FileUpdater
+      module UpdaterHelper
+        extend T::Sig
+
+        # Configure git rewrite rules for vanity import hosts
+        # This prevents SSH URL failures when Go toolchain discovers git hosts from vanity imports
+        sig { params(dependencies: T::Array[Dependabot::Dependency]).void }
+        def self.configure_git_vanity_imports(dependencies)
+          return unless dependencies.any?
+
+          resolver = Dependabot::GoModules::VanityImportResolver.new(dependencies: dependencies)
+          return unless resolver.has_vanity_imports?
+
+          begin
+            git_hosts = resolver.resolve_git_hosts
+
+            if git_hosts.any?
+              git_hosts.each do |host|
+                SharedHelpers.configure_git_to_use_https(host)
+              end
+              Dependabot.logger.info("Configured git rewrite rules for #{git_hosts.length} vanity import host(s)")
+            end
+          rescue => e
+            # Log the error but don't fail the entire update process
+            # Vanity import resolution is an optimization, not a requirement
+            Dependabot.logger.warn("Failed to configure vanity git hosts: #{e.message}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb
@@ -72,7 +72,7 @@ module Dependabot
         def fetch_available_versions
           SharedHelpers.in_a_temporary_directory do
             SharedHelpers.with_git_configured(credentials: credentials) do
-              UpdaterHelper.configure_git_vanity_imports([dependency])
+              UpdaterHelper.configure_git_vanity_imports([dependency], credentials)
               manifest = parse_manifest
 
               # Set up an empty go.mod so 'go list -m' won't attempt to download dependencies. This

--- a/go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb
@@ -10,6 +10,7 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/requirement"
 require "dependabot/go_modules/resolvability_errors"
+require "dependabot/go_modules/file_updater/updater_helper"
 
 module Dependabot
   module GoModules
@@ -71,6 +72,7 @@ module Dependabot
         def fetch_available_versions
           SharedHelpers.in_a_temporary_directory do
             SharedHelpers.with_git_configured(credentials: credentials) do
+              UpdaterHelper.configure_git_vanity_imports([dependency])
               manifest = parse_manifest
 
               # Set up an empty go.mod so 'go list -m' won't attempt to download dependencies. This

--- a/go_modules/lib/dependabot/go_modules/vanity_import_resolver.rb
+++ b/go_modules/lib/dependabot/go_modules/vanity_import_resolver.rb
@@ -1,0 +1,180 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "excon"
+require "dependabot/logger"
+
+module Dependabot
+  module GoModules
+    # Helper class for resolving vanity imports and extracting git hosts
+    # This can be used across the Go modules ecosystem (file updater, update checker, etc.)
+    # to handle vanity imports that redirect to actual git repositories
+    class VanityImportResolver
+      extend T::Sig
+
+      # Known public hosting providers that don't require vanity import resolution
+      KNOWN_PUBLIC_HOSTS = T.let([
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org"
+      ].freeze, T::Array[String])
+
+      # Regex patterns for parsing git URLs from go-import meta tags
+      GO_IMPORT_META_TAG_REGEX = T.let(
+        /<meta[^>]*name=["']go-import["'][^>]*content=["']([^"']+)["']/,
+        Regexp
+      )
+
+      GIT_URL_HOST_REGEX = T.let(
+        /(?:ssh:\/\/git@|git@|https:\/\/)([^\/\s:]+)/,
+        Regexp
+      )
+
+      # Regex for identifying potential vanity import paths
+      VANITY_IMPORT_PATH_REGEX = T.let(
+        /^[^\/]+\.[^\/]+\//,
+        Regexp
+      )
+
+      # HTTP request configuration
+      GO_GET_QUERY_PARAM = "?go-get=1"
+      CONNECT_TIMEOUT_SECONDS = 10
+      READ_TIMEOUT_SECONDS = 10
+
+      # Common vanity import git host prefix
+      GIT_HOST_PREFIX = "git"
+
+      sig { params(dependencies: T::Array[Dependabot::Dependency]).void }
+      def initialize(dependencies:)
+        @dependencies = dependencies
+        @resolved_hosts = T.let(nil, T.nilable(T::Array[String]))
+      end
+
+      # Resolve vanity imports by fetching go-get=1 metadata, with fallback to prediction
+      # Returns array of git hosts that need git rewrite rules configured
+      # Results are memoized since dependencies don't change during processing
+      sig { returns(T::Array[String]) }
+      def resolve_git_hosts
+        @resolved_hosts ||= perform_resolution
+      end
+
+      # Check if any of the dependencies are potential vanity imports
+      sig { returns(T::Boolean) }
+      def has_vanity_imports?
+        vanity_dependencies.any?
+      end
+
+      # Get only the dependencies that are potential vanity imports
+      sig { returns(T::Array[Dependabot::Dependency]) }
+      def vanity_dependencies
+        @dependencies.select do |dep|
+          path = dep.name
+          # Skip known public hosting providers
+          next false if KNOWN_PUBLIC_HOSTS.any? { |host| path.start_with?("#{host}/") }
+
+          # Check if this looks like a vanity import (has domain with dots)
+          path.match?(VANITY_IMPORT_PATH_REGEX)
+        end
+      end
+
+      private
+
+      sig { returns(T::Array[Dependabot::Dependency]) }
+      attr_reader :dependencies
+
+      sig { returns(T::Array[String]) }
+      def perform_resolution
+        return [] unless has_vanity_imports?
+
+        git_hosts = Set.new
+
+        vanity_dependencies.each do |dep|
+          path = dep.name
+
+          begin
+            # Make the same request that Go toolchain makes for vanity import resolution
+            response = Excon.get(
+              "https://#{path}#{GO_GET_QUERY_PARAM}",
+              connect_timeout: CONNECT_TIMEOUT_SECONDS,
+              read_timeout: READ_TIMEOUT_SECONDS
+            )
+
+            if response.status == 200
+              resolved_hosts = extract_git_hosts_from_go_import_meta(response.body)
+              if resolved_hosts.any?
+                git_hosts.merge(resolved_hosts)
+              else
+                # Fall back to prediction if we can't parse the response
+                domain = T.must(path.split('/').first)
+                git_hosts.merge(predict_git_hosts_from_domain(domain))
+              end
+            else
+              # Fall back to prediction for non-200 responses
+              domain = T.must(path.split('/').first)
+              git_hosts.merge(predict_git_hosts_from_domain(domain))
+            end
+          rescue => e
+            # Fall back to prediction for any network/parsing errors
+            Dependabot.logger.debug("Error resolving vanity import #{path}: #{e.message}, using prediction")
+            domain = T.must(path.split('/').first)
+            git_hosts.merge(predict_git_hosts_from_domain(domain))
+          end
+        end
+
+        # Return all discovered git hosts - SharedHelpers.configure_git_to_use_https handles any host
+        git_hosts.to_a
+      end
+
+      # Extract git hosts from all go-import meta tags in HTML response
+      # A page can have multiple meta tags for different import prefixes
+      # Example: <meta name="go-import" content="go.example.com/pkg git ssh://git@git.example.com/pkg">
+      sig { params(html_body: String).returns(T::Array[String]) }
+      def extract_git_hosts_from_go_import_meta(html_body)
+        hosts = Set.new
+
+        # Find all go-import meta tags
+        html_body.scan(GO_IMPORT_META_TAG_REGEX) do |content_match|
+          content = content_match[0]
+          parts = content.split(/\s+/)
+          next unless parts.length >= 3
+
+          vcs_url = parts[2]
+
+          # Extract host from various git URL formats:
+          # ssh://git@git.example.com/repo → git.example.com
+          # git@git.example.com:repo → git.example.com
+          # https://git.example.com/repo → git.example.com
+          if (host_match = vcs_url.match(GIT_URL_HOST_REGEX))
+            hosts << host_match[1]
+          end
+        end
+
+        hosts.to_a
+      rescue => e
+        Dependabot.logger.debug("Error parsing go-import meta tags: #{e.message}")
+        []
+      end
+
+      # Fallback prediction logic for when vanity import resolution fails
+      sig { params(domain: String).returns(T::Set[String]) }
+      def predict_git_hosts_from_domain(domain)
+        hosts = Set.new([domain])
+
+        if domain.include?(".")
+          parts = domain.split(".")
+          if parts.length >= 2
+            # Common pattern: go.company.com → git.company.com
+            git_domain = [GIT_HOST_PREFIX] + T.must(parts[1..-1])
+            hosts << git_domain.join(".")
+          end
+        end
+
+        hosts
+      rescue => e
+        Dependabot.logger.debug("Error predicting git hosts for domain #{domain}: #{e.message}")
+        Set.new([domain])
+      end
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/file_updater/updater_helper_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/updater_helper_spec.rb
@@ -1,0 +1,211 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/shared_helpers"
+require "dependabot/go_modules/file_updater/updater_helper"
+
+RSpec.describe Dependabot::GoModules::FileUpdater::UpdaterHelper do
+  describe ".configure_git_vanity_imports" do
+    let(:dependencies) { [] }
+
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:configure_git_to_use_https)
+      allow(Dependabot.logger).to receive(:info)
+      allow(Dependabot.logger).to receive(:warn)
+    end
+
+    context "with no dependencies" do
+      let(:dependencies) { [] }
+
+      it "returns early without configuration" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(Dependabot::SharedHelpers).not_to have_received(:configure_git_to_use_https)
+        expect(Dependabot.logger).not_to have_received(:info)
+      end
+    end
+
+    context "with only public hosting provider dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "github.com/user/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns early without configuration" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(Dependabot::SharedHelpers).not_to have_received(:configure_git_to_use_https)
+        expect(Dependabot.logger).not_to have_received(:info)
+      end
+    end
+
+    context "with vanity import dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        # Mock successful vanity import resolution
+        resolver = instance_double(Dependabot::GoModules::VanityImportResolver)
+        allow(Dependabot::GoModules::VanityImportResolver).to receive(:new)
+          .with(dependencies: dependencies)
+          .and_return(resolver)
+        allow(resolver).to receive(:has_vanity_imports?).and_return(true)
+        allow(resolver).to receive(:resolve_git_hosts).and_return(["git.example.com"])
+      end
+
+      it "configures git rewrite rules for discovered git hosts" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(Dependabot::SharedHelpers).to have_received(:configure_git_to_use_https)
+          .with("git.example.com")
+        expect(Dependabot.logger).to have_received(:info)
+          .with("Configured git rewrite rules for 1 vanity import host(s)")
+      end
+    end
+
+    context "with multiple vanity import dependencies resolving to multiple hosts" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg1",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "custom.company.com/pkg2",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        resolver = instance_double(Dependabot::GoModules::VanityImportResolver)
+        allow(Dependabot::GoModules::VanityImportResolver).to receive(:new)
+          .with(dependencies: dependencies)
+          .and_return(resolver)
+        allow(resolver).to receive(:has_vanity_imports?).and_return(true)
+        allow(resolver).to receive(:resolve_git_hosts)
+          .and_return(["git.example.com", "git.company.com"])
+      end
+
+      it "configures git rewrite rules for all discovered hosts" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(Dependabot::SharedHelpers).to have_received(:configure_git_to_use_https)
+          .with("git.example.com")
+        expect(Dependabot::SharedHelpers).to have_received(:configure_git_to_use_https)
+          .with("git.company.com")
+        expect(Dependabot.logger).to have_received(:info)
+          .with("Configured git rewrite rules for 2 vanity import host(s)")
+      end
+    end
+
+    context "when vanity import resolution fails" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        resolver = instance_double(Dependabot::GoModules::VanityImportResolver)
+        allow(Dependabot::GoModules::VanityImportResolver).to receive(:new)
+          .with(dependencies: dependencies)
+          .and_return(resolver)
+        allow(resolver).to receive(:has_vanity_imports?).and_return(true)
+        allow(resolver).to receive(:resolve_git_hosts)
+          .and_raise(StandardError.new("Network timeout"))
+      end
+
+      it "logs a warning but does not fail the entire process" do
+        expect { described_class.configure_git_vanity_imports(dependencies) }
+          .not_to raise_error
+
+        expect(Dependabot.logger).to have_received(:warn)
+          .with("Failed to configure vanity git hosts: Network timeout")
+        expect(Dependabot::SharedHelpers).not_to have_received(:configure_git_to_use_https)
+      end
+    end
+
+    context "when resolver indicates no vanity imports" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        resolver = instance_double(Dependabot::GoModules::VanityImportResolver)
+        allow(Dependabot::GoModules::VanityImportResolver).to receive(:new)
+          .with(dependencies: dependencies)
+          .and_return(resolver)
+        allow(resolver).to receive(:has_vanity_imports?).and_return(false)
+      end
+
+      it "returns early without calling resolve_git_hosts" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(resolver).not_to have_received(:resolve_git_hosts)
+        expect(Dependabot::SharedHelpers).not_to have_received(:configure_git_to_use_https)
+      end
+    end
+
+    context "when resolver returns empty git hosts array" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        resolver = instance_double(Dependabot::GoModules::VanityImportResolver)
+        allow(Dependabot::GoModules::VanityImportResolver).to receive(:new)
+          .with(dependencies: dependencies)
+          .and_return(resolver)
+        allow(resolver).to receive(:has_vanity_imports?).and_return(true)
+        allow(resolver).to receive(:resolve_git_hosts).and_return([])
+      end
+
+      it "does not configure any git hosts" do
+        described_class.configure_git_vanity_imports(dependencies)
+
+        expect(Dependabot::SharedHelpers).not_to have_received(:configure_git_to_use_https)
+        expect(Dependabot.logger).not_to have_received(:info)
+      end
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/vanity_import_resolver_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/vanity_import_resolver_spec.rb
@@ -1,0 +1,603 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/go_modules/vanity_import_resolver"
+
+RSpec.describe Dependabot::GoModules::VanityImportResolver do
+  let(:resolver) { described_class.new(dependencies: dependencies) }
+  let(:dependencies) { [] }
+
+  describe "#initialize" do
+    it "stores the dependencies" do
+      dep = Dependabot::Dependency.new(
+        name: "go.example.com/pkg",
+        version: "v1.0.0",
+        requirements: [],
+        package_manager: "go_modules"
+      )
+      resolver = described_class.new(dependencies: [dep])
+      expect(resolver.instance_variable_get(:@dependencies)).to eq([dep])
+    end
+  end
+
+  describe "#has_vanity_imports?" do
+    context "with no dependencies" do
+      let(:dependencies) { [] }
+
+      it "returns false" do
+        expect(resolver.has_vanity_imports?).to be false
+      end
+    end
+
+    context "with only public hosting provider dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "github.com/user/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "gitlab.com/group/project",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns false" do
+        expect(resolver.has_vanity_imports?).to be false
+      end
+    end
+
+    context "with vanity import dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "go.example.com/pkg",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns true" do
+        expect(resolver.has_vanity_imports?).to be true
+      end
+    end
+
+    context "with mixed dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "github.com/user/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "go.company.com/internal/utils",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns true" do
+        expect(resolver.has_vanity_imports?).to be true
+      end
+    end
+  end
+
+  describe "#vanity_dependencies" do
+    context "with no dependencies" do
+      let(:dependencies) { [] }
+
+      it "returns empty array" do
+        expect(resolver.vanity_dependencies).to eq([])
+      end
+    end
+
+    context "with only public hosting provider dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "github.com/user/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "gitlab.com/group/project",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "bitbucket.org/team/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns empty array" do
+        expect(resolver.vanity_dependencies).to eq([])
+      end
+    end
+
+    context "with vanity import dependencies" do
+      let(:vanity_dep1) do
+        Dependabot::Dependency.new(
+          name: "go.example.com/pkg",
+          version: "v1.0.0",
+          requirements: [],
+          package_manager: "go_modules"
+        )
+      end
+
+      let(:vanity_dep2) do
+        Dependabot::Dependency.new(
+          name: "custom.company.com/internal/tools",
+          version: "v1.0.0",
+          requirements: [],
+          package_manager: "go_modules"
+        )
+      end
+
+      let(:dependencies) { [vanity_dep1, vanity_dep2] }
+
+      it "returns only vanity import dependencies" do
+        expect(resolver.vanity_dependencies).to contain_exactly(vanity_dep1, vanity_dep2)
+      end
+    end
+
+    context "with mixed dependencies" do
+      let(:github_dep) do
+        Dependabot::Dependency.new(
+          name: "github.com/user/repo",
+          version: "v1.0.0",
+          requirements: [],
+          package_manager: "go_modules"
+        )
+      end
+
+      let(:vanity_dep) do
+        Dependabot::Dependency.new(
+          name: "go.company.com/internal/utils",
+          version: "v1.0.0",
+          requirements: [],
+          package_manager: "go_modules"
+        )
+      end
+
+      let(:dependencies) { [github_dep, vanity_dep] }
+
+      it "returns only vanity import dependencies" do
+        expect(resolver.vanity_dependencies).to contain_exactly(vanity_dep)
+      end
+    end
+
+    context "with edge case dependency names" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "localhost/test", # No dots in domain - should be filtered out
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          Dependabot::Dependency.new(
+            name: "go.uber.org/zap", # Valid vanity import
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "only includes valid vanity imports with domain-like paths" do
+        expect(resolver.vanity_dependencies.map(&:name)).to eq(["go.uber.org/zap"])
+      end
+    end
+  end
+
+  describe "#resolve_git_hosts" do
+    let(:dependencies) do
+      [
+        Dependabot::Dependency.new(
+          name: "go.example.com/pkg",
+          version: "v1.0.0",
+          requirements: [],
+          package_manager: "go_modules"
+        )
+      ]
+    end
+
+    before do
+      # Mock HTTP response for vanity import resolution
+      response_body = <<~HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta name="go-import" content="go.example.com/pkg git ssh://git@git.example.com/pkg">
+          <meta name="go-source" content="go.example.com/pkg https://git.example.com/pkg https://git.example.com/pkg/tree/HEAD{/dir} https://git.example.com/pkg/tree/HEAD{/dir}/{file}#L{line}">
+        </head>
+        <body>Nothing to see here</body>
+        </html>
+      HTML
+
+      stub_request(:get, "https://go.example.com/pkg?go-get=1")
+        .to_return(status: 200, body: response_body)
+    end
+
+    it "resolves git hosts from vanity import responses" do
+      git_hosts = resolver.resolve_git_hosts
+      expect(git_hosts).to include("git.example.com")
+    end
+
+    it "memoizes the result" do
+      # First call
+      result1 = resolver.resolve_git_hosts
+      # Second call should return the same cached result
+      result2 = resolver.resolve_git_hosts
+      expect(result1).to equal(result2)
+    end
+
+    context "when HTTP request fails" do
+      before do
+        stub_request(:get, "https://go.example.com/pkg?go-get=1")
+          .to_raise(StandardError.new("Network error"))
+      end
+
+      it "falls back to prediction" do
+        git_hosts = resolver.resolve_git_hosts
+        # Should include predicted hosts based on domain pattern
+        expect(git_hosts).to include("go.example.com")
+        expect(git_hosts).to include("git.example.com")
+      end
+    end
+
+    context "when HTTP returns non-200 status" do
+      before do
+        stub_request(:get, "https://go.example.com/pkg?go-get=1")
+          .to_return(status: 404, body: "Not found")
+      end
+
+      it "falls back to prediction" do
+        git_hosts = resolver.resolve_git_hosts
+        expect(git_hosts).to include("go.example.com")
+        expect(git_hosts).to include("git.example.com")
+      end
+    end
+
+    context "when HTML response has malformed go-import meta tags" do
+      before do
+        stub_request(:get, "https://go.example.com/pkg?go-get=1")
+          .to_return(status: 200, body: "<html><body>Invalid HTML</body></html>")
+      end
+
+      it "falls back to prediction" do
+        git_hosts = resolver.resolve_git_hosts
+        expect(git_hosts).to include("go.example.com")
+        expect(git_hosts).to include("git.example.com")
+      end
+    end
+
+    context "with no vanity dependencies" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "github.com/user/repo",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      it "returns empty array" do
+        expect(resolver.resolve_git_hosts).to eq([])
+      end
+    end
+  end
+
+  describe "#extract_git_hosts_from_go_import_meta" do
+    let(:resolver) { described_class.new(dependencies: []) }
+
+    it "extracts git hosts from valid go-import meta tags" do
+      html = <<~HTML
+        <meta name="go-import" content="go.example.com/pkg git ssh://git@git.example.com/pkg">
+      HTML
+
+      hosts = resolver.send(:extract_git_hosts_from_go_import_meta, html)
+      expect(hosts).to eq(["git.example.com"])
+    end
+
+    it "extracts hosts from multiple go-import meta tags" do
+      html = <<~HTML
+        <meta name="go-import" content="go.example.com/pkg git ssh://git@git.example.com/pkg">
+        <meta name="go-import" content="go.example.com/tools git https://code.example.com/tools">
+      HTML
+
+      hosts = resolver.send(:extract_git_hosts_from_go_import_meta, html)
+      expect(hosts).to contain_exactly("git.example.com", "code.example.com")
+    end
+
+    it "handles different git URL formats" do
+      html = <<~HTML
+        <meta name="go-import" content="pkg1 git ssh://git@host1.com/repo">
+        <meta name="go-import" content="pkg2 git git@host2.com:repo">
+        <meta name="go-import" content="pkg3 git https://host3.com/repo">
+      HTML
+
+      hosts = resolver.send(:extract_git_hosts_from_go_import_meta, html)
+      expect(hosts).to contain_exactly("host1.com", "host2.com", "host3.com")
+    end
+
+    it "returns empty array for malformed HTML" do
+      html = "<html>No meta tags</html>"
+      hosts = resolver.send(:extract_git_hosts_from_go_import_meta, html)
+      expect(hosts).to eq([])
+    end
+
+    it "handles parsing errors gracefully" do
+      html = "invalid html <meta"
+      hosts = resolver.send(:extract_git_hosts_from_go_import_meta, html)
+      expect(hosts).to eq([])
+    end
+  end
+
+  describe "#predict_git_hosts_from_domain" do
+    let(:resolver) { described_class.new(dependencies: []) }
+
+    it "includes the domain itself" do
+      hosts = resolver.send(:predict_git_hosts_from_domain, "go.company.com")
+      expect(hosts).to include("go.company.com")
+    end
+
+    it "predicts git.domain pattern for multi-level domains" do
+      hosts = resolver.send(:predict_git_hosts_from_domain, "go.company.com")
+      expect(hosts).to include("git.company.com")
+    end
+
+    it "handles single-level domains" do
+      hosts = resolver.send(:predict_git_hosts_from_domain, "localhost")
+      expect(hosts).to include("localhost")
+    end
+
+    it "handles domains with multiple subdomains" do
+      hosts = resolver.send(:predict_git_hosts_from_domain, "api.internal.company.com")
+      expect(hosts).to include("api.internal.company.com")
+      expect(hosts).to include("git.internal.company.com")
+    end
+  end
+
+  describe "constants" do
+    it "defines known public hosts" do
+      expect(described_class::KNOWN_PUBLIC_HOSTS).to include("github.com")
+      expect(described_class::KNOWN_PUBLIC_HOSTS).to include("gitlab.com")
+      expect(described_class::KNOWN_PUBLIC_HOSTS).to include("bitbucket.org")
+    end
+
+    it "defines HTTP configuration constants" do
+      expect(described_class::GO_GET_QUERY_PARAM).to eq("?go-get=1")
+      expect(described_class::CONNECT_TIMEOUT_SECONDS).to eq(10)
+      expect(described_class::READ_TIMEOUT_SECONDS).to eq(10)
+    end
+
+    it "defines regex patterns" do
+      expect(described_class::GO_IMPORT_META_TAG_REGEX).to be_a(Regexp)
+      expect(described_class::GIT_URL_HOST_REGEX).to be_a(Regexp)
+      expect(described_class::VANITY_IMPORT_PATH_REGEX).to be_a(Regexp)
+    end
+  end
+
+  describe "common vanity import scenarios" do
+    context "with enterprise vanity imports (SSH URL handling)" do
+      let(:dependencies) do
+        [
+          # Kubernetes client-go - common vanity import that redirects to GitHub
+          Dependabot::Dependency.new(
+            name: "k8s.io/client-go",
+            version: "v0.30.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          # Google APIs - another common vanity import
+          Dependabot::Dependency.new(
+            name: "google.golang.org/api",
+            version: "v0.150.0",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          # Corporate internal package with vanity domain
+          Dependabot::Dependency.new(
+            name: "code.enterprise.com/platform/auth",
+            version: "v1.2.3",
+            requirements: [],
+            package_manager: "go_modules"
+          ),
+          # Regular GitHub dependency (should be ignored)
+          Dependabot::Dependency.new(
+            name: "github.com/stretchr/testify",
+            version: "v1.8.4",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        # Mock k8s.io/client-go -> redirects to GitHub with SSH URL (like customer issue)
+        stub_request(:get, "https://k8s.io/client-go?go-get=1")
+          .to_return(
+            status: 200,
+            body: <<~HTML
+              <html>
+              <head>
+                <meta name="go-import" content="k8s.io/client-go git ssh://git@github.com/kubernetes/client-go">
+                <meta name="go-source" content="k8s.io/client-go https://github.com/kubernetes/client-go https://github.com/kubernetes/client-go/tree/master{/dir} https://github.com/kubernetes/client-go/blob/master{/dir}/{file}#L{line}">
+              </head>
+              </html>
+            HTML
+          )
+
+        # Mock google.golang.org/api -> redirects to googlesource with HTTPS
+        stub_request(:get, "https://google.golang.org/api?go-get=1")
+          .to_return(
+            status: 200,
+            body: <<~HTML
+              <html>
+              <head>
+                <meta name="go-import" content="google.golang.org/api git https://go.googlesource.com/api">
+              </head>
+              </html>
+            HTML
+          )
+
+        # Mock enterprise vanity import -> internal GitLab with SSH
+        stub_request(:get, "https://code.enterprise.com/platform/auth?go-get=1")
+          .to_return(
+            status: 200,
+            body: <<~HTML
+              <html>
+              <head>
+                <meta name="go-import" content="code.enterprise.com/platform/auth git ssh://git@gitlab.enterprise.com/platform/auth">
+              </head>
+              </html>
+            HTML
+          )
+      end
+
+      it "identifies vanity import dependencies correctly" do
+        vanity_deps = resolver.vanity_dependencies
+        expect(vanity_deps.map(&:name)).to contain_exactly(
+          "k8s.io/client-go",
+          "google.golang.org/api", 
+          "code.enterprise.com/platform/auth"
+        )
+      end
+
+      it "resolves git hosts from vanity import meta tags" do
+        git_hosts = resolver.resolve_git_hosts
+        
+        # Should extract git hosts from SSH and HTTPS URLs
+        hosts = git_hosts.map { |entry| entry[:git] }
+        expect(hosts).to include("github.com/kubernetes/client-go")
+        expect(hosts).to include("go.googlesource.com/api")
+        expect(hosts).to include("gitlab.enterprise.com/platform/auth")
+      end
+
+      it "handles mixed SSH and HTTPS git URLs correctly" do
+        git_hosts = resolver.resolve_git_hosts
+        
+        # Should work with both SSH (github.com/kubernetes/client-go) and HTTPS formats
+        k8s_entry = git_hosts.find { |entry| entry[:vanity] == "k8s.io/client-go" }
+        expect(k8s_entry[:git]).to eq("github.com/kubernetes/client-go")
+        
+        google_entry = git_hosts.find { |entry| entry[:vanity] == "google.golang.org/api" }
+        expect(google_entry[:git]).to eq("go.googlesource.com/api")
+        
+        enterprise_entry = git_hosts.find { |entry| entry[:vanity] == "code.enterprise.com/platform/auth" }
+        expect(enterprise_entry[:git]).to eq("gitlab.enterprise.com/platform/auth")
+      end
+
+      context "when vanity import resolution fails (network issues)" do
+        before do
+          # Simulate network timeout for one vanity import
+          stub_request(:get, "https://k8s.io/client-go?go-get=1")
+            .to_timeout
+        end
+
+        it "falls back to prediction and continues processing other imports" do
+          git_hosts = resolver.resolve_git_hosts
+          
+          # Should predict k8s.io -> github.com mapping and still process others
+          predicted_hosts = git_hosts.select { |entry| entry[:vanity] == "k8s.io/client-go" }
+          expect(predicted_hosts).not_to be_empty
+          
+          # Should still resolve other working vanity imports
+          google_entry = git_hosts.find { |entry| entry[:vanity] == "google.golang.org/api" }
+          expect(google_entry).not_to be_nil
+        end
+      end
+
+      context "when vanity import returns malformed HTML" do
+        before do
+          stub_request(:get, "https://code.enterprise.com/platform/auth?go-get=1")
+            .to_return(
+              status: 200,
+              body: "<html><body>Not a valid go-import page</body></html>"
+            )
+        end
+
+        it "falls back to prediction for malformed responses" do
+          git_hosts = resolver.resolve_git_hosts
+          
+          # Should predict based on domain pattern
+          enterprise_entries = git_hosts.select { |entry| entry[:vanity] == "code.enterprise.com/platform/auth" }
+          expect(enterprise_entries).not_to be_empty
+          
+          # Should still resolve working vanity imports
+          k8s_entry = git_hosts.find { |entry| entry[:vanity] == "k8s.io/client-go" }
+          expect(k8s_entry).not_to be_nil
+        end
+      end
+    end
+
+    context "SSH URL vanity import scenario" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "internal.company.com/shared/logger",
+            version: "v1.0.0",
+            requirements: [],
+            package_manager: "go_modules"
+          )
+        ]
+      end
+
+      before do
+        # Mock vanity import response with SSH URL
+        stub_request(:get, "https://internal.company.com/shared/logger?go-get=1")
+          .to_return(
+            status: 200,
+            body: <<~HTML
+              <html>
+              <head>
+                <meta name="go-import" content="internal.company.com/shared/logger git ssh://git@git.company.com/shared/logger.git">
+              </head>
+              </html>
+            HTML
+          )
+      end
+
+      it "extracts git host from SSH URL for git rewrite rules" do
+        git_hosts = resolver.resolve_git_hosts
+        
+        expect(git_hosts).to have(1).item
+        expect(git_hosts.first[:vanity]).to eq("internal.company.com/shared/logger")
+        expect(git_hosts.first[:git]).to eq("git.company.com/shared/logger.git")
+      end
+
+      it "enables proper git configuration to convert SSH to HTTPS" do
+        # This test verifies the extracted host can be used for git rewrite rules
+        git_hosts = resolver.resolve_git_hosts
+        git_host = git_hosts.first[:git]
+        
+        # The extracted host should be usable for SharedHelpers.configure_git_to_use_https
+        expect(git_host).to match(/^git\.company\.com\//)
+        expect(git_host).not_to include("ssh://")
+        expect(git_host).not_to include("git@")
+      end
+    end
+  end
+end

--- a/go_modules/spec/fixtures/projects/vanity_imports/go.mod
+++ b/go_modules/spec/fixtures/projects/vanity_imports/go.mod
@@ -1,0 +1,8 @@
+module example.com/vanity-test
+
+go 1.20
+
+require (
+	k8s.io/client-go v0.29.0
+	gonum.org/v1/gonum v0.14.0
+)

--- a/go_modules/spec/fixtures/projects/vanity_imports/main.go
+++ b/go_modules/spec/fixtures/projects/vanity_imports/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"gonum.org/v1/gonum/floats"
+)
+
+func main() {
+	fmt.Println("Using vanity imports")
+}

--- a/go_modules/spec/fixtures/projects/vanity_ssh_test/go.mod
+++ b/go_modules/spec/fixtures/projects/vanity_ssh_test/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vanity-ssh-test
+
+go 1.20
+
+require (
+	go.testcompany.local/shared/logger v1.0.0
+)

--- a/go_modules/spec/fixtures/projects/vanity_ssh_test/main.go
+++ b/go_modules/spec/fixtures/projects/vanity_ssh_test/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"go.testcompany.local/shared/logger"
+)
+
+func main() {
+	logger.Info("Hello world")
+	fmt.Println("Using vanity import with SSH URL")
+}

--- a/go_modules/spec/fixtures/projects/vanity_ssh_test/main.go
+++ b/go_modules/spec/fixtures/projects/vanity_ssh_test/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"go.testcompany.local/shared/logger"
 )
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes SSH URL failures when Go modules use vanity imports in Dependabot updates. The issue occurs when vanity import servers return SSH git URLs (like `ssh://git@git.company.com/repo`) in their go-import meta tags, but the target git hosts are not accessible via SSH in Dependabot's environment.

**What**: Proactively configure git rewrite rules to convert SSH URLs to HTTPS URLs for vanity import git hosts before Go toolchain execution.

**Why**: When Go toolchain (`go mod tidy`, `go get`, etc.) discovers SSH URLs from vanity import resolution, the subsequent `git ls-remote` commands fail with SSH connection errors, preventing Dependabot from updating Go module dependencies.

**Issues this fixes**: Addresses the root cause described in GitHub issue discussions where vanity imports like `go.ouryahoo.com/module` fail because they resolve to inaccessible SSH URLs.

### Anything you want to highlight for special attention from reviewers?

**Architecture Decision**: Created a dedicated `VanityImportResolver` class in the Go modules ecosystem rather than adding vanity-specific logic directly to the file updater. This approach:

1. **Reusability**: Can be used across Go modules components (file updater, update checker, etc.)
2. **Separation of concerns**: Keeps vanity import resolution logic isolated and testable
3. **Robustness**: Includes fallback prediction when HTTP resolution fails
4. **Performance**: Memoizes results since dependencies don't change during processing

**Integration Point**: The vanity import resolution happens during git configuration setup (line 254 in `go_mod_updater.rb`), ensuring git rewrite rules are configured before any Go toolchain commands execute.

**Error Handling**: Vanity import resolution failures are logged but don't break the update process, treating this as an optimization rather than a requirement.

### How will you know you've accomplished your goal?

**Before this fix**: 
- Go modules with vanity imports fail with SSH connection errors
- Error messages like `ssh: Could not resolve hostname git.company.com: Temporary failure in name resolution`
- Dependabot unable to update dependencies that use vanity imports

**After this fix**:
- Vanity import git hosts are automatically detected from go-import meta tags
- Git rewrite rules configured to convert SSH → HTTPS for discovered hosts
- Go toolchain commands succeed because SSH URLs are transparently rewritten to HTTPS
- Dependabot successfully updates Go modules with vanity imports

**Demonstration**: 
- The `VanityImportResolver` parses HTML responses from vanity servers to extract git hosts
- Git rewrite rules are configured via `SharedHelpers.configure_git_to_use_https(host)`
- Comprehensive test coverage will be added in follow-up commits

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.

**Note**: Comprehensive test coverage following Dependabot core standards will be added in subsequent commits as discussed.