### PR TITLE
Allow for missing go directive in `go.mod`

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -130,17 +130,15 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def language
         @language ||= T.let(
-          begin
-            Language.new(go_version)
-          end,
+          go_version ? Language.new(T.must(go_version)) : nil,
           T.nilable(Dependabot::GoModules::Language)
         )
       end
 
-      sig { returns(String) }
+      sig { returns(T.nilable(String)) }
       def go_version
         @go_version ||= T.let(
-          T.must(go_mod&.content&.match(/^go\s(\d+\.\d+(.\d+)*)/)&.captures&.first),
+          go_mod&.content&.match(/^go\s(\d+\.\d+(.\d+)*)/)&.captures&.first,
           T.nilable(String)
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

We're seeing the following issue in some repositories

```
Passed `nil` into T.must
file_parser.rb:70:in 'Dependabot::GoModules::FileParser#go_version
```

The issue is that the `go` directive in `go.mod` files was optional before Go 1.21[^1]. So some projects which rely on vendor dependencies that have not been updated since then will not have the `go` directive.

> The go directive sets the minimum version of Go required to use this module. Before Go 1.21, the directive was advisory only; now it is a mandatory requirement: Go toolchains refuse to use modules declaring newer Go versions.

This change makes it optional in Dependabot as well.

[^1]: https://go.dev/doc/modules/gomod-ref#go

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
