### PR TITLE
allow for and display extra message with `private_source_bad_response`

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
@@ -293,7 +293,7 @@ public class VersionFinderTests : TestBase
         var error = JobErrorBase.ErrorFromException(exception, "TEST-JOB-ID", tempDir.DirectoryPath);
 
         // assert
-        var expected = new PrivateSourceBadResponse([feedUrl]);
+        var expected = new PrivateSourceBadResponse([feedUrl], "unused");
         var expectedJson = JsonSerializer.Serialize(expected, RunWorker.SerializerOptions);
         var actualJson = JsonSerializer.Serialize(error, RunWorker.SerializerOptions);
         Assert.Equal(expectedJson, actualJson);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1124,7 +1124,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ],
             expectedResult: new()
             {
-                Error = new PrivateSourceBadResponse([$"{http.BaseUrl.TrimEnd('/')}/index.json"]),
+                Error = new PrivateSourceBadResponse([$"{http.BaseUrl.TrimEnd('/')}/index.json"], "unused"),
                 Path = "",
                 Projects = [],
             }
@@ -1199,7 +1199,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ],
             expectedResult: new()
             {
-                Error = new PrivateSourceBadResponse([$"{http.BaseUrl.TrimEnd('/')}/index.json"]),
+                Error = new PrivateSourceBadResponse([$"{http.BaseUrl.TrimEnd('/')}/index.json"], "unused"),
                 Path = "",
                 Projects = [],
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -148,7 +148,7 @@ public class HttpApiHandlerTests
         yield return [new DependencyNotFound("unused"), "record_update_job_error"];
         yield return [new JobRepoNotFound("unused"), "record_update_job_error"];
         yield return [new PrivateSourceAuthenticationFailure(["unused"]), "record_update_job_error"];
-        yield return [new PrivateSourceBadResponse(["unused"]), "record_update_job_error"];
+        yield return [new PrivateSourceBadResponse(["unused"], "unused"), "record_update_job_error"];
         yield return [new PrivateSourceTimedOut("unused"), "record_update_job_error"];
         yield return [new PullRequestExistsForLatestVersion("unused", "unused"), "record_update_job_error"];
         yield return [new PullRequestExistsForSecurityUpdate([]), "record_update_job_error"];

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
@@ -40,32 +40,39 @@ public class JobErrorBaseTests : TestBase
 
     public static IEnumerable<object[]> GenerateErrorFromExceptionTestData()
     {
+        // something elevated to a bad response
+        yield return
+        [
+            new BadResponseException("nope", "http://nuget.example.com/v3/index.json"),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"], "nope"),
+        ];
+
         // internal error from package feed
         yield return
         [
             new HttpRequestException("nope", null, HttpStatusCode.InternalServerError),
-            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"], "nope"),
         ];
 
         // inner exception turns into private_source_bad_response; 500
         yield return
         [
-            new FatalProtocolException("nope", new HttpRequestException("nope", null, HttpStatusCode.InternalServerError)),
-            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+            new FatalProtocolException("nope", new HttpRequestException("inner nope", null, HttpStatusCode.InternalServerError)),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"], "inner nope"),
         ];
 
         // inner exception turns into private_source_bad_response; ResponseEnded
         yield return
         [
-            new FatalProtocolException("nope", new HttpRequestException("nope", new HttpIOException(HttpRequestError.ResponseEnded))),
-            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+            new FatalProtocolException("nope", new HttpRequestException("inner nope", new HttpIOException(HttpRequestError.ResponseEnded))),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"], "inner nope"),
         ];
 
         // service returned corrupt package
         yield return
         [
             new InvalidDataException("Central Directory corrupt."),
-            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"]),
+            new PrivateSourceBadResponse(["http://nuget.example.com/v3/index.json"], "Central Directory corrupt."),
         ];
 
         // top-level exception turns into private_source_authentication_failure

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -152,11 +152,12 @@ public class MessageReportTests
         yield return
         [
             // message
-            new PrivateSourceBadResponse(["url1", "url2"]),
+            new PrivateSourceBadResponse(["url1", "url2"], "some extra info"),
             // expected
             """
             Error type: private_source_bad_response
             - source: (url1|url2)
+            - message: some extra info
             """
         ];
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -766,7 +766,7 @@ public class SerializationTests : TestBase
 
         yield return
         [
-            new PrivateSourceBadResponse(["url1", "url2"]),
+            new PrivateSourceBadResponse(["url1", "url2"], "unused"),
             """
             {"data":{"error-type":"private_source_bad_response","error-details":{"source":"(url1|url2)"}}}
             """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -452,7 +452,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "Response status code does not indicate success: 500 (Internal Server Error).",
             // expectedError
-            new PrivateSourceBadResponse(["http://localhost/test-feed"]),
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
         ];
 
         yield return
@@ -460,7 +460,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "The response ended prematurely. (ResponseEnded)",
             // expectedError
-            new PrivateSourceBadResponse(["http://localhost/test-feed"]),
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
         ];
 
         yield return
@@ -468,7 +468,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "The file is not a valid nupkg.",
             // expectedError
-            new PrivateSourceBadResponse(["http://localhost/test-feed"]),
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
         ];
 
         yield return
@@ -476,7 +476,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "The content at 'http://localhost/test-feed/Packages(Id='Some.Package',Version='1.2.3')' is not valid XML.",
             // expectedError
-            new PrivateSourceBadResponse(["http://localhost/test-feed"]),
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
         ];
 
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceBadResponse.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/PrivateSourceBadResponse.cs
@@ -1,10 +1,25 @@
+using System.Text.Json.Serialization;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record PrivateSourceBadResponse : JobErrorBase
 {
-    public PrivateSourceBadResponse(string[] urls)
+    [JsonIgnore]
+    public string Message { get; }
+
+    public PrivateSourceBadResponse(string[] urls, string message)
         : base("private_source_bad_response")
     {
         Details["source"] = $"({string.Join("|", urls)})";
+        Message = message;
+    }
+
+    public override string GetReport()
+    {
+        var report = base.GetReport();
+
+        // this extra info isn't part of the reported shape but is useful to have in the log
+        var fullReport = string.Concat(report, "\n", $"- message: {Message}");
+        return fullReport;
     }
 }


### PR DESCRIPTION
There are many reasons a response to a NuGet query could eventually get turned into `private_source_bad_response` but that information isn't conveyed to the log which makes determining what actually went wrong very difficult.

This PR adds a `Message` property to that object.  The official API doesn't allow for this extra field so it has to be excluded from the official error serialization and reporting but it is added to the log so a manual review can report the exact error that occurred.

`JobErrorBase.cs` is where the extra info is elevated to this `Message` property and `MessageReportTests.cs` shows that it will appear in the log.  The rest of the changes are to verify this `Message` property is appropriately populated and/or aren't relevant for the given test but need to be present to make it build.