### PR TITLE
Enable the inclusion of maven_install.json files in the temporary folder during Bazel sync operations.

### DIFF
--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -11,7 +11,7 @@ module Dependabot
 
       WORKSPACE_FILES = T.let(%w(WORKSPACE WORKSPACE.bazel).freeze, T::Array[String])
       MODULE_FILES = T.let(%w(MODULE.bazel).freeze, T::Array[String])
-      CONFIG_FILES = T.let(%w(.bazelrc MODULE.bazel.lock).freeze, T::Array[String])
+      CONFIG_FILES = T.let(%w(.bazelrc MODULE.bazel.lock .bazelversion maven_install.json).freeze, T::Array[String])
       SKIP_DIRECTORIES = T.let(%w(.git .bazel-* bazel-* node_modules .github).freeze, T::Array[String])
 
       sig { override.returns(String) }
@@ -86,13 +86,10 @@ module Dependabot
       def config_files
         files = T.let([], T::Array[DependencyFile])
 
-        CONFIG_FILES.each do |filename|
+        CONFIG_FILES.map do |filename|
           file = fetch_file_if_present(filename)
           files << file if file
         end
-
-        bazelversion = fetch_file_if_present(".bazelversion")
-        files << bazelversion if bazelversion
 
         files
       end

--- a/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
@@ -113,6 +113,29 @@ RSpec.describe Dependabot::Bazel::FileFetcher do
       it "fetches the MODULE.bazel file" do
         expect(fetched_files.map(&:name)).to include("MODULE.bazel")
       end
+
+      context "with a maven_install.json file" do
+        before do
+          stub_request(:get, url + "?ref=sha")
+            .to_return(
+              status: 200,
+              body: fixture("github", "contents_bazel_with_maven_install.json"),
+              headers: { "content-type" => "application/json" }
+            )
+
+          stub_request(:get, url + "maven_install.json?ref=sha")
+            .to_return(
+              status: 200,
+              body: fixture("github", "contents_bazel_maven_install.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "includes maven_install.json" do
+          puts "files: #{fetched_files.map(&:name)}"
+          expect(fetched_files.map(&:name)).to include("maven_install.json")
+        end
+      end
     end
 
     context "when beta ecosystems are not allowed" do

--- a/bazel/spec/fixtures/github/contents_bazel_maven_install.json
+++ b/bazel/spec/fixtures/github/contents_bazel_maven_install.json
@@ -1,0 +1,13 @@
+{
+  "name": "maven_install.json",
+  "path": "maven_install.json",
+  "sha": "abc123",
+  "size": 1234,
+  "url": "https://api.github.com/repos/example/repo/contents/maven_install.json?ref=sha",
+  "html_url": "https://github.com/example/repo/blob/sha/maven_install.json",
+  "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc123",
+  "download_url": "https://raw.githubusercontent.com/example/repo/sha/maven_install.json",
+  "type": "file",
+  "content": "bW9kdWxlKG5hbWUgPSAiZXhhbXBsZSIsIHZlcnNpb24gPSAiMS4wLjAiKQ==\n",
+  "encoding": "base64"
+}

--- a/bazel/spec/fixtures/github/contents_bazel_with_maven_install.json
+++ b/bazel/spec/fixtures/github/contents_bazel_with_maven_install.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "MODULE.bazel",
+    "path": "MODULE.bazel",
+    "sha": "abc123",
+    "size": 1234,
+    "url": "https://api.github.com/repos/example/repo/contents/MODULE.bazel?ref=sha",
+    "html_url": "https://github.com/example/repo/blob/sha/MODULE.bazel",
+    "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc123",
+    "download_url": "https://raw.githubusercontent.com/example/repo/sha/MODULE.bazel",
+    "type": "file",
+    "content": "bW9kdWxlKG5hbWUgPSAiZXhhbXBsZSIsIHZlcnNpb24gPSAiMS4wLjAiKQ==\n",
+    "encoding": "base64"
+  },
+  {
+    "name": "maven_install.json",
+    "path": "maven_install.json",
+    "sha": "abc123",
+    "size": 1234,
+    "url": "https://api.github.com/repos/example/repo/contents/maven_install.json?ref=sha",
+    "html_url": "https://github.com/example/repo/blob/sha/maven_install.json",
+    "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc123",
+    "download_url": "https://raw.githubusercontent.com/example/repo/sha/maven_install.json",
+    "type": "file",
+    "content": "bW9kdWxlKG5hbWUgPSAiZXhhbXBsZSIsIHZlcnNpb24gPSAiMS4wLjAiKQ==\n",
+    "encoding": "base64"
+  }
+]


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
Whilst testing the new Bazel support using [google/bazel-common](https://github.com/google/bazel-common) the `bazel sync ...` command was failing because the `./maven_install.json` file was not available in the temp directory used for this invocation.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
We have included `maven_install.json` in the Bazel dependency files retrieved by the file fetcher.

We are aware that there may be more such files. @robaiken has reached out to the bazel maintainers for confirmation of what we should support: https://github.com/bazelbuild/bazel/discussions/27142#discussioncomment-14882693

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
Pull requests raised against [google/bazel-common](https://github.com/google/bazel-common) should include the updated `MODULE.bazel.lock` file.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
