### PR TITLE
feat(labeler): Respect custom labels

### DIFF
--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -71,6 +71,8 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def labels_for_pr
+        return *default_labels_for_pr if custom_labels
+
         [
           *default_labels_for_pr,
           includes_security_fixes? ? security_label : nil,


### PR DESCRIPTION
### What are you trying to accomplish?

Trying to allow an empty labels list.
I believe it will fix the following: #11783, #12345, #3465, #8232,

### Anything you want to highlight for special attention from reviewers?

My Ruby isn't very strong, so please correct me if I've misunderstood the codebase.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

If dependabot no longer creates pull requests with `patch`, `minor`, or `major` labels when custom labels are defined.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
