### PR TITLE
reset smoke test branch

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: dev/brettfo/nuget-pr-title
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR #12962 required an update to the smoke tests which meant the smoke test branch had to be updated.  This is the final follow up to reset that to `main`.

Failing Swift smoke test is due to https://github.com/dependabot/dependabot-core/issues/12647.