### PR TITLE
Register Julia to register production check

### DIFF
--- a/julia/lib/dependabot/julia.rb
+++ b/julia/lib/dependabot/julia.rb
@@ -63,3 +63,11 @@ require "dependabot/julia/update_checker"
 require "dependabot/julia/file_updater"
 require "dependabot/julia/metadata_finder"
 require "dependabot/julia/dependency"
+
+require "dependabot/pull_request_creator/labeler"
+Dependabot::PullRequestCreator::Labeler
+  .register_label_details("julia", name: "julia", colour: "a270ba")
+
+require "dependabot/dependency"
+Dependabot::Dependency
+  .register_production_check("julia", ->(_) { true })

--- a/julia/spec/dependabot/julia_spec.rb
+++ b/julia/spec/dependabot/julia_spec.rb
@@ -3,8 +3,11 @@
 
 require "spec_helper"
 require "dependabot/julia"
+require_common_spec "shared_examples_for_autoloading"
 
 RSpec.describe Dependabot::Julia do
+  it_behaves_like "it registers the required classes", "julia"
+
   it "has a version number" do
     expect(Dependabot::Julia::VERSION).not_to be_nil
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Fix failing Julia ecosystem tests by registering the required production check and label details for the "julia" package manager.

### Anything you want to highlight for special attention from reviewers?

This follows the exact same pattern used by all other ecosystems (bundler, go_modules, etc.) by adding the registration calls at the end of the main module file

### How will you know you've accomplished your goal?

The Julia ecosystem tests now pass successfully:
- The shared example "it registers the required classes" no longer raises "Unsupported package_manager julia" errors
- The Julia ecosystem is properly integrated with Dependabot's core infrastructure

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.