### PR TITLE
Workaround: Skip fetching relationships for now

### DIFF
--- a/go_modules/lib/dependabot/go_modules/dependency_grapher.rb
+++ b/go_modules/lib/dependabot/go_modules/dependency_grapher.rb
@@ -72,21 +72,24 @@ module Dependabot
         )
       end
 
+      # TODO: Re-instate method once we consider how we are handling `replace` directives
       sig { returns(T::Hash[String, T.untyped]) }
       def fetch_package_relationships
-        T.cast(
-          file_parser,
-          Dependabot::GoModules::FileParser
-        ).run_in_parsed_context("go mod graph").lines.each_with_object({}) do |line, rels|
-          match = line.match(GO_MOD_GRAPH_LINE_REGEX)
-          unless match
-            Dependabot.logger.warn("Unexpected output from 'go mod graph': 'line'")
-            next
-          end
+        {}
 
-          rels[match[:parent]] ||= []
-          rels[match[:parent]] << match[:child]
-        end
+        # T.cast(
+        #   file_parser,
+        #   Dependabot::GoModules::FileParser
+        # ).run_in_parsed_context("go mod graph").lines.each_with_object({}) do |line, rels|
+        #   match = line.match(GO_MOD_GRAPH_LINE_REGEX)
+        #   unless match
+        #     Dependabot.logger.warn("Unexpected output from 'go mod graph': 'line'")
+        #     next
+        #   end
+
+        #   rels[match[:parent]] ||= []
+        #   rels[match[:parent]] << match[:child]
+        # end
       end
     end
   end

--- a/go_modules/spec/dependabot/go_modules/dependency_grapher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/dependency_grapher_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe Dependabot::GoModules::DependencyGrapher do
         expect(isatty.runtime).to be(true)
       end
 
-      describe "assigns child dependencies using go mod graph" do
+      # We have disabled fetching of relationships due to a problem with `go mod graph` and our handling of
+      # `replace` directives causing some projects to choke on this step.
+      describe "assigns child dependencies using go mod graph", skip: "behaviour disabled temporarily" do
         let(:dependency_graph_expectations) do
           [
             {


### PR DESCRIPTION
### What are you trying to accomplish?

While testing the go parser against large projects that make use of `replace` directives to point to subfolders within the same repositories, e.g. k8s/k8s, the job would fail on a parser error.

After some investigation we identified that our recent addition of `go mod graph` to populate subdependencies was the root cause.

As a workaround, we can disable this behaviour for now as it is an enhancement we definitely want to have, but we can live without it for now and ship it once we consider our handling of `replace` more broadly.

### Anything you want to highlight for special attention from reviewers?

Nope!

### How will you know you've accomplished your goal?

I can run `dependabot graph go_modules kubernetes/kubernetes` and get a dependency graph rather than an error.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
