### PR TITLE
Prefer scm url for source url in maven (#2084)

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_metadata_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_metadata_finder.rb
@@ -67,11 +67,24 @@ module Dependabot
 
         sig { params(pom: Nokogiri::XML::Document).returns(T.nilable(Dependabot::Source)) }
         def look_up_source_in_pom(pom)
-          potential_source_urls = [
-            pom.at_css("project > url")&.content,
-            pom.at_css("project > scm > url")&.content,
-            pom.at_css("project > issueManagement > url")&.content
-          ].compact
+          source_selectors =
+            if Dependabot::Experiments.enabled?(:prioritize_scm_source)
+              # Prefer scm url, followed by project url, and finally issue management url (#2084)
+              [
+                "project > scm > url",
+                "project > url",
+                "project > issueManagement > url"
+              ]
+            else
+              [
+                "project > url",
+                "project > scm > url",
+                "project > issueManagement > url"
+              ]
+            end
+          potential_source_urls = source_selectors.filter_map do |selector|
+            pom.at_css(selector)&.content
+          end
 
           source_url = potential_source_urls.find { |url| Source.from_url(url) }
           source_url ||= source_from_anywhere_in_pom(pom)

--- a/maven/spec/dependabot/maven/metadata_finder_spec.rb
+++ b/maven/spec/dependabot/maven/metadata_finder_spec.rb
@@ -65,6 +65,50 @@ RSpec.describe Dependabot::Maven::MetadataFinder do
       )
     end
 
+    context "when prioritize_scm_source enabled" do
+      before do
+        Dependabot::Experiments.register(:prioritize_scm_source, true)
+      end
+
+      context "when project url, scm url, and issue management url are present" do
+        let(:maven_response) { fixture("poms", "sourceurl_project_scm_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_scm") }
+      end
+
+      context "when project url and issue management url are present" do
+        let(:maven_response) { fixture("poms", "sourceurl_project_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_project") }
+      end
+
+      context "when only issue management url is present" do
+        let(:maven_response) { fixture("poms", "sourceurl_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_issuemanagement") }
+      end
+    end
+
+    context "when prioritize_scm_source disabled" do
+      context "when project url, scm url, and issue management url are present" do
+        let(:maven_response) { fixture("poms", "sourceurl_project_scm_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_project") }
+      end
+
+      context "when scm url and issue management url are present" do
+        let(:maven_response) { fixture("poms", "sourceurl_scm_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_scm") }
+      end
+
+      context "when only issue management url is present" do
+        let(:maven_response) { fixture("poms", "sourceurl_issuemanagement_pom.xml") }
+
+        it { is_expected.to eq("https://github.com/dependabot/sourceurl_issuemanagement") }
+      end
+    end
+
     context "when the github link is buried in the pom" do
       let(:maven_response) { fixture("poms", "guava-23.3-jre.xml") }
 

--- a/maven/spec/fixtures/poms/sourceurl_issuemanagement_pom.xml
+++ b/maven/spec/fixtures/poms/sourceurl_issuemanagement_pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>sourceurl_issuemanagement_pom</artifactId>
+  <version>1.0.0</version>
+  <name>POM Providing Issue Management URL as possible source URL.</name>
+
+  <!-- Issue Management URL -->
+  <issueManagement>
+    <url>https://github.com/dependabot/sourceurl_issuemanagement</url>
+  </issueManagement>
+
+</project>

--- a/maven/spec/fixtures/poms/sourceurl_project_issuemanagement_pom.xml
+++ b/maven/spec/fixtures/poms/sourceurl_project_issuemanagement_pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>sourceurl_project_issuemanagement_pom</artifactId>
+  <version>1.0.0</version>
+  <name>POM Providing Project URL and Issue Management URL as possible source URLs.</name>
+
+  <!-- Project URL -->
+  <url>https://github.com/dependabot/sourceurl_project</url>
+
+  <!-- Issue Management URL -->
+  <issueManagement>
+    <url>https://github.com/dependabot/sourceurl_issuemanagement</url>
+  </issueManagement>
+
+</project>

--- a/maven/spec/fixtures/poms/sourceurl_project_scm_issuemanagement_pom.xml
+++ b/maven/spec/fixtures/poms/sourceurl_project_scm_issuemanagement_pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>sourceurl_project_scm_issuemanagement_pom</artifactId>
+  <version>1.0.0</version>
+  <name>POM Providing Project URL, SCM URL, and Issue Management URL as possible source URLs.</name>
+
+  <!-- Project URL -->
+  <url>https://github.com/dependabot/sourceurl_project</url>
+
+  <!-- SCM URL -->
+  <scm>
+    <url>https://github.com/dependabot/sourceurl_scm</url>
+  </scm>
+
+  <!-- Issue Management URL -->
+  <issueManagement>
+    <url>https://github.com/dependabot/sourceurl_issuemanagement</url>
+  </issueManagement>
+
+</project>

--- a/maven/spec/fixtures/poms/sourceurl_scm_issuemanagement_pom.xml
+++ b/maven/spec/fixtures/poms/sourceurl_scm_issuemanagement_pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>sourceurl_scm_issuemanagement_pom</artifactId>
+  <version>1.0.0</version>
+  <name>POM Providing SCM URL and Issue Management URL as possible source URLs.</name>
+
+  <!-- SCM URL -->
+  <scm>
+    <url>https://github.com/dependabot/sourceurl_scm</url>
+  </scm>
+
+  <!-- Issue Management URL -->
+  <issueManagement>
+    <url>https://github.com/dependabot/sourceurl_issuemanagement</url>
+  </issueManagement>
+
+</project>


### PR DESCRIPTION
Swap the order of project url and scm url as potential source urls to ensure that scm url is preferred. Keep issue management url as the lowest priority potential source url. Add tests verifying that the correct source url is determined based on the presence or absence of scm url, project url, and issue management url.

### What are you trying to accomplish?

This is my proposed fix for #2084.

The issue notes that Dependabot uses the wrong URL for the [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson-databind) project. This project specifies both a project URL (`project -> url`) and a SCM URL (`project -> scm -> url`) in `pom.xml`. Dependabot currently prefers the project URL over the SCM URL. However, for this project the project URL leads to an umbrella project while the SCM URL leads to the specific GitHub repository for the project, and thus Dependabot uses the wrong URL for the project.

My fix is to swap the order of project URL and SCM URL as potential source URLs. The issue management URL is also included as a potential source URL, which I kept in last place. I also added tests to ensure that the correct source URL is determined based on SCM URL, project URL, and issue management URL.

### Anything you want to highlight for special attention from reviewers?

This is my first pull request making changes to Dependabot code. I've done my best to follow the contribution guide and ensure that I've done everything correctly, but I may have missed something.

I started my work by first implementing my fix and running the tests. I discovered my change did not break any existing tests so I added new tests to cover the cases I believe are relevant to this fix.

One potential concern have with this change: Is it possible there are projects out there that rely on the current Dependabot behavior and will break because of this change? I can't think of an easy way to check this.

### How will you know you've accomplished your goal?

I performed a dry run on a test project I created specifically to test this fix:

https://github.com/jjweston/dependabot-test-source-url

I performed a dry run both before and after I implemented my fix and noted the incorrect URL showing up before my fix and the correct URL showing up after my fix. I also see that the commit log works properly after my fix.

#### Dry Run - Before Change

<details>

```
[dependabot-core-dev] ~ $ bin/dry-run.rb maven jjweston/dependabot-test-source-url --pull-request
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> cloning into /home/dependabot/tmp/jjweston/dependabot-test-source-url
=> parsing dependency files
=> updating 1 dependencies: com.fasterxml.jackson.core:jackson-databind

=== com.fasterxml.jackson.core:jackson-databind (2.19.0)
 => checking for updates 1/1
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/maven-metadata.xml
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/maven-metadata.xml
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind
🌍 <-- 302 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/
I, [2025-10-08T20:12:55.560318 #11]  INFO -- : Filtered out 34 pre-release versions
🌍 --> HEAD https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.jar
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.jar
 => latest available version is 2.20.0
I, [2025-10-08T20:12:55.947507 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:55.991032 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.020768 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.040597 #11]  INFO -- : Filtered out 34 pre-release versions
 => latest allowed version is 2.20.0
I, [2025-10-08T20:12:56.065880 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.085048 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.115242 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.135171 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.155618 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.175006 #11]  INFO -- : Filtered out 34 pre-release versions
 => requirements to unlock: own
 => requirements update strategy:
I, [2025-10-08T20:12:56.199925 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.218226 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.236820 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.280706 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.308982 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.328741 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.351855 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.374180 #11]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:12:56.393528 #11]  INFO -- : Filtered out 34 pre-release versions
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.pom
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.pom
🌍 --> GET https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
🌍 --> GET https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
🌍 --> GET https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/FasterXML/jackson.git/info/refs?service=git-upload-pack
 => bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0

    ± pom.xml
    ~~~
    --- /tmp/original20251008-11-g57cvr 2025-10-08 20:12:58.258720310 +0000
    +++ /tmp/updated20251008-11-ytuhnu  2025-10-08 20:12:58.258720310 +0000
    @@ -13,7 +13,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
    -            <version>2.19.0</version>
    +            <version>2.20.0</version>
             </dependency>
         </dependencies>

    ~~~
    2 insertions (+), 2 deletions (-)
Pull Request Title: Bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0
--description--
Bumps [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson) from 2.19.0 to 2.20.0.
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/FasterXML/jackson/commits">compare view</a></li>
</ul>
</details>
<br />

--/description--
--commit--
Bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0

Bumps [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson) from 2.19.0 to 2.20.0.
- [Commits](https://github.com/FasterXML/jackson/commits)
--/commit--
🌍 Total requests made: '8'
Dry-run completed successfully.
```

</details>

#### Dry Run - After Change

<details>

```
[dependabot-core-dev] ~ $ bin/dry-run.rb maven jjweston/dependabot-test-source-url --pull-request
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> cloning into /home/dependabot/tmp/jjweston/dependabot-test-source-url
=> parsing dependency files
=> updating 1 dependencies: com.fasterxml.jackson.core:jackson-databind

=== com.fasterxml.jackson.core:jackson-databind (2.19.0)
 => checking for updates 1/1
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/maven-metadata.xml
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/maven-metadata.xml
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind
🌍 <-- 302 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/
I, [2025-10-08T20:09:30.149637 #176]  INFO -- : Filtered out 34 pre-release versions
🌍 --> HEAD https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.jar
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.jar
 => latest available version is 2.20.0
I, [2025-10-08T20:09:30.356435 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.365580 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.386342 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.417615 #176]  INFO -- : Filtered out 34 pre-release versions
 => latest allowed version is 2.20.0
I, [2025-10-08T20:09:30.457621 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.477989 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.502037 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.523352 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.546548 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.564933 #176]  INFO -- : Filtered out 34 pre-release versions
 => requirements to unlock: own
 => requirements update strategy:
I, [2025-10-08T20:09:30.589619 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.613910 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.643744 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.744974 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.772753 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.797196 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.834635 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.858265 #176]  INFO -- : Filtered out 34 pre-release versions
I, [2025-10-08T20:09:30.877882 #176]  INFO -- : Filtered out 34 pre-release versions
🌍 --> GET https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.pom
🌍 <-- 200 https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.20.0/jackson-databind-2.20.0.pom
🌍 --> GET https://github.com/FasterXML/jackson-databind.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/FasterXML/jackson-databind.git/info/refs?service=git-upload-pack
🌍 --> GET https://github.com/FasterXML/jackson-databind.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/FasterXML/jackson-databind.git/info/refs?service=git-upload-pack
 => bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0

    ± pom.xml
    ~~~
    --- /tmp/original20251008-176-im2plt        2025-10-08 20:09:35.855609931 +0000
    +++ /tmp/updated20251008-176-mbpfve 2025-10-08 20:09:35.855609931 +0000
    @@ -13,7 +13,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
    -            <version>2.19.0</version>
    +            <version>2.20.0</version>
             </dependency>
         </dependencies>

    ~~~
    2 insertions (+), 2 deletions (-)
Pull Request Title: Bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0
--description--
Bumps [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson-databind) from 2.19.0 to 2.20.0.
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/4260f88180e5e45f3be1a290114e55c042bb2213"><code>4260f88</code></a> [maven-release-plugin] prepare release jackson-databind-2.20.0</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/283fc505347dfe0aa7fe07ad37c943cd8a4885e9"><code>283fc50</code></a> Prep for 2.20.0</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/d4220ed27198847e13ce75d9bee805e028a100e0"><code>d4220ed</code></a> Add test, fix <a href="https://redirect.github.com/FasterXML/jackson-databind/issues/5271">#5271</a> (<a href="https://redirect.github.com/FasterXML/jackson-databind/issues/5282">#5282</a>)</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/eee6226439eb556fca70fd891200c6fcfa048253"><code>eee6226</code></a> More deprecated method removals wrt EnumDeserializer</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/c6805b86c739a560354cb8df063c1389c512f9fe"><code>c6805b8</code></a> Deprecated method removal</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/06627ad93faefc77eaa9f967838cfdadc80db4d5"><code>06627ad</code></a> ...</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/c47944c4dd03e55f6785bf3d4b788092f7300d39"><code>c47944c</code></a> Merge branch '2.19' into 2.x</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/acb1fc48634a4522c5095e596b0ee30609dfa340"><code>acb1fc4</code></a> Merge branch '2.18' into 2.19</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/ee9240cc325d9f9871d8574c1fbabdd885082459"><code>ee9240c</code></a> Minor test improvement</li>
<li><a href="https://github.com/FasterXML/jackson-databind/commit/81f5a89cb4e1fed36c3d9ade3ec1ffe6fb315e49"><code>81f5a89</code></a> Merge branch '2.x' of github.com:FasterXML/jackson-databind into 2.x</li>
<li>Additional commits viewable in <a href="https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.19.0...jackson-databind-2.20.0">compare view</a></li>
</ul>
</details>
<br />

--/description--
--commit--
Bump com.fasterxml.jackson.core:jackson-databind from 2.19.0 to 2.20.0

Bumps [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson-databind) from 2.19.0 to 2.20.0.
- [Commits](https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.19.0...jackson-databind-2.20.0)
--/commit--
🌍 Total requests made: '7'
Dry-run completed successfully.
```

</details>

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.