### PR TITLE
Upgrade to Node.js 24

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -16,7 +16,7 @@ ARG YARN_VERSION=4.9.2
 # Always update NODEJS_VERSION with a compatible NPM_VERSION
 # See https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch for more information
 # Note : Always use the Active LTS version
-ARG NODEJS_VERSION=22
+ARG NODEJS_VERSION=24
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the NODEJS_VERSION version declared above. See https://nodejs.org/en/download/releases as well


### PR DESCRIPTION
### What are you trying to accomplish?

Node.js 24 is the active LTS version now. The comment in the Dockerfile itself suggests this should be using the active LTS version. We've run into issues with Dependabot not updating our dependencies due to Dependabot not supporting Node.js 24.

### Anything you want to highlight for special attention from reviewers?

This was a blind change via GitHub's UI, please do test!

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
