### PR TITLE
Use `NODE_EXTRA_CA_CERTS` for all Node package managers

### DIFF
--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -23,17 +23,17 @@ RUN mkdir -p /etc/apt/keyrings \
 
 USER dependabot
 
+# Configure Node to use our custom CA bundle
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot bun/helpers /opt/bun/helpers
 RUN bash /opt/bun/helpers/build
 
-# Create the config file manually instead of using yarn/npm config set as this
+# Create the config file manually instead of using npm config set as this
 # executes the package manager outputs to every job log
 # This is here because bun supports .npmrc as well. See https://bun.com/docs/pm/npmrc#npmrc-support
 COPY --chown=dependabot:dependabot updater/config/.npmrc $DEPENDABOT_HOME/
-
-# Configure Node to use our custom CA bundle
-ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 COPY --chown=dependabot:dependabot --parents bun common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -49,6 +49,9 @@ RUN corepack install npm@$NPM_VERSION --global \
   && corepack prepare npm@9 \
   && corepack prepare npm@8
 
+# Configure Node to use our custom CA bundle
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers
 RUN bash /opt/npm_and_yarn/helpers/build
@@ -60,10 +63,7 @@ RUN bash /opt/npm_and_yarn/helpers/build
 
 # Create the config file manually instead of using yarn/npm config set as this
 # executes the package manager outputs to every job log
-COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
-
-# For Yarn Berry we can set this via an environment variable
-ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+COPY --chown=dependabot:dependabot updater/config/.npmrc $DEPENDABOT_HOME/
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 

--- a/npm_and_yarn/spec/npm_and_yarn_config_spec.rb
+++ b/npm_and_yarn/spec/npm_and_yarn_config_spec.rb
@@ -13,13 +13,4 @@ RSpec.describe "npm and yarn config" do # rubocop:disable RSpec/DescribeClass
     expect(npm_result).to include("dry-run = true")
     expect(npm_result).to include("ignore-scripts = true")
   end
-
-  # NOTE: This comes from updater/config/.yarnrc
-  it "contains a valid .yarnrc config file" do
-    yarn_config = File.read("/home/dependabot/.yarnrc")
-    # Output from yarn config set
-    expect(yarn_config).to include(
-      "cafile \"/etc/ssl/certs/ca-certificates.crt\""
-    )
-  end
 end

--- a/updater/config/.yarnrc
+++ b/updater/config/.yarnrc
@@ -1,6 +1,0 @@
-# TODO: Remove these hacks once we've deprecated npm 6 support as it no longer
-# spwans a child process to npm install git dependencies.
-# yarn lockfile v1
-
-# Tell yarn to use the system-wide CA bundle overriding the .npmrc cafile
-cafile "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
The `NODE_EXTRA_CA_CERTS` env var was previously set with a comment that it only applied to yarn berry. However, it actually applies to all Node.js package managers, so that will include the yarn v1 package manager. However, there's a caveat... from my reading this appears to _only_ happen when we don't set an explicit `ca`/`cafile` in `.yarnrc` or `.npmrc`:
* https://github.com/yarnpkg/yarn/issues/6578#issuecomment-640516022

Now that we no longer set a custom cafile in `.npmrc`:
* https://github.com/dependabot/dependabot-core/pull/11307

Then if we stop setting it in `.yarnrc` then yarn v1 will now respect `NODE_EXTRA_CA_CERTS`.

I also moved the `NODE_EXTRA_CA_CERTS` env var to earlier in the Dockerfiles so that it's set before any package manager commands are run as part of the native helpers build step.

The dockerfiles still mention hacky workarounds for npm 6, which I do plan to address because we've [deprecated support for NPM 6](https://github.blog/changelog/2025-01-20-dependabot-will-no-longer-support-npm-v6/), but that is out of scope for this change.