### PR TITLE
Fix unqualified MANIFEST_FILENAME constant reference in DependencyGrapher

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
@@ -40,7 +40,7 @@ module Dependabot
 
         T.must(
           @package_json = T.let(
-            T.must(dependency_files.find { |f| f.name.end_with?(MANIFEST_FILENAME) }),
+            T.must(dependency_files.find { |f| f.name.end_with?(NpmAndYarn::MANIFEST_FILENAME) }),
             T.nilable(Dependabot::DependencyFile)
           )
         )


### PR DESCRIPTION
The DependencyGrapher inherits from a base class in a different module, causing Ruby to fail finding MANIFEST_FILENAME. This broke the graph command for npm repos without a committed lockfile (when ephemeral lockfile generation kicks in) with:
"uninitialized constant Dependabot::NpmAndYarn::FileParser::MANIFEST_FILENAME"

In tests, we're loading the full environment and not hitting this issue.

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
