### PR TITLE
improve tag name extractor

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
@@ -12,6 +12,8 @@ public class IPackageDetailFinderTests
     [InlineData("version-one.zero.zero", "v1.0.0", "1.0.0")]
     [InlineData("v-one.zero.zero", "v-one.zero.zero", null)]
     [InlineData("Stable", "version-1.0.0", "1.0.0")]
+    [InlineData("some.package/1.0.0", "some.package/1.0.0", "1.0.0")]
+    [InlineData("some.package 1.0.0", "some.package 1.0.0", "1.0.0")]
     public void GetVersionFromNames(string releaseName, string tagName, string? expectedVersion)
     {
         var actualVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);


### PR DESCRIPTION
The code to extract tag names from releases was too restrictive; only trimming off prefixes like `version-` and `v-`.  This brings the prefix trimmer in line with [the method used by other ecosystems](https://github.com/dependabot/dependabot-core/blob/955e112535f557929636f57c3ce80a9edc7b579b/common/lib/dependabot/metadata_finders/base/release_finder.rb#L148-L149) by removing all non-numeric prefix characters.

Fixes #13003