### PR TITLE
make `fetch_files` command noop

### DIFF
--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -81,8 +81,8 @@ function Update-Files {
 
 try {
     Switch ($args[0]) {
-        "fetch_files" { Get-Files }
-        "update_files" { Update-Files }
+        "fetch_files" { }
+        "update_files" { Get-Files; Update-Files }
         default { throw "unknown command: $args[0]" }
     }
     exit $operationExitCode


### PR DESCRIPTION
Follow up to #13275, this PR makes the `fetch_files` command a noop in the NuGet updater and does everything as part of the `update_files` command.