### PR TITLE
Skip the pattern Specificity calculator if there is no pattern set

### DIFF
--- a/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
+++ b/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
@@ -45,6 +45,9 @@ module Dependabot
         ).returns(T::Boolean)
       end
       def dependency_belongs_to_more_specific_group?(current_group, dep, groups, contains_checker, directory)
+        patterns = T.unsafe(current_group.rules["patterns"])
+        return false unless patterns
+
         current_group_specificity = calculate_group_specificity_for_dependency(current_group, dep)
 
         return false if current_group_specificity >= EXPLICIT_MEMBER_SCORE

--- a/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
+++ b/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
@@ -46,7 +46,7 @@ module Dependabot
       end
       def dependency_belongs_to_more_specific_group?(current_group, dep, groups, contains_checker, directory)
         patterns = T.unsafe(current_group.rules["patterns"])
-        return false unless patterns
+        return false unless patterns&.any?
 
         current_group_specificity = calculate_group_specificity_for_dependency(current_group, dep)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Add early return optimization to skip pattern matching when dependency groups have no patterns defined (e.g., groups with only `"update-types" => ["patch"]` rules).

Fixes: https://github.com/dependabot/dependabot-core/issues/13154

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Returns false immediately when `rules["patterns"]` is empty, avoiding expensive pattern specificity calculations for rule-based groups.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

We will no longer to check patterns when no patterns are present

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
