### PR TITLE
Upgrade uv to v0.9.8

### DIFF
--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -11,7 +11,7 @@ ARG PY_3_9=3.9.24
 ARG PYENV_VERSION=v2.6.11
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
-FROM ghcr.io/astral-sh/uv:0.8.4 AS uv
+FROM ghcr.io/astral-sh/uv:0.9.8 AS uv
 
 FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
 ARG PY_3_14

--- a/uv/helpers/requirements.txt
+++ b/uv/helpers/requirements.txt
@@ -7,7 +7,7 @@ plette==2.1.0
 poetry==1.8.5
 # TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
 tomli==2.0.1
-uv==0.8.6
+uv==0.9.8
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.10


### PR DESCRIPTION
## Summary

This PR upgrades uv to v0.9.8, the latest version.
