### PR TITLE
Rust toolchain cache bust headers

### DIFF
--- a/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
@@ -19,7 +19,7 @@ module Dependabot
       class PackageDetailsFetcher
         extend T::Sig
 
-        MANIFESTS_URL = "https://static.rust-lang.org/manifests.txt"
+  MANIFESTS_URL = "https://static.rust-lang.org/manifests.txt"
 
         sig do
           params(
@@ -53,7 +53,10 @@ module Dependabot
         # Fetch the manifests.txt file and parse each line to extract version information
         sig { returns(T::Array[Dependabot::RustToolchain::Version]) }
         def fetch_and_parse_manifests
-          response = Dependabot::RegistryClient.get(url: MANIFESTS_URL)
+          # Cache bust by appending a timestamp query param so CDN treats each request uniquely
+          # This avoids relying on headers that might be ignored by intermediate caches.
+          busted_url = "#{MANIFESTS_URL}?t=#{Time.now.to_i}"
+          response = Dependabot::RegistryClient.get(url: busted_url)
           manifests_content = response.body
 
           channels = T.let([], T::Array[Dependabot::RustToolchain::Version])

--- a/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
@@ -19,7 +19,7 @@ module Dependabot
       class PackageDetailsFetcher
         extend T::Sig
 
-  MANIFESTS_URL = "https://static.rust-lang.org/manifests.txt"
+        MANIFESTS_URL = "https://static.rust-lang.org/manifests.txt"
 
         sig do
           params(


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
Add cache busting so users get latest version. Users on different time zones sometimes receive stale versions. 

<!-- What issues does this affect or fix? -->
Fixes: https://github.com/dependabot/dependabot-core/issues/13583

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
This is easier than using channel-rust-nightly.toml instead of manifests.txt as it requires less code changes. 

### How will you know you've accomplished your goal?
Users always see the latest manifest even if CDN caches.
No stale versions are served after a new release appears.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
