### PR TITLE
Bump npm version from 10.9.3 to 11.6.2 latest

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -23,7 +23,7 @@ ARG NODEJS_VERSION=22
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the NODEJS_VERSION version declared above. See https://nodejs.org/en/download/releases as well
 # With every major release update, also update npm_and_yarn/lib/dependabot/npm_and_yarn/npm_package_manager.rb (Section : Update instructions)
-ARG NPM_VERSION=10.9.3
+ARG NPM_VERSION=11.6.2
 
 # Install Node and npm
 RUN mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
### What are you trying to accomplish?

Updating npm version from 10.9.3 to 11.6.2 latest

### Anything you want to highlight for special attention from reviewers?

By pre-installing `npm@11.6.2` in the Docker build stage, we avoid corepack's automatic attempt to fetch and install the latest `npm` version when the updater runs.

### How will you know you've accomplished your goal?

Previously, `corepack` would attempt to install `npm@latest` during updater execution, which could fail due to signature verification issues with private registries. This change ensures the desired `npm` version is already available in the container, eliminating that runtime dependency.

Ensured all the CI runs succeed.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
