### PR TITLE
Match release stability for dated Rust toolchain releases

### DIFF
--- a/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
@@ -48,6 +48,7 @@ module Dependabot
 
         private
 
+        # rubocop:disable Metrics/PerceivedComplexity
         sig do
           params(releases: T::Array[Dependabot::Package::PackageRelease])
             .returns(T::Array[Dependabot::Package::PackageRelease])
@@ -75,6 +76,13 @@ module Dependabot
             # Check that the release version is in the same channel type
             next unless release_channel.channel_type == current_type
 
+            # For DatedStability channels, also check that the stability levels match
+            # e.g., "nightly-2025-08-19" should only match other "nightly-*" releases,
+            # not "stable-*" or "beta-*" releases
+            if current_type == ChannelType::DatedStability && release_channel.stability != current_channel.stability
+              next
+            end
+
             next release unless release_channel.channel_type == ChannelType::Version
 
             # For version channels, we need to ensure that the version format matches
@@ -91,6 +99,7 @@ module Dependabot
             release.version.to_s
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         # Check if a version string is in major.minor format (e.g., "1.72" vs "1.72.0")
         sig { params(version_string: String).returns(T::Boolean) }

--- a/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
@@ -48,7 +48,6 @@ module Dependabot
 
         private
 
-        # rubocop:disable Metrics/PerceivedComplexity
         sig do
           params(releases: T::Array[Dependabot::Package::PackageRelease])
             .returns(T::Array[Dependabot::Package::PackageRelease])
@@ -60,46 +59,72 @@ module Dependabot
           current_channel = current_version.channel
           return [] unless current_channel
 
-          current_type = current_channel.channel_type
-
-          # There are no updates for channels
-          # i.e. "stable", "beta", "nightly"
-          return [] if current_type == ChannelType::Stability
+          return [] if stability_channel_without_updates?(current_channel)
 
           is_current_major_minor = major_minor_format?(current_version.to_s)
 
-          channel_matched_releases = releases.filter_map do |release|
-            release_rust_version = T.cast(release.version, Dependabot::RustToolchain::Version)
-            release_channel = release_rust_version.channel
-            next unless release_channel
-
-            # Check that the release version is in the same channel type
-            next unless release_channel.channel_type == current_type
-
-            # For DatedStability channels, also check that the stability levels match
-            # e.g., "nightly-2025-08-19" should only match other "nightly-*" releases,
-            # not "stable-*" or "beta-*" releases
-            if current_type == ChannelType::DatedStability && release_channel.stability != current_channel.stability
-              next
-            end
-
-            next release unless release_channel.channel_type == ChannelType::Version
-
-            # For version channels, we need to ensure that the version format matches
-            is_release_major_minor = major_minor_format?(release_rust_version.to_s)
-            case [is_current_major_minor, is_release_major_minor]
-            in [true, true] | [false, false]
-              release
-            else
-              nil
-            end
+          channel_matched_releases = releases.select do |release|
+            compatible_release?(release, current_channel, is_current_major_minor)
           end
 
           channel_matched_releases.uniq do |release|
             release.version.to_s
           end
         end
-        # rubocop:enable Metrics/PerceivedComplexity
+
+        sig { params(channel: T.untyped).returns(T::Boolean) }
+        def stability_channel_without_updates?(channel)
+          channel.channel_type == ChannelType::Stability
+        end
+
+        sig do
+          params(
+            release: Dependabot::Package::PackageRelease,
+            current_channel: T.untyped,
+            is_current_major_minor: T::Boolean
+          )
+            .returns(T::Boolean)
+        end
+        def compatible_release?(release, current_channel, is_current_major_minor)
+          release_rust_version = T.cast(release.version, Dependabot::RustToolchain::Version)
+          release_channel = release_rust_version.channel
+          return false unless release_channel
+
+          return false unless matching_channel_type?(release_channel, current_channel)
+          return false unless matching_dated_stability?(release_channel, current_channel)
+          return true unless version_channel?(release_channel)
+
+          matching_version_format?(release_rust_version, is_current_major_minor)
+        end
+
+        sig { params(release_channel: T.untyped, current_channel: T.untyped).returns(T::Boolean) }
+        def matching_channel_type?(release_channel, current_channel)
+          release_channel.channel_type == current_channel.channel_type
+        end
+
+        sig { params(release_channel: T.untyped, current_channel: T.untyped).returns(T::Boolean) }
+        def matching_dated_stability?(release_channel, current_channel)
+          return true unless current_channel.channel_type == ChannelType::DatedStability
+
+          release_channel.stability == current_channel.stability
+        end
+
+        sig { params(channel: T.untyped).returns(T::Boolean) }
+        def version_channel?(channel)
+          channel.channel_type == ChannelType::Version
+        end
+
+        sig do
+          params(
+            release_version: Dependabot::RustToolchain::Version,
+            is_current_major_minor: T::Boolean
+          )
+            .returns(T::Boolean)
+        end
+        def matching_version_format?(release_version, is_current_major_minor)
+          is_release_major_minor = major_minor_format?(release_version.to_s)
+          is_current_major_minor == is_release_major_minor
+        end
 
         # Check if a version string is in major.minor format (e.g., "1.72" vs "1.72.0")
         sig { params(version_string: String).returns(T::Boolean) }

--- a/rust_toolchain/spec/dependabot/rust_toolchain/update_checker/latest_version_finder_spec.rb
+++ b/rust_toolchain/spec/dependabot/rust_toolchain/update_checker/latest_version_finder_spec.rb
@@ -179,6 +179,58 @@ RSpec.describe Dependabot::RustToolchain::UpdateChecker::LatestVersionFinder do
           .to match_array(%w(nightly-2023-12-25))
       end
     end
+
+    context "when dependency requirement is a nightly dated channel with mixed stability releases" do
+      let(:dependency_requirement) { "nightly-2025-08-19" }
+      let(:dependency_version) { "nightly-2025-08-19" }
+      let(:mock_versions) do
+        [
+          Dependabot::RustToolchain::Version.new("nightly-2025-08-01"),
+          Dependabot::RustToolchain::Version.new("nightly-2025-08-19"),
+          Dependabot::RustToolchain::Version.new("nightly-2025-08-20"),
+          Dependabot::RustToolchain::Version.new("stable-2025-08-07"),
+          Dependabot::RustToolchain::Version.new("stable-2025-08-14"),
+          Dependabot::RustToolchain::Version.new("beta-2025-08-10"),
+          Dependabot::RustToolchain::Version.new("1.72.0")
+        ]
+      end
+
+      it "only includes nightly releases, not stable or beta releases" do
+        package_details = version_finder.package_details
+        filtered_releases = version_finder.send(:apply_post_fetch_latest_versions_filter, package_details.releases)
+
+        expect(filtered_releases.map { |x| x.version.to_s })
+          .to match_array(%w(nightly-2025-08-01 nightly-2025-08-19 nightly-2025-08-20))
+        expect(filtered_releases.map { |x| x.version.to_s })
+          .not_to include("stable-2025-08-07", "stable-2025-08-14", "beta-2025-08-10", "1.72.0")
+      end
+    end
+
+    context "when dependency requirement is a stable dated channel with mixed stability releases" do
+      let(:dependency_requirement) { "stable-2025-08-07" }
+      let(:dependency_version) { "stable-2025-08-07" }
+      let(:mock_versions) do
+        [
+          Dependabot::RustToolchain::Version.new("nightly-2025-08-01"),
+          Dependabot::RustToolchain::Version.new("nightly-2025-08-19"),
+          Dependabot::RustToolchain::Version.new("stable-2025-08-07"),
+          Dependabot::RustToolchain::Version.new("stable-2025-08-14"),
+          Dependabot::RustToolchain::Version.new("stable-2025-08-21"),
+          Dependabot::RustToolchain::Version.new("beta-2025-08-10"),
+          Dependabot::RustToolchain::Version.new("1.72.0")
+        ]
+      end
+
+      it "only includes stable releases, not nightly or beta releases" do
+        package_details = version_finder.package_details
+        filtered_releases = version_finder.send(:apply_post_fetch_latest_versions_filter, package_details.releases)
+
+        expect(filtered_releases.map { |x| x.version.to_s })
+          .to match_array(%w(stable-2025-08-07 stable-2025-08-14 stable-2025-08-21))
+        expect(filtered_releases.map { |x| x.version.to_s })
+          .not_to include("nightly-2025-08-01", "nightly-2025-08-19", "beta-2025-08-10", "1.72.0")
+      end
+    end
   end
 
   describe "#apply_post_fetch_lowest_security_fix_versions_filter" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
When comparing dated Rust toolchain releases, we need to ensure that the release stability matches i.e. `nightly-2025-01-01` should only ever be compared against `nightly-*` releases, not `stable-*` or `beta-*`.

Closes #12950

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
