### PR TITLE
allow for dependency discovery with a single restore operation

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -61,10 +61,13 @@ public partial class DiscoveryWorkerTests
             );
         }
 
-        [Fact]
-        public async Task DiscoveryIsMergedWithPackageReferences()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DiscoveryIsMergedWithPackageReferences(bool useSingleRestore)
         {
             await TestDiscoveryAsync(
+                experimentsManager: new ExperimentsManager() { UseSingleRestore = useSingleRestore },
                 packages:
                 [
                     MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net46"),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -8,12 +8,14 @@ namespace NuGetUpdater.Core;
 public record ExperimentsManager
 {
     public bool GenerateSimplePrBody { get; init; } = false;
+    public bool UseSingleRestore { get; init; } = false;
 
     public Dictionary<string, object> ToDictionary()
     {
         return new()
         {
             ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
+            ["nuget_use_single_restore"] = UseSingleRestore,
         };
     }
 
@@ -22,6 +24,7 @@ public record ExperimentsManager
         return new ExperimentsManager()
         {
             GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
+            UseSingleRestore = IsEnabled(experiments, "nuget_use_single_restore"),
         };
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -8,7 +8,11 @@ public static class ProcessEx
     /// <summary>
     /// Run the `dotnet` command with the given values.  This will exclude all `MSBuild*` environment variables from the execution.
     /// </summary>
-    public static Task<(int ExitCode, string Output, string Error)> RunDotnetWithoutMSBuildEnvironmentVariablesAsync(IEnumerable<string> arguments, string workingDirectory)
+    public static Task<(int ExitCode, string Output, string Error)> RunDotnetWithoutMSBuildEnvironmentVariablesAsync(
+        IEnumerable<string> arguments,
+        string workingDirectory,
+        IEnumerable<(string Name, string? Value)>? extraEnvironmentVariables = null
+    )
     {
         // When using the SDK specified by a `global.json` file, these environment variables need to be unset to
         // allow the new process to discover the correct MSBuild binaries to load, and not load the ones that
@@ -24,6 +28,11 @@ public static class ProcessEx
         };
 
         var environmentVariableOverrides = environmentVariablesToUnset.Select(name => (name, (string?)null));
+        if (extraEnvironmentVariables is not null)
+        {
+            environmentVariableOverrides = environmentVariableOverrides.Concat(extraEnvironmentVariables);
+        }
+
         return RunAsync("dotnet",
             arguments,
             workingDirectory,


### PR DESCRIPTION
More than just a call to the `Restore` target is required to fully realize all NuGet dependencies and we're currently doing that by performing a partial build which can be slow due to invoking it for each target framework and can lead to some red herrings when packages were correctly discovered but the build failed for reasons not relevant to dependabot.

This PR adds a new experiment flag `nuget_use_single_restore` which directly invokes the relevant targets and reduces the number of process invocations required for dependency discovery.

In short, three targets are required: `Restore`, `ResolveProjectReferences`, and `ResolvePackageAssets`.  If operating against a `.csproj` with a single target framework this is sufficient.

There is one special case: If we're operating against a `.csproj` with multiple target frameworks, those targets don't exist at the top level and we instead execute the `Build` target on the MSBuild-created metaproject, but we can then set the property `InnerTargets` with those three values.  This case is detected by running the command `dotnet msbuild path/to/project.csproj -targets` to list all targets and if the three required ones are missing, we take this option.