### PR TITLE
[Graph] Use a non-zero value for version

### DIFF
--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -12,7 +12,7 @@ module GithubApi
   class DependencySubmission
     extend T::Sig
 
-    SNAPSHOT_VERSION = 0
+    SNAPSHOT_VERSION = 1
     SNAPSHOT_DETECTOR_NAME = "dependabot"
     SNAPSHOT_DETECTOR_URL = "https://github.com/dependabot/dependabot-core"
 


### PR DESCRIPTION
### What are you trying to accomplish?

The snapshot payload was being loosely validated in the past, but now we are strictly enforcing required fields.

A nuance of this is that we previously allowed zero values for the Snapshot's `version` key, but with proto validation in place this means that zero values are interpreted as being missing.

Rather than loosen the specification, let's just use `1` here - the version doesn't matter a huge amount as we rely on incrementing `scanned` time rather than re-versing a snapshot of a single repository ref.

### Anything you want to highlight for special attention from reviewers?

Nope!

### How will you know you've accomplished your goal?

I stop seeing validation errors when testing the validated request route.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
