### PR TITLE
report specific error when disk is full

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -147,6 +147,7 @@ public class HttpApiHandlerTests
         yield return [new DependencyFileNotParseable("unused"), "record_update_job_error"];
         yield return [new DependencyNotFound("unused"), "record_update_job_error"];
         yield return [new JobRepoNotFound("unused"), "record_update_job_error"];
+        yield return [new OutOfDisk(), "record_update_job_error"];
         yield return [new PrivateSourceAuthenticationFailure(["unused"]), "record_update_job_error"];
         yield return [new PrivateSourceBadResponse(["unused"], "unused"), "record_update_job_error"];
         yield return [new PrivateSourceTimedOut("unused"), "record_update_job_error"];

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/JobErrorBaseTests.cs
@@ -40,6 +40,13 @@ public class JobErrorBaseTests : TestBase
 
     public static IEnumerable<object[]> GenerateErrorFromExceptionTestData()
     {
+        // disk full
+        yield return
+        [
+            new IOException("No space left on device : '/path/to/directory'"),
+            new OutOfDisk(),
+        ];
+
         // something elevated to a bad response
         yield return
         [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -141,6 +141,17 @@ public class MessageReportTests
         yield return
         [
             // message
+            new OutOfDisk(),
+            // expected
+            """
+            Error type: out_of_disk
+            """
+
+        ];
+
+        yield return
+        [
+            // message
             new PrivateSourceAuthenticationFailure(["url1", "url2"]),
             // expected
             """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -793,6 +793,14 @@ public class SerializationTests : TestBase
 
         yield return
         [
+            new OutOfDisk(),
+            """
+            {"data":{"error-type":"out_of_disk","error-details":{}}}
+            """
+        ];
+
+        yield return
+        [
             new PrivateSourceAuthenticationFailure(["url1", "url2"]),
             """
             {"data":{"error-type":"private_source_authentication_failure","error-details":{"source":"(url1|url2)"}}}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobErrorBase.cs
@@ -74,6 +74,8 @@ public abstract record JobErrorBase : MessageBase
                 return new PrivateSourceBadResponse(NuGetContext.GetPackageSourceUrls(currentDirectory), invalidData.Message);
             case InvalidProjectFileException invalidProjectFile:
                 return new DependencyFileNotParseable(Path.GetRelativePath(currentDirectory, invalidProjectFile.ProjectFile).NormalizePathToUnix());
+            case IOException ioException when ioException.Message.Contains("No space left on device", StringComparison.OrdinalIgnoreCase):
+                return new OutOfDisk();
             case MissingFileException missingFile:
                 return new DependencyFileNotFound(missingFile.FilePath, missingFile.Message);
             case PrivateSourceTimedOutException timeout:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/OutOfDisk.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/OutOfDisk.cs
@@ -1,0 +1,9 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public record OutOfDisk : JobErrorBase
+{
+    public OutOfDisk()
+        : base("out_of_disk")
+    {
+    }
+}


### PR DESCRIPTION
If a particularly large job is running and the VM disk fills up, it appears as an `unknown_error` of type `System.IO.IOException`.  This just classifies that error appropriately so it doesn't appear in the `unknown_error` bucket.

`out_of_disk` is a [known error shape](https://github.com/dependabot/dependabot-core/blob/8cee4d773f76129dd4ca276df7153d0d9d878935/common/lib/dependabot/errors.rb#L322-L326).