### PR TITLE
Add pattern scoring to group engine

### DIFF
--- a/updater/lib/dependabot/updater/group_dependency_selector.rb
+++ b/updater/lib/dependabot/updater/group_dependency_selector.rb
@@ -204,7 +204,7 @@ module Dependabot
         contains_checker = T.let(
           proc { |group, dependency, dir| group_contains_dependency_for_group?(group, dependency, dir) },
           T.proc.params(group: Dependabot::DependencyGroup, dep: Dependabot::Dependency,
-                        directory: String).returns(T::Boolean)
+                        directory: T.nilable(String)).returns(T::Boolean)
         )
 
         @specificity_calculator.dependency_belongs_to_more_specific_group?(

--- a/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
+++ b/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
@@ -39,8 +39,9 @@ module Dependabot
           dep: Dependabot::Dependency,
           groups: T::Array[Dependabot::DependencyGroup],
           contains_checker:
-            T.proc.params(group: Dependabot::DependencyGroup, dep: Dependabot::Dependency, directory: String)
-                             .returns(T::Boolean), directory: String
+            T.proc.params(group: Dependabot::DependencyGroup, dep: Dependabot::Dependency, directory: T.nilable(String))
+                             .returns(T::Boolean),
+          directory: T.nilable(String)
         ).returns(T::Boolean)
       end
       def dependency_belongs_to_more_specific_group?(current_group, dep, groups, contains_checker, directory)

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -344,18 +344,22 @@ RSpec.describe Dependabot::DependencyGroupEngine do
 
           it "returns true when dependency belongs to more specific group" do
             # dummy-pkg-a belongs to very-specific-group, so should skip generic and specific groups
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a, specificity_calculator)).to be(true)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a, specificity_calculator)).to be(true)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(true)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(true)
           end
 
           it "returns false when dependency belongs to most specific group" do
             # dummy-pkg-a in very-specific-group (most specific) should not be skipped
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(false)
           end
 
           it "returns false when no more specific group exists" do
             # ungrouped_pkg only matches generic-group, so should not be skipped
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, ungrouped_pkg, specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, ungrouped_pkg,
+                                                specificity_calculator)).to be(false)
           end
         end
 
@@ -363,9 +367,12 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           let(:experiment_enabled) { false }
 
           it "always returns false regardless of specificity" do
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a, specificity_calculator)).to be(false)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a,
+                                                specificity_calculator)).to be(false)
           end
         end
       end

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -337,28 +337,25 @@ RSpec.describe Dependabot::DependencyGroupEngine do
         let(:generic_group) { dependency_group_engine.find_group(name: "generic-group") }
         let(:specific_group) { dependency_group_engine.find_group(name: "specific-group") }
         let(:very_specific_group) { dependency_group_engine.find_group(name: "very-specific-group") }
+        let(:specificity_calculator) { Dependabot::Updater::PatternSpecificityCalculator.new }
 
         context "when experiment is enabled" do
           let(:experiment_enabled) { true }
 
           it "returns true when dependency belongs to more specific group" do
             # dummy-pkg-a belongs to very-specific-group, so should skip generic and specific groups
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group,
-                                                dummy_pkg_a)).to be(true)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group,
-                                                dummy_pkg_a)).to be(true)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a, specificity_calculator)).to be(true)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a, specificity_calculator)).to be(true)
           end
 
           it "returns false when dependency belongs to most specific group" do
             # dummy-pkg-a in very-specific-group (most specific) should not be skipped
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group,
-                                                dummy_pkg_a)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
           end
 
           it "returns false when no more specific group exists" do
             # ungrouped_pkg only matches generic-group, so should not be skipped
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group,
-                                                ungrouped_pkg)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, ungrouped_pkg, specificity_calculator)).to be(false)
           end
         end
 
@@ -366,12 +363,9 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           let(:experiment_enabled) { false }
 
           it "always returns false regardless of specificity" do
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group,
-                                                dummy_pkg_a)).to be(false)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group,
-                                                dummy_pkg_a)).to be(false)
-            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group,
-                                                dummy_pkg_a)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, generic_group, dummy_pkg_a, specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
+            expect(dependency_group_engine.send(:should_skip_due_to_specificity?, very_specific_group, dummy_pkg_a, specificity_calculator)).to be(false)
           end
         end
       end

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -114,6 +114,11 @@ RSpec.describe Dependabot::DependencySnapshot do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:allow_refresh_for_existing_pr_dependencies)
       .and_return(true)
+    # Default stub for group membership enforcement so specs that don't explicitly
+    # stub this flag won't fail when the code queries it.
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:group_membership_enforcement)
+      .and_return(false)
   end
 
   after do

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -114,8 +114,6 @@ RSpec.describe Dependabot::DependencySnapshot do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:allow_refresh_for_existing_pr_dependencies)
       .and_return(true)
-    # Default stub for group membership enforcement so specs that don't explicitly
-    # stub this flag won't fail when the code queries it.
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:group_membership_enforcement)
       .and_return(false)


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces pattern scoring to the group engine. The goal is to enhance how dependency groups are evaluated and prioritized by assigning scores to patterns, allowing for more nuanced and flexible grouping logic.

By adding a scoring mechanism, we can:
- Better control which dependencies are grouped together, based on their pattern specificity.
- Resolve conflicts where multiple patterns could apply to a dependency by preferring the highest-scoring (most specific) pattern.
- Lay the groundwork for future enhancements that may require more granular group selection and matching.

This change does not alter the default grouping behavior, but it makes the underlying logic more extensible and predictable.

### What issues does this affect or fix?

- Lays the foundation for addressing issues where grouping logic was too coarse or ambiguous.
- No specific GitHub issues are fixed in this PR, but it prepares the codebase for future improvements and bugfixes related to dependency grouping.

### Anything you want to highlight for special attention from reviewers?

Please review the new pattern scoring logic and how scores are calculated for various patterns.

### How will you know you've accomplished your goal?

Grouping logic now prefers more specific patterns when multiple matches are possible.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.