### PR TITLE
Fixes a `Passed 'nil' into T.must` error in the Cargo file fetcher when workspace paths are exactly `"*"` 

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -399,7 +399,8 @@ module Dependabot
       def expand_workspaces(path)
         path = Pathname.new(path).cleanpath.to_path
         dir = directory.gsub(%r{(^/|/$)}, "")
-        unglobbed_path = T.must(path.split("*").first).gsub(%r{(?<=/)[^/]*$}, "")
+
+        unglobbed_path = (path.split("*").first || "").gsub(%r{(?<=/)[^/]*$}, "")
 
         repo_contents(dir: unglobbed_path, raise_errors: false)
           .select { |file| file.type == "dir" }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes a `Passed 'nil' into T.must` error in the Cargo file fetcher when workspace paths are exactly `"*"` (wildcard-only).

### Anything you want to highlight for special attention from reviewers?

The `expand_workspaces` method in `Dependabot::Cargo::FileFetcher` was failing with a Sorbet type error when processing workspace member paths that are exactly `"*"`. This occurred because `path.split("*").first` returns `nil` when the path is a single wildcard character, causing `T.must(nil)` to throw an exception.

### How will you know you've accomplished your goal?

- **Modified `expand_workspaces` method** to handle the nil case by using `|| ""` fallback
- **Changed**: `T.must(path.split("*").first)` → `(path.split("*").first || "")`
- **Added comprehensive test coverage** for all wildcard scenarios including the edge case

Ran cli and ensured all files got fetched without any error.

Added extensive RSpec tests covering:
- Simple glob patterns (`packages/*`)
- Exact wildcard (`*`) - the problematic edge case
- Leading wildcards (`*-crate`)
- Multiple wildcards (`src/*-crate-*`)
- Nested patterns (`apps/*/frontend`)
- No matches scenarios

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
