### PR TITLE
fix: check versions across all the defined maven registries

### DIFF
--- a/maven/lib/dependabot/maven/package/package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/package/package_details_fetcher.rb
@@ -135,7 +135,7 @@ module Dependabot
             xml = dependency_metadata(repository_details)
             next [] if xml.nil?
 
-            break extract_metadata_from_xml(xml, url)
+            extract_metadata_from_xml(xml, url)
           end
 
           raise PrivateSourceAuthenticationFailure, forbidden_urls.first if version_details.none? && forbidden_urls.any?

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("23.6-jre")) }
 
       its([:source_url]) do
-        is_expected.to eq("https://private.registry.org/repo")
+        is_expected.to eq("https://repo.maven.apache.org/maven2")
       end
 
       context "when gitlab maven repository is used" do
@@ -434,6 +434,49 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         end
       end
 
+      context "when the dependency exists in more than one repository, it should check all the repositories" do
+        let(:credentials) do
+          [
+            Dependabot::Credential.new(
+              {
+                "type" => "maven_repository",
+                "url" => "https://repo.jenkins-ci.org/releases/"
+              }
+            )
+          ]
+        end
+
+        let(:jenkins_releases) do
+          fixture("maven_central_metadata", "with_release_older_version.xml")
+        end
+
+        let(:maven_central_releases) do
+          fixture("maven_central_metadata", "with_release.xml")
+        end
+
+        before do
+          # The Jenkins repo returns an older version
+          stub_request(:get, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/maven-metadata.xml")
+            .to_return(status: 200, body: jenkins_releases)
+          stub_request(:head, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/10.0/guava-10.0-jre.jar")
+            .to_return(status: 200)
+          stub_request(:head, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar")
+            .to_return(status: 404)
+
+          # In central, we have a newer version
+          stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/maven-metadata.xml")
+            .to_return(status: 200, body: maven_central_releases)
+          stub_request(:head, "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar")
+            .to_return(status: 200)
+        end
+
+        its([:version]) { is_expected.to eq(version_class.new("23.6-jre")) }
+
+        its([:source_url]) do
+          is_expected.to eq("https://repo.maven.apache.org/maven2")
+        end
+      end
+
       context "when there is no auth details" do
         let(:credentials) do
           [Dependabot::Credential.new(
@@ -452,7 +495,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         its([:version]) { is_expected.to eq(version_class.new("23.6-jre")) }
 
         its([:source_url]) do
-          is_expected.to eq("https://private.registry.org/repo")
+          is_expected.to eq("https://repo.maven.apache.org/maven2")
         end
 
         context "when credentials are required" do

--- a/maven/spec/fixtures/maven_central_metadata/with_release_older_version.xml
+++ b/maven/spec/fixtures/maven_central_metadata/with_release_older_version.xml
@@ -1,0 +1,18 @@
+<metadata modelVersion="1.1.0">
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <!--
+    This metadata example represents a repository that contains the dependency we are trying to update, but only an older version rather than the latest.
+    This demonstrates why it is important that Dependabot does not make any assumption about registry order based on discovery.
+    And that instead it should always check across all available repositories to determine the latest version.
+  -->
+  <versioning>
+    <latest>10.0</latest>
+    <release>10.0</release>
+    <versions>
+      <version>9.0</version>
+      <version>10.0</version>
+    </versions>
+    <lastUpdated>20171221012203</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
### What are you trying to accomplish?

When checking for new versions, we shouldn’t assume that the first repository to respond has the latest version, as it might return a stale one. Instead, Dependabot should scan all repositories, aggregate all available metadata for an artifact, and select the highest version available across them

This behavior was introduced with #5872 in order to reduce the network load, and while the following is true while resolving 

> Remote repository URLs are queried in the following order for artifacts until one returns a valid result

This does not directly translate while looking for new versions as documented in the spec. 

For more details, see https://github.com/dependabot/dependabot-core/pull/5872#issuecomment-2024735690

Fixes #9383

### How will you know you've accomplished your goal?

Running the updated version using my reproducer works as expected

See: https://github.com/yeikel/dependabot-reproducer-9383

Current 

> updater | 2025/12/10 06:13:56 INFO Latest version is 0.11.0-sshd-314-1
> updater | 2025/12/10 06:13:56 INFO No update needed for org.apache.sshd:sshd-core 2.11.0
> {"data":{"base-commit-sha":"6dbf65dc2b7a652b60054518953e70fe2a9fa21e"},"type":"mark_as_processed"}
>   proxy | 2025/12/10 06:13:56 [023] PATCH http://host.docker.internal:57186/update_jobs/cli/mark_as_processed
>   proxy | 2025/12/10 06:13:56 [023] 200 http://host.docker.internal:57186/update_jobs/cli/mark_as_processed
> updater | 2025/12/10 06:13:56 INFO Finished job processing
>   proxy | 2025/12/10 06:13:56 Skipping sending metrics because api endpoint is empty
>   proxy | 2025/12/10 06:13:56 0/10 calls cached (0%)

After: 

> updater | 2025/12/10 06:19:56 INFO Latest version is 2.16.0
> {"data":{"base-commit-sha":"6dbf65dc2b7a652b60054518953e70fe2a9fa21e"},"type":"mark_as_processed"}
>   proxy | 2025/12/10 06:20:00 [062] PATCH http://host.docker.internal:57437/update_jobs/cli/mark_as_processed
>   proxy | 2025/12/10 06:20:00 [062] 200 http://host.docker.internal:57437/update_jobs/cli/mark_as_processed
> updater | 2025/12/10 06:20:00 INFO Finished job processing
> updater | 2025/12/10 06:20:00 INFO Results:
> updater | +---------------------------------------------------------------+
> updater | |              Changes to Dependabot Pull Requests              |
> updater | +---------+-----------------------------------------------------+
> updater | | created | org.apache.sshd:sshd-core ( from 2.11.0 to 2.16.0 ) |
> updater | +---------+-----------------------------------------------------+
>   proxy | 2025/12/10 06:20:00 Skipping sending metrics because api endpoint is empty
>   proxy | 2025/12/10 06:20:00 4/29 calls cached (13%)

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
