### PR TITLE
Add GitHub Package Registry support for Bundler ecosystem.

### DIFF
--- a/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
@@ -143,7 +143,9 @@ module Dependabot
           rescue URI::InvalidURIError
             raise "Invalid registry URL: #{registry_url}"
           end
-          return package_details([]) if parsed_url.host == "rubygems.pkg.github.com"
+
+          # Handle GitHub Package Registry
+          return github_packages_versions(registry_url) if parsed_url.host == "rubygems.pkg.github.com"
 
           response = registry_json_response_for_dependency(registry_url)
 
@@ -191,6 +193,61 @@ module Dependabot
             url: url,
             headers: { "Accept" => APPLICATION_JSON }
           )
+        end
+
+        sig { params(registry_url: String).returns(Dependabot::Package::PackageDetails) }
+        def github_packages_versions(registry_url)
+          # Extract org name from URL like "https://rubygems.pkg.github.com/dsp-testing/"
+          org_name = registry_url.split("/").last
+
+          # GitHub Packages API endpoint for RubyGems packages
+          api_url = "https://api.github.com/orgs/#{org_name}/packages/rubygems/#{dependency.name}/versions"
+
+          response = Dependabot::RegistryClient.get(
+            url: api_url,
+            headers: {
+              "Accept" => "application/vnd.github.v3+json",
+              "Authorization" => "Bearer #{github_token}"
+            }
+          )
+
+          unless response.status == 200
+            error_details = "Status: #{response.status}"
+            error_details += " (Package not found in GitHub Registry)" if response.status == 404
+            error_message = "Failed to fetch versions for '#{dependency.name}' from GitHub Packages. #{error_details}"
+            Dependabot.logger.info(error_message)
+            return package_details([])
+          end
+
+          begin
+            versions_data = JSON.parse(response.body)
+            package_releases = versions_data.map do |version_info|
+              # GitHub Packages API returns different structure than RubyGems
+              version_number = version_info["name"] # GitHub uses "name" for version
+              created_at = version_info["created_at"]
+
+              package_release(
+                version: version_number,
+                released_at: Time.parse(created_at),
+                downloads: 0, # GitHub Packages doesn't provide download counts
+                url: "#{registry_url}/gems/#{dependency.name}-#{version_number}.gem",
+                ruby_version: nil # GitHub Packages API doesn't provide ruby version requirements
+              )
+            end
+
+            package_details(package_releases)
+          rescue JSON::ParserError => e
+            Dependabot.logger.info("Failed to parse GitHub Packages response: #{e.message}")
+            package_details([])
+          end
+        end
+
+        sig { returns(T.nilable(String)) }
+        def github_token
+          github_credential = credentials.find do |cred|
+            cred["type"] == "rubygems_server" && cred["host"] == "rubygems.pkg.github.com"
+          end
+          github_credential&.fetch("token", nil)
         end
 
         sig { params(req_string: String).returns(Requirement) }

--- a/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
@@ -102,5 +102,284 @@ RSpec.describe Dependabot::Bundler::Package::PackageDetailsFetcher do
         end
       end
     end
+
+    describe "GitHub Package Registry support" do
+      let(:dependency_name) { "json" }
+      let(:source) do
+        {
+          type: "rubygems",
+          url: "https://rubygems.pkg.github.com/dsp-testing/"
+        }
+      end
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "rubygems_server",
+              "host" => "rubygems.pkg.github.com",
+              "token" => "ghp_test_token_123"
+            }
+          )
+        ]
+      end
+      let(:github_api_url) { "https://api.github.com/orgs/dsp-testing/packages/rubygems/json/versions" }
+
+      context "when package exists in GitHub registry" do
+        let(:github_api_response) do
+          [
+            {
+              "id" => 123,
+              "name" => "2.12.2",
+              "created_at" => "2023-09-01T10:00:00Z",
+              "updated_at" => "2023-09-01T10:00:00Z"
+            },
+            {
+              "id" => 122,
+              "name" => "2.12.1",
+              "created_at" => "2023-08-15T09:30:00Z",
+              "updated_at" => "2023-08-15T09:30:00Z"
+            },
+            {
+              "id" => 121,
+              "name" => "2.11.0",
+              "created_at" => "2023-07-01T08:00:00Z",
+              "updated_at" => "2023-07-01T08:00:00Z"
+            }
+          ]
+        end
+
+        before do
+          stub_request(:get, github_api_url)
+            .with(
+              headers: {
+                "Accept" => "application/vnd.github.v3+json",
+                "Authorization" => "Bearer ghp_test_token_123"
+              }
+            )
+            .to_return(
+              status: 200,
+              body: github_api_response.to_json,
+              headers: { "Content-Type" => "application/json" }
+            )
+        end
+
+        it "returns package details with all versions" do
+          result = fetch
+
+          expect(result).to be_a(Dependabot::Package::PackageDetails)
+          expect(result.releases.length).to eq(3)
+
+          # Check versions are in correct order (oldest first)
+          versions = result.releases.map { |release| release.version.to_s }
+          expect(versions).to eq(["2.12.2", "2.12.1", "2.11.0"])
+        end
+
+        it "creates package releases with correct GitHub attributes" do
+          result = fetch
+          latest_release = result.releases.first
+
+          expect(latest_release.version.to_s).to eq("2.12.2")
+          expect(latest_release.released_at).to eq(Time.parse("2023-09-01T10:00:00Z"))
+          expect(latest_release.downloads).to eq(0) # GitHub doesn't provide download counts
+          expect(latest_release.url).to eq("https://rubygems.pkg.github.com/dsp-testing/gems/json-2.12.2.gem")
+          expect(latest_release.yanked).to be false
+          expect(latest_release.package_type).to eq("gem")
+          expect(latest_release.language.name).to eq("ruby")
+          expect(latest_release.language.requirement).to be_nil # GitHub doesn't provide ruby version
+        end
+
+        it "makes authenticated request to GitHub API" do
+          fetch
+
+          expect(
+            a_request(:get, github_api_url)
+                        .with(
+                          headers: {
+                            "Accept" => "application/vnd.github.v3+json",
+                            "Authorization" => "Bearer ghp_test_token_123"
+                          }
+                        )
+          ).to have_been_made.once
+        end
+      end
+
+      context "when package is not found in GitHub registry" do
+        before do
+          stub_request(:get, github_api_url)
+            .with(
+              headers: {
+                "Accept" => "application/vnd.github.v3+json",
+                "Authorization" => "Bearer ghp_test_token_123"
+              }
+            )
+            .to_return(status: 404, body: "Not Found")
+        end
+
+        it "returns empty package details" do
+          result = fetch
+
+          expect(result).to be_a(Dependabot::Package::PackageDetails)
+          expect(result.releases).to be_empty
+        end
+
+        it "logs package not found error" do
+          expect(Dependabot.logger).to receive(:info)
+            .with("Failed to fetch versions for 'json' from GitHub Packages. " \
+                  "Status: 404 (Package not found in GitHub Registry)")
+
+          fetch
+        end
+      end
+
+      context "when GitHub API returns server error" do
+        before do
+          stub_request(:get, github_api_url)
+            .to_return(status: 500, body: "Internal Server Error")
+        end
+
+        it "returns empty package details" do
+          result = fetch
+
+          expect(result).to be_a(Dependabot::Package::PackageDetails)
+          expect(result.releases).to be_empty
+        end
+
+        it "logs server error" do
+          expect(Dependabot.logger).to receive(:info)
+            .with("Failed to fetch versions for 'json' from GitHub Packages. Status: 500")
+
+          fetch
+        end
+      end
+
+      context "when GitHub API returns invalid JSON" do
+        before do
+          stub_request(:get, github_api_url)
+            .to_return(
+              status: 200,
+              body: "invalid json{",
+              headers: { "Content-Type" => "application/json" }
+            )
+        end
+
+        it "returns empty package details" do
+          result = fetch
+
+          expect(result).to be_a(Dependabot::Package::PackageDetails)
+          expect(result.releases).to be_empty
+        end
+
+        it "logs JSON parsing error" do
+          expect(Dependabot.logger).to receive(:info)
+            .with(/Failed to parse GitHub Packages response:/)
+
+          fetch
+        end
+      end
+
+      context "when no GitHub token is provided" do
+        let(:credentials) { [] }
+
+        before do
+          stub_request(:get, github_api_url)
+            .with(
+              headers: {
+                "Accept" => "application/vnd.github.v3+json",
+                "Authorization" => "Bearer "
+              }
+            )
+            .to_return(status: 401, body: "Unauthorized")
+        end
+
+        it "makes request with empty authorization header" do
+          fetch
+
+          expect(
+            a_request(:get, github_api_url)
+                        .with(
+                          headers: {
+                            "Accept" => "application/vnd.github.v3+json",
+                            "Authorization" => "Bearer "
+                          }
+                        )
+          ).to have_been_made.once
+        end
+      end
+    end
+
+    describe "#github_token" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "rubygems_server",
+              "host" => "rubygems.pkg.github.com",
+              "token" => "ghp_test_token_123"
+            }
+          )
+        ]
+      end
+
+      it "extracts token from rubygems_server credentials" do
+        expect(fetcher.send(:github_token)).to eq("ghp_test_token_123")
+      end
+
+      context "when no matching credentials" do
+        let(:credentials) { [] }
+
+        it "returns nil" do
+          expect(fetcher.send(:github_token)).to be_nil
+        end
+      end
+
+      context "with multiple credential types" do
+        let(:credentials) do
+          [
+            Dependabot::Credential.new(
+              {
+                "type" => "git_source",
+                "host" => "github.com",
+                "token" => "different_token"
+              }
+            ),
+            Dependabot::Credential.new(
+              {
+                "type" => "rubygems_server",
+                "host" => "rubygems.pkg.github.com",
+                "token" => "correct_token"
+              }
+            )
+          ]
+        end
+
+        it "returns the correct GitHub Package Registry token" do
+          expect(fetcher.send(:github_token)).to eq("correct_token")
+        end
+      end
+    end
+
+    describe "#get_url_from_dependency" do
+      context "with GitHub Package Registry source URL" do
+        let(:source) do
+          {
+            type: "rubygems",
+            url: "https://rubygems.pkg.github.com/dsp-testing/"
+          }
+        end
+
+        it "returns URL without trailing slash" do
+          expect(fetcher.send(:get_url_from_dependency, dependency))
+            .to eq("https://rubygems.pkg.github.com/dsp-testing")
+        end
+      end
+
+      context "without source URL" do
+        let(:source) { { type: "rubygems" } }
+
+        it "returns nil" do
+          expect(fetcher.send(:get_url_from_dependency, dependency)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Bundler grouping failed initially because the latest version couldn't be resolved.
Example logs:
```
updater | 2025/09/22 12:54:21 INFO <job_1105772381> Finished job processing
updater | 2025/09/22 12:54:21 INFO Results:
+------------------------------------------+
|   Changes to Dependabot Pull Requests    |
+---------+--------------------------------+
| created | json ( from 2.10.2 to 2.12.2 ) |
| created | json ( from 2.11.0 to 2.12.2 ) |
+---------+--------------------------------+
Cleaned up container 34b53fbba59c1a6662aa5b95f6ad98a4f290d27c6c85a7bdebcc0d18620a6100
```
The latest version was not identified:
```
proxy | 2025/09/22 12:54:14 [024] GET [https://rubygems.pkg.github.com:443/dsp-testing/versions](https://rubygems.pkg.github.com/dsp-testing/versions)
  proxy | 2025/09/22 12:54:14 [024] * authenticating rubygems server request (host: rubygems.pkg.github.com)
  proxy | 2025/09/22 12:54:15 [024] 304 [https://rubygems.pkg.github.com:443/dsp-testing/versions](https://rubygems.pkg.github.com/dsp-testing/versions)
updater | 2025/09/22 12:54:15 INFO <job_1105772381> Process PID: 1730 completed with status: pid 1730 exit 0
2025/09/22 12:54:15 INFO <job_1105772381> Total execution time: 0.45 seconds
updater | 2025/09/22 12:54:15 INFO <job_1105772381> Latest version is
```

### Anything you want to highlight for special attention from reviewers?

After applying the changes, the latest version was successfully identified and grouping worked as expected.
Latest version log:
```
2025/09/23 10:57:21 INFO Process PID: 1396 completed with status: pid 1396 exit 0
2025/09/23 10:57:21 INFO Total execution time: 0.49 seconds
2025/09/23 10:57:21 INFO Latest version is 2.12.2
```
Grouping log:
```
2025/09/23 10:57:24 INFO Results:
+--------------------------------------------------------------------------+
|                   Changes to Dependabot Pull Requests                    |
+---------+----------------------------------------------------------------+
| created | json ( from 2.10.2 to 2.12.2 ), json ( from 2.11.0 to 2.12.2 ) |
+---------+----------------------------------------------------------------+
```

### How will you know you've accomplished your goal?

Executed the CLI on a local development machine and confirmed the expected results. Also added RSpec tests to validate the implementation.

Key updates:
- Introduced `github_packages_versions` method to retrieve versions from the GitHub Packages API
- Enabled authentication using `rubygems_server` credentials
- Handled GitHub-specific response formats and error scenarios
- Added thorough RSpec coverage for success paths, failure modes, and edge cases
- Corrected URL construction and ensured proper version ordering for GitHub packages

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
