### PR TITLE
Remove unnecessary RuboCop `Sorbet/StrictSigil` exclusions

### DIFF
--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -10,21 +10,15 @@ Sorbet/TrueSigil:
 
 Sorbet/StrictSigil:
   Exclude:
-    - "helpers/**/*.rb"
-    - lib/dependabot/bundler/file_parser.rb
+    - helpers/**/*.rb
     - lib/dependabot/bundler/file_updater/git_pin_replacer.rb
     - lib/dependabot/bundler/file_updater/git_source_remover.rb
     - lib/dependabot/bundler/file_updater/lockfile_updater.rb
     - lib/dependabot/bundler/file_updater/requirement_replacer.rb
-    - lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
     - lib/dependabot/bundler/file_updater.rb
     - lib/dependabot/bundler/metadata_finder.rb
     - lib/dependabot/bundler/requirement.rb
-    - lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
     - lib/dependabot/bundler/update_checker/file_preparer.rb
-    - lib/dependabot/bundler/update_checker/force_updater.rb
     - lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
     - lib/dependabot/bundler/update_checker/requirements_updater.rb
-    - lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
-    - lib/dependabot/bundler/update_checker/version_resolver.rb
     - lib/dependabot/bundler/update_checker.rb

--- a/cargo/.rubocop.yml
+++ b/cargo/.rubocop.yml
@@ -6,13 +6,9 @@ inherit_mode:
 
 Sorbet/StrictSigil:
   Exclude:
-    - lib/dependabot/cargo/file_parser.rb
-    - lib/dependabot/cargo/file_updater/lockfile_updater.rb
     - lib/dependabot/cargo/file_updater/manifest_updater.rb
-    - lib/dependabot/cargo/helpers.rb
     - lib/dependabot/cargo/metadata_finder.rb
     - lib/dependabot/cargo/update_checker/file_preparer.rb
     - lib/dependabot/cargo/update_checker/requirements_updater.rb
-    - lib/dependabot/cargo/update_checker/version_resolver.rb
     - lib/dependabot/cargo/update_checker.rb
     - lib/dependabot/cargo/version.rb

--- a/hex/.rubocop.yml
+++ b/hex/.rubocop.yml
@@ -13,5 +13,4 @@ Sorbet/StrictSigil:
     - lib/dependabot/hex/update_checker/file_preparer.rb
     - lib/dependabot/hex/update_checker/requirements_updater.rb
     - lib/dependabot/hex/update_checker/version_resolver.rb
-    - lib/dependabot/hex/update_checker.rb
     - lib/dependabot/hex/version.rb

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -20,26 +20,26 @@ module Dependabot
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version, Gem::Version))) }
       def latest_version
-        @latest_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version, Gem::Version)))
-
-        @latest_version ||=
+        @latest_version ||= T.let(
           if git_dependency?
             latest_version_for_git_dependency
           else
             latest_release_from_hex_registry || latest_resolvable_version
-          end
+          end,
+          T.nilable(T.any(String, Dependabot::Version, Gem::Version))
+        )
       end
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version, Gem::Version))) }
       def latest_resolvable_version
-        @latest_resolvable_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version, Gem::Version)))
-
-        @latest_resolvable_version ||=
+        @latest_resolvable_version ||= T.let(
           if git_dependency?
             latest_resolvable_version_for_git_dependency
           else
             fetch_latest_resolvable_version(unlock_requirement: true)
-          end
+          end,
+          T.nilable(T.any(String, Dependabot::Version, Gem::Version))
+        )
       end
 
       sig { override.returns(T.any(String, T.nilable(Dependabot::Version))) }
@@ -247,13 +247,13 @@ module Dependabot
 
       sig { returns(Dependabot::GitCommitChecker) }
       def git_commit_checker
-        @git_commit_checker = T.let(nil, T.nilable(Dependabot::GitCommitChecker))
-
-        @git_commit_checker ||=
+        @git_commit_checker ||= T.let(
           GitCommitChecker.new(
             dependency: dependency,
             credentials: credentials
-          )
+          ),
+          T.nilable(Dependabot::GitCommitChecker)
+        )
       end
     end
   end

--- a/python/.rubocop.yml
+++ b/python/.rubocop.yml
@@ -6,17 +6,5 @@ inherit_mode:
 
 Sorbet/StrictSigil:
   Exclude:
-    - lib/dependabot/python/authed_url_builder.rb
     - lib/dependabot/python/file_fetcher.rb
-    - lib/dependabot/python/file_updater/requirement_file_updater.rb
-    - lib/dependabot/python/file_updater/requirement_replacer.rb
-    - lib/dependabot/python/file_updater/setup_file_sanitizer.rb
-    - lib/dependabot/python/package/package_registry_finder.rb
-    - lib/dependabot/python/requirement.rb
-    - lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
-    - lib/dependabot/python/update_checker/pip_version_resolver.rb
-    - lib/dependabot/python/update_checker/pipenv_version_resolver.rb
-    - lib/dependabot/python/update_checker/poetry_version_resolver.rb
-    - lib/dependabot/python/update_checker/requirements_updater.rb
     - lib/dependabot/python/update_checker.rb
-    - lib/dependabot/python/version.rb

--- a/updater/.rubocop.yml
+++ b/updater/.rubocop.yml
@@ -7,7 +7,6 @@ inherit_mode:
 Sorbet/StrictSigil:
   Exclude:
     - lib/dependabot/base_command.rb
-    - lib/dependabot/file_fetcher_command.rb
     - lib/dependabot/update_files_command.rb
     - lib/dependabot/updater/dependency_group_change_batch.rb
     - lib/dependabot/updater/group_update_refreshing.rb

--- a/uv/.rubocop.yml
+++ b/uv/.rubocop.yml
@@ -7,10 +7,8 @@ inherit_mode:
 Sorbet/StrictSigil:
   Exclude:
     - lib/dependabot/uv/authed_url_builder.rb
-    - lib/dependabot/uv/file_fetcher.rb
     - lib/dependabot/uv/file_parser/python_requirement_parser.rb
     - lib/dependabot/uv/file_updater/compile_file_updater.rb
-    - lib/dependabot/uv/file_updater/lock_file_updater.rb
     - lib/dependabot/uv/file_updater/requirement_replacer.rb
     - lib/dependabot/uv/metadata_finder.rb
     - lib/dependabot/uv/package/package_registry_finder.rb


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->
As part of #12101 Sorbet `strict` typing was made opt-out instead of opt-in. That meant we made a manual list of file exclusions in each ecosystem. Unfortunately, we didn't have a way to automatically clean up that list.

This change removes the files that are already strict typed from the relevant exclusion list

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

It looks like the exclusion list also gates some other RuboCop warnings, as I encountered a couple of errors in `hex/lib/dependabot/hex/update_checker.rb`

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
