### PR TITLE
Consider dependency suffixes for `maven` and `gradle`

### DIFF
--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -12,11 +12,12 @@ require "dependabot/maven/utils/auth_headers_finder"
 require "sorbet-runtime"
 require "dependabot/gradle/package/package_details_fetcher"
 require "dependabot/package/package_latest_version_finder"
+require "dependabot/maven/shared/shared_version_finder"
 
 module Dependabot
   module Gradle
     class UpdateChecker
-      class VersionFinder < Dependabot::Package::PackageLatestVersionFinder
+      class VersionFinder < Dependabot::Maven::Shared::SharedVersionFinder
         extend T::Sig
 
         KOTLIN_PLUGIN_REPO_PREFIX = "org.jetbrains.kotlin"
@@ -292,27 +293,6 @@ module Dependabot
           return false unless dependency.numeric_version
 
           T.must(dependency.numeric_version) >= version_class.new(100)
-        end
-
-        sig { params(comparison_version: T.untyped).returns(T::Boolean) }
-        def matches_dependency_version_type?(comparison_version)
-          return true unless dependency.version
-
-          current_type = T.must(dependency.version)
-                          .gsub("native-mt", "native_mt")
-                          .split(/[.\-]/)
-                          .find do |type|
-            TYPE_SUFFICES.find { |s| type.include?(s) }
-          end
-
-          version_type = comparison_version.to_s
-                                           .gsub("native-mt", "native_mt")
-                                           .split(/[.\-]/)
-                                           .find do |type|
-            TYPE_SUFFICES.find { |s| type.include?(s) }
-          end
-
-          current_type == version_type
         end
 
         sig { returns(T.class_of(Dependabot::Version)) }

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       .to_return(status: 200, body: maven_central_releases)
   end
 
+  describe "class extension behavior" do
+    it "inherits from SharedVersionFinder" do
+      expect(described_class < Dependabot::Maven::Shared::SharedVersionFinder).to be true
+    end
+
+    it "matches_dependency_version_type? is reused from the shared class" do
+      method_owner = described_class.instance_method(:matches_dependency_version_type?).owner
+      expect(method_owner).to eq(Dependabot::Maven::Shared::SharedVersionFinder)
+    end
+  end
+
   describe "#latest_version_details" do
     subject(:latest_version_details) { finder.latest_version_details }
 

--- a/maven/lib/dependabot/maven/shared/shared_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_version_finder.rb
@@ -1,0 +1,117 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/file_fetchers"
+require "dependabot/file_fetchers/base"
+require "dependabot/package/package_latest_version_finder"
+
+module Dependabot
+  module Maven
+    module Shared
+      class SharedVersionFinder < Dependabot::Package::PackageLatestVersionFinder
+        extend T::Sig
+
+        # Regex to match common Maven release qualifiers that indicate stable releases.
+        # See https://github.com/apache/maven/blob/848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java#L315-L320
+        MAVEN_RELEASE_QUALIFIERS = /
+          ^.+[-._](
+            RELEASE|# Official release
+            FINAL|# Final build
+            GA# General Availability
+          )$
+        /ix
+
+        # Common Maven pre-release qualifiers.
+        # They often indicate versions that are not yet stable but that are released to the public for testing.
+        # Examples: 1.0.0-RC1, 2.0.0-ALPHA2, 3.1.0-BETA, 4.0.0-DEV5, etc.
+        # See https://maven.apache.org/guides/mini/guide-naming-conventions.html#version-identifier
+        MAVEN_PRE_RELEASE_QUALIFIERS = /
+            [-._]?(
+              # --- Qualifiers that usually REQUIRE a number ---
+              # Examples: "RC1", "BETA2", "M3", "ALPHA-1", "EAP.2"
+              # The number differentiates multiple pre-releases; a version like "1.0.0-RC"
+              (?i)(?:RC|CR|M|MILESTONE|ALPHA|BETA|EA|EAP)(?:[-._]?\d+)?
+              |
+              # --- Qualifiers that do NOT usually have numbers ---
+              DEV|
+              PREVIEW|
+              PRERELEASE|
+              EXPERIMENTAL|
+              UNSTABLE
+            )$
+          /ix
+
+        MAVEN_SNAPSHOT_QUALIFIER = /-SNAPSHOT$/i
+
+        sig { params(comparison_version: Dependabot::Version).returns(T::Boolean) }
+        def matches_dependency_version_type?(comparison_version)
+          return true unless dependency.version
+
+          current_version_string = dependency.version
+          candidate_version_string = comparison_version.to_s
+
+          current_is_pre_release = current_version_string&.match?(MAVEN_PRE_RELEASE_QUALIFIERS)
+          candidate_is_pre_release = candidate_version_string.match?(MAVEN_PRE_RELEASE_QUALIFIERS)
+
+          # Pre-releases are only compatible with other pre-releases
+          # When this happens, the suffix does not need to match exactly
+          # This allows transitions between 1.0.0-RC1 and 1.0.0-CR2, for example
+          return true if current_is_pre_release && candidate_is_pre_release
+
+          current_is_snapshot = current_version_string&.match?(MAVEN_SNAPSHOT_QUALIFIER)
+          # If the current version is a pre-release or a snapshot, allow upgrading to a stable release
+          # This can help move from pre-release to the stable version that supersedes it,
+          # but this should not happen vice versa as a stable release should not be downgraded to a pre-release
+          return true if (current_is_pre_release || current_is_snapshot) && !candidate_is_pre_release
+
+          current_suffix = extract_version_suffix(current_version_string)
+          candidate_suffix = extract_version_suffix(candidate_version_string)
+
+          # If both versions share the exact suffix or no suffix, they are compatible
+          current_suffix == candidate_suffix
+        end
+
+        private
+
+        # Extracts the qualifier/suffix from a Maven version string.
+        #
+        # Maven versions consist of numeric parts and optional string qualifiers.
+        # This method identifies the suffix by finding the first segment (separated by '.')
+        # that contains a non-digit character.
+        sig { params(version_string: T.nilable(String)).returns(T.nilable(String)) }
+        def extract_version_suffix(version_string)
+          return nil unless version_string
+
+          # Exclude common Maven release qualifiers that indicate stable releases
+          return nil if version_string.match?(MAVEN_RELEASE_QUALIFIERS)
+
+          version_string.split(".").each do |part|
+            # Skip fully numeric segments
+            next if part.match?(/\A\d+\z/)
+
+            # strip leading digits and capture the suffix
+            suffix = part.sub(/\A\d+/, "")
+            # Normalize delimiters to ensure consistent comparison
+            # e.g., "beta-1" and "beta_1" are treated the same
+            suffix = suffix.tr("-", "_")
+
+            # Ignore purely numeric suffixes (e.g., "-1", "_2")
+            # e.g., "1.0.0-1" or "1.0.0_2" are not considered to have a meaningful suffix
+            return nil if suffix.match?(/^_?\d+$/)
+
+            # Must contain a hyphen to be considered a valid suffix
+            return suffix if suffix.include?("-") || suffix.include?("_")
+          end
+
+          nil
+        end
+
+        sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }
+        def package_details
+          raise NotImplementedError, "Subclasses must implement `package_details`"
+        end
+      end
+    end
+  end
+end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -6,15 +6,14 @@ require "dependabot/package/release_cooldown_options"
 require "dependabot/update_checkers/version_filters"
 require "dependabot/maven/package/package_details_fetcher"
 require "dependabot/maven/update_checker"
+require "dependabot/maven/shared/shared_version_finder"
 require "sorbet-runtime"
 
 module Dependabot
   module Maven
     class UpdateChecker
-      class VersionFinder < Dependabot::Package::PackageLatestVersionFinder
+      class VersionFinder < Dependabot::Maven::Shared::SharedVersionFinder
         extend T::Sig
-
-        TYPE_SUFFICES = %w(jre android java native_mt agp).freeze
 
         sig do
           params(
@@ -190,27 +189,6 @@ module Dependabot
           return false unless dependency.numeric_version
 
           T.must(dependency.numeric_version) >= version_class.new(100)
-        end
-
-        sig { params(comparison_version: Dependabot::Version).returns(T::Boolean) }
-        def matches_dependency_version_type?(comparison_version)
-          return true unless dependency.version
-
-          current_type = dependency.version
-                                   &.gsub("native-mt", "native_mt")
-                                   &.split(/[.\-]/)
-                                   &.find do |type|
-            TYPE_SUFFICES.find { |s| type.include?(s) }
-          end
-
-          version_type = comparison_version.to_s
-                                           .gsub("native-mt", "native_mt")
-                                           .split(/[.\-]/)
-                                           .find do |type|
-            TYPE_SUFFICES.find { |s| type.include?(s) }
-          end
-
-          current_type == version_type
         end
 
         sig { returns(T.class_of(Dependabot::Version)) }

--- a/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
@@ -1,0 +1,405 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/credential"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/maven/shared/shared_version_finder"
+require "dependabot/maven/version"
+
+RSpec.describe Dependabot::Maven::Shared::SharedVersionFinder do
+  let(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      credentials: credentials,
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
+      security_advisories: security_advisories,
+      cooldown_options: cooldown_options
+    )
+  end
+  let(:dependency_files) { [pom] }
+  let(:pom) do
+    Dependabot::DependencyFile.new(
+      name: "pom.xml",
+      content: fixture("poms", pom_fixture_name)
+    )
+  end
+  let(:pom_fixture_name) { "basic_pom.xml" }
+  let(:version_class) { Dependabot::Maven::Version }
+  let(:credentials) { [] }
+  let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
+  let(:security_advisories) { [] }
+  let(:cooldown_options) { nil }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: dependency_version,
+      requirements: dependency_requirements,
+      package_manager: "maven"
+    )
+  end
+  let(:dependency_name) { "com.google.guava:guava" }
+  let(:dependency_version) { "23.3-jre" }
+  let(:dependency_requirements) do
+    [{
+      file: "pom.xml",
+      requirement: dependency_version,
+      groups: [],
+      source: nil,
+      metadata: { packaging_type: "jar" }
+    }]
+  end
+
+  describe "#releases" do
+    context "when comparing version types with suffixes" do
+      subject { finder.send(:matches_dependency_version_type?, version_class.new(comparison_version)) }
+
+      context "when the dependency has no suffix" do
+        let(:dependency_version) { "1.0.0" }
+        let(:comparison_version) { "1.1.0" }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the suffixes are the same" do
+        let(:dependency_version) { "7.9.0-ccs" }
+        let(:comparison_version) { "7.9.1-ccs" }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the suffixes are different" do
+        let(:dependency_version) { "7.9.0-ccs" }
+        let(:comparison_version) { "7.9.0-ce" }
+
+        it { is_expected.to be false }
+      end
+
+      context "when only the version to compare has a suffix" do
+        let(:dependency_version) { "1.0.0" }
+        let(:comparison_version) { "1.1.0-css" }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the existing version has a suffix but the candidate doesn't" do
+        let(:dependency_version) { "1.0.0-css" }
+        let(:comparison_version) { "1.1.0" }
+
+        it { is_expected.to be false }
+      end
+
+      context "when release candidates (rc) are presented" do
+        let(:dependency_version) { "1.0.1" }
+        let(:comparison_version) { "1.0.2-rc" }
+
+        it { is_expected.to be false }
+      end
+
+      context "when release candidates (cr) are presented" do
+        let(:dependency_version) { "1.0.1" }
+        let(:comparison_version) { "1.0.2-cr" }
+
+        it { is_expected.to be false }
+      end
+
+      context "when the dependency version has a numeric-only suffix" do
+        let(:dependency_version) { "1.0.1-1" }
+        let(:comparison_version) { "1.0.2" }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the comparison version has a numeric-only suffix" do
+        let(:dependency_version) { "1.0.1" }
+        let(:comparison_version) { "1.0.2-1" }
+
+        it { is_expected.to be true }
+      end
+
+      context "when equivalent release candidates are presented" do
+        context "when comparing CR and RC variants" do
+          context "when upgrading from -cr to -rc" do
+            let(:dependency_version) { "1.0.0-cr1" }
+            let(:comparison_version) { "1.0.0-rc1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -rc to -cr" do
+            let(:dependency_version) { "1.0.0-rc1" }
+            let(:comparison_version) { "1.0.0-cr1" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when using mixed-case qualifiers" do
+          context "when upgrading from -rc to -CR" do
+            let(:dependency_version) { "1.0.0-rc1" }
+            let(:comparison_version) { "1.0.0-cr1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -CR to -rc" do
+            let(:dependency_version) { "1.0.0-cr1" }
+            let(:comparison_version) { "1.0.0-cr1" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when the release candidates have numeric suffixes" do
+          let(:dependency_version) { "1.0.0-cr11" }
+          let(:comparison_version) { "1.0.0-rc11" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when using milestone releases" do
+          context "when using short milestone notation" do
+            let(:dependency_version) { "1.0.0-M1" }
+            let(:comparison_version) { "1.0.0-M2" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when using fully qualified milestone notation" do
+            let(:dependency_version) { "1.0.0-milestone-1" }
+            let(:comparison_version) { "1.0.0-milestone-2" }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+
+      context "when upgrading from a pre-release to a released version" do
+        let(:comparison_version) { "1.0.0" }
+
+        context "when upgrading from release candidate–like versions" do
+          context "when upgrading from -cr to final version" do
+            let(:dependency_version) { "1.0.0-cr1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -rc to final version" do
+            let(:dependency_version) { "1.0.0-rc1" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when upgrading from early-stage versions" do
+          context "when upgrading from -ALPHA to final version" do
+            let(:dependency_version) { "1.0.0-ALPHA" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -BETA to final version" do
+            let(:dependency_version) { "1.0.0-BETA" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -M1 to final version" do
+            let(:dependency_version) { "1.0.0-M1" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when upgrading from development and experimental versions" do
+          context "when upgrading from -DEV to final version" do
+            let(:dependency_version) { "1.0.0-DEV" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -EA to final version" do
+            let(:dependency_version) { "1.0.0-EA-1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -EAP to final version" do
+            let(:dependency_version) { "1.0.0-EAP-1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -PRERELEASE to final version" do
+            let(:dependency_version) { "1.0.0-PRERELEASE" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from -EXPERIMENTAL to final version" do
+            let(:dependency_version) { "1.0.0-EXPERIMENTAL" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when upgrading from snapshot versions" do
+          context "when upgrading from -SNAPSHOT to final version" do
+            let(:dependency_version) { "1.0.0-SNAPSHOT" }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+
+      context "when upgrading from a released version to a pre-release" do
+        let(:dependency_version) { "1.0.0" }
+
+        context "when upgrading to release candidate–like versions" do
+          context "when upgrading to -cr" do
+            let(:comparison_version) { "1.0.1-cr" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -rc" do
+            let(:comparison_version) { "1.0.1-rc" }
+
+            it { is_expected.to be false }
+          end
+        end
+
+        context "when upgrading to early-stage versions" do
+          context "when upgrading to -alpha" do
+            let(:comparison_version) { "1.0.1-alpha" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -beta" do
+            let(:comparison_version) { "1.0.1-beta" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -milestone" do
+            let(:comparison_version) { "1.0.2-M1" }
+
+            it { is_expected.to be false }
+          end
+        end
+
+        context "when upgrading to development and experimental versions" do
+          context "when upgrading to -dev" do
+            let(:comparison_version) { "1.0.1-dev" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -EA" do
+            let(:comparison_version) { "1.0.2-EA" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -EAP" do
+            let(:comparison_version) { "1.0.1-EAP" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -PRERELEASE" do
+            let(:comparison_version) { "1.0.1-PRERELEASE" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when upgrading to -EXPERIMENTAL" do
+            let(:comparison_version) { "1.0.1-EXPERIMENTAL" }
+
+            it { is_expected.to be false }
+          end
+        end
+      end
+
+      context "when using special Maven release qualifiers" do
+        context "when using RELEASE qualifiers" do
+          context "when the suffix is -RELEASE" do
+            let(:dependency_version) { "1.0.0-RELEASE" }
+            let(:comparison_version) { "2.0.0" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the suffix is -Release (case-insensitive)" do
+            let(:dependency_version) { "1.0.0-Release" }
+            let(:comparison_version) { "2.0.0" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when using FINAL and GA qualifiers" do
+          context "when the suffix is -FINAL" do
+            let(:dependency_version) { "1.0.0-FINAL" }
+            let(:comparison_version) { "2.0.0" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the suffix is -GA" do
+            let(:dependency_version) { "1.0.0-GA" }
+            let(:comparison_version) { "2.0.0" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when transitioning from FINAL to GA" do
+            let(:dependency_version) { "1.0.0-FINAL" }
+            let(:comparison_version) { "2.0.0-GA" }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+
+      context "when common Maven release suffixes exist" do
+        context "when using platform-specific release qualifiers" do
+          context "when the suffix is -jre" do
+            let(:dependency_version) { "1.2.3-jre" }
+            let(:comparison_version) { "1.2.4-jre" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the suffix is -android" do
+            let(:dependency_version) { "1.2.3-android" }
+            let(:comparison_version) { "1.2.4-android" }
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when using native classifier variations" do
+          context "when the version uses hyphenated -mt suffix" do
+            let(:dependency_version) { "native-mt" }
+            let(:comparison_version) { "native_mt" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the version uses underscored _mt suffix" do
+            let(:dependency_version) { "native_mt" }
+            let(:comparison_version) { "native-mt" }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+    end
+  end
+end

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -97,6 +97,17 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       .to_return(status: 200)
   end
 
+  describe "class extension behavior" do
+    it "inherits from SharedVersionFinder" do
+      expect(described_class < Dependabot::Maven::Shared::SharedVersionFinder).to be true
+    end
+
+    it "matches_dependency_version_type? is reused from the shared class" do
+      method_owner = described_class.instance_method(:matches_dependency_version_type?).owner
+      expect(method_owner).to eq(Dependabot::Maven::Shared::SharedVersionFinder)
+    end
+  end
+
   describe "#latest_version_details when the dependency has a classifier" do
     subject { finder.latest_version_details }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Updates the maven and gradle suffix comparison logic to handle any kind of suffix and not just the pre-determined list of suffixes.

This improves accuracy of dependency updates by preventing invalid upgrades across incompatible version types while allowing appropriate pre-release to release transitions.

Fixes #11068

### Anything you want to highlight for special attention from reviewers?

There is considerable duplicated logic between the `maven` and `gradle` ecosystems, which is understandable since they operate on the same repository type.

Ideally, we should explore extracting common components to consolidate this logic into a single, reusable implementation, reducing the need for duplication.

For now, I have only extracted the shared logic required to address this issue. In a future change, I plan to propose additional refactoring to centralize even more of this logic.


### How will you know you've accomplished your goal?

- The existing tests pass
- The reproducer I documented in #11068 works as expected 
    - No suffix mismatch should occur
    - Upgrades are still recommended 

Before: 

<details>
  <summary>Full logs</summary>
```
dependabot update -f job.json
    cli | 2025/12/19 04:20:43 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2025/12/19 04:20:44 pulling image: ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest
    cli | 2025/12/19 04:20:46 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:cd436ba52ca956dfbf8beaf71a603d8ed99c4fc3a7232fee6f8c4a665533b0de
    cli | 2025/12/19 04:20:46 pulling image: ghcr.io/dependabot/dependabot-updater-maven
    cli | 2025/12/19 04:21:10 using image ghcr.io/dependabot/dependabot-updater-maven at sha256:014c0906989502a251f4f7da303ceb33f8be23416a3fad258273eb57f88da3f7
  proxy | 2025/12/19 04:21:14 proxy starting, commit: 1bebae39886086abc69efcd2249f2a5ff31f72b2
  proxy | 2025/12/19 04:21:14 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | Processing triggers for ca-certificates-java (20240118) ...
updater | Adding debian:dbot-ca.pem
updater | done.
updater | done.
updater | fetch_files command is no longer used directly
updater | 2025/12/19 04:21:19 INFO Starting job processing
updater | 2025/12/19 04:21:19 INFO Job definition: {"job":{"command":"version","package-manager":"maven","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[{"dependency-name":"*","update-types":["version-update:semver-major"]}],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-11068","directory":"/.","hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2025/12/19 04:21:19 [002] GET https://github.com:443/yeikel/dependabot-reproducer-issue-11068/info/refs?service=git-upload-pack
  proxy | 2025/12/19 04:21:19 [002] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:21:19 [002] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/info/refs?service=git-upload-pack
  proxy | 2025/12/19 04:21:19 [004] POST https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:21:19 [004] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:21:19 [004] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:21:19 [006] POST https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:21:19 [006] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:21:19 [006] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
updater | 2025/12/19 04:21:20 INFO Base commit SHA: 01e1b3846b4a45d5de1ed0961c139ee829e1b238
updater | 2025/12/19 04:21:20 INFO Finished job processing
updater | 2025/12/19 04:21:20 INFO Starting job processing
  proxy | 2025/12/19 04:21:20 [007] POST http://host.docker.internal:49219/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"org.apache.kafka:connect-api","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.0-ccs","source":null}],"version":"7.9.0-ccs"},{"name":"org.apache.kafka:kafka-streams","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.2-ccs","source":null}],"version":"7.9.2-ccs"}],"dependency_files":["/pom.xml"]},"type":"update_dependency_list"}
  proxy | 2025/12/19 04:21:20 [007] 200 http://host.docker.internal:49219/update_jobs/cli/update_dependency_list
{"data":{"metric":"updater.started","tags":{"operation":"group_update_all_versions"}},"type":"increment_metric"}
  proxy | 2025/12/19 04:21:20 [008] POST http://host.docker.internal:49219/update_jobs/cli/increment_metric
  proxy | 2025/12/19 04:21:20 [008] 200 http://host.docker.internal:49219/update_jobs/cli/increment_metric
updater | 2025/12/19 04:21:20 INFO Starting update job for yeikel/dependabot-reproducer-issue-11068
updater | 2025/12/19 04:21:20 INFO Checking all dependencies for version updates...
updater | 2025/12/19 04:21:20 INFO Checking if org.apache.kafka:connect-api 7.9.0-ccs needs updating
updater | 2025/12/19 04:21:20 INFO Ignored versions:
updater | 2025/12/19 04:21:20 INFO   version-update:semver-major - from
  proxy | 2025/12/19 04:21:20 [010] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api/maven-metadata.xml
  proxy | 2025/12/19 04:21:20 [010] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/maven-metadata.xml
  proxy | 2025/12/19 04:21:21 [012] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:21:21 [012] 404 https://packages.confluent.io/maven/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:21:21 [014] GET https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:21:22 [014] 302 https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:21:22 [016] GET https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api/
  proxy | 2025/12/19 04:21:22 [016] 200 https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api/
updater | 2025/12/19 04:21:22 INFO Filtered out 12 ignored versions
  proxy | 2025/12/19 04:21:22 [018] HEAD https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ce/connect-api-7.9.5-ce.jar
  proxy | 2025/12/19 04:21:22 [018] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ce/connect-api-7.9.5-ce.jar
updater | 2025/12/19 04:21:22 INFO Latest version is 7.9.5-ce
updater | 2025/12/19 04:21:23 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:23 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:23 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:23 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:23 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:24 INFO Requirements to unlock own
updater | 2025/12/19 04:21:24 INFO Requirements update strategy
updater | 2025/12/19 04:21:25 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:25 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:25 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:25 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:26 INFO Updating org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ce
updater | 2025/12/19 04:21:26 INFO Submitting org.apache.kafka:connect-api pull request for creation
  proxy | 2025/12/19 04:21:26 [020] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:21:26 [020] * authenticating github api request with token for api.github.com
  proxy | 2025/12/19 04:21:27 [020] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:21:27 [022] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ce/connect-api-7.9.5-ce.pom
  proxy | 2025/12/19 04:21:27 [022] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ce/connect-api-7.9.5-ce.pom
  proxy | 2025/12/19 04:21:27 [024] GET https://docs.confluent.io/status
  proxy | 2025/12/19 04:21:28 [024] 302 https://docs.confluent.io/status
  proxy | 2025/12/19 04:21:28 [025] POST http://host.docker.internal:49219/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238","dependencies":[{"name":"org.apache.kafka:connect-api","previous-requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.0-ccs","source":null}],"previous-version":"7.9.0-ccs","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.5-ce","source":{"type":"maven_repo","url":"https://packages.confluent.io/maven"}}],"version":"7.9.5-ce","directory":"/"}],"updated-dependency-files":[{"content":"\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\n\u003cproject\n        xmlns=\"http://maven.apache.org/POM/4.0.0\"\n        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n        xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\"\u003e\n  \u003cmodelVersion\u003e4.0.0\u003c/modelVersion\u003e\n  \u003cgroupId\u003eorg.test\u003c/groupId\u003e\n  \u003cartifactId\u003etest\u003c/artifactId\u003e\n  \u003cpackaging\u003ejar\u003c/packaging\u003e\n  \u003cversion\u003e1.0-SNAPSHOT\u003c/version\u003e\n  \u003cname\u003edemos\u003c/name\u003e\n  \u003crepositories\u003e\n    \u003crepository\u003e\n      \u003cid\u003emy-internal-site\u003c/id\u003e\n      \u003curl\u003ehttps://packages.confluent.io/maven\u003c/url\u003e\n    \u003c/repository\u003e\n  \u003c/repositories\u003e\n\n  \u003cdependencies\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003econnect-api\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.5-ce\u003c/version\u003e\n    \u003c/dependency\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003ekafka-streams\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.2-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n  \u003c/dependencies\u003e\n\u003c/project\u003e\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"pom.xml","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ce","pr-body":"Bumps org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ce.\n","commit-message":"Bump org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ce\n\nBumps org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ce.","dependency-group":null},"type":"create_pull_request"}
  proxy | 2025/12/19 04:21:28 [025] 200 http://host.docker.internal:49219/update_jobs/cli/create_pull_request
updater | 2025/12/19 04:21:28 INFO Checking if org.apache.kafka:kafka-streams 7.9.2-ccs needs updating
updater | 2025/12/19 04:21:28 INFO Ignored versions:
updater | 2025/12/19 04:21:28 INFO   version-update:semver-major - from
  proxy | 2025/12/19 04:21:28 [027] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/maven-metadata.xml
  proxy | 2025/12/19 04:21:28 [027] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/maven-metadata.xml
  proxy | 2025/12/19 04:21:28 [029] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:21:28 [029] 404 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:21:28 [031] GET https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:21:29 [031] 302 https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:21:29 [033] GET https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams/
  proxy | 2025/12/19 04:21:29 [033] 200 https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams/
updater | 2025/12/19 04:21:29 INFO Filtered out 12 ignored versions
  proxy | 2025/12/19 04:21:29 [035] HEAD https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ce/kafka-streams-7.9.5-ce.jar
  proxy | 2025/12/19 04:21:29 [035] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ce/kafka-streams-7.9.5-ce.jar
updater | 2025/12/19 04:21:29 INFO Latest version is 7.9.5-ce
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:30 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:31 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:31 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:31 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:31 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:31 INFO Requirements to unlock own
updater | 2025/12/19 04:21:31 INFO Requirements update strategy
updater | 2025/12/19 04:21:31 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:32 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:33 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:33 INFO Filtered out 12 ignored versions
updater | 2025/12/19 04:21:33 INFO Updating org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ce
updater | 2025/12/19 04:21:33 INFO Submitting org.apache.kafka:kafka-streams pull request for creation
  proxy | 2025/12/19 04:21:33 [037] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:21:33 [037] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100 (cached)
  proxy | 2025/12/19 04:21:33 [039] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ce/kafka-streams-7.9.5-ce.pom
  proxy | 2025/12/19 04:21:33 [039] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ce/kafka-streams-7.9.5-ce.pom
  proxy | 2025/12/19 04:21:33 [041] GET https://docs.confluent.io/status
  proxy | 2025/12/19 04:21:33 [041] 302 https://docs.confluent.io/status (cached)
  proxy | 2025/12/19 04:21:34 [042] POST http://host.docker.internal:49219/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238","dependencies":[{"name":"org.apache.kafka:kafka-streams","previous-requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.2-ccs","source":null}],"previous-version":"7.9.2-ccs","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.5-ce","source":{"type":"maven_repo","url":"https://packages.confluent.io/maven"}}],"version":"7.9.5-ce","directory":"/"}],"updated-dependency-files":[{"content":"\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\n\u003cproject\n        xmlns=\"http://maven.apache.org/POM/4.0.0\"\n        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n        xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\"\u003e\n  \u003cmodelVersion\u003e4.0.0\u003c/modelVersion\u003e\n  \u003cgroupId\u003eorg.test\u003c/groupId\u003e\n  \u003cartifactId\u003etest\u003c/artifactId\u003e\n  \u003cpackaging\u003ejar\u003c/packaging\u003e\n  \u003cversion\u003e1.0-SNAPSHOT\u003c/version\u003e\n  \u003cname\u003edemos\u003c/name\u003e\n  \u003crepositories\u003e\n    \u003crepository\u003e\n      \u003cid\u003emy-internal-site\u003c/id\u003e\n      \u003curl\u003ehttps://packages.confluent.io/maven\u003c/url\u003e\n    \u003c/repository\u003e\n  \u003c/repositories\u003e\n\n  \u003cdependencies\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003econnect-api\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.0-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003ekafka-streams\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.5-ce\u003c/version\u003e\n    \u003c/dependency\u003e\n  \u003c/dependencies\u003e\n\u003c/project\u003e\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"pom.xml","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ce","pr-body":"Bumps org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ce.\n","commit-message":"Bump org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ce\n\nBumps org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ce.","dependency-group":null},"type":"create_pull_request"}
  proxy | 2025/12/19 04:21:34 [042] 200 http://host.docker.internal:49219/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238"},"type":"mark_as_processed"}
  proxy | 2025/12/19 04:21:34 [043] PATCH http://host.docker.internal:49219/update_jobs/cli/mark_as_processed
  proxy | 2025/12/19 04:21:34 [043] 200 http://host.docker.internal:49219/update_jobs/cli/mark_as_processed
updater | 2025/12/19 04:21:34 INFO Finished job processing
updater | 2025/12/19 04:21:34 INFO Results:
updater | +-------------------------------------------------------------------------+
updater | |                   Changes to Dependabot Pull Requests                   |
updater | +---------+---------------------------------------------------------------+
updater | | created | org.apache.kafka:connect-api ( from 7.9.0-ccs to 7.9.5-ce )   |
updater | | created | org.apache.kafka:kafka-streams ( from 7.9.2-ccs to 7.9.5-ce ) |
updater | +---------+---------------------------------------------------------------+
  proxy | 2025/12/19 04:21:34 2/19 calls cached (10%)
  proxy | 2025/12/19 04:21:34 Skipping sending metrics because api endpoint is empty
  ```
</details>

<img width="1456" height="343" alt="image" src="https://github.com/user-attachments/assets/4f7060a0-cd70-42c5-910a-6446de5320b3" />

Notice how it tries to upgrade from `-css` to `-ce`

After: 

<details>
  <summary>Full logs</summary>
```
dependabot update -f job.json
    cli | 2025/12/19 04:25:07 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2025/12/19 04:25:08 image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest is already up to date
    cli | 2025/12/19 04:25:08 using image ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest at sha256:6bf9953d5284c2d2f6cc0bf9044d70d4a198eed7a04dbcb63c225e706bf7e320
    cli | 2025/12/19 04:25:08 digest sha256:20911ef74591cbec72235d907d879327a375d678652ecb82a9dedff100e218e4 for image ghcr.io/dependabot/dependabot-updater-maven does not exist remotely
  proxy | 2025/12/19 04:25:10 proxy starting, commit: 1bebae39886086abc69efcd2249f2a5ff31f72b2
  proxy | 2025/12/19 04:25:10 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | Processing triggers for ca-certificates-java (20240118) ...
updater | Adding debian:dbot-ca.pem
updater | done.
updater | done.
updater | fetch_files command is no longer used directly
updater | 2025/12/19 04:25:15 INFO Starting job processing
updater | 2025/12/19 04:25:15 INFO Job definition: {"job":{"command":"version","package-manager":"maven","allowed-updates":[{"update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":null,"ignore-conditions":[{"dependency-name":"*","update-types":["version-update:semver-major"]}],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-11068","directory":"/.","hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":null,"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2025/12/19 04:25:15 [002] GET https://github.com:443/yeikel/dependabot-reproducer-issue-11068/info/refs?service=git-upload-pack
  proxy | 2025/12/19 04:25:15 [002] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:25:15 [002] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/info/refs?service=git-upload-pack
  proxy | 2025/12/19 04:25:15 [004] POST https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:25:15 [004] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:25:15 [004] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:25:15 [006] POST https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
  proxy | 2025/12/19 04:25:15 [006] * authenticating git server request (host: github.com)
  proxy | 2025/12/19 04:25:15 [006] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-11068/git-upload-pack
updater | 2025/12/19 04:25:16 INFO Base commit SHA: 01e1b3846b4a45d5de1ed0961c139ee829e1b238
updater | 2025/12/19 04:25:16 INFO Finished job processing
updater | 2025/12/19 04:25:16 INFO Starting job processing
  proxy | 2025/12/19 04:25:16 [007] POST http://host.docker.internal:49538/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"org.apache.kafka:connect-api","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.0-ccs","source":null}],"version":"7.9.0-ccs"},{"name":"org.apache.kafka:kafka-streams","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.2-ccs","source":null}],"version":"7.9.2-ccs"}],"dependency_files":["/pom.xml"]},"type":"update_dependency_list"}
  proxy | 2025/12/19 04:25:16 [007] 200 http://host.docker.internal:49538/update_jobs/cli/update_dependency_list
  proxy | 2025/12/19 04:25:16 [008] POST http://host.docker.internal:49538/update_jobs/cli/increment_metric
{"data":{"metric":"updater.started","tags":{"operation":"group_update_all_versions"}},"type":"increment_metric"}
  proxy | 2025/12/19 04:25:16 [008] 200 http://host.docker.internal:49538/update_jobs/cli/increment_metric
updater | 2025/12/19 04:25:16 INFO Starting update job for yeikel/dependabot-reproducer-issue-11068
updater | 2025/12/19 04:25:16 INFO Checking all dependencies for version updates...
updater | 2025/12/19 04:25:16 INFO Checking if org.apache.kafka:connect-api 7.9.0-ccs needs updating
updater | 2025/12/19 04:25:16 INFO Ignored versions:
updater | 2025/12/19 04:25:16 INFO   version-update:semver-major - from
  proxy | 2025/12/19 04:25:16 [010] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api/maven-metadata.xml
  proxy | 2025/12/19 04:25:16 [010] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/maven-metadata.xml
  proxy | 2025/12/19 04:25:16 [012] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:25:16 [012] 404 https://packages.confluent.io/maven/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:25:17 [014] GET https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:25:17 [014] 302 https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api
  proxy | 2025/12/19 04:25:17 [016] GET https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api/
  proxy | 2025/12/19 04:25:17 [016] 200 https://repo.maven.apache.org/maven2/org/apache/kafka/connect-api/
updater | 2025/12/19 04:25:17 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:17 INFO Filtered out 6 ignored versions
  proxy | 2025/12/19 04:25:17 [018] HEAD https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ccs/connect-api-7.9.5-ccs.jar
  proxy | 2025/12/19 04:25:18 [018] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ccs/connect-api-7.9.5-ccs.jar
updater | 2025/12/19 04:25:18 INFO Latest version is 7.9.5-ccs
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:18 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:18 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Requirements to unlock own
updater | 2025/12/19 04:25:19 INFO Requirements update strategy
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:19 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:19 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:20 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:20 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:20 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:20 INFO Filtered out 262 non-ccs classifier versions
updater | 2025/12/19 04:25:20 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:20 INFO Updating org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ccs
updater | 2025/12/19 04:25:20 INFO Submitting org.apache.kafka:connect-api pull request for creation
  proxy | 2025/12/19 04:25:20 [020] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:25:20 [020] * authenticating github api request with token for api.github.com
  proxy | 2025/12/19 04:25:20 [020] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:25:21 [022] GET https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ccs/connect-api-7.9.5-ccs.pom
  proxy | 2025/12/19 04:25:21 [022] 200 https://packages.confluent.io/maven/org/apache/kafka/connect-api/7.9.5-ccs/connect-api-7.9.5-ccs.pom
  proxy | 2025/12/19 04:25:21 [023] POST http://host.docker.internal:49538/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238","dependencies":[{"name":"org.apache.kafka:connect-api","previous-requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.0-ccs","source":null}],"previous-version":"7.9.0-ccs","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.5-ccs","source":{"type":"maven_repo","url":"https://packages.confluent.io/maven"}}],"version":"7.9.5-ccs","directory":"/"}],"updated-dependency-files":[{"content":"\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\n\u003cproject\n        xmlns=\"http://maven.apache.org/POM/4.0.0\"\n        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n        xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\"\u003e\n  \u003cmodelVersion\u003e4.0.0\u003c/modelVersion\u003e\n  \u003cgroupId\u003eorg.test\u003c/groupId\u003e\n  \u003cartifactId\u003etest\u003c/artifactId\u003e\n  \u003cpackaging\u003ejar\u003c/packaging\u003e\n  \u003cversion\u003e1.0-SNAPSHOT\u003c/version\u003e\n  \u003cname\u003edemos\u003c/name\u003e\n  \u003crepositories\u003e\n    \u003crepository\u003e\n      \u003cid\u003emy-internal-site\u003c/id\u003e\n      \u003curl\u003ehttps://packages.confluent.io/maven\u003c/url\u003e\n    \u003c/repository\u003e\n  \u003c/repositories\u003e\n\n  \u003cdependencies\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003econnect-api\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.5-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003ekafka-streams\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.2-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n  \u003c/dependencies\u003e\n\u003c/project\u003e\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"pom.xml","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ccs","pr-body":"Bumps org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ccs.\n","commit-message":"Bump org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ccs\n\nBumps org.apache.kafka:connect-api from 7.9.0-ccs to 7.9.5-ccs.","dependency-group":null},"type":"create_pull_request"}
  proxy | 2025/12/19 04:25:21 [023] 200 http://host.docker.internal:49538/update_jobs/cli/create_pull_request
updater | 2025/12/19 04:25:21 INFO Checking if org.apache.kafka:kafka-streams 7.9.2-ccs needs updating
updater | 2025/12/19 04:25:21 INFO Ignored versions:
updater | 2025/12/19 04:25:21 INFO   version-update:semver-major - from
  proxy | 2025/12/19 04:25:21 [025] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/maven-metadata.xml
  proxy | 2025/12/19 04:25:21 [025] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/maven-metadata.xml
  proxy | 2025/12/19 04:25:21 [027] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:25:22 [027] 404 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:25:22 [029] GET https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:25:22 [029] 302 https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams
  proxy | 2025/12/19 04:25:22 [031] GET https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams/
  proxy | 2025/12/19 04:25:22 [031] 200 https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-streams/
updater | 2025/12/19 04:25:22 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:22 INFO Filtered out 6 ignored versions
  proxy | 2025/12/19 04:25:22 [033] HEAD https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ccs/kafka-streams-7.9.5-ccs.jar
  proxy | 2025/12/19 04:25:23 [033] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ccs/kafka-streams-7.9.5-ccs.jar
updater | 2025/12/19 04:25:23 INFO Latest version is 7.9.5-ccs
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:23 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:23 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Requirements to unlock own
updater | 2025/12/19 04:25:24 INFO Requirements update strategy
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:24 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:24 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:25 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:25 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:25 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:25 INFO Filtered out 260 non-ccs classifier versions
updater | 2025/12/19 04:25:25 INFO Filtered out 6 ignored versions
updater | 2025/12/19 04:25:25 INFO Updating org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ccs
updater | 2025/12/19 04:25:25 INFO Submitting org.apache.kafka:kafka-streams pull request for creation
  proxy | 2025/12/19 04:25:25 [035] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100
  proxy | 2025/12/19 04:25:25 [035] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-11068/commits?per_page=100 (cached)
  proxy | 2025/12/19 04:25:25 [037] GET https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ccs/kafka-streams-7.9.5-ccs.pom
  proxy | 2025/12/19 04:25:25 [037] 200 https://packages.confluent.io/maven/org/apache/kafka/kafka-streams/7.9.5-ccs/kafka-streams-7.9.5-ccs.pom
  proxy | 2025/12/19 04:25:25 [038] POST http://host.docker.internal:49538/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238","dependencies":[{"name":"org.apache.kafka:kafka-streams","previous-requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.2-ccs","source":null}],"previous-version":"7.9.2-ccs","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"7.9.5-ccs","source":{"type":"maven_repo","url":"https://packages.confluent.io/maven"}}],"version":"7.9.5-ccs","directory":"/"}],"updated-dependency-files":[{"content":"\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\n\u003cproject\n        xmlns=\"http://maven.apache.org/POM/4.0.0\"\n        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n        xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\"\u003e\n  \u003cmodelVersion\u003e4.0.0\u003c/modelVersion\u003e\n  \u003cgroupId\u003eorg.test\u003c/groupId\u003e\n  \u003cartifactId\u003etest\u003c/artifactId\u003e\n  \u003cpackaging\u003ejar\u003c/packaging\u003e\n  \u003cversion\u003e1.0-SNAPSHOT\u003c/version\u003e\n  \u003cname\u003edemos\u003c/name\u003e\n  \u003crepositories\u003e\n    \u003crepository\u003e\n      \u003cid\u003emy-internal-site\u003c/id\u003e\n      \u003curl\u003ehttps://packages.confluent.io/maven\u003c/url\u003e\n    \u003c/repository\u003e\n  \u003c/repositories\u003e\n\n  \u003cdependencies\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003econnect-api\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.0-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n    \u003cdependency\u003e\n      \u003cgroupId\u003eorg.apache.kafka\u003c/groupId\u003e\n      \u003cartifactId\u003ekafka-streams\u003c/artifactId\u003e\n      \u003cversion\u003e7.9.5-ccs\u003c/version\u003e\n    \u003c/dependency\u003e\n  \u003c/dependencies\u003e\n\u003c/project\u003e\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"pom.xml","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ccs","pr-body":"Bumps org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ccs.\n","commit-message":"Bump org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ccs\n\nBumps org.apache.kafka:kafka-streams from 7.9.2-ccs to 7.9.5-ccs.","dependency-group":null},"type":"create_pull_request"}
  proxy | 2025/12/19 04:25:25 [038] 200 http://host.docker.internal:49538/update_jobs/cli/create_pull_request
  proxy | 2025/12/19 04:25:25 [039] PATCH http://host.docker.internal:49538/update_jobs/cli/mark_as_processed
{"data":{"base-commit-sha":"01e1b3846b4a45d5de1ed0961c139ee829e1b238"},"type":"mark_as_processed"}
updater | 2025/12/19 04:25:25 INFO Finished job processing
  proxy | 2025/12/19 04:25:25 [039] 200 http://host.docker.internal:49538/update_jobs/cli/mark_as_processed
updater | 2025/12/19 04:25:25 INFO Results:
updater | +--------------------------------------------------------------------------+
updater | |                   Changes to Dependabot Pull Requests                    |
updater | +---------+----------------------------------------------------------------+
updater | | created | org.apache.kafka:connect-api ( from 7.9.0-ccs to 7.9.5-ccs )   |
updater | | created | org.apache.kafka:kafka-streams ( from 7.9.2-ccs to 7.9.5-ccs ) |
updater | +---------+----------------------------------------------------------------+
  proxy | 2025/12/19 04:25:26 Skipping sending metrics because api endpoint is empty
  proxy | 2025/12/19 04:25:26 1/17 calls cached (5%)
```
</details>


<img width="1295" height="322" alt="image" src="https://github.com/user-attachments/assets/e075bc15-da8e-4196-8c22-bcdb61e863f0" />

Notice how it correctly upgrades `-css` to `-css` and `-ce` to `-ce` as expected

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.