### PR TITLE
Handle situations where the OpenTofu registry errors

### DIFF
--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -187,7 +187,8 @@ module Dependabot
               # Server error - likely a temporary outage
               raise RegistryError.new(
                 response.status,
-                "Registry at #{hostname} is currently unavailable (HTTP #{response.status}). This may be a temporary outage - please try again later."
+                "Registry at #{hostname} is currently unavailable (HTTP #{response.status})." \
+                "This may be a temporary outage - please try again later."
               )
             when 401
               # Authentication required or failed

--- a/opentofu/spec/dependabot/opentofu/registry_client_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/registry_client_spec.rb
@@ -80,12 +80,8 @@ RSpec.describe Dependabot::Opentofu::RegistryClient do
     stub_request(:get, "https://#{hostname}/.well-known/terraform.json").and_return(status: 404)
     client = described_class.new(hostname: hostname)
 
-    expect do
-      client.all_provider_versions(identifier: "hashicorp/aws")
-    end.to raise_error(Dependabot::RegistryError) do |error|
-      expect(error.status).to eq(404)
-      expect(error.message).to match(/does not support service discovery/)
-    end
+    expect { client.all_provider_versions(identifier: "hashicorp/aws") }
+      .to raise_error(Dependabot::RegistryError, /does not support service discovery/)
   end
 
   it "raises an error when the registry returns a 500 error" do
@@ -93,12 +89,8 @@ RSpec.describe Dependabot::Opentofu::RegistryClient do
     stub_request(:get, "https://#{hostname}/.well-known/terraform.json").and_return(status: 500)
     client = described_class.new(hostname: hostname)
 
-    expect do
-      client.all_provider_versions(identifier: "hashicorp/aws")
-    end.to raise_error(Dependabot::RegistryError) do |error|
-      expect(error.status).to eq(500)
-      expect(error.message).to match(/currently unavailable/)
-    end
+    expect { client.all_provider_versions(identifier: "hashicorp/aws") }
+      .to raise_error(Dependabot::RegistryError, /currently unavailable/)
   end
 
   it "fetches provider versions form a custom registry secured by a token" do
@@ -252,12 +244,8 @@ RSpec.describe Dependabot::Opentofu::RegistryClient do
       it "raises an error" do
         stub_request(:get, metadata).and_return(status: 404)
 
-        expect do
-          client.service_url_for_registry("modules.v1")
-        end.to raise_error(Dependabot::RegistryError) do |error|
-          expect(error.status).to eq(404)
-          expect(error.message).to match(/does not support service discovery/)
-        end
+        expect { client.service_url_for_registry("modules.v1") }
+          .to raise_error(Dependabot::RegistryError, /does not support service discovery/)
       end
     end
 
@@ -265,12 +253,8 @@ RSpec.describe Dependabot::Opentofu::RegistryClient do
       it "raises a registry error" do
         stub_request(:get, metadata).and_return(status: 500)
 
-        expect do
-          client.service_url_for_registry("modules.v1")
-        end.to raise_error(Dependabot::RegistryError) do |error|
-          expect(error.status).to eq(500)
-          expect(error.message).to match(/currently unavailable/)
-        end
+        expect { client.service_url_for_registry("modules.v1") }
+          .to raise_error(Dependabot::RegistryError, /currently unavailable/)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

There are situations where the OpenTofu registry returns a non-200 status code for a reason (Such as a cloudflare outage!) And this commit aims to improve the error logging around this to not confuse end users of Dependabot with OpenTofu.

It adds in different status code handling branches to ensure that the correct type of error and message is surfaced up to the end-user.


### Anything you want to highlight for special attention from reviewers?
I'm not 100% certain on the types of errors as it's not super well documented when to use each one. I think I've made a correct judgement call on each of these but please feel free to correct me. I'm happy to change them.

### How will you know you've accomplished your goal?
- If end-users are less confused maybe?

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
