### PR TITLE
fix NilClass exception due to ecosystem not being set

### DIFF
--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -71,7 +71,7 @@ module Dependabot
         job_id: job.id.to_s,
         branch: job.source.branch || "main",
         sha: dependency_snapshot.base_commit_sha,
-        ecosystem: T.must(dependency_snapshot.ecosystem),
+        package_manager: job.package_manager,
         dependency_files: dependency_snapshot.dependency_files,
         dependencies: dependency_snapshot.dependencies
       )

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -34,16 +34,16 @@ module GithubApi
         job_id: String,
         branch: String,
         sha: String,
-        ecosystem: Dependabot::Ecosystem,
+        package_manager: String,
         dependency_files: T::Array[Dependabot::DependencyFile],
         dependencies: T::Array[Dependabot::Dependency]
       ).void
     end
-    def initialize(job_id:, branch:, sha:, ecosystem:, dependency_files:, dependencies:)
+    def initialize(job_id:, branch:, sha:, package_manager:, dependency_files:, dependencies:)
       @job_id = job_id
       @branch = branch
       @sha = sha
-      @package_manager = T.let(ecosystem.name, String)
+      @package_manager = package_manager
 
       @grapher = T.let(Dependabot::DependencyGraphers.for_package_manager(package_manager).new(
                          dependency_files:,


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes an error using the ecosystem from DependencySnapshot in the `graph` command. 

It looks like we're trying to get the package_manager which is always set on the job, so this is a simplification as well as fixing the error.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
