### PR TITLE
Use openjdk-21-jdk-headless to reduce the image size

### DIFF
--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Install Java
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
+    openjdk-21-jdk-headless \
     ca-certificates-java \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -5,7 +5,7 @@ FROM maven:3.9.9 as maven
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    openjdk-21-jdk \
+    openjdk-21-jdk-headless \
     ca-certificates-java \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### What are you trying to accomplish?

Reduce image sizes by using `openjdk-21-jdk-headless` instead of the full JDK. The full JDK includes GUI components like Swing and JavaFX, which are not needed by Dependabot. 

Using the headless version leads to smaller images and  faster builds

### How will you know you've accomplished your goal?

The images are smaller 

```
docker image inspect ghcr.io/dependabot/dependabot-updater-maven:latest --format='{{.Size}}'
577263991

docker image inspect ghcr.io/dependabot/dependabot-updater-maven:latest --format='{{.Size}}'
472538018

Decompressed: 

Original: 2.1GB

New: 1.65 GB
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.