### PR TITLE
case-correct web.config and app.config locations when reporting

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
@@ -216,7 +216,7 @@ public class BindingRedirectsTests : TestBase
         await File.WriteAllTextAsync(configFilePath, configContents);
 
         var projectBuildFile = ProjectBuildFile.Open(tempDir.DirectoryPath, projectFilePath);
-        await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, updatedPackageName, updatedPackageVersion);
+        await BindingRedirectManager.UpdateBindingRedirectsAsync(tempDir.DirectoryPath, projectBuildFile, updatedPackageName, updatedPackageVersion);
 
         var actualConfigContents = (await File.ReadAllTextAsync(configFilePath)).Replace("\r", "");
         expectedConfigContents = expectedConfigContents.Replace("\r", "");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/ProjectHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/ProjectHelperTests.cs
@@ -13,7 +13,7 @@ public class ProjectHelperTests : TestBase
         using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(files);
         var fullProjectPath = Path.Join(tempDirectory.DirectoryPath, projectPath);
 
-        var actualAdditionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(fullProjectPath, ProjectHelper.PathFormat.Relative);
+        var actualAdditionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(tempDirectory.DirectoryPath, fullProjectPath, ProjectHelper.PathFormat.Relative);
         AssertEx.Equal(expectedAdditionalFiles, actualAdditionalFiles);
     }
 
@@ -59,6 +59,33 @@ public class ProjectHelperTests : TestBase
             new[]
             {
                 "../unexpected-path/packages.config"
+            }
+        ];
+
+        // files with different casing
+        yield return
+        [
+            // project path
+            "src/project.csproj",
+            // files
+            new[]
+            {
+                ("src/project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <None Include="PACKAGES.CONFIG" />
+                        <None Include="APP.CONFIG" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/app.config", "contents irrelevant"),
+                ("src/packages.config", "contents irrelevant"),
+            },
+            // expected additional files
+            new[]
+            {
+                "app.config",
+                "packages.config"
             }
         ];
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackagesConfigDiscovery.cs
@@ -9,8 +9,8 @@ internal static class PackagesConfigDiscovery
     public static async Task<PackagesConfigDiscoveryResult?> Discover(string repoRootPath, string workspacePath, string projectPath, ILogger logger)
     {
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
-        var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(projectPath, ProjectHelper.PathFormat.Full);
-        var packagesConfigPath = additionalFiles.FirstOrDefault(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesConfigFileName, StringComparison.Ordinal));
+        var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(repoRootPath, projectPath, ProjectHelper.PathFormat.Full);
+        var packagesConfigPath = additionalFiles.FirstOrDefault(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesConfigFileName, StringComparison.OrdinalIgnoreCase));
 
         if (packagesConfigPath is null)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
@@ -112,7 +112,7 @@ public class FileWriterWorker
         NuGetVersion newDependencyVersion
     )
     {
-        var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(projectPath.FullName, ProjectHelper.PathFormat.Full);
+        var additionalFiles = ProjectHelper.GetAllAdditionalFilesFromProject(repoContentsPath.FullName, projectPath.FullName, ProjectHelper.PathFormat.Full);
         var packagesConfigFullPath = additionalFiles.Where(p => Path.GetFileName(p).Equals(ProjectHelper.PackagesConfigFileName, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
         if (packagesConfigFullPath is null)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -96,7 +96,7 @@ internal static partial class PackagesConfigUpdater
         projectBuildFile.NormalizeDirectorySeparatorsInProject();
 
         // Update binding redirects
-        var updatedConfigFiles = await BindingRedirectManager.UpdateBindingRedirectsAsync(projectBuildFile, dependencyName, newDependencyVersion);
+        var updatedConfigFiles = await BindingRedirectManager.UpdateBindingRedirectsAsync(repoRootPath, projectBuildFile, dependencyName, newDependencyVersion);
 
         logger.Info("    Writing project file back to disk");
         await projectBuildFile.SaveAsync();


### PR DESCRIPTION
From a manual scan of the telemetry I found that a `.csproj` might contain `<None include="App.config" />` but on disk the file is named `app.config` (note the differing case.)  Since most projects with those files are built on Windows but dependabot runs in a Linux container, we do a case-correction pass on those paths because the intent is obvious.