### PR TITLE
Add HEX PM organization token support Pivate Registry on CI and update specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
             --env "CI=true" \
             --env "RAISE_ON_WARNINGS=true" \
             --env "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
+            --env "HEX_PM_ORGANIZATION_TOKEN=${{ secrets.HEX_PM_ORGANIZATION_TOKEN }}" \
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
             --rm ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} bash -c \
             "cd /home/dependabot/${{ matrix.suite.path }} && ./script/ci-test"

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -469,6 +469,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
 
       context "with bad credentials" do
+        let(:hex_pm_org_token) { ENV.fetch("HEX_PM_ORGANIZATION_TOKEN", nil) }
         let(:credentials) do
           [Dependabot::Credential.new(
             {
@@ -487,6 +488,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         it "raises a helpful error" do
+          skip("skipped because env var HEX_PM_ORGANIZATION_TOKEN is not set") if hex_pm_org_token.nil?
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { latest_resolvable_version }
             .to raise_error(error_class) do |error|
@@ -496,6 +498,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
 
       context "with no token" do
+        let(:hex_pm_org_token) { ENV.fetch("HEX_PM_ORGANIZATION_TOKEN", nil) }
         let(:credentials) do
           [Dependabot::Credential.new(
             {
@@ -514,6 +517,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
 
         # This needs to changes to the Elixir helper
         it "raises a helpful error" do
+          skip("skipped because env var HEX_PM_ORGANIZATION_TOKEN is not set") if hex_pm_org_token.nil?
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { latest_resolvable_version }
             .to raise_error(error_class) do |error|
@@ -523,6 +527,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
 
       context "with no credentials" do
+        let(:hex_pm_org_token) { ENV.fetch("HEX_PM_ORGANIZATION_TOKEN", nil) }
         let(:credentials) do
           [Dependabot::Credential.new(
             {
@@ -537,6 +542,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         # The Elixir process hangs waiting for input in this case. This spec
         # passes as long as we're intelligently timing out.
         it "raises a helpful error" do
+          skip("skipped because env var HEX_PM_ORGANIZATION_TOKEN is not set") if hex_pm_org_token.nil?
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { latest_resolvable_version }
             .to raise_error(error_class) do |error|


### PR DESCRIPTION
## What

Fixes #11760 - Migrate Hex integration tests from external self-hosted registry to team-controlled [Hex.pm organization](https://hex.pm/orgs/dependabot).

## Why

The integration specs relied on `dependabot-private.fly.dev`, an external self-hosted registry that was frequently unavailable (503 errors), requiring complex mocking workarounds and causing flaky tests.

This PR migrates to our Hex.pm organization infrastructure for more reliable testing.

**Approach**: Real integration tests for `hex_organization` credentials (Hex.pm hosted), mocked tests for `hex_repository` credentials (self-hosted registries). 

## How

- **Credential migration**: Changed from `hex_repository` to `hex_organization` credential type
- **Test fixtures**: Updated to use test packages from `dependabot` organization on Hex.pm  
- **Skip logic**: Tests gracefully skip without token, following [Composer pattern](https://github.com/dependabot/dependabot-core/blob/7325a0f211ef752cfcd670a989e32dcf511bf258/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb#L355-L397)
- **CI integration**: Added `HEX_PM_ORGANIZATION_TOKEN` environment variable to [workflow](https://github.com/dependabot/dependabot-core/blob/7325a0f211ef752cfcd670a989e32dcf511bf258/.github/workflows/ci.yml)
- **Documentation**: Created [setup guide](https://github.com/dependabot/dependabot-core/blob/7325a0f211ef752cfcd670a989e32dcf511bf258/hex/PRIVATE_REGISTRY_SETUP.md) for contributors

## Key Changes

- **Integration specs** - Migrated to `hex_organization` credentials with graceful skip logic
- **Test fixtures** - Updated to use `dependabot` organization packages and lockfile format
- **CI workflow** - Added `HEX_PM_ORGANIZATION_TOKEN` environment variable  
- **Documentation** - New contributor [setup guide](https://github.com/dependabot/dependabot-core/blob/7325a0f211ef752cfcd670a989e32dcf511bf258/hex/PRIVATE_REGISTRY_SETUP.md)

## Testing

**With token** (CI after secret configured):
```bash
bin/docker-dev-shell hex
rspec spec/dependabot/hex/file_updater/lockfile_updater_spec.rb:440
rspec spec/dependabot/hex/update_checker_spec.rb:467
```

**Without token** (tests skip gracefully):
```bash
unset HEX_PM_ORGANIZATION_TOKEN
rspec spec/dependabot/hex/update_checker_spec.rb:437
# Output: "skipped because env var HEX_PM_ORGANIZATION_TOKEN is not set"
```