### PR TITLE
Fix changelog finder matching files with changelog names in the middle

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -180,7 +180,7 @@ module Dependabot
         sig { params(files: T::Array[T.untyped]).returns(T.untyped) }
         def select_best_changelog(files)
           CHANGELOG_NAMES.each do |name|
-            candidates = files.select { |f| f.name =~ /#{name}/i }
+            candidates = files.select { |f| f.name =~ /\A#{name}/i }
             file = candidates.first if candidates.one?
             file ||=
               candidates.find do |f|

--- a/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
@@ -257,6 +257,21 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
         end
       end
 
+      context "with a file containing changelog name in the middle" do
+        let(:github_response) do
+          fixture("github", "business_files_with_misleading_release_doc.json")
+        end
+
+        before do
+          stub_request(:get, github_url + "?ref=v1.4.0")
+            .to_return(status: github_status,
+                       body: github_response,
+                       headers: { "Content-Type" => "application/json" })
+        end
+
+        it { is_expected.to be_nil }
+      end
+
       context "with a docs folder" do
         let(:source) do
           Dependabot::Source.new(

--- a/common/spec/fixtures/github/business_files_with_misleading_release_doc.json
+++ b/common/spec/fixtures/github/business_files_with_misleading_release_doc.json
@@ -1,0 +1,98 @@
+[
+    {
+        "name": ".gitignore",
+        "path": ".gitignore",
+        "sha": "d87d4be66f458acd52878902bbf1391732ad21e1",
+        "size": 154,
+        "url": "https://api.github.com/repos/gocardless/business/contents/.gitignore?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/.gitignore",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/d87d4be66f458acd52878902bbf1391732ad21e1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/.gitignore",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/.gitignore?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/d87d4be66f458acd52878902bbf1391732ad21e1",
+            "html": "https://github.com/gocardless/business/blob/master/.gitignore"
+        }
+    },
+    {
+        "name": "Gemfile",
+        "path": "Gemfile",
+        "sha": "a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+        "size": 93,
+        "url": "https://api.github.com/repos/gocardless/business/contents/Gemfile?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/Gemfile",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/Gemfile",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/Gemfile?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+            "html": "https://github.com/gocardless/business/blob/master/Gemfile"
+        }
+    },
+    {
+        "name": "LICENSE",
+        "path": "LICENSE",
+        "sha": "f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+        "size": 1054,
+        "url": "https://api.github.com/repos/gocardless/business/contents/LICENSE?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/LICENSE",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/LICENSE",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/LICENSE?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+            "html": "https://github.com/gocardless/business/blob/master/LICENSE"
+        }
+    },
+    {
+        "name": "README.md",
+        "path": "README.md",
+        "sha": "f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "size": 4187,
+        "url": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/README.md",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/README.md",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+            "html": "https://github.com/gocardless/business/blob/master/README.md"
+        }
+    },
+    {
+        "name": "making_a_new_release.md",
+        "path": "making_a_new_release.md",
+        "sha": "f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "size": 1500,
+        "url": "https://api.github.com/repos/gocardless/business/contents/making_a_new_release.md?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/making_a_new_release.md",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/making_a_new_release.md",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/making_a_new_release.md?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+            "html": "https://github.com/gocardless/business/blob/master/making_a_new_release.md"
+        }
+    },
+    {
+        "name": "lib",
+        "path": "lib",
+        "sha": "9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "size": 0,
+        "url": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+        "html_url": "https://github.com/gocardless/business/tree/master/lib",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "download_url": null,
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+            "html": "https://github.com/gocardless/business/tree/master/lib"
+        }
+    }
+]


### PR DESCRIPTION
### What are you trying to accomplish?

Previously, files like `devdocs/making_a_new_release.md` would incorrectly be selected as changelogs because the regex `/release/i` matched anywhere in the filename.

This change anchors the regex to the start of the filename using `\A`, so only files that actually start with changelog-like names (e.g., `RELEASE.md`, `CHANGELOG.md`, `releases.md`) are matched.

Fixes #10545

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
