### PR TITLE
fix: builtin/terraform error while updating OpenTofu

### DIFF
--- a/opentofu/README.md
+++ b/opentofu/README.md
@@ -15,6 +15,11 @@ OpenTofu support for [`dependabot-core`][core-repo].
    [dependabot-core-dev] ~ $ cd opentofu && rspec
    ```
 
+3. Run against an existing repo:
+   ```
+   bin/dry-run.rb opentofu diofeher/dependabot-example --dep="specific-dependency"
+   ```
+
 ### Configuration
 
 To enable OpenTofu support, add to your `dependabot.yml`:

--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -57,6 +57,7 @@ module Dependabot
       private
 
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/MethodLength
       sig { params(dependency_set: Dependabot::FileParsers::Base::DependencySet).void }
       def parse_opentofu_files(dependency_set)
         opentofu_files.each do |file|
@@ -106,6 +107,7 @@ module Dependabot
           end
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       sig { params(dependency_set: Dependabot::FileParsers::Base::DependencySet).void }
       def parse_terragrunt_files(dependency_set)

--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -93,7 +93,14 @@ module Dependabot
             required_providers = opentofu.fetch("required_providers", {})
             required_providers.each do |provider|
               provider.each do |name, details|
-                dependency_set << build_provider_dependency(file, name, details)
+                Dependabot.logger.info("Building provider dependency for #{name} in #{file.name}")
+                dep = build_provider_dependency(file, name, details)
+                if dep.name == "builtin/terraform"
+                  Dependabot.logger.info("Skipping builtin/terraform provider as it's not possible to update it")
+                  next
+                end
+
+                dependency_set << dep
               end
             end
           end

--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -30,6 +30,18 @@ module Dependabot
       # https://opentofu.org/docs/language/providers/requirements/#source-addresses
       PROVIDER_SOURCE_ADDRESS = %r{\A((?<hostname>.+)/)?(?<namespace>.+)/(?<name>.+)\z}
 
+      # Namespaces reserved for providers bundled with the OpenTofu/Terraform
+      # binary. Providers in these namespaces cannot be updated independently
+      # because their version tracks the binary itself.
+      # See: https://pkg.go.dev/github.com/opentofu/registry-address/v2#Provider.IsBuiltIn
+      BUILTIN_PROVIDER_NAMESPACES = T.let(
+        %w(
+          terraform.io/builtin
+          opentofu.org/builtin
+        ).freeze,
+        T::Array[String]
+      )
+
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
         dependency_set = DependencySet.new
@@ -56,8 +68,18 @@ module Dependabot
 
       private
 
+      sig { params(details: T.any(String, T::Hash[String, T.untyped])).returns(T::Boolean) }
+      def builtin_provider?(details)
+        return false unless details.is_a?(Hash)
+
+        source_address = details["source"]
+        return false unless source_address.is_a?(String)
+
+        normalized = source_address.downcase
+        BUILTIN_PROVIDER_NAMESPACES.any? { |ns| normalized.start_with?("#{ns}/") }
+      end
+
       # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/MethodLength
       sig { params(dependency_set: Dependabot::FileParsers::Base::DependencySet).void }
       def parse_opentofu_files(dependency_set)
         opentofu_files.each do |file|
@@ -94,20 +116,17 @@ module Dependabot
             required_providers = opentofu.fetch("required_providers", {})
             required_providers.each do |provider|
               provider.each do |name, details|
-                Dependabot.logger.info("Building provider dependency for #{name} in #{file.name}")
-                dep = build_provider_dependency(file, name, details)
-                if dep.name == "builtin/terraform"
-                  Dependabot.logger.info("Skipping builtin/terraform provider as it's not possible to update it")
+                if builtin_provider?(details)
+                  Dependabot.logger.info("Skipping built-in provider #{name} in #{file.name}")
                   next
                 end
 
-                dependency_set << dep
+                dependency_set << build_provider_dependency(file, name, details)
               end
             end
           end
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       sig { params(dependency_set: Dependabot::FileParsers::Base::DependencySet).void }
       def parse_terragrunt_files(dependency_set)

--- a/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
@@ -986,13 +986,14 @@ RSpec.describe Dependabot::Opentofu::FileParser do
       end
     end
 
-    context "with a terraform.io/builtin/terraform provider" do
+    context "with built-in providers" do
       let(:files) { project_dependency_files("provider_with_builtin_terraform") }
 
-      it "skips the builtin/terraform provider" do
+      it "skips providers in built-in namespaces" do
         expect(dependencies.length).to eq(2)
-        # Should not include builtin/terraform provider
+        # Should not include any built-in provider (terraform.io/builtin/* or opentofu.org/builtin/*)
         expect(dependencies.find { |d| d.name == "builtin/terraform" }).to be_nil
+        expect(dependencies.find { |d| d.name == "builtin/example" }).to be_nil
         # Should include other providers
         expect(dependencies.find { |d| d.name == "hashicorp/http" }).not_to be_nil
         expect(dependencies.find { |d| d.name == "hashicorp/aws" }).not_to be_nil

--- a/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
@@ -986,6 +986,29 @@ RSpec.describe Dependabot::Opentofu::FileParser do
       end
     end
 
+    context "with a terraform.io/builtin/terraform provider" do
+      let(:files) { project_dependency_files("provider_with_builtin_terraform") }
+
+      it "skips the builtin/terraform provider" do
+        expect(dependencies.length).to eq(2)
+        # Should not include builtin/terraform provider
+        expect(dependencies.find { |d| d.name == "builtin/terraform" }).to be_nil
+        # Should include other providers
+        expect(dependencies.find { |d| d.name == "hashicorp/http" }).not_to be_nil
+        expect(dependencies.find { |d| d.name == "hashicorp/aws" }).not_to be_nil
+      end
+
+      it "parses other providers correctly" do
+        http_provider = dependencies.find { |d| d.name == "hashicorp/http" }
+        expect(http_provider.version).to eq("2.1.0")
+        expect(http_provider.requirements.first[:requirement]).to eq("~> 2.0")
+
+        aws_provider = dependencies.find { |d| d.name == "hashicorp/aws" }
+        expect(aws_provider.version).to eq("3.37.0")
+        expect(aws_provider.requirements.first[:requirement]).to eq("3.37.0")
+      end
+    end
+
     context "with a private module with directory suffix" do
       let(:files) { project_dependency_files("private_module_with_dir_suffix") }
 

--- a/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/.terraform.lock.hcl
+++ b/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "builtin/terraform" {
+  version = "1.0.0"
+}
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "3.37.0"
+  constraints = "3.37.0"
+  hashes = [
+    "h1:mJschciSYzJWKqAXZ9YqgB4S28DCFvJXwErCQV/5Vkw=",
+    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf"
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/http" {
+  version     = "2.1.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:GYoVrTtiSAE3nlDJ2wqM8l0hjBF9eIj0R9f+Z1sOw0c=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826"
+  ]
+}
+

--- a/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/main.tf
+++ b/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    terraform = {
+      source  = "terraform.io/builtin/terraform"
+    }
+
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.37.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+

--- a/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/main.tf
+++ b/opentofu/spec/fixtures/projects/provider_with_builtin_terraform/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "terraform.io/builtin/terraform"
     }
 
+    opentofu_builtin = {
+      source  = "opentofu.org/builtin/example"
+    }
+
     http = {
       source  = "hashicorp/http"
       version = "~> 2.0"


### PR DESCRIPTION
Resolves #13627

Skips trying to update `terraform.io/builtin/terraform`, since it's not possible to update it, as it follows the same version of the OpenTofu binary.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
