### PR TITLE
Bazel update checker to filter ignored versions

### DIFF
--- a/bazel/lib/dependabot/bazel/requirement.rb
+++ b/bazel/lib/dependabot/bazel/requirement.rb
@@ -10,39 +10,44 @@ module Dependabot
     class Requirement < Dependabot::Requirement
       extend T::Sig
 
-      # Bazel dependencies typically use exact versions, not version ranges
-      # This class exists for consistency with Dependabot patterns but
-      # may not be heavily used since Bazel tends to pin exact versions
-
       sig { params(requirement_string: String).returns(String) }
       def self.normalize_requirement(requirement_string)
-        # Handle exact version specifications (most common in Bazel)
         return requirement_string if requirement_string.match?(/^[<>=~]/)
 
-        # For bare version strings, treat as exact match
         return "= #{requirement_string}" if requirement_string.match?(/^\d+(\.\d+)*(-[\w\d.]+)?(\+[\w\d.]+)?$/)
 
         requirement_string
       end
 
-      # This abstract method must be implemented
       sig do
         override
           .params(requirement_string: T.nilable(String))
           .returns(T::Array[Dependabot::Requirement])
       end
       def self.requirements_array(requirement_string)
-        # For Bazel, most requirements are simple exact versions
         return [] if requirement_string.nil? || requirement_string.strip.empty?
 
-        normalized = normalize_requirement(requirement_string)
-        [new(normalized)]
+        # Handle comma-separated constraints (e.g., ">= 1.0, < 2.0")
+        constraints = requirement_string.split(",").map do |req_string|
+          normalize_requirement(req_string.strip)
+        end.reject(&:empty?)
+
+        return [] if constraints.empty?
+
+        [new(constraints)]
+      end
+
+      sig { params(requirements: T.nilable(T.any(String, T::Array[String]))).void }
+      def initialize(*requirements)
+        requirements = requirements.flatten.flat_map do |req_string|
+          T.must(req_string).split(",").map(&:strip)
+        end
+
+        super(requirements)
       end
 
       sig { override.params(version: Gem::Version).returns(T::Boolean) }
       def satisfied_by?(version)
-        # For Bazel versions, delegate to the base class
-        # but ensure we're working with proper version objects
         bazel_version = case version
                         when Dependabot::Bazel::Version
                           version


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the Bazel updater to respect `ignore` configuration for version updates (e.g., `version-update:semver-major`). Previously, the updater would suggest ignored versions because it wasn't filtering them out.

### Anything you want to highlight for special attention from reviewers?

- Follows the same pattern as other ecosystems (Go modules, Docker, npm_and_yarn)
- Fixed `Requirement` class to handle comma-separated constraints properly (e.g., `">= 1.0, < 2.0"`)
- Logs informational messages instead of raising exceptions when all versions are ignored

### How will you know you've accomplished your goal?

- All 244 tests pass, including new tests for ignored version filtering
- RuboCop and Sorbet checks pass with no offenses
- Manual testing: configure `ignore: version-update:semver-major` and verify only minor/patch updates are suggested

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.