### PR TITLE
Extended Gradle TOML support

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -81,9 +81,11 @@ module Dependabot
 
       sig { params(root_dir: String).returns(T::Array[DependencyFile]) }
       def all_buildfiles_in_build(root_dir)
-        files = [buildfile(root_dir), settings_file(root_dir), version_catalog_file(root_dir), lockfile(root_dir)]
+        files = [buildfile(root_dir), settings_file(root_dir), lockfile(root_dir)]
                 .compact
         files += wrapper_files(root_dir)
+        files += catalog_files(root_dir)
+        files += subproject_catalog_files(root_dir)
         files += subproject_buildfiles(root_dir)
         files += subproject_lockfiles(root_dir)
         files += dependency_script_plugins(root_dir)
@@ -199,13 +201,6 @@ module Dependabot
         end
       end
 
-      sig { params(root_dir: String).returns(T.nilable(DependencyFile)) }
-      def version_catalog_file(root_dir)
-        return nil unless root_dir == "."
-
-        gradle_toml_file(root_dir)
-      end
-
       # rubocop:disable Metrics/PerceivedComplexity
       sig { params(root_dir: String).returns(T::Array[DependencyFile]) }
       def dependency_script_plugins(root_dir)
@@ -258,9 +253,29 @@ module Dependabot
         file
       end
 
-      sig { params(dir: String).returns(T.nilable(DependencyFile)) }
-      def gradle_toml_file(dir)
-        find_first(dir, SUPPORTED_VERSION_CATALOG_FILE_PATH)
+      sig { params(dir: String, look_at_gradle_dir: T::Boolean).returns(T::Array[DependencyFile]) }
+      def catalog_files(dir, look_at_gradle_dir: true)
+        files = repo_contents(dir: dir, raise_errors: false).flat_map do |f|
+          next [f] if f.type == "file"
+          next [] unless look_at_gradle_dir && f.type == "dir" && f.name == "gradle"
+
+          catalog_files(File.join(dir, f.name), look_at_gradle_dir: false)
+        end
+
+        files.select { |f| f.type == "file" && f.name.end_with?(".versions.toml") }
+             .map { |f| fetch_file_from_host(File.join(dir, f.name)) }
+      end
+
+      sig { params(root_dir: String).returns(T::Array[DependencyFile]) }
+      def subproject_catalog_files(root_dir)
+        return [] unless settings_file(root_dir)
+
+        subproject_paths =
+          SettingsFileParser
+          .new(settings_file: T.must(settings_file(root_dir)))
+          .subproject_paths
+
+        subproject_paths.flat_map { |path| catalog_files(File.join(root_dir, path), look_at_gradle_dir: false) }
       end
 
       sig { params(dir: String).returns(T.nilable(DependencyFile)) }

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       stub_content_request("?ref=sha", "contents_java.json")
       stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
       stub_no_content_request("gradle.lockfile?ref=sha")
+      stub_no_content_request("app?ref=sha")
+      stub_no_content_request("libs.versions.toml?ref=sha")
     end
 
     it "fetches the buildfile" do
@@ -143,6 +145,31 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           expect(file_fetcher_instance.files.map(&:name))
             .to match_array(%w(build.gradle settings.gradle app/build.gradle gradle/libs.versions.toml))
         end
+
+        context "with many catalogs" do
+          before do
+            stub_content_request("?ref=sha", "contents_with_tomls.json")
+            stub_content_request("settings.gradle?ref=sha", "contents_java_simple_settings.json")
+            stub_content_request("gradle?ref=sha", "content_gradle_toml_many.json")
+            stub_content_request("gradle/buildSrc.versions.toml?ref=sha", "libs_versions_toml.json")
+            stub_content_request("app?ref=sha", "content_app_toml.json")
+            stub_content_request("app/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+          end
+
+          it "fetches the toml file" do
+            expect(file_fetcher_instance.files.map(&:name))
+              .to match_array(
+                %w(
+                  gradle/libs.versions.toml
+                  gradle/buildSrc.versions.toml
+                  build.gradle
+                  settings.gradle
+                  app/build.gradle
+                  app/libs.versions.toml
+                )
+              )
+          end
+        end
       end
     end
 
@@ -150,6 +177,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       context "when has buildSrc" do
         before do
           stub_content_request("buildSrc?ref=sha", "contents_java.json")
+          stub_no_content_request("buildSrc/gradle?ref=sha")
           stub_content_request("buildSrc/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("buildSrc/gradle.lockfile?ref=sha")
         end
@@ -182,6 +210,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
             stub_content_request("?ref=sha", "contents_java_with_buildsrc_and_settings.json")
             stub_content_request("settings.gradle?ref=sha", "contents_java_settings_explicit_buildsrc.json")
             stub_content_request("included?ref=sha", "contents_java.json")
+            stub_no_content_request("included/gradle?ref=sha")
             stub_content_request("included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
             stub_no_content_request("included/gradle.lockfile?ref=sha")
           end
@@ -208,9 +237,11 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("app/gradle.lockfile?ref=sha")
           stub_content_request("included?ref=sha", "contents_java_with_settings.json")
+          stub_no_content_request("included/gradle?ref=sha")
           stub_content_request("included/settings.gradle?ref=sha", "contents_java_simple_settings.json")
           stub_content_request("included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/gradle.lockfile?ref=sha")
+          stub_no_content_request("included/app?ref=sha")
           stub_content_request("included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/app/gradle.lockfile?ref=sha")
         end
@@ -237,14 +268,18 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("app/gradle.lockfile?ref=sha")
           stub_content_request("included?ref=sha", "contents_java_with_settings.json")
+          stub_no_content_request("included/gradle?ref=sha")
           stub_content_request("included/settings.gradle?ref=sha", "contents_java_simple_settings.json")
           stub_content_request("included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/gradle.lockfile?ref=sha")
+          stub_no_content_request("included/app?ref=sha")
           stub_content_request("included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/app/gradle.lockfile?ref=sha")
           stub_content_request("included2?ref=sha", "contents_java_with_settings.json")
+          stub_no_content_request("included2/gradle?ref=sha")
           stub_content_request("included2/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included2/gradle.lockfile?ref=sha")
+          stub_no_content_request("included2/app?ref=sha")
           stub_content_request("included2/settings.gradle?ref=sha", "contents_java_simple_settings.json")
           stub_content_request("included2/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included2/app/gradle.lockfile?ref=sha")
@@ -274,24 +309,30 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("app/gradle.lockfile?ref=sha")
           stub_content_request("included?ref=sha", "contents_java_with_settings.json")
+          stub_no_content_request("included/gradle?ref=sha")
           stub_content_request("included/settings.gradle?ref=sha", "contents_java_settings_1_included_build.json")
           stub_content_request("included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/gradle.lockfile?ref=sha")
           stub_content_request("included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/app/gradle.lockfile?ref=sha")
           stub_content_request("included/included?ref=sha", "contents_java_with_settings.json")
+          stub_no_content_request("included/included/gradle?ref=sha")
           stub_content_request("included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/included/gradle.lockfile?ref=sha")
           stub_content_request(
             "included/included/settings.gradle?ref=sha",
             "contents_java_settings_1_included_build.json"
           )
+          stub_no_content_request("included/app?ref=sha")
           stub_content_request("included/included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/included/app/gradle.lockfile?ref=sha")
           stub_content_request("included/included/included?ref=sha", "contents_java_with_buildsrc.json")
+          stub_no_content_request("included/included/included/gradle?ref=sha")
           stub_content_request("included/included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("included/included/included/gradle.lockfile?ref=sha")
+          stub_no_content_request("included/included/app?ref=sha")
           stub_content_request("included/included/included/buildSrc?ref=sha", "contents_java.json")
+          stub_no_content_request("included/included/included/buildSrc/gradle?ref=sha")
           stub_content_request(
             "included/included/included/buildSrc/build.gradle?ref=sha",
             "contents_java_basic_buildfile.json"
@@ -325,6 +366,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_no_content_request("app/gradle.lockfile?ref=sha")
           stub_content_request("included?ref=sha", "contents_java.json")
+          stub_no_content_request("included/gradle?ref=sha")
           stub_content_request("included/build.gradle?ref=sha", "contents_java_buildfile_with_script_plugins.json")
           stub_no_content_request("included/gradle.lockfile?ref=sha")
           stub_content_request("included/gradle/dependencies.gradle?ref=sha", "contents_java_simple_settings.json")

--- a/gradle/spec/fixtures/github/content_app_toml.json
+++ b/gradle/spec/fixtures/github/content_app_toml.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "build.gradle",
+    "path": "app/build.gradle",
+    "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "size": 2355,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/build.gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/blob/main/build.gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "download_url": "https://raw.githubusercontent.com/dependabot-fixtures/gradle/main/build.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/build.gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+      "html": "https://github.com/dependabot-fixtures/gradle/blob/main/build.gradle"
+    }
+  },
+  {
+    "name": "libs.versions.toml",
+    "path": "app/libs.versions.toml",
+    "sha": "61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "size": 1470,
+    "url": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/app/libs.versions.toml?ref=main",
+    "html_url": "https://github.com/bigandroidenergies/version_catalog/blob/main/app/libs.versions.toml",
+    "git_url": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "download_url": "https://raw.githubusercontent.com/bigandroidenergies/version_catalog/main/app/libs.versions.toml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/app/libs.versions.toml?ref=main",
+      "git": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+      "html": "https://github.com/bigandroidenergies/version_catalog/blob/main/app/libs.versions.toml"
+    }
+  }
+]

--- a/gradle/spec/fixtures/github/content_gradle_toml_many.json
+++ b/gradle/spec/fixtures/github/content_gradle_toml_many.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "libs.versions.toml",
+    "path": "gradle/libs.versions.toml",
+    "sha": "61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "size": 1470,
+    "url": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+    "html_url": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml",
+    "git_url": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "download_url": "https://raw.githubusercontent.com/bigandroidenergies/version_catalog/main/gradle/libs.versions.toml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+      "git": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+      "html": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml"
+    }
+  },
+  {
+    "name": "buildSrc.versions.toml",
+    "path": "gradle/buildSrc.versions.toml",
+    "sha": "61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "size": 1470,
+    "url": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/buildSrc.versions.toml?ref=main",
+    "html_url": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/buildSrc.versions.toml",
+    "git_url": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+    "download_url": "https://raw.githubusercontent.com/bigandroidenergies/version_catalog/main/gradle/buildSrc.versions.toml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/buildSrc.versions.toml?ref=main",
+      "git": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+      "html": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/buildSrc.versions.toml"
+    }
+  }
+]

--- a/gradle/spec/fixtures/github/contents_java.json
+++ b/gradle/spec/fixtures/github/contents_java.json
@@ -16,6 +16,22 @@
     }
   },
   {
+    "name": "gradle",
+    "path": "gradle",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle"
+    }
+  },
+  {
     "name": "build.gradle",
     "path": "build.gradle",
     "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",

--- a/gradle/spec/fixtures/github/contents_java_only_settings.json
+++ b/gradle/spec/fixtures/github/contents_java_only_settings.json
@@ -16,6 +16,22 @@
     }
   },
   {
+    "name": "gradle",
+    "path": "gradle",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle"
+    }
+  },
+  {
     "name": "dependencies",
     "path": "dependencies",
     "sha": "5df7f650b80fef281199e7d1c6bf53c6a5280802",

--- a/gradle/spec/fixtures/github/contents_java_with_buildsrc.json
+++ b/gradle/spec/fixtures/github/contents_java_with_buildsrc.json
@@ -16,6 +16,22 @@
     }
   },
   {
+    "name": "gradle",
+    "path": "gradle",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle"
+    }
+  },
+  {
     "name": "buildSrc",
     "path": "buildSrc",
     "sha": "5df7f650b80fef281199e7d1c6bf53c6a5280802",

--- a/gradle/spec/fixtures/github/contents_java_with_settings.json
+++ b/gradle/spec/fixtures/github/contents_java_with_settings.json
@@ -16,6 +16,22 @@
     }
   },
   {
+    "name": "gradle",
+    "path": "gradle",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle-with-settings/contents/gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle-with-settings/tree/main/gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle-with-settings/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle-with-settings/contents/gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle-with-settings/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle-with-settings/tree/main/gradle"
+    }
+  },
+  {
     "name": "build.gradle",
     "path": "build.gradle",
     "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",

--- a/gradle/spec/fixtures/github/contents_with_tomls.json
+++ b/gradle/spec/fixtures/github/contents_with_tomls.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "gradle",
+    "path": "gradle",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle/tree/main/gradle"
+    }
+  },
+  {
+    "name": "app",
+    "path": "app",
+    "sha": "193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/app?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/tree/main/app",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/app/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/app?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/trees/193ef2b05a8976c5ff11d575bc3f00b74dd1955e",
+      "html": "https://github.com/dependabot-fixtures/gradle/tree/main/app"
+    }
+  },
+  {
+    "name": "build.gradle",
+    "path": "build.gradle",
+    "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "size": 2355,
+    "url": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/build.gradle?ref=main",
+    "html_url": "https://github.com/dependabot-fixtures/gradle/blob/main/build.gradle",
+    "git_url": "https://api.github.com/repos/dependabot-fixtures/gradle/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "download_url": "https://raw.githubusercontent.com/dependabot-fixtures/gradle/main/build.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot-fixtures/gradle/contents/build.gradle?ref=main",
+      "git": "https://api.github.com/repos/dependabot-fixtures/gradle/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+      "html": "https://github.com/dependabot-fixtures/gradle/blob/main/build.gradle"
+    }
+  },
+  {
+    "name": "settings.gradle",
+    "path": "settings.gradle",
+    "sha": "cbc2afee9c9e1a0849ceade9d3b166dcea5e5a64",
+    "size": 185,
+    "url": "https://api.github.com/repos/chriswk/isharelib2/contents/settings.gradle?ref=master",
+    "html_url": "https://github.com/chriswk/isharelib2/blob/master/settings.gradle",
+    "git_url": "https://api.github.com/repos/chriswk/isharelib2/git/blobs/cbc2afee9c9e1a0849ceade9d3b166dcea5e5a64",
+    "download_url": "https://raw.githubusercontent.com/chriswk/isharelib2/master/settings.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/chriswk/isharelib2/contents/settings.gradle?ref=master",
+      "git": "https://api.github.com/repos/chriswk/isharelib2/git/blobs/cbc2afee9c9e1a0849ceade9d3b166dcea5e5a64",
+      "html": "https://github.com/chriswk/isharelib2/blob/master/settings.gradle"
+    }
+  }
+]


### PR DESCRIPTION
### What are you trying to accomplish?
Extends Gradle's Catalog support (`.versions.toml` files) to collect more file locations

### Anything you want to highlight for special attention from reviewers?
Currently, `dependabot` will only consider `gradle/libs.versions.toml` file for pick dependencies. Even this may fit most of the standard cases, there some project setups that may require more catalog files.

The proposal is to support more cases:
- Any catalog under a root build (or included build) `gradle` folder: `gradle/*.versions.toml`, i.e.:
  - `gradle/libs.versions.toml`
  - `gradle/buildSrc.versions.toml`
  - `gradle/shared.libs.versions.toml`
  - `buildSrc/gradle/libs.versions.toml`
  - `build-logic/gradle/libs.versions.toml`
- Any catalog under a child module, i.e.:
  - `app/libs.versions.toml`
  - `app/dependencies.versions.toml`
  - `module1/libs.versions.toml`
  
> [!NOTE]
> Even in theory, any `.version.toml` file could be potentially a dependency file, I just limited to extend some "convention locations" to limit the queries and prevent scanning the whole repo.

### How will you know you've accomplished your goal?
Tests of `gradle/file_fetcher.rb` were updated, an [its `smoke-gradle-version-catalog.yaml` as well](https://github.com/dependabot/smoke-tests/pull/330)

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfils the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
