### PR TITLE
Use bundle exec for rake task in release workflow to ensure Bundler dependencies are loaded

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -30,4 +30,4 @@ jobs:
 
       # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.
       # `rake release` causes problems because it tries to push a git tag, but we've already manually tagged the release as part of the `gems-bump-version` workflow.
-      - run: gem exec rake gems:release
+      - run: bundle exec rake gems:release


### PR DESCRIPTION
Without bundle install we have dependency issues running the rake task in CI

### What are you trying to accomplish?

The goal is to fix the CI workflow so that all Bundler-managed dependencies (like `sorbet-runtime`) are available when running `rake gems:release`. The previous workflow used `gem exec rake`, which does not activate gems installed by Bundler, leading to `LoadError` failures.  
This change replaces `gem exec rake gems:release` with `bundle exec rake gems:release` in the release workflow, ensuring all required gems from the Gemfile are loaded.

<!-- What issues does this affect or fix? -->
Fixes the `LoadError: cannot load such file -- sorbet-runtime` error when releasing gems in CI.

### Anything you want to highlight for special attention from reviewers?

There were a couple of possible approaches: installing gems globally or running via Bundler. I chose `bundle exec` because it is standard for Ruby projects using Bundler and guarantees the correct gems and versions from the Gemfile are used.

### How will you know you've accomplished your goal?

- The release workflow will complete successfully without dependency-related errors.
- The `LoadError: cannot load such file -- sorbet-runtime` will not appear in CI logs.
- Successful gem releases via the workflow after merging.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.