### PR TITLE
Update temporary sigstore gem installation to use main repository fix

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install patched sigstore gem (temporary workaround)
         run: |
           gem install specific_install
-          gem specific_install https://github.com/landongrindheim/sigstore-ruby.git -r 6fafa2324662735b9c93e067e1c3465ba5ab69d8
+          gem specific_install https://github.com/sigstore/sigstore-ruby.git -r 8d5b49629ddcda7d61b328a37a42fb10291d96ad
 
       # We can't use the https://github.com/rubygems/release-gem workflow because it calls `rake release` rather than `rake gems:release`.
       # `rake release` causes problems because it tries to push a git tag, but we've already manually tagged the release as part of the `gems-bump-version` workflow.


### PR DESCRIPTION
### What are you trying to accomplish?

We are updating the temporary workaround for the sigstore gem installation in our RubyGems release workflow. The previous temporary fix from [PR #13312](https://github.com/dependabot/dependabot-core/pull/13312) that used a forked repository (`landongrindheim/sigstore-ruby`) has been superseded by an official fix that was merged into the main sigstore repository.

The original issue was caused by a sigstore production environment update around October 10th that broke the sigstore-ruby gem with the error `Sigstore::Error::UnsupportedKeyType: Unsupported key type PKIX_ED25519`. This affected multiple projects including rubygems.org and Rails.

The fix has now been officially merged in [sigstore/sigstore-ruby#266](https://github.com/sigstore/sigstore-ruby/pull/266), which implements skipping unrecognized key types as a temporary solution until broader Rekor v2 support is available.

**Why**: The previous temporary workaround was pointing to a fork that is no longer needed since the fix has been merged into the official repository. We need to update our reference to use the commit hash from the main sigstore repository.

**Impact**: This unblocks our gem release process by ensuring the sigstore gem can be properly installed during the "Gems - Release to RubyGems" workflow.

### Anything you want to highlight for special attention from reviewers?

We've switched from using the fork `landongrindheim/sigstore-ruby` (commit `6fafa2324662735b9c93e067e1c3465ba5ab69d8`) to the official `sigstore/sigstore-ruby` repository (commit `8d5b49629ddcda7d61b328a37a42fb10291d96ad`).

This is still a temporary workaround using a specific commit hash because the version bump to v0.2.2 is still pending in [sigstore/sigstore-ruby#270](https://github.com/sigstore/sigstore-ruby/pull/270). Once that PR is merged and the new gem version is published to RubyGems, we should update this workflow to use the official gem version instead of the git commit.

<details><summary>local test</summary>

```bash
@markhallen ➜ /workspaces/dependabot-core (markhallen/update-temp-sigstor-sha) $ gem specific_install https://github.com/sigstore/sigstore-ruby.git -r 8d5b49629ddcda7d61b328a37a42fb10291d96ad
git version 2.38.1
git installing from https://github.com/sigstore/sigstore-ruby.git
Cloning into '/tmp/d20251022-13072-qbbyhh'...
remote: Enumerating objects: 1921, done.
remote: Counting objects: 100% (556/556), done.
remote: Compressing objects: 100% (211/211), done.
remote: Total 1921 (delta 476), reused 348 (delta 345), pack-reused 1365 (from 1)
Receiving objects: 100% (1921/1921), 586.88 KiB | 34.52 MiB/s, done.
Resolving deltas: 100% (1187/1187), done.
HEAD is now at 8d5b496 Skip unrecognized keys (#266)
commit 8d5b49629ddcda7d61b328a37a42fb10291d96ad (HEAD -> main)
Author: Landon Grindheim <landon.grindheim@gmail.com>
Date:   Mon Oct 20 12:49:42 2025 -0400

    Skip unrecognized keys (#266)
    
    This library does not support Rekor v2, which has caused issues when a
    new key type is attempted. Until we have comprehensive support for Rekor
    v2, we can skip unrecognized keys.
    
    Signed-off-by: Landon Grindheim <landon.grindheim@gmail.com>
WARNING:  open-ended dependency on logger (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
WARNING:  open-ended dependency on net-http (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
WARNING:  open-ended dependency on uri (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: sigstore
  Version: 0.2.1
  File: sigstore-0.2.1.gem
Successfully installed
```
</details>

### How will you know you've accomplished your goal?

- [x] The "Gems - Release to RubyGems" workflow completes successfully
- [x] The sigstore gem installs without the `Unsupported key type PKIX_ED25519` error
- [x] Our gem release process remains unblocked
- [ ] **Future goal**: Replace this temporary fix with the official v0.2.2 gem version once [sigstore/sigstore-ruby#270](https://github.com/sigstore/sigstore-ruby/pull/270) is released

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

**Note**: This is a continuation of the temporary workaround from PR #13312. We should create a follow-up issue to track switching to the official gem version once sigstore-ruby v0.2.2 is released.