### PR TITLE
remove unnecessary parameter

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -104,8 +104,6 @@ public partial class EntryPointTests
                 http.BaseUrl,
                 "--job-id",
                 "TEST-ID",
-                "--output-path",
-                Path.Combine(tempDirectory.DirectoryPath, "output.json"),
                 "--base-commit-sha",
                 "BASE-COMMIT-SHA"
             };

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/RunCommand.cs
@@ -18,7 +18,6 @@ internal static class RunCommand
         CustomParser = (argumentResult) => Uri.TryCreate(argumentResult.Tokens.Single().Value, UriKind.Absolute, out var uri) ? uri : throw new ArgumentException("Invalid API URL format.")
     };
     internal static readonly Option<string> JobIdOption = new("--job-id") { Required = true };
-    internal static readonly Option<FileInfo> OutputPathOption = new("--output-path") { Required = true };
     internal static readonly Option<string> BaseCommitShaOption = new("--base-commit-sha") { Required = true };
 
     internal static Command GetCommand(Action<int> setExitCode)
@@ -30,7 +29,6 @@ internal static class RunCommand
             CaseInsensitiveRepoContentsPathOption,
             ApiUrlOption,
             JobIdOption,
-            OutputPathOption,
             BaseCommitShaOption
         };
 
@@ -43,7 +41,6 @@ internal static class RunCommand
             var caseInsensitiveRepoContentsPath = parseResult.GetValue(CaseInsensitiveRepoContentsPathOption);
             var apiUrl = parseResult.GetValue(ApiUrlOption);
             var jobId = parseResult.GetValue(JobIdOption);
-            var outputPath = parseResult.GetValue(OutputPathOption);
             var baseCommitSha = parseResult.GetValue(BaseCommitShaOption);
 
             var apiHandler = new HttpApiHandler(apiUrl!.ToString(), jobId!);
@@ -53,7 +50,7 @@ internal static class RunCommand
             var analyzeWorker = new AnalyzeWorker(jobId!, experimentsManager, logger);
             var updateWorker = new UpdaterWorker(jobId!, experimentsManager, logger);
             var worker = new RunWorker(jobId!, apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
-            await worker.RunAsync(jobPath!, repoContentsPath!, caseInsensitiveRepoContentsPath, baseCommitSha!, outputPath!);
+            await worker.RunAsync(jobPath!, repoContentsPath!, caseInsensitiveRepoContentsPath, baseCommitSha!);
             return 0;
         });
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -40,7 +40,7 @@ public class RunWorker
         _updaterWorker = updateWorker;
     }
 
-    public async Task RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, FileInfo outputFilePath)
+    public async Task RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha)
     {
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
         var jobWrapper = Deserialize(jobFileContent);

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -57,7 +57,6 @@ function Update-Files {
     $arguments += "--repo-contents-path", $env:DEPENDABOT_REPO_CONTENTS_PATH
     $arguments += "--api-url", $env:DEPENDABOT_API_URL
     $arguments += "--job-id", $env:DEPENDABOT_JOB_ID
-    $arguments += "--output-path", $env:DEPENDABOT_OUTPUT_PATH
     $arguments += "--base-commit-sha", $baseCommitSha
     if ("$env:DEPENDABOT_CASE_INSENSITIVE_REPO_CONTENTS_PATH" -ne "") {
         # ensure the updater gets this optional path


### PR DESCRIPTION
With the removal of the `fetch_files` command, the environment variable `%DEPENDABOT_OUTPUT_PATH%` is no longer set.  It wasn't used in the updater anyway so it's safe to directly remove.