### PR TITLE
Add nil checks to fix NilClass exceptions

### DIFF
--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -84,10 +84,10 @@ module Dependabot
           parse_pep621_pep735_dependencies.each do |dep|
             # If a requirement has a `<` or `<=` marker then updating it is
             # probably blocked. Ignore it.
-            next if dep["markers"].include?("<")
+            next if dep["markers"]&.include?("<")
 
             # In uv no constraint means any version is acceptable
-            requirement_value = dep["requirement"].empty? ? "*" : dep["requirement"]
+            requirement_value = dep["requirement"].nil? || dep["requirement"].empty? ? "*" : dep["requirement"]
 
             dependencies <<
               Dependency.new(

--- a/uv/spec/dependabot/uv/file_parser/pyproject_files_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser/pyproject_files_parser_spec.rb
@@ -381,6 +381,19 @@ RSpec.describe Dependabot::Uv::FileParser::PyprojectFilesParser do
         # setuptools-scm (from build-system.requires)
         its(:length) { is_expected.to eq(2) }
       end
+
+      context "with uv path dependencies" do
+        subject(:dependency) { dependencies[1] }
+
+        let(:pyproject_fixture_name) { "uv_path_dependencies.toml" }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("protos")
+          expect(dependency.version).to be_nil
+          expect(dependency.package_manager).to eq("uv")
+        end
+      end
     end
 
     describe "with pep 735" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
<!-- What issues does this affect or fix? -->

This change adds safe navigation operator (&.) for dep["markers"] and explicit nil check for dep["requirement"] to prevent NilClass errors.
This fixes an issue where updating a package with a pyproject.toml that includes a path source under tool.uv.sources would result in an error when using uv package-ecosystem.

Fixes #12696

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

- script/dependabot update uv Ariana-Hlavaty/dependabot-error-test -d project2/
- rspec spec -e "with uv path dependencies"

Both commands succeed after the fix.
Previously, they failed with an error like the one below:

```
Failure/Error: next if dep["markers"].include?("<")
     
     NoMethodError:
       undefined method 'include?' for nil
```

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.