### PR TITLE
Fix npm_and_yarn file_updater specs for js-yaml 3.14.2

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -3434,7 +3434,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:files) { project_dependency_files("yarn/multiple_sub_dependencies") }
 
         let(:dependency_name) { "js-yaml" }
-        let(:version) { "3.14.1" }
+        let(:version) { "3.14.2" }
         let(:previous_version) { "3.9.0" }
         let(:requirements) { [] }
         let(:previous_requirements) { nil }
@@ -3444,7 +3444,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           expect(updated_yarn_lock.content)
             .to include(
               "js-yaml@^3.10.0, js-yaml@^3.4.6, js-yaml@^3.9.0:\n" \
-              '  version "3.14.1"'
+              '  version "3.14.2"'
             )
         end
       end
@@ -3761,7 +3761,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:project_name) { "pnpm/multiple_sub_dependencies" }
 
         let(:dependency_name) { "js-yaml" }
-        let(:version) { "3.14.1" }
+        let(:version) { "3.14.2" }
         let(:previous_version) { "3.9.0" }
         let(:requirements) { [] }
         let(:previous_requirements) { nil }
@@ -3769,7 +3769,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "de-duplicates all entries to the same version" do
           expect(updated_files.map(&:name)).to contain_exactly("pnpm-lock.yaml")
 
-          expect(updated_pnpm_lock.content).to include("js-yaml@3.14.1:\n    resolution").once
+          expect(updated_pnpm_lock.content).to include("js-yaml@3.14.2:\n    resolution").once
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Updates test expectations for `js-yaml` from `3.14.1` to `3.14.2` to reflect the current version available in the npm registry when de-duplicating sub-dependencies with multiple version requirements in Yarn and PNPM.

### Anything you want to highlight for special attention from reviewers?

This PR generated to fix [this CI Run failure](https://github.com/dependabot/dependabot-core/actions/runs/19396913004/job/55498186646?pr=13514)

### How will you know you've accomplished your goal?

Existing tests pass. 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
