### PR TITLE
Fix Markdown formatting in ecosystem readme files

### DIFF
--- a/bun/README.md
+++ b/bun/README.md
@@ -6,11 +6,12 @@ Bun support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell bun
-  ```
+   ```
+   $ bin/docker-dev-shell bun
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd bun && rspec
    ```

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -6,11 +6,12 @@ Ruby (bundler) support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell bundler
-  ```
+   ```
+   $ bin/docker-dev-shell bundler
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd bundler && rspec
    ```

--- a/cargo/README.md
+++ b/cargo/README.md
@@ -6,11 +6,12 @@ Rust (Cargo) support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell cargo
-  ```
+   ```
+   $ bin/docker-dev-shell cargo
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd cargo && rspec
    ```

--- a/composer/README.md
+++ b/composer/README.md
@@ -6,11 +6,12 @@ PHP (Composer) support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell composer
-  ```
+   ```
+   $ bin/docker-dev-shell composer
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd composer && rspec
    ```

--- a/devcontainers/README.md
+++ b/devcontainers/README.md
@@ -6,11 +6,12 @@ Dev Containers support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell devcontainers
-  ```
+   ```
+   $ bin/docker-dev-shell devcontainers
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd devcontainers && rspec
    ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,11 +6,12 @@ Docker support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell docker
-  ```
+   ```
+   $ bin/docker-dev-shell docker
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd docker && rspec
    ```
@@ -25,7 +26,7 @@ https://github.com/dependabot/dependabot-core/blob/main/docker/lib/dependabot/do
 
 #### Semver
 
-Dependabot will attempt to parse a semver version from a tag and will only update it to a tag with a matching prefix and suffix. 
+Dependabot will attempt to parse a semver version from a tag and will only update it to a tag with a matching prefix and suffix.
 
 As an example, `base-12.5.1` and `base-12.5.1-golden` would be parsed as `<prefix>-<version>` and `<prefix>-<version>-<suffix>` respectively.
 
@@ -33,7 +34,7 @@ That means for `base-12.5.1` only another `<prefix>-<version>` tag would be a vi
 
 #### Dates
 
-Dependabot will parse dates in the `yyyy-mm`, `yyyy-mm-dd` formats (or with `.` instead of `-`) and update tags to the latest date. 
+Dependabot will parse dates in the `yyyy-mm`, `yyyy-mm-dd` formats (or with `.` instead of `-`) and update tags to the latest date.
 
 As an example, `2024-01` will get updated to `2024-02` and `2024.01.29` will get updated to `2024.03.15`.
 

--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -6,11 +6,12 @@ Docker support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell docker_compose
-  ```
+   ```
+   $ bin/docker-dev-shell docker_compose
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd docker_compose && rspec
    ```

--- a/dotnet_sdk/README.md
+++ b/dotnet_sdk/README.md
@@ -6,11 +6,12 @@
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell dotnet-sdk
-  ```
+   ```
+   $ bin/docker-dev-shell dotnet-sdk
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd dotnet-sdk && rspec
    ```

--- a/elm/README.md
+++ b/elm/README.md
@@ -6,11 +6,12 @@ Elm support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell elm
-  ```
+   ```
+   $ bin/docker-dev-shell elm
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd elm && rspec
    ```

--- a/git_submodules/README.md
+++ b/git_submodules/README.md
@@ -6,11 +6,12 @@ Git Submodules support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell git_submodules
-  ```
+   ```
+   $ bin/docker-dev-shell git_submodules
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd git_submodules && rspec
    ```

--- a/github_actions/README.md
+++ b/github_actions/README.md
@@ -6,11 +6,12 @@ GitHub Actions support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell github_actions
-  ```
+   ```
+   $ bin/docker-dev-shell github_actions
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd github_actions && rspec
    ```

--- a/go_modules/README.md
+++ b/go_modules/README.md
@@ -6,11 +6,12 @@ Go modules support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell go_modules
-  ```
+   ```
+   $ bin/docker-dev-shell go_modules
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd go_modules && rspec
    ```

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -6,11 +6,12 @@ Gradle support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell gradle
-  ```
+   ```
+   $ bin/docker-dev-shell gradle
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd gradle && rspec
    ```

--- a/helm/README.md
+++ b/helm/README.md
@@ -6,11 +6,12 @@ Docker support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell helm
-  ```
+   ```
+   $ bin/docker-dev-shell helm
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd helm && rspec
    ```

--- a/hex/README.md
+++ b/hex/README.md
@@ -6,11 +6,12 @@ Elixir support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell hex
-  ```
+   ```
+   $ bin/docker-dev-shell hex
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd hex && rspec
    ```

--- a/maven/README.md
+++ b/maven/README.md
@@ -6,11 +6,12 @@ Maven support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell maven
-  ```
+   ```
+   $ bin/docker-dev-shell maven
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd maven && rspec
    ```

--- a/npm_and_yarn/README.md
+++ b/npm_and_yarn/README.md
@@ -6,11 +6,12 @@ Yarn and npm support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell npm_and_yarn
-  ```
+   ```
+   $ bin/docker-dev-shell npm_and_yarn
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd npm_and_yarn && rspec
    ```

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -10,11 +10,12 @@ Open the solution file at `helpers/lib/NuGetUpdater/NuGetUpdater.sln` in your pr
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell nuget
-  ```
+   ```
+   $ bin/docker-dev-shell nuget
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd nuget && rspec
    ```

--- a/pub/README.md
+++ b/pub/README.md
@@ -20,11 +20,12 @@ Dart (pub) support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell pub
-  ```
+   ```
+   $ bin/docker-dev-shell pub
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd pub && rspec
    ```

--- a/python/README.md
+++ b/python/README.md
@@ -19,9 +19,9 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Start a development shell
 
-  ```shell
-  $ bin/docker-dev-shell python
-  ```
+   ```shell
+   $ bin/docker-dev-shell python
+   ```
 
 2. Run tests
 

--- a/rust_toolchain/README.md
+++ b/rust_toolchain/README.md
@@ -6,11 +6,12 @@ Rust toolchain support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell rust-toolchain
-  ```
+   ```
+   $ bin/docker-dev-shell rust-toolchain
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd rust_toolchain && rspec
    ```

--- a/swift/README.md
+++ b/swift/README.md
@@ -6,11 +6,12 @@ Swift Package Manager support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell swift
-  ```
+   ```
+   $ bin/docker-dev-shell swift
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd swift && rspec
    ```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,11 +6,12 @@ Terraform support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell terraform
-  ```
+   ```
+   $ bin/docker-dev-shell terraform
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd terraform && rspec
    ```

--- a/uv/README.md
+++ b/uv/README.md
@@ -19,9 +19,9 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Start a development shell
 
-  ```shell
-  $ bin/docker-dev-shell uv
-  ```
+   ```shell
+   $ bin/docker-dev-shell uv
+   ```
 
 2. Run tests
 

--- a/vcpkg/README.md
+++ b/vcpkg/README.md
@@ -6,11 +6,12 @@ VCPKG support for [`dependabot-core`][core-repo].
 
 1. Start a development shell
 
-  ```
-  $ bin/docker-dev-shell vcpkg
-  ```
+   ```
+   $ bin/docker-dev-shell vcpkg
+   ```
 
 2. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd vcpkg && rspec
    ```


### PR DESCRIPTION
Fix inconsistent indentation in ecosystem readme files which is causing the second code block to be indented in GitHub's Markdown renderer while the first is not. This is fixed by indenting the first code block using three spaces, matching the second code block.

Make the text formatting between the two list items consistent by adding a line break between the second list item and its corresponding code block. This does not affect how the file is rendered in GitHub's Markdown renderer, but it is an inconsistent text-formatting style between the two list items.

Remove trailing whitespace from two lines in the "docker" ecosystem readme file.

### What are you trying to accomplish?

I am attempting to fix a visual inconsistency with how the ecosystem readme files are displayed on GitHub. In the readme file for many ecosystems the second code block is indented while the first is not. This appears to be caused by inconsistent indentation in the code blocks between the two list items. The first code block is indented with two spaces while the second is indented with three spaces. Increasing the indent of the first code block to match the indent of the second code block appears to fix the issue.

I also noticed inconsistent text formatting between the two list items. There is a line break between the first list item and its corresponding code block, but not between the second list item and its corresponding code block. I added a line break between the second list item and its corresponding code block.

My editor automatically removed trailing whitespace from two lines in the `docker` ecosystem readme file.

### Anything you want to highlight for special attention from reviewers?

I can't think of anything to highlight for special attention. I did notice additional inconsistencies between different readme files (one example: some tag the code blocks with `shell`, some with `bash`, while most don't tag the code blocks at all). My focus was on the visual indentation of the two code blocks, so I fixed the indentation, added line break, and removed the trailing whitespace.

### How will you know you've accomplished your goal?

I can view the readme files on my branch and fork and see that the indentation of the two code blocks is now consistent.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.

I have not added new code or updated existing code, so I have not attempted to run the complete test suite. I assume that readme files fall outside the scope of the complete test suite. Apologies if that is not the case, let me know and I'll run the complete test suite.