### PR TITLE
`docker`: consider the tag when checking if a digest is up-to-date

### DIFF
--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1745,6 +1745,60 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
+  describe "#digest_up_to_date?" do
+    subject(:digest_up_to_date) { checker.send(:digest_up_to_date?) }
+
+    let(:image_name) { "gcr.io/distroless/base-nossl-debian11" }
+    let(:tag_nonroot) { "debug-nonroot" }
+    let(:tag_debug) { "debug" }
+
+    let(:digest_nonroot) { "934b713496a9ed100550aaa58636270c4d69c27040e44f2aed1fa39594c45eba" }
+    let(:digest_debug) { "d66c60eff6c55972af9e661a57c1afe96ef4ddfa4fff37b625a448df41a15820" }
+
+    before do
+      allow(checker).to receive(:updated_digest).and_return(updated_digest)
+      allow(checker).to receive(:digest_of).with(tag_nonroot).and_return(digest_nonroot)
+      allow(checker).to receive(:digest_of).with(tag_debug).and_return(digest_debug)
+    end
+
+    context "when a digest requirement includes a tag" do
+      let(:updated_digest) { "some_other_updated_digest" }
+      let(:dependency_name) { image_name }
+      let(:version) { tag_nonroot }
+      let(:source) { { tag: tag_nonroot, digest: digest_nonroot } }
+
+      it "considers the tag and compares against digest_of(tag)" do
+        expect(digest_up_to_date).to be(true)
+      end
+
+      context "when the digest does not match the tag digest" do
+        let(:source) { { tag: tag_nonroot, digest: digest_debug } }
+
+        it "returns false" do
+          expect(digest_up_to_date).to be(false)
+        end
+      end
+    end
+
+    context "when a digest requirement does not have a tag" do
+      let(:dependency_name) { image_name }
+      let(:version) { digest_debug }
+      let(:source) { { digest: digest_debug } }
+
+      context "when the digest matches updated_digest" do
+        let(:updated_digest) { digest_debug }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when the digest does not match updated_digest" do
+        let(:updated_digest) { digest_nonroot }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   private
 
   def stub_same_sha_for(*tags)


### PR DESCRIPTION
### What are you trying to accomplish?

When verifying whether Docker image digests are up to date, we previously compared every requirement’s `source.digest` against `updated_digest`. This was incorrect for requirements that include a `source.tag`, as the expected digest should be derived from that tag.

Fixes #11215

### How will you know you've accomplished your goal?

- The reproducer described in #11215 passes with my updated code
- The newly added specs also pass

Before: 

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/5d923347-506d-402e-bf3b-8f9847c0f499" />


After: 

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/a15576fd-d873-472e-9afd-a3bf3e996c15" />

### Checklist


- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.