### PR TITLE
Handle multiple `COPY` into `$DEPENDABOT_HOME/` as one command

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -37,6 +38,5 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_DIR=/etc/ssl/certs \
     BAZEL_SYSTEM_BAZELRC=/etc/bazel.bazelrc
 
-COPY --chown=dependabot:dependabot bazel $DEPENDABOT_HOME/bazel
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents bazel common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
@@ -34,6 +35,5 @@ COPY --chown=dependabot:dependabot updater/config/.npmrc $DEPENDABOT_HOME/
 # Configure Node to use our custom CA bundle
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
-COPY --chown=dependabot:dependabot bun $DEPENDABOT_HOME/bun
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents bun common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
@@ -5,6 +6,5 @@ USER dependabot
 COPY --chown=dependabot:dependabot bundler/helpers /opt/bundler/helpers
 RUN bash /opt/bundler/helpers/v2/build
 
-COPY --chown=dependabot:dependabot bundler $DEPENDABOT_HOME/bundler
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents bundler common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM docker.io/library/rust:1.89.0-bookworm AS rust
 
 FROM ghcr.io/dependabot/dependabot-updater-core
@@ -19,6 +20,5 @@ COPY --from=rust /usr/local/cargo $CARGO_HOME
 # Configure cargo to use Git CLI so the Git shim works
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 
-COPY --chown=dependabot:dependabot cargo $DEPENDABOT_HOME/cargo
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents cargo common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,8 +1,9 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # This isn't a real ecosystem, adding it to make CI work easily.
 # If you don't like this, it might be a good idea to move
 # Dockerfile.updater-core in here instead, or refactor CI.
 
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG COMPOSER_V2_VERSION=2.8.10
 ARG PHP_VERSION=8.4
@@ -53,6 +54,5 @@ COPY --chown=dependabot:dependabot composer/helpers /opt/composer/helpers
 
 RUN bash /opt/composer/helpers/v2/build
 
-COPY --chown=dependabot:dependabot composer $DEPENDABOT_HOME/composer
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents composer common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -23,7 +24,5 @@ RUN pip install pyyaml
 USER dependabot
 
 # Copy ecosystem-specific files
-COPY --chown=dependabot:dependabot python $DEPENDABOT_HOME/python
-COPY --chown=dependabot:dependabot conda $DEPENDABOT_HOME/conda
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents python conda common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/devcontainers/Dockerfile
+++ b/devcontainers/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -33,6 +34,5 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 # Sanity check
 RUN devcontainer --version
 
-COPY --chown=dependabot:dependabot devcontainers $DEPENDABOT_HOME/devcontainers
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents devcontainers common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 # From https://github.com/sigstore/cosign/releases
 FROM ghcr.io/sigstore/cosign/cosign:v2.6.1 AS cosign
 # From https://github.com/regclient/regclient/releases
@@ -23,6 +24,5 @@ RUN REGCTL_VERSION=$(regctl version --format '{{.VCSTag}}') && \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot docker $DEPENDABOT_HOME/docker
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents docker common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/docker_compose/Dockerfile
+++ b/docker_compose/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -20,7 +21,5 @@ RUN cd /tmp \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot docker_compose $DEPENDABOT_HOME/docker_compose
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents docker docker_compose common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
-COPY --chown=dependabot:dependabot docker $DEPENDABOT_HOME/docker

--- a/dotnet_sdk/Dockerfile
+++ b/dotnet_sdk/Dockerfile
@@ -1,7 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot dotnet_sdk $DEPENDABOT_HOME/dotnet_sdk
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents dotnet_sdk common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 # Install Elm
@@ -13,6 +14,5 @@ RUN [ "$TARGETARCH" != "amd64" ] \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot elm $DEPENDABOT_HOME/elm
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents elm common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/git_submodules/Dockerfile
+++ b/git_submodules/Dockerfile
@@ -1,7 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot git_submodules $DEPENDABOT_HOME/git_submodules
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents git_submodules common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/github_actions/Dockerfile
+++ b/github_actions/Dockerfile
@@ -1,7 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot github_actions $DEPENDABOT_HOME/github_actions
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents github_actions common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM docker.io/library/golang:1.25.0-bookworm AS go
 
 FROM ghcr.io/dependabot/dependabot-updater-core
@@ -15,6 +16,5 @@ COPY go_modules/helpers /opt/go_modules/helpers
 RUN bash /opt/go_modules/helpers/build
 
 USER dependabot
-COPY --chown=dependabot:dependabot go_modules $DEPENDABOT_HOME/go_modules
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents go_modules common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Install Java
@@ -32,7 +33,5 @@ RUN set -o errexit -o nounset \
     && echo "Testing Gradle installation" \
     && gradle --version
 
-COPY --chown=dependabot:dependabot maven $DEPENDABOT_HOME/maven
-COPY --chown=dependabot:dependabot gradle $DEPENDABOT_HOME/gradle
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents gradle maven common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -50,7 +51,5 @@ RUN cd /tmp \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot helm $DEPENDABOT_HOME/helm
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents docker helm common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
-COPY --chown=dependabot:dependabot docker $DEPENDABOT_HOME/docker

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 RUN apt-get update \
   && apt-get upgrade -y \
@@ -45,6 +46,5 @@ ENV HEX_VERSION="2.2.2"
 ENV HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt
 RUN bash /opt/hex/helpers/build
 
-COPY --chown=dependabot:dependabot hex $DEPENDABOT_HOME/hex
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents hex common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER root
@@ -22,6 +23,5 @@ RUN bash /opt/julia/helpers/build
 # The Julia depot (~/.julia) is already in place from the build step above
 # It contains precompiled packages, registries, and artifacts for fast startup
 
-COPY --chown=dependabot:dependabot julia $DEPENDABOT_HOME/julia
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents julia common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 # This cannot be inlined below (e.g., COPY --from=maven:...) because Dependabot does not support that syntax yet
 FROM maven:3.9.9 as maven
 
@@ -19,8 +20,7 @@ USER dependabot
 ENV PATH=$JAVA_HOME/bin:$PATH
 ENV MAVEN_CONFIG "$DEPENDABOT_HOME/.m2"
 
-COPY --chown=dependabot:dependabot maven $DEPENDABOT_HOME/maven
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents maven common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # symlink so script/dependabot just works

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/nodejs/corepack/releases
@@ -66,6 +67,5 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
-COPY --chown=dependabot:dependabot npm_and_yarn $DEPENDABOT_HOME/npm_and_yarn
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents npm_and_yarn common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 ARG TARGETARCH
@@ -69,8 +70,7 @@ USER dependabot
 COPY --chown=dependabot:dependabot nuget/helpers /opt/nuget/helpers
 RUN bash /opt/nuget/helpers/build
 
-COPY --chown=dependabot:dependabot nuget $DEPENDABOT_HOME/nuget
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents nuget common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # ensure windows-style environment variables are set

--- a/opentofu/Dockerfile
+++ b/opentofu/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -21,6 +22,5 @@ USER dependabot
 COPY --chown=dependabot:dependabot opentofu/helpers /opt/opentofu/helpers
 RUN bash /opt/opentofu/helpers/build
 
-COPY --chown=dependabot:dependabot opentofu $DEPENDABOT_HOME/opentofu
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents opentofu common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/pub/Dockerfile
+++ b/pub/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 # Install Dart
@@ -27,6 +28,5 @@ USER dependabot
 COPY --chown=dependabot:dependabot pub/helpers /opt/pub/helpers
 RUN bash /opt/pub/helpers/build
 
-COPY --chown=dependabot:dependabot pub $DEPENDABOT_HOME/pub
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents pub common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 # This list must match the versions specified in
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
@@ -167,8 +168,7 @@ RUN apt-get update \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot python $DEPENDABOT_HOME/python
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents python common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # Running these steps last means that if the builds in the concurrent stages take longer it doesn't block the pipeline until the end.
@@ -201,6 +201,6 @@ COPY --from=rust /usr/local/cargo $CARGO_HOME
 # Configure cargo to use Git CLI so the Git shim works
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 
-COPY --chown=dependabot:dependabot cargo $DEPENDABOT_HOME/cargo
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents cargo common $DEPENDABOT_HOME/
+
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/rakelib/support/ecosystem_templates/Dockerfile.erb
+++ b/rakelib/support/ecosystem_templates/Dockerfile.erb
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # TODO: Install any required dependencies for your ecosystem
@@ -14,6 +15,5 @@ USER dependabot
 # COPY --chown=dependabot:dependabot <%= ecosystem_name %>/helpers /opt/<%= ecosystem_name %>/helpers
 # RUN bash /opt/<%= ecosystem_name %>/helpers/build
 
-COPY --chown=dependabot:dependabot <%= ecosystem_name %> $DEPENDABOT_HOME/<%= ecosystem_name %>
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents <%= ecosystem_name %> common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/rust_toolchain/Dockerfile
+++ b/rust_toolchain/Dockerfile
@@ -1,7 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot rust_toolchain $DEPENDABOT_HOME/rust_toolchain
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents rust_toolchain common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/silent/Dockerfile
+++ b/silent/Dockerfile
@@ -1,7 +1,7 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot silent $DEPENDABOT_HOME/silent
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents silent common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -43,6 +44,5 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VE
   && tar -C /opt/swift -xzf /tmp/${SWIFT_TARBALL} --strip-components 1 \
   && rm -f /tmp/${SWIFT_TARBALL} /tmp/${SWIFT_SIGNATURE}
 
-COPY --chown=dependabot:dependabot swift $DEPENDABOT_HOME/swift
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents swift common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
@@ -20,6 +21,5 @@ USER dependabot
 COPY --chown=dependabot:dependabot terraform/helpers /opt/terraform/helpers
 RUN bash /opt/terraform/helpers/build
 
-COPY --chown=dependabot:dependabot terraform $DEPENDABOT_HOME/terraform
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents terraform common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 # This list must match the versions specified in
 # uv/lib/dependabot/uv/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # Python versions are pinned to the release of each minor/patch version.
@@ -167,9 +168,7 @@ RUN apt-get update \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot uv $DEPENDABOT_HOME/uv
-COPY --chown=dependabot:dependabot python $DEPENDABOT_HOME/python
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents uv python common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 # Running these steps last means that if the builds in the concurrent stages take longer it doesn't block the pipeline until the end.
@@ -205,6 +204,5 @@ RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo
 # Install uv by copying from the official image
 COPY --from=uv /uv /uvx /usr/local/bin/
 
-COPY --chown=dependabot:dependabot cargo $DEPENDABOT_HOME/cargo
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents cargo common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/vcpkg/Dockerfile
+++ b/vcpkg/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Install VCPKG and dependencies
@@ -22,6 +23,5 @@ USER dependabot
 ENV VCPKG_ROOT="/opt/vcpkg"
 ENV PATH="/opt/vcpkg:$PATH"
 
-COPY --chown=dependabot:dependabot vcpkg $DEPENDABOT_HOME/vcpkg
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot --parents vcpkg common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater


### PR DESCRIPTION
This streamlines the `COPY` into `$DEPENDABOT_HOME/` as a single command.

This reduces the layer count from two (or more) to only one.

This shouldn't have _that_ much impact on the cache hits since the two layers were adjacent. But it will reduce the calls to the docker registry since each layer is a separate call. And should make for slightly faster / trimmer builds when building from scratch.
