### PR TITLE
changed structure of pull requests

### DIFF
--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -196,7 +196,7 @@ module Dependabot
         def log_existing_pr_for_latest_version(dependency_name, latest_version, latest_version_obj)
           pr_number = job.existing_pull_requests
                          .find { |pr| pr.contains_dependency?(dependency_name, latest_version) }
-                         &.dependencies&.first&.pr_number
+                         &.pr_number
 
           pr_number_text = pr_number ? "##{pr_number} " : ""
 

--- a/updater/spec/dependabot/pull_request_spec.rb
+++ b/updater/spec/dependabot/pull_request_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).to eq(pr2)
@@ -33,19 +33,19 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "bar",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).not_to eq(pr2)
@@ -56,19 +56,19 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "2.0.0",
-            pr_number: 123
+            version: "2.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).not_to eq(pr2)
@@ -79,20 +79,20 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
             version: "1.0.0",
-            removed: true,
-            pr_number: 123
+            removed: true
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).not_to eq(pr2)
@@ -104,20 +104,20 @@ RSpec.describe Dependabot::PullRequest do
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
             version: "1.0.0",
-            directory: "/foo",
-            pr_number: 123
+            directory: "/foo"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
             version: "1.0.0",
-            directory: "/bar",
-            pr_number: 123
+            directory: "/bar"
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).not_to eq(pr2)
@@ -128,24 +128,23 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           ),
           Dependabot::PullRequest::Dependency.new(
             name: "bar",
-            version: "2.0.0",
-            pr_number: 456
+            version: "2.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
 
       expect(pr1).not_to eq(pr2)
@@ -156,24 +155,23 @@ RSpec.describe Dependabot::PullRequest do
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           )
-        ]
+        ],
+        pr_number: 123
       )
       pr2 = described_class.new(
         [
           Dependabot::PullRequest::Dependency.new(
             name: "foo",
-            version: "1.0.0",
-            pr_number: 123
+            version: "1.0.0"
           ),
           Dependabot::PullRequest::Dependency.new(
             name: "bar",
-            version: "2.0.0",
-            pr_number: 456
+            version: "2.0.0"
           )
-        ]
+        ],
+        pr_number: 456
       )
 
       expect(pr1).not_to eq(pr2)

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -285,10 +285,10 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
             [
               Dependabot::PullRequest::Dependency.new(
                 name: "dummy-pkg-a",
-                version: "2.0.1",
-                pr_number: 123
+                version: "2.0.1"
               )
-            ]
+            ],
+            pr_number: 123
           )
         ])
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Changed the structure of the pull request object.

Including the PR number inside the dependency object was creating issues when a PR had to be created.
So moving the pr number outside the dependency object in to the pull request object make more sense. This fix change will change rebase update. 
* fix : https://github.com/dependabot/dependabot-core/pull/13161
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
Change does not break rebase updates again and is still compatible with older version of API that GHES is running on
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
