### PR TITLE
added hyphen to fix mismatch

### DIFF
--- a/updater/lib/dependabot/pull_request.rb
+++ b/updater/lib/dependabot/pull_request.rb
@@ -67,7 +67,7 @@ module Dependabot
               version: dep.fetch("dependency-version", nil),
               removed: dep.fetch("dependency-removed", false),
               directory: dep.fetch("directory", nil),
-              pr_number: dep.fetch("pr_number", nil)&.to_i
+              pr_number: dep.fetch("pr-number", nil)&.to_i
             )
           end
         )

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -838,7 +838,7 @@ RSpec.describe Dependabot::Updater do
             {
               "dependency-name" => "dummy-pkg-b",
               "dependency-version" => "1.2.0",
-              "pr_number" => 123
+              "pr-number" => 123
             }
           ]
         ])


### PR DESCRIPTION
### What are you trying to accomplish?

the job definition from API was sending pr_number ,but it gets transformed into pr-number [here ](https://github.com/dependabot/dependabot-core/blob/5dedf3910282d03f486bb393dd1f225eabc2100a/updater/lib/dependabot/job.rb#L141), but core still expects pr_number [here ](https://github.com/dependabot/dependabot-core/blob/5dedf3910282d03f486bb393dd1f225eabc2100a/updater/lib/dependabot/pull_request.rb#L70)which is wrong
so i fixed that mismatch.
### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
succesfull testing in API
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
