### PR TITLE
Fix Python version defaulting to 3.9 (lowest available) instead of latest when no explicit version specified

### DIFF
--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -121,6 +121,8 @@ module Dependabot
           @python_requirement_parser.imputed_requirements.map do |r|
             Dependabot::Python::Requirement.new(r)
           end
+        return unless compiled_file_python_requirement_markers.any?
+
         python_version_matching(compiled_file_python_requirement_markers)
       end
 

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -527,7 +527,8 @@ RSpec.describe Dependabot::Python::FileFetcher do
       it "exposes the expected ecosystem_versions metric" do
         expect(file_fetcher_instance.ecosystem_versions).to eq(
           {
-            languages: { python: { "max" => "3.9", "raw" => "unknown" } }
+            # When there is no version specified, we assume the max supported
+            languages: { python: { "max" => "3.13", "raw" => "unknown" } }
           }
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

When no explicit Python version is specified in manifest files, Dependabot incorrectly defaults to Python 3.9.23 instead of the latest supported version (3.13.5). This prevents updates to packages like Django 5.2.7 that require Python 3.10+.

Related issue: https://github.com/dependabot/dependabot-core/issues/12256

### Anything you want to highlight for special attention from reviewers?

The `python_version_matching_imputed_requirements` method is incorrectly inferring Python 3.9 (the lowest available version) compatibility from existing dependencies, preventing the fallback to `Language::PRE_INSTALLED_HIGHEST_VERSION`.


### How will you know you've accomplished your goal?

With Rspec
With Cli run

```
updater | 2025/10/02 15:34:48 INFO Checking if django 5.2.6 needs updating
updater | 2025/10/02 15:34:48 INFO Fetching release information from json registry at https://pypi.org/pypi/ for django
  proxy | 2025/10/02 15:34:48 [021] GET https://pypi.org/pypi/django/json
  proxy | 2025/10/02 15:34:48 [021] 200 https://pypi.org/pypi/django/json
updater | 2025/10/02 15:34:48 INFO Filtered out 2 yanked versions
updater | 2025/10/02 15:34:48 INFO Filtered out 51 pre-release versions
updater | 2025/10/02 15:34:48 INFO Latest version is 5.2.7
updater | 2025/10/02 15:34:48 INFO Python package resolver : requirements
updater | 2025/10/02 15:34:48 INFO Fetching release information from json registry at https://pypi.org/pypi/ for django
  proxy | 2025/10/02 15:34:49 [023] GET https://pypi.org/pypi/django/json
  proxy | 2025/10/02 15:34:49 [023] 200 https://pypi.org/pypi/django/json (cached)
updater | 2025/10/02 15:34:49 INFO Filtered out 2 yanked versions
updater | 2025/10/02 15:34:49 INFO Filtered out 51 pre-release versions
updater | 2025/10/02 15:34:49 INFO Requirements to unlock own
updater | 2025/10/02 15:34:49 INFO Requirements update strategy bump_versions
updater | 2025/10/02 15:34:49 INFO Updating django from 5.2.6 to 5.2.7
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
