### PR TITLE
Align `uv` helper dependencies with the `python` ecosystem 

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,3 +1,4 @@
+# When updating this file, please consider updating uv/helpers/requirements.txt
 pip==24.2
 pip-tools==7.4.1
 flake8==7.3.0

--- a/uv/helpers/requirements.txt
+++ b/uv/helpers/requirements.txt
@@ -1,13 +1,14 @@
-pip==24.0
+# When updating this file, please consider updating python/helpers/requirements.txt
+pip==24.2
 pip-tools==7.4.1
-flake8==7.1.0
-hashin==1.0.3
-pipenv==2024.0.2
+flake8==7.3.0
+hashin==1.0.5
+pipenv==2024.4.1
 plette==2.1.0
 poetry==1.8.5
 # TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
-tomli==2.0.1
+tomli==2.2.1
 uv==0.9.11
 
 # Some dependencies will only install if Cython is present
-Cython==3.0.10
+Cython==3.1.2


### PR DESCRIPTION
### What are you trying to accomplish?

Upgrades the `uv` helpers to use the same versions as the `python` ecosystem whenever possible 

https://github.com/dependabot/dependabot-core/blob/4ea40bf8edef207e287badaf4c509569bc091a50/python/helpers/requirements.txt#L1-L12

The only exception is `poetry` because I need some help to understand if `poetry` should a dependency of the `uv` ecosystem to begin with. The effort to upgrade `poetry` to v2 is larger and can be a follow up pull request

This does not fix any issue but it is part of #13686 

### Anything you want to highlight for special attention from reviewers?



### How will you know you've accomplished your goal?

Existing tests continue to pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
