### PR TITLE
Use a unique label for unknown graphing errors

### DIFF
--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -14,14 +14,7 @@ module Dependabot
   class UpdateGraphCommand < BaseCommand
     extend T::Sig
 
-    # TODO(brrygrdn): Change label to update_graph_error?
-    #
-    # It feels odd to return update_files_error, but Dependabot's backend service does a lot of categorisation
-    # based on this label.
-    #
-    # We need to ensure that the service handles a new update_graph_error appropriately before we change this,
-    # but this is something we can address later.
-    ERROR_TYPE_LABEL = "update_files_error"
+    ERROR_TYPE_LABEL = "update_graph_error"
 
     sig { override.void }
     def perform_job

--- a/updater/spec/dependabot/update_graph_command_spec.rb
+++ b/updater/spec/dependabot/update_graph_command_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       end
     end
 
-    context "with an update files error (cloud)" do
+    context "with an update graph error (cloud)" do
       let(:error) { StandardError.new("hell") }
 
       before do
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       it "captures the exception and records to a update job error api" do
         expect(service).to receive(:capture_exception)
         expect(service).to receive(:record_update_job_error).with(
-          error_type: "update_files_error",
+          error_type: "update_graph_error",
           error_details: {
             Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
             Dependabot::ErrorAttributes::MESSAGE => "hell",
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       it "captures the exception and records the a update job unknown error api" do
         expect(service).to receive(:capture_exception)
         expect(service).to receive(:record_update_job_unknown_error).with(
-          error_type: "update_files_error",
+          error_type: "update_graph_error",
           error_details: {
             Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
             Dependabot::ErrorAttributes::MESSAGE => "hell",
@@ -185,7 +185,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       end
     end
 
-    context "with an update files error (ghes)" do
+    context "with an update graph error (ghes)" do
       let(:error) { StandardError.new("hell") }
 
       it_behaves_like "a fast-failed job"
@@ -193,7 +193,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       it "captures the exception and records to a update job error api" do
         expect(service).to receive(:capture_exception)
         expect(service).to receive(:record_update_job_error).with(
-          error_type: "update_files_error",
+          error_type: "update_graph_error",
           error_details: {
             Dependabot::ErrorAttributes::BACKTRACE => an_instance_of(String),
             Dependabot::ErrorAttributes::MESSAGE => "hell",


### PR DESCRIPTION
### What are you trying to accomplish?

This PR resolves a TODO in the `UpdateGraphCommand` to ensure we use a distinct label for unknown errors from this command:
https://github.com/dependabot/dependabot-core/blob/9a3bc9da41f690a8d752fcf8b5c88c7d2269efdb/updater/lib/dependabot/update_graph_command.rb#L17-L24

### Anything you want to highlight for special attention from reviewers?

This PR depends on a backend change before it can ship.

### How will you know you've accomplished your goal?

This is primarily validated by tests, but if we get unexpected errors as we work we should start seeing them instrumented correctly.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
