### PR TITLE
Remove unrelated dependencies from the bun ecosystem

### DIFF
--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -3,24 +3,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 # Check for updates at https://github.com/nodejs/corepack/releases
 ARG COREPACK_VERSION=0.33.0
 
-# Check for updates at https://github.com/pnpm/pnpm/releases
-ARG PNPM_VERSION=9.15.5
-
-# Check for updates at https://github.com/yarnpkg/berry/releases
-ARG YARN_VERSION=4.5.3
-
 # Check for updates at https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=1.2.5
 
 # See https://github.com/nodesource/distributions#installation-instructions
 ARG NODEJS_VERSION=20
 
-# Check for updates at https://github.com/npm/cli/releases
-# This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well
-# TODO: Upgrade to 9.6.7 depending on the outcome of https://github.com/npm/cli/issues/6742
-ARG NPM_VERSION=9.6.5
-
-# Install Node and npm
+# Install Node and bun
 RUN mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_VERSION}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
@@ -28,38 +17,22 @@ RUN mkdir -p /etc/apt/keyrings \
   && apt-get install -y --no-install-recommends \
   nodejs \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install -g corepack@$COREPACK_VERSION \
   && npm install -g corepack@$COREPACK_VERSION bun@$BUN_VERSION \
   && rm -rf ~/.npm
 
 USER dependabot
 
-# Install pnpm and set it to a stable version
-RUN corepack install pnpm@$PNPM_VERSION --global
-
-# Install yarn berry and set it to a stable version
-RUN corepack install yarn@$YARN_VERSION --global
-
-# Install npm and set it to a stable version
-RUN corepack install npm@$NPM_VERSION --global
-
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot bun/helpers /opt/bun/helpers
 RUN bash /opt/bun/helpers/build
 
-# START: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
-
-# TODO: Remove these hacks once we've deprecated npm 6 support as it no longer
-# spawns a child process to npm install git dependencies.
-
 # Create the config file manually instead of using yarn/npm config set as this
 # executes the package manager outputs to every job log
-COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
+# This is here because bun supports .npmrc as well. See https://bun.com/docs/pm/npmrc#npmrc-support
+COPY --chown=dependabot:dependabot updater/config/.npmrc $DEPENDABOT_HOME/
 
-# For Yarn Berry we can set this via an environment variable
+# Configure Node to use our custom CA bundle
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
-
-# END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
 COPY --chown=dependabot:dependabot bun $DEPENDABOT_HOME/bun
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common


### PR DESCRIPTION
### What are you trying to accomplish?

When the `bun` and `npm_and_yarn` ecosystems were split into separate ecosystems with #11559, the `bun` Dockerfile was copied from the `npm_and_yarn` build. While this duplication was understandable at the time, the extra package managers (`pnpm`, `yarn`, and `npm`) are no longer relevant to the Bun ecosystem and these extras only increase the image size and add complexity. 

As per the [bun documentation](https://bun.com/docs/installation), `bun` has no dependencies 

> Bun ships as a single, dependency-free executable. You can install it via script, package manager, or Docker across macOS, Linux, and Windows.

With this change, we remove all non–Bun related dependencies and redundant setup steps from the `bun` builds. The resulting image now focuses solely on what’s needed for Bun updates, making it smaller, simpler, and easier to maintain.

### How will you know you've accomplished your goal?

All the existing tests pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
