### PR TITLE
always restore packages.config before attempting update

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Files/ProjectBuildFileTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Files/ProjectBuildFileTests.cs
@@ -161,4 +161,32 @@ public class ProjectBuildFileTests
         buildFile.NormalizeDirectorySeparatorsInProject();
         Assert.Equal(expectedXml, buildFile.Contents.ToFullString());
     }
+
+    [Theory]
+    [InlineData(
+        // language=xml
+        """
+        <Project>
+          <Target>
+            <Error Condition="!Exists('../packages/Some.Package.1.0.0/build/Some.Package.targets')" Text="$([System.String]::Format('$(ErrorText)', '../packages/Some.Package.1.0.0/build/Some.Package.targets'))" />
+          </Target>
+          <Import Project="../packages/Some.Package.1.0.0/build/Some.Package.targets" Condition="Exists('../packages/Some.Package.1.0.0/build/Some.Package.targets')" />
+        </Project>
+        """,
+        // language=xml
+        """
+        <Project>
+          <Target>
+            <Error Condition="!Exists('..\packages\Some.Package.1.0.0\build\Some.Package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Some.Package.1.0.0\build\Some.Package.targets'))" />
+          </Target>
+          <Import Project="..\packages\Some.Package.1.0.0\build\Some.Package.targets" Condition="Exists('..\packages\Some.Package.1.0.0\build\Some.Package.targets')" />
+        </Project>
+        """
+    )]
+    public void ImportPathsCanBeNormalized(string originalXml, string expectedXml)
+    {
+        var buildFile = GetBuildFile(originalXml, "project.csproj");
+        buildFile.NormalizeDirectorySeparatorsInProject();
+        Assert.Equal(expectedXml, buildFile.Contents.ToFullString());
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackagesConfigUpdaterTests.cs
@@ -1868,7 +1868,7 @@ public class PackagesConfigUpdaterTests : TestBase
         var error = JobErrorBase.ErrorFromException(notFoundException, "TEST-JOB-ID", temporaryDirectory.DirectoryPath);
         var notFound = Assert.IsType<DependencyNotFound>(error);
         var depName = Assert.IsType<string>(notFound.Details["source"]);
-        Assert.Equal("Unrelated.Package", depName);
+        Assert.Equal("Unrelated.Package.1.0.0", depName);
     }
 
     [Theory]


### PR DESCRIPTION
When attempting an update with `packages.config`, it was possible that the old `<Import Project="..." />` elements wouldn't get cleaned up eventually resulting in a failing PR.

E.g., the diff might look like this (note that the first import directive is still present, but at PR time that file won't exist because it wasn't restored because it's not in `packages.config`)...

``` diff
 <Import Project="..\packages\Some.Package.1.0.0\build\Some.Package.targets" />
+<Import Project="..\packages\Some.Package.2.0.0\build\Some.Package.targets" />
```

...but it was expected to look like this...

``` diff
-<Import Project="..\packages\Some.Package.1.0.0\build\Some.Package.targets" />
+<Import Project="..\packages\Some.Package.2.0.0\build\Some.Package.targets" />
```

Normally NuGet interprets a call to the `update` command as two separate actions: uninstall and install, but if the `<Import>` elements didn't have any files yet on disk, the uninstall operation wasn't added to the list resulting in stale directives in the project.

The fix is to always run the `restore` command first because this allows NuGet to properly detect the initial uninstall required action.  There were many instances where we detected a restore was necessary and ran it anyway, so we're not likely to incur a huge cost in always running the restore.