### PR TITLE
`docker`: skip `.sig` tags

### DIFF
--- a/docker/spec/fixtures/docker/registry_tags/regctl.json
+++ b/docker/spec/fixtures/docker/registry_tags/regctl.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "This is a fixture representing a response with both tags and digests for the regclient/regctl repository.",
+  "name": "regclient/regctl",
+  "tags": [
+    "sha256-000c6080b831b91619e3ab89292b16ecfe3cbbfe7e024a599cc1067f79cc25bb",
+    "sha256-000c6080b831b91619e3ab89292b16ecfe3cbbfe7e024a599cc1067f79cc25bb.sig",
+    "sha256-000d3562e60a68c5ab3d36dc45105986fad1dcd27ce4040001578ac109238eaf",
+    "sha256-000d3562e60a68c5ab3d36dc45105986fad1dcd27ce4040001578ac109238eaf.sig",
+    "sha256-000f5480cf286549d586461c52859f2607e224ee74e5d6bdc72adf0e2db6e330",
+    "v0",
+    "latest",
+    "v0.10.0",
+    "v0.10.1"
+  ]
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Skip the unnecessary processing of `sha256-*` tags as these are not real meaningful tags for Dependabot and they just increase the network load unnecessarily 

### Anything you want to highlight for special attention from reviewers?

With the current setup, Dependabot sends a large number of requests unnecessarily. For example 

[Sample Job](https://productionresultssa4.blob.core.windows.net/actions-results/586762d5-8acb-4d10-be2f-18c31b962452/workflow-job-run-f332ffdd-ba2a-5950-8886-c2befcc43900/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-12-24T01%3A06%3A41Z&sig=aarlrZ4RP1Srh2Rz7lGJd7U45PR%2FcWr1G8UvFsEPXv4%3D&ske=2025-12-24T09%3A59%3A48Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-12-23T21%3A59%3A48Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-12-24T00%3A56%3A36Z&sv=2025-11-05)

```
2025-12-21T16:09:01.4660757Z   proxy | 2025/12/21 16:09:01 [052] GET https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list
2025-12-21T16:09:01.5266600Z   proxy | 2025/12/21 16:09:01 [052] 401 https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list
2025-12-21T16:09:01.5552509Z   proxy | 2025/12/21 16:09:01 [054] GET https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Asigstore%2Fcosign%2Fcosign%3Apull&account
2025-12-21T16:09:01.5804036Z   proxy | 2025/12/21 16:09:01 [054] 200 https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Asigstore%2Fcosign%2Fcosign%3Apull&account
2025-12-21T16:09:01.6085722Z   proxy | 2025/12/21 16:09:01 [056] GET https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list
2025-12-21T16:09:01.6419690Z   proxy | 2025/12/21 16:09:01 [056] 200 https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list
2025-12-21T16:09:01.6706705Z   proxy | 2025/12/21 16:09:01 [058] GET https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-63ca29e9cf1bf3ad3015cfa855f6c36847621fa14fb77b4197e5e89eea7da0e9.sig
2025-12-21T16:09:01.6896611Z   proxy | 2025/12/21 16:09:01 [058] 401 https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-63ca29e9cf1bf3ad3015cfa855f6c36847621fa14fb77b4197e5e89eea7da0e9.sig
2025-12-21T16:09:01.7175676Z   proxy | 2025/12/21 16:09:01 [060] GET https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Asigstore%2Fcosign%2Fcosign%3Apull&account
2025-12-21T16:09:01.7177220Z 2025/12/21 16:09:01 [060] 200 https://ghcr.io:443/token?service=ghcr.io&scope=repository%3Asigstore%2Fcosign%2Fcosign%3Apull&account (cached)
2025-12-21T16:09:01.7455045Z   proxy | 2025/12/21 16:09:01 [062] GET https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-63ca29e9cf1bf3ad3015cfa855f6c36847621fa14fb77b4197e5e89eea7da0e9.sig
2025-12-21T16:09:01.7773716Z   proxy | 2025/12/21 16:09:01 [062] 200 https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-63ca29e9cf1bf3ad3015cfa855f6c36847621fa14fb77b4197e5e89eea7da0e9.sig
2025-12-21T16:09:01.8055988Z   proxy | 2025/12/21 16:09:01 [064] GET https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-a2dd62be2dbcd491495a3984ed86aa233f7d933052adfb8db7932141a6f023c6.sig
2025-12-21T16:09:01.8239230Z   proxy | 2025/12/21 16:09:01 [064] 401 https://ghcr.io:443/v2/sigstore/cosign/cosign/tags/list?last=sha256-a2dd62be2dbcd491495a3984ed86aa233f7d933052adfb8db7932141a6f023c6.sig
``` 

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

- The existing and new specs continue to pass
- The network load is reduced and we no longer see fetches to digests like `sha256-a2dd62be2dbcd491495a3984ed86aa233f7d933052adfb8db7932141a6f023c6.sig` 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
