### PR TITLE
Fix git rewrite rules: configure SSH-to-HTTPS rewriting when credentials handled by proxy

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -371,11 +371,12 @@ module Dependabot
       git_store_content = ""
       deduped_credentials.each do |cred|
         next unless cred["type"] == "git_source"
-        next unless cred["username"] && cred["password"]
 
-        authenticated_url =
-          "https://#{cred.fetch('username')}:#{cred.fetch('password')}" \
-          "@#{cred.fetch('host')}"
+        has_creds = cred["username"] && cred["password"]
+
+        # Build authenticated URL with credentials if available
+        creds = has_creds ? "#{cred.fetch('username')}:#{cred.fetch('password')}@" : ""
+        authenticated_url = "https://#{creds}#{cred.fetch('host')}"
 
         git_store_content += authenticated_url + "\n"
         configure_git_to_use_https(cred.fetch("host"))


### PR DESCRIPTION
### What are you trying to accomplish?

This removes an outdated credential check that prevents Git SSH-to-HTTPS rewrite rules from being configured when credentials are managed by the proxy.

The original check `next unless cred["username"] && cred["password"]` was required in https://github.com/dependabot/dependabot-core/commit/ee23901b4f93e8317c4156755148e168ac6da97f (March 2019), but the proxy architecture was introduced later (November 2019). The check is no longer needed since credentials are handled by the proxy layer, and they not passed directly to dependabot-core.

Without this fix, Git rewrite rules aren't configured for proxy-managed custom git sources, causing SSH URLs (from vanity imports) to fail instead of being rewritten to HTTPS.

### Anything you want to highlight for special attention from reviewers?

This change maintains backward compatibility - authenticated URLs are still created when credentials are present, but Git rewrite rules are now configured regardless of credential availability.

### How will you know you've accomplished your goal?

- Added test cases for git_source hosts without credentials (the normal proxy scenario)
- Verified Git rewrite rules are configured even when credentials are absent
- All existing tests continue to pass

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.