### PR TITLE
removing timestamp which makes it harder to smoke test

### DIFF
--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -64,7 +64,6 @@ module GithubApi
           version: Dependabot::VERSION,
           url: SNAPSHOT_DETECTOR_URL
         },
-        scanned: scanned,
         manifests: manifests
       }
     end
@@ -74,11 +73,6 @@ module GithubApi
     sig { returns(String) }
     def job_correlator
       "#{SNAPSHOT_DETECTOR_NAME}-#{package_manager}"
-    end
-
-    sig { returns(String) }
-    def scanned
-      Time.now.utc.iso8601
     end
 
     sig { returns(String) }

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -497,7 +497,6 @@ RSpec.describe Dependabot::ApiClient do
           version: "1.0.0",
           url: "https://github.com/dependabot/dependabot-core"
         },
-        scanned: "2025-07-09T12:00:00Z",
         manifests: {
           "Gemfile" => {
             name: "Gemfile",

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -93,9 +93,6 @@ RSpec.describe GithubApi::DependencySubmission do
       expect(payload[:detector][:version]).to eq(Dependabot::VERSION)
       expect(payload[:job][:correlator]).to eq("dependabot-bundler")
       expect(payload[:job][:id]).to eq("9999")
-
-      # And check we have an iso8601 timestamp
-      expect(payload[:scanned]).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
     end
 
     it "generates git attributes correctly" do


### PR DESCRIPTION
### What are you trying to accomplish?

Having a timestamp always changing makes smoke tests harder, we'd have to implement an ignore of that field. Easier to remove it and add it back in the server.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
