### PR TITLE
Update Docker image with COPY statements in Dockerfile

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -14,10 +14,11 @@ module Dependabot
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
       DOCKER_REGEXP = /(docker|container)file/i
       FROM_REGEX = /FROM(\s+--platform\=\S+)?/i
+      COPY_FROM_REGEX = /COPY\s+--from\=\S+/i
 
       sig { override.returns(T::Array[Regexp]) }
       def self.updated_files_regex
-        [DOCKER_REGEXP, YAML_REGEXP]
+        [DOCKER_REGEXP, YAML_REGEXP, COPY_FROM_REGEX]
       end
 
       sig { override.returns(String) }
@@ -32,7 +33,7 @@ module Dependabot
 
       sig { override.returns(Regexp) }
       def container_image_regex
-        %r{^#{FROM_REGEX}\s+(docker\.io/)?}o
+        %r{^(#{FROM_REGEX}\s+|#{COPY_FROM_REGEX})(docker\.io/)?}o
       end
     end
   end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -688,6 +688,138 @@ RSpec.describe Dependabot::Docker::FileParser do
         end
       end
     end
+
+    context "with COPY line, copying from an image" do
+      let(:dockerfile_fixture_name) { "copy_from_image" }
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies.last }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "8.9.0" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("alpine/curl")
+          expect(dependency.version).to eq("8.9.0")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
+    context "with COPY line, copying from an image with --chown flag" do
+      let(:dockerfile_fixture_name) { "copy_from_image_with_chown" }
+
+      its(:length) { is_expected.to eq(3) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "17.04" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies[1] }
+
+        let(:expected_requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "8.9.0" }
+            },
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "8.8.0" }
+            }
+          ]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("alpine/curl")
+          expect(dependency.version).to eq("8.9.0")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+
+      describe "the third dependency" do
+        subject(:dependency) { dependencies.last }
+
+        let(:expected_requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "8.9.0" }
+            },
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "8.8.0" }
+            }
+          ]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("alpine/curl")
+          expect(dependency.version).to eq("8.8.0")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
+    context "with only one COPY line, copying from the previous stage" do
+      let(:dockerfile_fixture_name) { "copy_from_previous_stage" }
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the dependency" do
+        subject(:dependency) { dependencies.first }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "17.04" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
   end
 
   describe "YAML parse" do

--- a/docker/spec/fixtures/docker/dockerfiles/copy_from_image
+++ b/docker/spec/fixtures/docker/dockerfiles/copy_from_image
@@ -1,0 +1,3 @@
+FROM ubuntu:17.04
+
+COPY --from=alpine/curl:8.9.0 /usr/bin/curl /usr/bin/curl

--- a/docker/spec/fixtures/docker/dockerfiles/copy_from_image_with_chown
+++ b/docker/spec/fixtures/docker/dockerfiles/copy_from_image_with_chown
@@ -1,0 +1,10 @@
+FROM ubuntu:17.04
+
+RUN addgroup myuser && adduser -S -G myuser myuser
+RUN mkdir /myuserfolder && chown myuser:myuser /myuserfolder
+
+USER myuser
+
+COPY --chown=myuser:myuser --from=alpine/curl:8.9.0 /usr/bin/curl /myuserfolder/curl
+
+COPY --from=alpine/curl:8.8.0 --chown=myuser:myuser /usr/bin/curl /myuserfolder/curl

--- a/docker/spec/fixtures/docker/dockerfiles/copy_from_previous_stage
+++ b/docker/spec/fixtures/docker/dockerfiles/copy_from_previous_stage
@@ -1,0 +1,7 @@
+FROM ubuntu:17.04
+
+RUN touch /tmp/my_file
+
+FROM ubuntu:17.04
+
+COPY --from=0 /tmp/my_file /tmp/my_file


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces parsing and updating container images in `COPY` statements in Dockerfile/Containerfile.

In Dockerfiles, it's possible to copy folders or directories from other images using the `COPY` statement, i.e.

```dockerfile
FROM alpine:3.20

COPY --from=alpine/curl:8.8.0 /usr/bin/curl /usr/bin/curl
```

However, Dependabot doesn't detect these kinds of statements currently. See also https://github.com/dependabot/dependabot-core/issues/5103.

A possible workaround mentioned in https://github.com/dependabot/dependabot-core/issues/5103#issuecomment-1692420920 is to introduce a "do-nothing" stage with the image you want to copy files from and an alias, then use the alias in `COPY` statement.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
