### PR TITLE
Enable bundler cache in Ruby setup step of Gems - Release to RubyGems workflow

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
+        with:
+          bundler-cache: true
 
       - name: Install the RubyGems version specified in the Dockerfile.updater-core file
         run: |


### PR DESCRIPTION
Without bundle install we have dependency issues running the rake task in CI

### What are you trying to accomplish?

The goal is to ensure all Ruby gem dependencies are installed in the CI workflow before running `rake gems:release`. After the Rakefile refactor (PR #13223), the release workflow began requiring gems like `sorbet-runtime` to be present. Without installing dependencies, the workflow fails with a `LoadError: cannot load such file -- sorbet-runtime`.  
This change adds `bundler-cache: true` to the `ruby/setup-ruby` step, which runs `bundle install` and caches the dependencies, ensuring the required gems are available for Rake tasks.

<!-- What issues does this affect or fix? -->
Fixes workflow failures such as:  
https://github.com/dependabot/dependabot-core/actions/runs/18370235292/job/52332604149  
and addresses dependency management issues introduced after modularizing the Rakefile.

### Anything you want to highlight for special attention from reviewers?

I chose to use the recommended `bundler-cache: true` option in `ruby/setup-ruby` rather than a manual `bundle install` step, as it is best practice for Ruby projects on GitHub Actions. This approach both installs and caches gems, improving workflow speed and reliability. 

### How will you know you've accomplished your goal?

- The error `LoadError: cannot load such file -- sorbet-runtime` will no longer occur in CI runs for the release workflow.
- Successful execution of the `gems:release` rake task in CI.
- The workflow will complete without dependency-related failures, and gems will be released to RubyGems as expected.
- This can be verified by re-running the workflow or observing the next release run.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.