### PR TITLE
allow new format for existing pull requests

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -407,7 +407,7 @@ public class SerializationTests : TestBase
     }
 
     [Fact]
-    public void DeserializeExistingPullRequests()
+    public void DeserializeExistingPullRequestsOldFormat()
     {
         var jsonWrapperJson = """
             {
@@ -429,6 +429,41 @@ public class SerializationTests : TestBase
             """;
         var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
         Assert.Single(jobWrapper.Job.ExistingPullRequests);
+        Assert.Null(jobWrapper.Job.ExistingPullRequests[0].PrNumber);
+        Assert.Single(jobWrapper.Job.ExistingPullRequests[0].Dependencies);
+        Assert.Equal("Some.Package", jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyName);
+        Assert.Equal(NuGetVersion.Parse("1.2.3"), jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyVersion);
+        Assert.False(jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyRemoved);
+        Assert.Null(jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].Directory);
+    }
+
+    [Fact]
+    public void DeserializeExistingPullRequestsNewFormat()
+    {
+        var jsonWrapperJson = """
+            {
+                "job": {
+                    "source": {
+                        "provider": "github",
+                        "repo": "some/repo"
+                    },
+                    "existing-pull-requests": [
+                        {
+                            "pr-number": 123,
+                            "dependencies": [
+                                {
+                                    "dependency-name": "Some.Package",
+                                    "dependency-version": "1.2.3"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+            """;
+        var jobWrapper = RunWorker.Deserialize(jsonWrapperJson)!;
+        Assert.Single(jobWrapper.Job.ExistingPullRequests);
+        Assert.Equal(123, jobWrapper.Job.ExistingPullRequests[0].PrNumber);
         Assert.Single(jobWrapper.Job.ExistingPullRequests[0].Dependencies);
         Assert.Equal("Some.Package", jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyName);
         Assert.Equal(NuGetVersion.Parse("1.2.3"), jobWrapper.Job.ExistingPullRequests[0].Dependencies[0].DependencyVersion);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PullRequest.cs
@@ -1,8 +1,12 @@
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record PullRequest
 {
+    [JsonPropertyName("pr-number")]
+    public int? PrNumber { get; init; } = null;
+    [JsonPropertyName("dependencies")]
     public ImmutableArray<PullRequestDependency> Dependencies { get; init; } = [];
 }


### PR DESCRIPTION
Allows the NuGet job deserializer to handle the new format for existing pull requests to correspond to #13174.