### PR TITLE
improve directory matcher with trailing slash

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -283,6 +283,24 @@ public class PathHelperTests
                 "/src/client/ios/ui"
             }
         ];
+
+        // leading and trailing slashes
+        yield return
+        [
+            // searchPattern
+            "/src/",
+            // directoriesOnDisk
+            new[]
+            {
+                "src",
+                "tests"
+            },
+            // expectedDirectories
+            new[]
+            {
+                "/src"
+            }
+        ];
     }
 
     [LinuxOnlyFact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -256,6 +256,7 @@ internal static class PathHelper
         // translate pattern to regex
         searchPattern = searchPattern.Replace("\\", "/"); // unix-style paths make things easier
         searchPattern = searchPattern.TrimStart('/'); // pattern shouldn't be rooted
+        searchPattern = searchPattern.TrimEnd('/'); // trailing slash is meaningless for directory matching
         if (searchPattern == string.Empty)
         {
             searchPattern = "/"; // special case repo root


### PR DESCRIPTION
Allow for trailing slash in directory glob expansion.

Functionally there is no difference between specifying a directory like `/src` and `/src/` and we already have a special case for a leading slash so we can simply repeat that for a trailing slash as well.