### PR TITLE
make nuget single restore the default

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -61,13 +61,10 @@ public partial class DiscoveryWorkerTests
             );
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task DiscoveryIsMergedWithPackageReferences(bool useSingleRestore)
+        [Fact]
+        public async Task DiscoveryIsMergedWithPackageReferences()
         {
             await TestDiscoveryAsync(
-                experimentsManager: new ExperimentsManager() { UseSingleRestore = useSingleRestore },
                 packages:
                 [
                     MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net46"),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -626,7 +626,7 @@ public partial class DiscoveryWorkerTests
                     ("src/project.csproj", """
                         <Project Sdk="Microsoft.NET.Sdk">
                           <PropertyGroup>
-                            <TargetFrameworks>net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;net8.0-windows</TargetFrameworks>
+                            <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos;net8.0-windows</TargetFrameworks>
                           </PropertyGroup>
                           <ItemGroup>
                             <PackageReference Include="Some.Package" Version="1.2.3" />
@@ -645,7 +645,7 @@ public partial class DiscoveryWorkerTests
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos", "net8.0-windows"], IsDirect: true),
                             ],
                             Properties = [
-                                new("TargetFrameworks", "net8.0-ios;net8.0-android;net8.0-macos;net8.0-maccatalyst;net8.0-windows", @"src/project.csproj"),
+                                new("TargetFrameworks", "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos;net8.0-windows", @"src/project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos", "net8.0-windows"],
                             ReferencedProjectPaths = [],
@@ -737,7 +737,7 @@ public partial class DiscoveryWorkerTests
 
             // The SDK package handling is detected in a very specific circumstance; an assembly being removed from the
             // `@(References)` item group in the `_HandlePackageFileConflicts` target.  Since we don't want to involve
-            // the real SDK, we fake some required targets.
+            // the real SDK, we fake some required targets in the same shape as the real SDK.
             await TestDiscoveryAsync(
                 packages: [],
                 workspacePath: "",
@@ -764,6 +764,14 @@ public partial class DiscoveryWorkerTests
                             <Reference Include="@(RuntimeCopyLocalItems)" />
                           </ItemGroup>
 
+                          <Target Name="ResolveProjectReferences">
+                            <!-- this target needs to exist for discovery to work -->
+                          </Target>
+
+                          <Target Name="Restore">
+                            <!-- this target needs to exist for discovery to work -->
+                          </Target>
+
                           <Target Name="_HandlePackageFileConflicts">
                             <!-- this target needs to exist for discovery to work -->
                             <ItemGroup>
@@ -775,20 +783,24 @@ public partial class DiscoveryWorkerTests
                             </ItemGroup>
                           </Target>
 
-                          <Target Name="ResolveAssemblyReferences" DependsOnTargets="_HandlePackageFileConflicts">
+                          <Target Name="ResolvePackageAssets">
                             <!-- this target needs to exist for discovery to work -->
                           </Target>
 
-                          <Target Name="GenerateBuildDependencyFile">
+                          <Target Name="ResolveFrameworkReferences" DependsOnTargets="ResolvePackageAssets">
+                            <!-- this target needs to exist for discovery to work -->
+                          </Target>
+
+                          <Target Name="ResolveRuntimePackAssets" DependsOnTargets="ResolveFrameworkReferences">
+                            <!-- this target needs to exist for discovery to work -->
+                          </Target>
+
+                          <Target Name="GenerateBuildDependencyFile" DependsOnTargets="_HandlePackageFileConflicts;ResolveRuntimePackAssets">
                             <!-- this target needs to exist for discovery to work -->
                             <ItemGroup>
                               <!-- this removal is what removes the regular package reference from the project -->
                               <RuntimeCopyLocalItems Remove="TestOnlyAssembly.dll" />
                             </ItemGroup>
-                          </Target>
-
-                          <Target Name="ResolvePackageAssets">
-                            <!-- this target needs to exist for discovery to work -->
                           </Target>
                         </Project>
                         """)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -414,6 +414,11 @@ public class MSBuildHelperTests : TestBase
                 // normalize default message for the test
                 actualError = new DependencyFileNotFound(notFound.Details["file-path"].ToString()!, "test message");
             }
+            if (actualError is DependencyFileNotParseable notParseable)
+            {
+                // normalize the path for the test
+                actualError = new DependencyFileNotParseable("/" + notParseable.Details["file-path"].ToString()!.TrimStart('.', '/'), notParseable.Details["message"]?.ToString());
+            }
 
             var actualErrorJson = JsonSerializer.Serialize(actualError, RunWorker.SerializerOptions);
             var expectedErrorJson = JsonSerializer.Serialize(expectedError, RunWorker.SerializerOptions);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -252,52 +252,26 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                         filesToExpand.Push(projectPath);
                     }
                 }
-
-                if (experimentsManager.UseSingleRestore)
+                else if (extension == ".proj")
                 {
-                    // projects get shunted directly to the result because regular discovery handles it from there
-                    switch (extension)
+                    var foundProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectFile", "ProjectReference");
+                    foreach (var foundProject in foundProjects)
                     {
-                        case ".proj":
-                        case ".csproj":
-                        case ".fbproj":
-                        case ".fsproj":
-                            expandedProjects.Add(candidateEntryPoint);
-                            break;
-                        default:
-                            // unsupported project
-                            break;
+                        filesToExpand.Push(foundProject);
                     }
                 }
-                else
+
+                // projects get shunted directly to the result because regular discovery handles it from there
+                switch (extension)
                 {
-                    if (extension == ".proj")
-                    {
-                        IEnumerable<string> foundProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectFile", "ProjectReference");
-                        foreach (string foundProject in foundProjects)
-                        {
-                            filesToExpand.Push(foundProject);
-                        }
-                    }
-                    else
-                    {
-                        switch (extension)
-                        {
-                            case ".csproj":
-                            case ".fsproj":
-                            case ".vbproj":
-                                // keep this project and check for references
-                                expandedProjects.Add(candidateEntryPoint);
-                                IEnumerable<string> referencedProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectReference");
-                                foreach (string referencedProject in referencedProjects)
-                                {
-                                    filesToExpand.Push(referencedProject);
-                                }
-                                break;
-                            default:
-                                continue;
-                        }
-                    }
+                    case ".csproj":
+                    case ".vbproj":
+                    case ".fsproj":
+                        expandedProjects.Add(candidateEntryPoint);
+                        break;
+                    default:
+                        // unsupported project
+                        break;
                 }
             }
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -8,14 +8,12 @@ namespace NuGetUpdater.Core;
 public record ExperimentsManager
 {
     public bool GenerateSimplePrBody { get; init; } = false;
-    public bool UseSingleRestore { get; init; } = false;
 
     public Dictionary<string, object> ToDictionary()
     {
         return new()
         {
             ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
-            ["nuget_use_single_restore"] = UseSingleRestore,
         };
     }
 
@@ -24,7 +22,6 @@ public record ExperimentsManager
         return new ExperimentsManager()
         {
             GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
-            UseSingleRestore = IsEnabled(experiments, "nuget_use_single_restore"),
         };
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -73,13 +73,13 @@ public abstract record JobErrorBase : MessageBase
             case InvalidDataException invalidData when invalidData.Message == "Central Directory corrupt.":
                 return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory), invalidData.Message);
             case InvalidProjectFileException invalidProjectFile:
-                return new DependencyFileNotParseable(invalidProjectFile.ProjectFile);
+                return new DependencyFileNotParseable(Path.GetRelativePath(currentDirectory, invalidProjectFile.ProjectFile).NormalizePathToUnix());
             case MissingFileException missingFile:
                 return new DependencyFileNotFound(missingFile.FilePath, missingFile.Message);
             case PrivateSourceTimedOutException timeout:
                 return new PrivateSourceTimedOut(timeout.Url);
             case UnparseableFileException unparseableFile:
-                return new DependencyFileNotParseable(unparseableFile.FilePath, unparseableFile.Message);
+                return new DependencyFileNotParseable(Path.GetRelativePath(currentDirectory, unparseableFile.FilePath).NormalizePathToUnix(), unparseableFile.Message);
             case UpdateNotPossibleException updateNotPossible:
                 return new UpdateNotPossible(updateNotPossible.Dependencies);
             default:


### PR DESCRIPTION
PR #13532 added the ability for the NuGet updater to do fewer restore operations during dependency discovery.  That experiment has been running for a few weeks without issue so this PR makes that behavior the default.

A future internal PR will remove that experiment flag once this behavior is confirmed.

Some things to note that were also changed as part of this PR:
- Project references from `*.proj` files was moved back to manual expansion because we don't yet have MSBuild support for that.
- If a project contains multiple target frameworks _AND_ at least one of those is platform specific (e.g., `net8.0-windows`) we need to still do individual invocations for each TFM.
- The list of required targets for proper package restore was updated; GenerateBuildDependencyFile replaced ResolvePackageAssets.
- Some tests that no longer make sense were deleted.