### PR TITLE
Fix Python MetadataFinder URL construction for private registries

### DIFF
--- a/python/lib/dependabot/python/metadata_finder.rb
+++ b/python/lib/dependabot/python/metadata_finder.rb
@@ -197,7 +197,9 @@ module Dependabot
           .map { |c| AuthedUrlBuilder.authed_url(credential: c) }
 
         (credential_urls + [MAIN_PYPI_URL]).map do |base_url|
-          base_url.gsub(%r{/$}, "") + "/#{normalised_dependency_name}/json"
+          # Convert /simple/ endpoints to /pypi/ for JSON API access
+          json_base_url = base_url.sub(%r{/simple/?$}i, "/pypi")
+          json_base_url.gsub(%r{/$}, "") + "/#{normalised_dependency_name}/json"
         end
       end
 

--- a/python/spec/dependabot/python/metadata_finder_spec.rb
+++ b/python/spec/dependabot/python/metadata_finder_spec.rb
@@ -154,6 +154,77 @@ RSpec.describe Dependabot::Python::MetadataFinder do
       end
     end
 
+    context "with a private index using /simple/ endpoint" do
+      let(:credentials) do
+        [Dependabot::Credential.new({
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }), Dependabot::Credential.new({
+          "type" => "python_index",
+          "index-url" => "https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/simple",
+          "token" => "testuser:testpass",
+          "replaces-base" => true
+        })]
+      end
+      let(:pypi_response) { fixture("pypi", "pypi_response.json") }
+
+      before do
+        # Stub the public PyPI to return 404 (private registry replaces base)
+        stub_request(:get, pypi_url).to_return(status: 404, body: "")
+
+        # Stub the correctly converted private registry URL (/simple/ -> /pypi/)
+        private_url = "https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/pypi/#{dependency_name}/json"
+        stub_request(:get, private_url)
+          .with(basic_auth: %w(testuser testpass))
+          .to_return(status: 200, body: pypi_response)
+      end
+
+      it "correctly converts /simple/ endpoint to /pypi/ endpoint for JSON API" do
+        expect(source_url).to eq("https://github.com/spotify/luigi")
+      end
+
+      it "generates the correct possible listing URLs" do
+        possible_urls = finder.send(:possible_listing_urls)
+
+        # Should convert /simple/ to /pypi/ for the private registry
+        expect(possible_urls).to include(
+          "https://testuser:testpass@jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/pypi/luigi/json"
+        )
+
+        # Should not include the incorrect /simple/ URL for JSON API
+        expect(possible_urls).not_to include(
+          "https://testuser:testpass@jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/simple/luigi/json"
+        )
+      end
+
+      context "when the private registry endpoint doesn't end with /simple/" do
+        let(:credentials) do
+          [Dependabot::Credential.new({
+            "type" => "python_index",
+            "index-url" => "https://custom.registry.com/custom/path",
+            "token" => "testtoken"
+          })]
+        end
+
+        before do
+          # For non-simple endpoints, should append /json directly
+          private_url = "https://custom.registry.com/custom/path/#{dependency_name}/json"
+          stub_request(:get, private_url)
+            .to_return(status: 200, body: pypi_response)
+        end
+
+        it "doesn't convert URLs that don't end with /simple/" do
+          possible_urls = finder.send(:possible_listing_urls)
+
+          expect(possible_urls).to include(
+            "https://testtoken@custom.registry.com/custom/path/luigi/json"
+          )
+        end
+      end
+    end
+
     context "when the dependency came from a local repository" do
       let(:pypi_response) { fixture("pypi", "pypi_response.json") }
       let(:version) { "1.0+gc.1" }


### PR DESCRIPTION
### What are you trying to accomplish?

#### Error:
`200 https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/pypi/structlog/json` => PackageDetailsFetcher
`404 https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/simple/structlog/json` => MetadataFinder

#### Fix Python MetadataFinder URL construction for private registries

Convert `/simple/` endpoints to `/pypi/` for JSON API access in `MetadataFinder`.
This ensures consistency with `PackageDetailsFetcher` and fixes 404 errors
when accessing private registries like `JFrog Artifactory`.

The issue occurred because MetadataFinder was directly appending /json
to`/simple/` endpoints, while JSON APIs require `/pypi/` endpoints.

Changes:
- Update `possible_listing_urls` method to convert `/simple/` to `/pypi/`
- Add comprehensive test coverage for the URL conversion
- Ensure non-simple endpoints remain unchanged

Fixes metadata retrieval for dependencies hosted on private Python
registries that separate simple index and JSON API endpoints.


### Anything you want to highlight for special attention from reviewers?

Before update
```
updater | 2025/09/16 12:15:08 INFO Submitting structlog pull request for creation
  proxy | 2025/09/16 12:15:08 [045] GET https://api.github.com:443/repos/thavaahariharangit/Pipfile-index-update-with-private-registry/commits?per_page=100
  proxy | 2025/09/16 12:15:08 [045] * authenticating github api request with token for api.github.com
  proxy | 2025/09/16 12:15:08 [045] 200 https://api.github.com:443/repos/thavaahariharangit/Pipfile-index-update-with-private-registry/commits?per_page=100
  proxy | 2025/09/16 12:15:08 [047] GET https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/simple/structlog/json
  proxy | 2025/09/16 12:15:08 [047] * authenticating python index request (host: jfrogghdemo.jfrog.io)
  proxy | 2025/09/16 12:15:08 [047] 404 https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/simple/structlog/json
  proxy | 2025/09/16 12:15:09 [049] GET https://pypi.org/pypi/structlog/json
  proxy | 2025/09/16 12:15:09 [049] 200 https://pypi.org/pypi/structlog/json
  proxy | 2025/09/16 12:15:09 [051] GET https://bsky.app/status
  proxy | 2025/09/16 12:15:09 [051] 302 https://bsky.app/status
```

### How will you know you've accomplished your goal?

After update
```
updater | 2025/09/16 12:17:52 INFO Submitting structlog pull request for creation
  proxy | 2025/09/16 12:17:52 [045] GET https://api.github.com:443/repos/thavaahariharangit/Pipfile-index-update-with-private-registry/commits?per_page=100
  proxy | 2025/09/16 12:17:52 [045] * authenticating github api request with token for api.github.com
  proxy | 2025/09/16 12:17:52 [045] 200 https://api.github.com:443/repos/thavaahariharangit/Pipfile-index-update-with-private-registry/commits?per_page=100
  proxy | 2025/09/16 12:17:52 [047] GET https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/pypi/structlog/json
  proxy | 2025/09/16 12:17:52 [047] * authenticating python index request (host: jfrogghdemo.jfrog.io)
  proxy | 2025/09/16 12:17:52 [047] 200 https://jfrogghdemo.jfrog.io/artifactory/api/pypi/dependabot-pip/pypi/structlog/json
  proxy | 2025/09/16 12:17:52 [048] POST http://host.docker.internal:33815/update_jobs/cli/create_pull_request
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
