### PR TITLE
Dependency Graphing: Update job.correlator to use the relevant manifest path

### DIFF
--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -90,7 +90,6 @@ module GithubApi
       # If manifest is at repository root, append the file name
       return "#{base}-#{basename}" if dirname == ""
 
-      # If the dirname is pathologically long, we replace it with a SHA256
       sanitized_path = if dirname.bytesize > 32
                          # If the dirname is pathologically long, we replace it with a SHA256
                          Digest::SHA256.hexdigest(dirname)

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -49,7 +49,7 @@ module GithubApi
                          dependency_files:,
                          dependencies:
                        ), Dependabot::DependencyGraphers::Base)
-      @manifests = T.let(build_manifests(dependency_files, dependencies), T::Hash[String, T.untyped])
+      @manifests = T.let(build_manifests(dependencies), T::Hash[String, T.untyped])
     end
 
     # TODO: Change to a typed structure?
@@ -109,11 +109,10 @@ module GithubApi
 
     sig do
       params(
-        dependency_files: T::Array[Dependabot::DependencyFile],
         dependencies: T::Array[Dependabot::Dependency]
       ).returns(T::Hash[String, T.untyped])
     end
-    def build_manifests(dependency_files, dependencies)
+    def build_manifests(dependencies)
       return {} if dependencies.empty?
 
       file = grapher.relevant_dependency_file


### PR DESCRIPTION
### What are you trying to accomplish?

Our `job.correlator` value in Dependency Submission payloads is currently very simple and just states that the submission is from Dependabot for a given ecosystem.

In order to support monorepos where there may be more than one snapshot for each ecosystem, and jobs where multiple directories may be graphed at once, we need to make this unique on the manifest.

I've updated the correlation to do this in a fairly straightforward way, let's just append the manifest path to the value.

### Anything you want to highlight for special attention from reviewers?

We store this value as part of the snapshot so there isn't a strict character length, but I didn't want to leave us handling unbounded strings so I've put in a bytesize check that replaces any path longer than 32 bytes with a SHA256 so we have a stable upper boundary that still remains unique on path.

### How will you know you've accomplished your goal?

We start seeing correlators that include the manifest path

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
