### PR TITLE
Skip external issue in lfs file fetching test

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
 
     after { FileUtils.rm_rf(repo_contents_path) }
 
-    it "pulls files from lfs after cloning" do
+    it "pulls files from lfs after cloning", skip: "External issue - waiting for resolution" do
       # Calling #files triggers the clone
       expect(file_fetcher_instance.files.map(&:name)).to contain_exactly("package.json", "yarn.lock", ".yarnrc.yml")
       expect(


### PR DESCRIPTION
### What are you trying to accomplish?

Skipping LFS test due to external issue

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The test is failing because the external test repository `dependabot-fixtures/dependabot-yarn-lfs-fixture` has exceeded its GitHub LFS budget/quota. 

<img width="720" height="87" alt="image" src="https://github.com/user-attachments/assets/64ebd169-a23b-4e6c-a6d6-a1f3ff47ff12" />

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Test will be skipped, unblocking npm ecosystem deployments

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
