### PR TITLE
Clarify error message

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -131,9 +131,9 @@ def guard_tag_match
   tag = "v#{Dependabot::VERSION}"
   tag_commit = `git rev-list -n 1 #{tag} 2> /dev/null`.strip
   abort_msg = "Can't release - tag #{tag} does not exist. " \
-              "This may be due to an issue with the Actions runner or workflow. " \
-              "Please delete the failing tag and branch, and run the bump-versions workflow again. " \
-              "See https://github.com/github/dependabot-updates/issues/10603 for more info."
+              "This may be due to a bug in the Actions runner resulting in a stale copy of the git repo. " \
+              "Please delete the failing git tag and then recreate the GitHub release for this version. " \
+              "This will retrigger the gems-release-to-rubygems.yml workflow."
   abort abort_msg unless $CHILD_STATUS == 0
 
   head_commit = `git rev-parse HEAD`.strip


### PR DESCRIPTION
This is a follow-on to:
* https://github.com/dependabot/dependabot-core/pull/12984

A few tweaks:
* If we get to this point, the `bump-version` has already completed successfully and bumped the version in the Gemfile. So nothing more needs to happen there and once the PR was merged, the branch should have auto-deleted.
* So the only thing that needs to happen is to re-run the `gems-release-to-rubygems.yml` workflow again. However, because the bug appears to be in GitHub Actions, re-running the job within that actions UI didn't fix it... we needed to trigger a completely new copy of the runner/action. 
* And the only way to do that is to have a new GitHub release. So we need to delete the previously created git tag, and publish a new GitHub release using the same version.
