### PR TITLE
Change smoke test branch to 'main'

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: dev/brettfo/nuget-ungrouped-updates
+  SMOKE_TEST_BRANCH: main
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR #13211 had to redirect the smoke tests.  Those have now been updated so this simply resets the smoke test branch to `main`.