### PR TITLE
find command to run from job definition

### DIFF
--- a/updater/bin/run
+++ b/updater/bin/run
@@ -2,9 +2,18 @@
 set -e
 
 command="$1"
+
+# When no command is provided, attempt to read it from job.json
 if [ -z "$command" ]; then
-  echo "usage: run [update_files|update_graph]"
-  exit 1
+  if [ -f "job.json" ]; then
+    # Use Ruby to parse the command field; default to update_files unless explicitly graph
+    command=$(ruby -rjson -e 'j=JSON.parse(File.read("job.json")); c=j.dig("job","command") || ""; puts(c == "graph" ? "update_graph" : "update_files")')
+    echo "No command argument supplied, found command '$command' from job definition."
+  else
+    echo "usage: run [update_files|update_graph]"
+    echo "Or run without arguments if a job.json file is present."
+    exit 1
+  fi
 fi
 
 # ignore fetch_files command for backward compatibility


### PR DESCRIPTION
### What are you trying to accomplish?

This will allow us to begin to remove Updater information from dependabot-action and Dependabot CLI. Currently there is a need for them to know what type of job this is, graph vs update, but we've started putting the command directly in the job definition and so the Updater can decide what it needs to run in `bin/run`. 

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Currently this code will not be executed unless an arg is not provided, so jobs should complete as usual. But adding it this way allows us to gradually migrate and try out this new method for running.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
