### PR TITLE
only report discovery for projects in the repo

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -106,7 +106,11 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             _logger.Info($"Workspace path [{workspacePath}] does not exist.");
         }
 
-        //if any projectResults are not successful, return a failed result
+        // filter to only projects in the repo that could possibly be updated
+        var repoRoot = new DirectoryInfo(repoRootPath);
+        projectResults = [.. projectResults.Where(p => PathHelper.IsFileUnderDirectory(repoRoot, new FileInfo(Path.Join(workspacePath, p.FilePath))))];
+
+        // if any projectResults are not successful, return a failed result
         if (projectResults.Any(p => p.IsSuccess == false))
         {
             var failedProjectResult = projectResults.Where(p => p.IsSuccess == false).First();


### PR DESCRIPTION
This is an attempt to track down a transient bug that I haven't been able to reproduce locally.

The `Microsoft.Azure.Functions.Worker.Sdk` package creates a file under temp named `WorkerExtensions.csproj` that sometimes exists after dependency discovery is complete and is reported in the discovery object.

Later steps of the process then try to track the contents of that file but it has by then been deleted.

To avoid adding a bunch of `if (!File.Exists(...))` checks, this instead excludes any project from discovery that doesn't live under the repo root because no matter what those files may contain, there is nothing we could do for them.