### PR TITLE
Fix double replacement of image tags

### DIFF
--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -66,7 +66,6 @@ module Dependabot
         updated_content
       end
 
-      # rubocop:disable Metrics/MethodLength
       sig do
         params(
           previous_content: String,
@@ -115,13 +114,10 @@ module Dependabot
           end
 
           old_dec = old_dec.gsub(":#{old_tag}", ":#{new_tag}") unless old_tag.to_s.empty?
+
           old_dec
-            .gsub("@sha256:#{old_digest}", "@sha256:#{new_digest}")
-            .gsub(":#{old_tag}", ":#{new_tag}")
         end
       end
-      # rubocop:enable Metrics/MethodLength
-
       sig { params(escaped_declaration: String).returns(Regexp) }
       def build_old_declaration_regex(escaped_declaration)
         %r{^#{FROM_REGEX}\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)}

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -158,6 +158,39 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       its(:content) { is_expected.to include "RUN apt-get update" }
     end
 
+    context "when the old tag is a prefix of the new tag" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "python",
+          version: "3.6.30",
+          previous_version: "3.6.3",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "3.6.30" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "3.6.3" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated Dockerfile" do
+        subject(:updated_dockerfile) do
+          updated_files.find { |f| f.name == "Dockerfile" }
+        end
+
+        its(:content) { is_expected.to include "FROM ubuntu:17.04\n" }
+        its(:content) { is_expected.to include "FROM python:3.6.30\n" }
+        its(:content) { is_expected.to include "RUN apt-get update" }
+      end
+    end
+
     context "when multiple identical lines need to be updated" do
       let(:dockerfile_body) do
         fixture("docker", "dockerfiles", "multiple_identical")

--- a/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
+++ b/docker_compose/spec/dependabot/docker_compose/file_updater_spec.rb
@@ -88,6 +88,38 @@ RSpec.describe Dependabot::DockerCompose::FileUpdater do
       end
     end
 
+    context "when the old tag is a prefix of the new tag" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "python",
+          version: "3.6.30",
+          previous_version: "3.6.3",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "docker-compose.yml",
+            source: { tag: "3.6.30" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "docker-compose.yml",
+            source: { tag: "3.6.3" }
+          }],
+          package_manager: "docker_compose"
+        )
+      end
+
+      describe "the updated docker-compose.yml" do
+        subject(:updated_dockerfile) do
+          updated_files.find { |f| f.name == "docker-compose.yml" }
+        end
+
+        its(:content) { is_expected.to include "image: ubuntu:17.04\n" }
+        its(:content) { is_expected.to include "image: python:3.6.30\n" }
+      end
+    end
+
     context "when multiple identical lines need to be updated" do
       let(:dockerfile_body) do
         fixture("docker_compose", "composefiles", "multiple_identical")


### PR DESCRIPTION
### What are you trying to accomplish?

I've noticed when the Docker updater tries to update an image tag where the old tag is a prefix of the new tag, an incorrect update occurs. For example:

* Old image: `python:3.9`
* New image: `python:3.9.24`
* Expected update: `python:3.9.24`
* Actual update: `python:3.9.24.24`

This issue is because the file updater was running find-and-replace for the old tag twice. For example:

1. Original: `python:3.9`
2. Find and replace `python:3.9` with `python:3.9.24`: `python:3.9.24`
3. Find and replace `python:3.9` with `python:3.9.24`: `python:3.9.24.24`

This PR fixes the underlying issuing by only executing the find-and-replace gsub once.

### Anything you want to highlight for special attention from reviewers?

Nothin in particular.

### How will you know you've accomplished your goal?

Regression tests added to docker and docker compose ecosystems.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
