### PR TITLE
Removing `exclude_paths` from dry-run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -157,8 +157,7 @@ $options = {
   vendor_dependencies: false,
   ignore_conditions: [],
   pull_request: false,
-  cooldown: nil,
-  exclude_paths: []
+  cooldown: nil
 }
 
 unless ENV["LOCAL_GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
@@ -213,11 +212,6 @@ end
 
 if ENV.key?("COOLDOWN") && !ENV["COOLDOWN"].to_s.strip.empty?
   $options[:cooldown] = JSON.parse(ENV.fetch("COOLDOWN", "{}"))
-end
-
-unless ENV["EXCLUDE_PATHS"].to_s.strip.empty?
-  # Comma separated list of paths to exclude
-  $options[:exclude_paths] = ENV.fetch("EXCLUDE_PATHS", "").split(",").map(&:strip)
 end
 
 # rubocop:disable Metrics/BlockLength
@@ -327,10 +321,6 @@ option_parse = OptionParser.new do |opts|
   rescue JSON::ParserError
     puts "Invalid JSON format for cooldown parameter. Please provide a valid JSON string."
     exit 1
-  end
-
-  opts.on("--exclude-paths PATHS", "Comma separated list of paths to exclude") do |value|
-    $options[:exclude_paths] = value.split(",").map(&:strip)
   end
 end
 # rubocop:enable Metrics/BlockLength
@@ -615,7 +605,6 @@ begin
       $package_manager,
       directory: $options[:directory],
       target_branch: $options[:branch],
-      exclude_paths: $options[:exclude_paths] || []
     )
     config
   rescue KeyError

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -604,7 +604,7 @@ begin
     config = $config_file.update_config(
       $package_manager,
       directory: $options[:directory],
-      target_branch: $options[:branch],
+      target_branch: $options[:branch]
     )
     config
   rescue KeyError


### PR DESCRIPTION
### What are you trying to accomplish?

This PR removes the `exclude path` parameter from `bin/dry-run.rb` because the dry run does not exercise the code path for exclude paths, and passing it causes an `ArgumentError: unknown keyword: :exclude_paths`. This keeps the script focused and prevents confusion or errors. 

closes: https://github.com/dependabot/dependabot-core/issues/12889

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

This change prevents runtime errors and clarifies that exclude path logic is not supported in dry runs.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Run `bin/dry-run.rb` without the exclude path parameter and confirm there are no `ArgumentError` exceptions. All expected files are processed.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
