### PR TITLE
Prevent mislabeling pub issues

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -53,7 +53,7 @@
     - '(dotnet(?:[-_]sdk)?|\.NET)'
 
 "L: dart:pub":
-    - '(dart|pub)'
+    - '\b(?:dart|pub)\b'
 
 "L: python":
     - '(python|pip|poetry|uv|conda)'


### PR DESCRIPTION
### What are you trying to accomplish?

Updates the `pub` labeling configuration to enforce word boundaries around “dart” and “pub”. This prevents incorrect matches with similar terms like “publishing” like https://github.com/dependabot/dependabot-core/issues/13405

After this change, only the exact words “dart” or “pub” will be matched, not larger words containing them.

Closes https://github.com/dependabot/dependabot-core/issues/13406

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Only issues that strictly mention `pub` are labelled 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
