### PR TITLE
remove unique data from unknown error

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -602,6 +602,7 @@ internal static partial class MSBuildHelper
         ThrowOnTimeout(output);
         ThrowOnBadResponse(output);
         ThrowOnUnparseableFile(output);
+        ThrowOnMultipleProjectsForPackagesConfig(output);
     }
 
     private static void ThrowOnUnauthenticatedFeed(string stdout)
@@ -732,6 +733,14 @@ internal static partial class MSBuildHelper
         if (match is not null)
         {
             throw new UnparseableFileException(match.Groups["Message"].Value, match.Groups["FilePath"].Value);
+        }
+    }
+
+    private static void ThrowOnMultipleProjectsForPackagesConfig(string output)
+    {
+        if (output.Contains("Found multiple project files for "))
+        {
+            throw new Exception("Multiple project files found for single packages.config");
         }
     }
 


### PR DESCRIPTION
An unknown error appearing in the telemetry contains some unique data which makes bucketing difficult.  The error text looks like:

```
Unable to run NuGet.exe with args: update /path/to/packages.config -Id Some.Package -Version 1.2.3 -RepositoryPath /path/to/packages -NonInteractive -MSBuildPath /usr/local/dotnet/current/sdk/9.0.307
Output:
Using Msbuild from '/usr/local/dotnet/current/sdk/9.0.307'.
Found multiple project files for '/path/to/packages.config'.
```

Because the path to `packages.config` and the package name and version can differ, there are multiple "unique" instances of this error and it's difficult to investigate.

This just strips the uniqueness so all errors are combined into the same bucket so we can see the real spread of the problem.