### PR TITLE
Return [] instead of raising NoChangeError when no files are updated

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -67,18 +67,14 @@ module Dependabot
             raise_miss_configured_tooling_if_pnpm_subdirectory
           end
 
-          raise NoChangeError.new(
-            message: "No files were updated!",
-            error_context: error_context(updated_files: updated_files)
-          )
+          # Return empty array instead of raising error when no updates needed
+          return []
         end
 
         sorted_updated_files = updated_files.sort_by(&:name)
         if sorted_updated_files == filtered_dependency_files.sort_by(&:name)
-          raise NoChangeError.new(
-            message: "Updated files are unchanged!",
-            error_context: error_context(updated_files: updated_files)
-          )
+          # Return empty array instead of raising error when files are unchanged
+          return []
         end
 
         vendor_updated_files(updated_files)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       context "when nothing has changed" do
         let(:requirements) { previous_requirements }
 
-        specify { expect { updated_files }.to raise_error(/No files/) }
+        specify { expect(updated_files).to eq([]) }
       end
     end
 
@@ -1800,10 +1800,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             }]
           end
 
-          it "doesn't update any files and raises" do
-            expect { updated_files }.to raise_error(
-              described_class::NoChangeError, "No files were updated!"
-            )
+          it "doesn't update any files and returns empty array" do
+            expect(updated_files).to eq([])
           end
         end
 


### PR DESCRIPTION


### What are you trying to accomplish?
npm_and_yarn: Return empty array instead of raising NoChangeError when no files are updated

- Updates FileUpdater to return [] instead of raising NoChangeError if no dependency files are changed.
- Updates relevant specs to expect [] rather than an error.
- Prevents unnecessary Sentry errors for no-op updates.
<!-- Provide both a what and a _why_ for the change. -->

The Sentry error was caused by Dependabot's npm_and_yarn FileUpdater raising a NoChangeError exception when no dependency files needed updating after running the update process. This occurs in legitimate scenarios where dependencies are already at their target versions or when security advisories don't require actual file changes. The fix modifies the [updated_dependency_files](vscode-file://vscode-app/private/var/folders/q7/_8nm4mls1jb_y9h5vsts50yr0000gn/T/AppTranslocation/923074C8-B498-4E9E-B0FB-B09A002B1926/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method to return an empty array instead of raising an exception

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
