### PR TITLE
halve the amount of layers in Updater images

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -2,6 +2,13 @@
 FROM docker.io/library/ubuntu:24.04
 
 ARG TARGETARCH
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+FROM docker.io/library/ubuntu:24.04 AS base_system
+
+ARG USER_UID
+ARG USER_GID
 
 LABEL org.opencontainers.image.source="https://github.com/dependabot/dependabot-core"
 
@@ -108,9 +115,6 @@ RUN apt-get update \
   && apt purge software-properties-common apt-transport-https -y && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 RUN <<EOT
   # Check if the group and user already exist, if not create them
   if ! getent group "$USER_GID"; then
@@ -142,24 +146,63 @@ USER dependabot
 ENV DEPENDABOT_HOME="/home/dependabot"
 WORKDIR $DEPENDABOT_HOME
 
-# Install Ruby from official Docker image
-# When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb`
-COPY --from=docker.io/library/ruby:3.4.7-bookworm --chown=dependabot:dependabot /usr/local /usr/local
-
 # For users to determine if dependabot is running
 ENV DEPENDABOT=true
 
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
+ENV PATH="$DEPENDABOT_HOME/bin:$PATH"
 
-# Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
-ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-${TARGETARCH}.tar.gz"
-RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
+FROM docker.io/library/ruby:3.4.7-bookworm AS ruby_home
+
+ARG TARGETARCH
+ARG USER_UID
+ARG USER_GID
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+  DEPENDABOT_HOME="/home/dependabot"
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libgmp-dev \
+    libyaml-dev \
+    curl \
+    ca-certificates \
+    unzip \
+    zstd \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN <<EOT
+  if ! getent group "$USER_GID"; then
+    groupadd --gid "$USER_GID" dependabot
+  fi
+
+  if ! getent passwd "$USER_UID"; then
+    useradd --uid "$USER_UID" --gid "$USER_GID" -m dependabot
+  fi
+
+  mkdir -p /opt
+  chown dependabot:dependabot /opt
+EOT
+
+USER dependabot
+WORKDIR $DEPENDABOT_HOME
+ENV DEPENDABOT=true
+ENV GIT_LFS_SKIP_SMUDGE=1
+ENV PATH="$DEPENDABOT_HOME/bin:$PATH"
 
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 
 COPY --chown=dependabot:dependabot --parents */.bundle */*.gemspec common/lib/dependabot.rb LICENSE omnibus $DEPENDABOT_HOME
+
+# Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
+ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-${TARGETARCH}.tar.gz"
+RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
 # prevent having all the source in every ecosystem image
 RUN for ecosystem in git_submodules terraform github_actions hex elm docker docker_compose nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler silent swift devcontainers dotnet_sdk bun uv helm julia vcpkg rust_toolchain conda bazel opentofu; do \
@@ -188,14 +231,20 @@ RUN if [[ "$GEM_ENABLED" == "true" ]]; then \
     rm -rf ~/.bundle; \
   fi
 
+FROM base_system
 
-ENV PATH="$DEPENDABOT_HOME/bin:$PATH"
+USER root
+# Install Ruby from official Docker image
+# When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb`
+COPY --from=ruby_home --chown=dependabot:dependabot /usr/local /usr/local
+COPY --from=ruby_home --chown=dependabot:dependabot /home/dependabot /home/dependabot
+
+WORKDIR $DEPENDABOT_HOME/dependabot-updater
+
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
 # Make the build arg available inside the Dependabot container
 ARG DEPENDABOT_UPDATER_VERSION=development
 ENV DEPENDABOT_UPDATER_VERSION=$DEPENDABOT_UPDATER_VERSION
-
-USER root
 
 CMD ["bin/run"]


### PR DESCRIPTION
### What are you trying to accomplish?

By reducing the amount of layers in the final image we can reduce the load on GHCR. 

My strategy here was to stick all the COPY statements, which each produce a layer, into a builder image and then just do one final COPY to move $DEPENDABOT_HOME into it's final place.

On my local machine this reduced the Go image from 80 to 39 layers.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The builds will pass. Deploy cautiously as Copilot helped with this.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
