### PR TITLE
update devcontainer to correct sdk version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,11 @@
     "ghcr.io/devcontainers/features/go": "latest",
     "ghcr.io/devcontainers/features/ruby": "3.4.5",
     "ghcr.io/devcontainers/features/rust": "latest",
-    "ghcr.io/devcontainers/features/dotnet": "latest",
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      // these versions should be kept in sync with the files `nuget/Dockerfile` and `nuget/helpers/lib/NuGetUpdater/global.json`
+      "version": "8.0.412",
+      "additionalVersions": "9.0.302"
+    },
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
     }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,11 +4,6 @@ tar xzvf ./*.tar.gz >/dev/null 2>&1
 sudo mv dependabot /usr/local/bin
 rm ./*.tar.gz
 
-# The image comes loaded with 8.0 SDK, but we need the 7.0 and 9.0 runtimes for running tests
-sudo wget https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh
-sudo chmod +x dotnet-install.sh
-sudo ./dotnet-install.sh -c 7.0 --runtime dotnet --install-dir /usr/share/dotnet/shared
-sudo ./dotnet-install.sh -c 9.0 --install-dir /usr/share/dotnet
-sudo rm ./dotnet-install.sh
+bundle install
 
 echo "export LOCAL_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" >> ~/.bashrc

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -42,6 +42,7 @@ RUN ARCH=$([ $TARGETARCH = "arm64" ] && echo "arm64" || echo "x64") \
  && pwsh --version
 
 # Install .NET SDK
+# these versions should be kept in sync with the files `.devcontainer/devcontainer.json` and `nuget/helpers/lib/NuGetUpdater/global.json`
 ARG DOTNET_LTS_SDK_VERSION=8.0.412
 ARG DOTNET_STS_SDK_VERSION=9.0.302
 ARG DOTNET_SDK_INSTALL_URL=https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh

--- a/nuget/helpers/lib/NuGetUpdater/global.json
+++ b/nuget/helpers/lib/NuGetUpdater/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
+    "// comment": "this version should be kept in sync with the files `.devcontainer/devcontainer.json` and `nuget/Dockerfile`",
     "version": "9.0.302",
     "rollForward": "latestMinor"
   }


### PR DESCRIPTION
This simplifes the devcontainer setup for .NET and adds comments to all locations where SDK versions are specified so everything remains in sync.