### PR TITLE
mark implicit packages as transitive

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -20,15 +20,17 @@ public class DiscoveryWorkerTestBase : TestBase
         ExpectedWorkspaceDiscoveryResult expectedResult,
         MockNuGetPackage[]? packages = null,
         bool includeCommonPackages = true,
-        ExperimentsManager? experimentsManager = null)
+        ExperimentsManager? experimentsManager = null,
+        string? repoContentsPath = null)
     {
         experimentsManager ??= new ExperimentsManager();
         var actualResult = await RunDiscoveryAsync(files, async directoryPath =>
         {
             await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath, includeCommonPackages: includeCommonPackages);
 
+            repoContentsPath ??= directoryPath;
             var worker = new DiscoveryWorker("TEST-JOB-ID", experimentsManager, new TestLogger());
-            var result = await worker.RunWithErrorHandlingAsync(directoryPath, workspacePath);
+            var result = await worker.RunWithErrorHandlingAsync(repoContentsPath, workspacePath);
             return result;
         });
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -635,6 +635,14 @@ internal static class SdkProjectDiscovery
 
                         if (doAddOperation)
                         {
+                            var isImplicitlyDefined = GetChildMetadataBooleanValue(child, "IsImplicitlyDefined");
+                            if (isImplicitlyDefined)
+                            {
+                                // packages with `IsImplicitlyDefined="true"` aren't to be treated as top-level packages and shouldn't be candidates for regular update operations
+                                // they should still appear in the discovery list, though, so security jobs can update them as necessary
+                                continue;
+                            }
+
                             topLevelPackagesPerTfm.Add(packageName);
                             var packageVersion = GetChildMetadataValue(child, "Version");
                             if (packageVersion is not null)
@@ -725,6 +733,13 @@ internal static class SdkProjectDiscovery
         var metadata = node.Children.OfType<Metadata>();
         var metadataValue = metadata.FirstOrDefault(m => m.Name.Equals(metadataItemName, StringComparison.OrdinalIgnoreCase))?.Value;
         return metadataValue;
+    }
+
+    private static bool GetChildMetadataBooleanValue(TreeNode node, string metadataItemName)
+    {
+        var metadataString = GetChildMetadataValue(node, metadataItemName);
+        var metadataBooleanValue = bool.TryParse(metadataString, out var parsedMetadataValue) && parsedMetadataValue;
+        return metadataBooleanValue;
     }
 
     private static ProjectEvaluation? GetNearestProjectEvaluation(BaseNode node)


### PR DESCRIPTION
The SDK can add packages to a project restore graph and when it does the extra metadata `IsImplicitlyDefined="true"` is set.  Those packages should still appear in the dependency graph because security jobs might need to update them, but they _shouldn't_ appear as top-level items (even though they technically are) because regular version update jobs shouldn't update them.

The fix is to not report the package as top-level if the `IsImplicitlyDefined` metadata is set and instead report them as transitive dependencies (because they ultimately come through `Microsoft.NET.Sdk`).