### PR TITLE
include old version number whenever possible

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: main
+  SMOKE_TEST_BRANCH: dev/brettfo/nuget-pr-title
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -32,6 +32,22 @@ public class PullRequestTextTests
         Assert.Equal(expectedTitle, actualTitle);
     }
 
+    [Fact]
+    public void FromClauseInTitleIsIncludedIfVersionUpdatesAreIdentical()
+    {
+        // this can happen if the same update was performed for multiple projects
+        var job = FromCommitOptions(null);
+        var updateOperations = new UpdateOperationBase[]
+        {
+            new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+            new DirectUpdate() { DependencyName = "Some.Dependency", OldVersion = NuGetVersion.Parse("1.0.0"), NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = [] },
+        };
+
+        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperations], dependencyGroupName: null);
+        var expectedTitle = "Bump Some.Dependency from 1.0.0 to 2.0.0";
+        Assert.Equal(expectedTitle, actualTitle);
+    }
+
     [Theory]
     [MemberData(nameof(GetPullRequestTextTestData))]
     public async Task PullRequestText(
@@ -422,7 +438,7 @@ public class PullRequestTextTests
                 new DirectUpdate()
                 {
                     DependencyName = "Some.Package",
-                    OldVersion = NuGetVersion.Parse("1.0.0"),
+                    OldVersion = NuGetVersion.Parse("1.1.0"),
                     NewVersion = NuGetVersion.Parse("1.2.3"),
                     UpdatedFiles = ["b.txt"]
                 }
@@ -439,6 +455,7 @@ public class PullRequestTextTests
             """
             Performed the following updates:
             - Updated Some.Package from 1.0.0 to 1.2.3
+            - Updated Some.Package from 1.1.0 to 1.2.3
             """
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -95,8 +95,11 @@ public class PullRequestTextGenerator
     private static string GetDependencySetBumpText(DependencySet dependencySet, bool isCommitMessageDetail)
     {
         var bumpSuffix = isCommitMessageDetail ? "s" : string.Empty; // "Bumps" for commit message details, "Bump" otherwise
-        var fromText = dependencySet.Versions.Length == 1 && dependencySet.Versions[0].OldVersion is not null
-            ? $"from {dependencySet.Versions[0].OldVersion} "
+        var versionSets = dependencySet.Versions
+            .DistinctBy(versionSet => $"{versionSet.OldVersion}/{versionSet.NewVersion}".ToLowerInvariant())
+            .ToArray();
+        var fromText = versionSets.Length == 1 && versionSets[0].OldVersion is not null
+            ? $"from {versionSets[0].OldVersion} "
             : string.Empty;
         var newVersions = dependencySet.Versions
             .Select(v => v.NewVersion)


### PR DESCRIPTION
When generating a PR title, the old version number is mentioned if only a single version update was performed.  If the same update was performed in multiple directories, however, this didn't happen.

The fix is to get the distinct set of old and new version numbers and only _then_ see if it's appropriate to mention the old version number.

Swift smoke test failure due to #12647.