### PR TITLE
use unique annotations to track equivalent nodes

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1833,4 +1833,78 @@ public class XmlFileWriterTests : FileWriterTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task MultipleEdits_AttributeSpansChange()
+    {
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup Condition="'$(Configuration)' == 'Release'">
+                        <PackageReference Include="Some.Dependency" Version="9.0.0" />
+                      </ItemGroup>
+                      <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+                        <PackageReference Include="Some.Dependency" Version="9.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/9.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/10.0.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup Condition="'$(Configuration)' == 'Release'">
+                        <PackageReference Include="Some.Dependency" Version="10.0.0" />
+                      </ItemGroup>
+                      <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+                        <PackageReference Include="Some.Dependency" Version="10.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task MultipleEdits_ElementSpansChange()
+    {
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup Condition="'$(Configuration)' == 'Release'">
+                        <PackageReference Include="Some.Dependency">
+                          <Version>9.0.0</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                      <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+                        <PackageReference Include="Some.Dependency">
+                          <Version>9.0.0</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/9.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/10.0.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup Condition="'$(Configuration)' == 'Release'">
+                        <PackageReference Include="Some.Dependency">
+                          <Version>10.0.0</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                      <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+                        <PackageReference Include="Some.Dependency">
+                          <Version>10.0.0</Version>
+                        </PackageReference>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
 }


### PR DESCRIPTION
The XML library we use to perform edits is immutable which means we have to re-find the equivalent node to perform an update.  Previously we used the span start to do this and for single edits this was fine and for some multi-edits this was also fine, however I've found that if we're doing a multi-edit and the length of the old and new version strings isn't the same, the spans after the first don't match up which means we fail to make an edit.

The solution is to use the XML library's built-in annotation feature where we add an annotation (e.g., "metadata") to each relevant node when reading the file and we then use that equivalence check to re-find the node later.  The result is that we can do edits now that we couldn't before.

Error found during a manual scan of the error telemetry.  Not a super common scenario, but common enough it was annoying to see.