### PR TITLE
Revert "`docker`: consider the tag when checking if a digest is up-to-date"

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -101,33 +101,12 @@ module Dependabot
         comparable_version_from(latest_tag) <= comparable_version_from(version_tag)
       end
 
-      # Digest requirements come in two forms:
-      #
-      # - Tag + digest (e.g. `image:debug@sha256:<digest>`):
-      #   the tag is the source of truth, so the expected digest is the digest of the tag.
-      #
-      # - Digest-only (e.g. `image@sha256:<digest>`):
-      #   there is no tag to resolve, so the expected digest is `updated_digest`.
-      #
-      # A dependency may have multiple digest requirements (across multiple files), so
-      # we compute the expected digest per requirement rather than using a single
-      # global value.
       sig { returns(T::Boolean) }
       def digest_up_to_date?
-        return true unless updated_digest
-
         digest_requirements.all? do |req|
-          source = req.fetch(:source)
-          source_digest = source.fetch(:digest)
-          source_tag = source[:tag]
+          next true unless updated_digest
 
-          expected_digest =
-            if source_tag
-              digest_of(source_tag)
-            else
-              updated_digest
-            end
-          source_digest == expected_digest
+          req.fetch(:source).fetch(:digest) == updated_digest
         end
       end
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1745,60 +1745,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
-  describe "#digest_up_to_date?" do
-    subject(:digest_up_to_date) { checker.send(:digest_up_to_date?) }
-
-    let(:image_name) { "gcr.io/distroless/base-nossl-debian11" }
-    let(:tag_nonroot) { "debug-nonroot" }
-    let(:tag_debug) { "debug" }
-
-    let(:digest_nonroot) { "934b713496a9ed100550aaa58636270c4d69c27040e44f2aed1fa39594c45eba" }
-    let(:digest_debug) { "d66c60eff6c55972af9e661a57c1afe96ef4ddfa4fff37b625a448df41a15820" }
-
-    before do
-      allow(checker).to receive(:updated_digest).and_return(updated_digest)
-      allow(checker).to receive(:digest_of).with(tag_nonroot).and_return(digest_nonroot)
-      allow(checker).to receive(:digest_of).with(tag_debug).and_return(digest_debug)
-    end
-
-    context "when a digest requirement includes a tag" do
-      let(:updated_digest) { "some_other_updated_digest" }
-      let(:dependency_name) { image_name }
-      let(:version) { tag_nonroot }
-      let(:source) { { tag: tag_nonroot, digest: digest_nonroot } }
-
-      it "considers the tag and compares against digest_of(tag)" do
-        expect(digest_up_to_date).to be(true)
-      end
-
-      context "when the digest does not match the tag digest" do
-        let(:source) { { tag: tag_nonroot, digest: digest_debug } }
-
-        it "returns false" do
-          expect(digest_up_to_date).to be(false)
-        end
-      end
-    end
-
-    context "when a digest requirement does not have a tag" do
-      let(:dependency_name) { image_name }
-      let(:version) { digest_debug }
-      let(:source) { { digest: digest_debug } }
-
-      context "when the digest matches updated_digest" do
-        let(:updated_digest) { digest_debug }
-
-        it { is_expected.to be(true) }
-      end
-
-      context "when the digest does not match updated_digest" do
-        let(:updated_digest) { digest_nonroot }
-
-        it { is_expected.to be(false) }
-      end
-    end
-  end
-
   private
 
   def stub_same_sha_for(*tags)


### PR DESCRIPTION
Reverts dependabot/dependabot-core#13794

Since merging #13794, Docker updates have started failing with `update_not_possible`, causing Dependabot to close PRs when updates should have been possible. 

Based on initial investigation, this may be related to missing safeguarding in the digest comparison logic—specifically, handling cases when the expected digest cannot be determined (for example, due to transient registry errors):

```ruby
# If we can't determine the expected digest (e.g., due to transient registry errors),
# we can't prove the digest is out of date, so conservatively assume it's up to date.
# This prevents false positives where we incorrectly mark dependencies as needing updates.
next true if expected_digest.nil?