### PR TITLE
[Update Graph] If the `job.source.branch` is nil, this means we need to ask for the default branch

### DIFF
--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -49,14 +49,16 @@ module Dependabot
       raise Dependabot::DependabotError, "job.source.directories is nil" if job.source.directories.nil?
       raise Dependabot::DependabotError, "job.source.directories is empty" unless job.source.directories&.any?
 
+      branch = job.source.branch || fetch_default_branch_from_github
+
       T.must(job.source.directories).each do |directory|
         directory_source = create_source_for(directory)
         directory_dependency_files = dependency_files_for(directory)
 
         submission = if directory_dependency_files.empty?
-                       empty_submission(directory_source)
+                       empty_submission(branch, directory_source)
                      else
-                       create_submission(directory_source, directory_dependency_files)
+                       create_submission(branch, directory_source, directory_dependency_files)
                      end
 
         Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
@@ -93,12 +95,11 @@ module Dependabot
       dependency_files.select { |f| f.directory == directory }
     end
 
-    sig { params(source: Dependabot::Source).returns(GithubApi::DependencySubmission) }
-    def empty_submission(source)
+    sig { params(branch: String, source: Dependabot::Source).returns(GithubApi::DependencySubmission) }
+    def empty_submission(branch, source)
       GithubApi::DependencySubmission.new(
         job_id: job.id.to_s,
-        # FIXME(brrygrdn): We should obtain the ref from git -or- inject it via the backend service
-        branch: source.branch || "main",
+        branch: branch,
         sha: base_commit_sha,
         package_manager: job.package_manager,
         manifest_file: DependencyFile.new(name: "", content: "", directory: T.must(source.directory)),
@@ -108,11 +109,12 @@ module Dependabot
 
     sig do
       params(
+        branch: String,
         source: Dependabot::Source,
         files: T::Array[Dependabot::DependencyFile]
       ).returns(GithubApi::DependencySubmission)
     end
-    def create_submission(source, files)
+    def create_submission(branch, source, files)
       parser = Dependabot::FileParsers.for_package_manager(job.package_manager).new(
         dependency_files: files,
         repo_contents_path: job.repo_contents_path,
@@ -127,13 +129,36 @@ module Dependabot
 
       GithubApi::DependencySubmission.new(
         job_id: job.id.to_s,
-        # FIXME(brrygrdn): We should obtain the ref from git -or- inject it via the backend service
-        branch: source.branch || "main",
+        branch: branch,
         sha: base_commit_sha,
         package_manager: job.package_manager,
         manifest_file: grapher.relevant_dependency_file,
         resolved_dependencies: grapher.resolved_dependencies
       )
+    end
+
+    sig { returns(String) }
+    def fetch_default_branch_from_github
+      @fetch_default_branch_from_github ||= T.let(
+        github_client.fetch_default_branch(job.source.repo),
+        T.nilable(String)
+      )
+    rescue Octokit::NotFound
+      # This is unlikely to happen, but if it does it means the repository has been deleted
+      # while we are working, so let's handle it properly.
+      raise Dependabot::RepoNotFound, job.source
+    end
+
+    sig { returns(Dependabot::Clients::GithubWithRetries) }
+    def github_client
+      @github_client ||=
+        T.let(
+          Dependabot::Clients::GithubWithRetries.for_source(
+            source: job.source,
+            credentials: job.credentials
+          ),
+          T.nilable(Dependabot::Clients::GithubWithRetries)
+        )
     end
   end
 end

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -142,7 +142,7 @@ module Dependabot
       return fetch_default_branch_from_github if job.source.provider == "github"
 
       Dependabot.logger.warn(
-        "Dependency submissions are not fully support for provider '#{job.source.provider}'. " \
+        "Dependency submissions are not fully supported for provider '#{job.source.provider}'. " \
         "Substituting 'main' as default branch."
       )
       "main"

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -49,7 +49,7 @@ module Dependabot
       raise Dependabot::DependabotError, "job.source.directories is nil" if job.source.directories.nil?
       raise Dependabot::DependabotError, "job.source.directories is empty" unless job.source.directories&.any?
 
-      branch = job.source.branch || fetch_default_branch_from_github
+      branch = job.source.branch || default_branch
 
       T.must(job.source.directories).each do |directory|
         directory_source = create_source_for(directory)
@@ -135,6 +135,17 @@ module Dependabot
         manifest_file: grapher.relevant_dependency_file,
         resolved_dependencies: grapher.resolved_dependencies
       )
+    end
+
+    sig { returns(String) }
+    def default_branch
+      return fetch_default_branch_from_github if job.source.provider == "github"
+
+      Dependabot.logger.warn(
+        "Dependency submissions are not fully support for provider '#{job.source.provider}'. " \
+        "Substituting 'main' as default branch."
+      )
+      "main"
     end
 
     sig { returns(String) }

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -39,10 +39,11 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
   let(:repo) { "dependabot-fixtures/dependabot-test-ruby-package" }
   let(:branch) { "develop" }
+  let(:provider) { "github" }
 
   let(:source) do
     Dependabot::Source.new(
-      provider: "github",
+      provider: provider,
       repo: repo,
       directories: directories,
       branch: branch
@@ -418,25 +419,41 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       let(:directories) { ["/"] }
       let(:branch) { nil }
 
-      before do
-        stub_request(:get, "https://api.github.com/repos/#{repo}")
-          .to_return(
-            status: 200,
-            body: {
-              "default_branch" => "very-esoteric-naming"
-            }.to_json,
-            headers: { "content-type" => "application/json" }
-          )
-      end
-
-      it "retrieves the default branch via the GitHub API" do
-        expect(service).to receive(:create_dependency_submission) do |args|
-          payload = args[:dependency_submission].payload
-
-          expect(payload[:ref]).to eql("refs/heads/very-esoteric-naming")
+      context "when the source is GitHub" do
+        before do
+          stub_request(:get, "https://api.github.com/repos/#{repo}")
+            .to_return(
+              status: 200,
+              body: {
+                "default_branch" => "very-esoteric-naming"
+              }.to_json,
+              headers: { "content-type" => "application/json" }
+            )
         end
 
-        update_graph_processor.run
+        it "retrieves the default branch via the GitHub API" do
+          expect(service).to receive(:create_dependency_submission) do |args|
+            payload = args[:dependency_submission].payload
+
+            expect(payload[:ref]).to eql("refs/heads/very-esoteric-naming")
+          end
+
+          update_graph_processor.run
+        end
+      end
+
+      context "when the source is not GitHub" do
+        let(:provider) { "azure" }
+
+        it "uses a placeholder value" do
+          expect(service).to receive(:create_dependency_submission) do |args|
+            payload = args[:dependency_submission].payload
+
+            expect(payload[:ref]).to eql("refs/heads/main")
+          end
+
+          update_graph_processor.run
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

As a hacky workaround, we've been 'guessing' the default branch when a `job.source.branch` is nil by straight up injecting a static string value of `main`.

This won't survive first contact with real-world conditions, so let's do what the PR builder and other components do when this is nil, ask the VCS service.

### Anything you want to highlight for special attention from reviewers?

The updater is fairly hardwired unto GitHub and Update Graph jobs doubly so at present, so I haven't made an effort to instantiate all possible VCS clients based on the `job.source.provider`.

For now, if the provider is anything other than GitHub we will continue to 'guess' that `main` is the default branch rather than  hard fail so CLI users can still pull out data, but we will warn that the default branch is a guess for now.

Since the emitted payload is intended for the Dependency Submission API, it is not useful to other VCS platforms in its current form, so fixing this is YAGNI for now.

### How will you know you've accomplished your goal?

We will no longer see runs submit against a non-existing branch for repositories which do not use `main` as the default branch.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
