### PR TITLE
fix(docker): handle version tags with v prefix correctly

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -231,7 +231,7 @@ module Dependabot
         published_date = last_modified ? Time.parse(last_modified) : nil
 
         Dependabot::Package::PackageRelease.new(
-          version: Dependabot::Version.new(tag.name),
+          version: Docker::Version.new(tag.name),
           released_at: published_date,
           latest: false,
           yanked: false,

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1743,6 +1743,28 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         )
       end
     end
+
+    context "when tag has a 'v' prefix" do
+      let(:tag) { Dependabot::Docker::Tag.new("v2.7.2") }
+      let(:digest_string) { "sha256:abc123" }
+
+      before do
+        allow(mock_client).to receive(:digest).and_return(digest_string)
+      end
+
+      it "handles the version prefix correctly and returns publication details" do
+        result = get_tag_publication_details
+        expect(result).to be_a(Dependabot::Package::PackageRelease)
+        expect(result.version).to be_a(Dependabot::Docker::Version)
+        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
+      end
+
+      it "creates a Docker::Version instead of base Dependabot::Version" do
+        result = get_tag_publication_details
+        expect(result.version).to be_a(Dependabot::Docker::Version)
+        expect(result.version.class).to eq(Dependabot::Docker::Version)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes an ArgumentError that occurs when Dependabot processes Docker images with version tags containing a "v" prefix (e.g., "v2.7.2").

The issue was in the `get_tag_publication_details` method, which used `Dependabot::Version.new()` to create PackageRelease objects. Since `Dependabot::Version` inherits from `Gem::Version`, it cannot parse version 
strings with a "v" prefix and raises "Malformed version number string" errors.

The fix changes the method to use `Docker::Version.new()` instead, which is specifically designed to handle Docker tag formats including version prefixes, suffixes, and other Docker-specific version patterns.

This is a common pattern in Docker images (e.g., `golangci/golangci-lint` uses tags like `"v2.7.2"`) and was causing update checks to fail.

### Anything you want to highlight for special attention from reviewers?

The fix (using `Docker::Version` instead of `Dependabot::Version`) was suggested by @gitulisca after investigating the root cause.

Thanks to @gitulisca for the detailed analysis and solution!

### How will you know you've accomplished your goal?

I reproduced the issue locally with the `golangci/golangci-lint`, Testing repository uses v-prefixed tags (v2.7.2) and cooldown enabled:
```
updater | 2026/01/07 11:33:10 INFO <job_1201675422> Checking if golangci/golangci-lint v2.6.2 needs updating
  proxy | 2026/01/07 11:33:10 [013] GET [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/tags/list](https://registry.hub.docker.com/v2/golangci/golangci-lint/tags/list)
  proxy | 2026/01/07 11:33:10 [013] * authenticating docker registry request (host: registry.hub.docker.com)
  proxy | 2026/01/07 11:33:10 [013] 200 [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/tags/list](https://registry.hub.docker.com/v2/golangci/golangci-lint/tags/list)
updater | 2026/01/07 11:33:10 INFO <job_1201675422> Original tag components: 
  proxy | 2026/01/07 11:33:10 [016] HEAD [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/manifests/latest](https://registry.hub.docker.com/v2/golangci/golangci-lint/manifests/latest)
2026/01/07 11:33:10 [016] * authenticating docker registry request (host: registry.hub.docker.com)
  proxy | 2026/01/07 11:33:10 [016] 200 [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/manifests/latest](https://registry.hub.docker.com/v2/golangci/golangci-lint/manifests/latest)
  proxy | 2026/01/07 11:33:11 [018] GET [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/manifests/v2.7.2](https://registry.hub.docker.com/v2/golangci/golangci-lint/manifests/v2.7.2)
  proxy | 2026/01/07 11:33:11 [018] * authenticating docker registry request (host: registry.hub.docker.com)
  proxy | 2026/01/07 11:33:11 [018] 200 [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/manifests/v2.7.2](https://registry.hub.docker.com/v2/golangci/golangci-lint/manifests/v2.7.2)
  proxy | 2026/01/07 11:33:11 [020] HEAD [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/blobs/sha256:6fad8c144a47a608bc6e9f92a5312d3e7f3e1c9702d13d07e0133680106e0efb](https://registry.hub.docker.com/v2/golangci/golangci-lint/blobs/sha256:6fad8c144a47a608bc6e9f92a5312d3e7f3e1c9702d13d07e0133680106e0efb)
  proxy | 2026/01/07 11:33:11 [020] * authenticating docker registry request (host: registry.hub.docker.com)
  proxy | 2026/01/07 11:33:11 [020] 200 [https://registry.hub.docker.com:443/v2/golangci/golangci-lint/blobs/sha256:6fad8c144a47a608bc6e9f92a5312d3e7f3e1c9702d13d07e0133680106e0efb](https://registry.hub.docker.com/v2/golangci/golangci-lint/blobs/sha256:6fad8c144a47a608bc6e9f92a5312d3e7f3e1c9702d13d07e0133680106e0efb)
  proxy | 2026/01/07 11:33:11 [022] POST /update_jobs/1201675422/record_update_job_unknown_error
  proxy | 2026/01/07 11:33:11 [022] 204 /update_jobs/1201675422/record_update_job_unknown_error
  proxy | 2026/01/07 11:33:11 [024] POST /update_jobs/1201675422/record_update_job_error
  proxy | 2026/01/07 11:33:11 [024] 204 /update_jobs/1201675422/record_update_job_error
  proxy | 2026/01/07 11:33:11 [026] POST /update_jobs/1201675422/increment_metric
  proxy | 2026/01/07 11:33:11 [026] 204 /update_jobs/1201675422/increment_metric
  proxy | 2026/01/07 11:33:11 [028] POST /update_jobs/1201675422/record_update_job_unknown_error
  proxy | 2026/01/07 11:33:11 [028] 204 /update_jobs/1201675422/record_update_job_unknown_error
updater | 2026/01/07 11:33:11 ERROR <job_1201675422> Error processing golangci/golangci-lint (ArgumentError)
2026/01/07 11:33:11 ERROR <job_1201675422> Malformed version number string v2.7.2
updater | 2026/01/07 11:33:11 ERROR <job_1201675422> /usr/local/lib/ruby/3.4.0/rubygems/version.rb:223:in 'Gem::Version#initialize'
2026/01/07 11:33:11 ERROR <job_1201675422> /home/dependabot/common/lib/dependabot/version.rb:19:in 'Dependabot::Version#initialize'
2026/01/07 11:33:11 ERROR <job_1201675422> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.12544/lib/types/private/methods/call_validation_2_7.rb:1547:in 'UnboundMethod#bind_call'
```

After applying the fix:
1. All 105 existing tests in docker/spec/dependabot/docker/update_checker_spec.rb 
   continue to pass
2. Added 2 new test cases specifically for v-prefixed tags that verify:
   - Tags like "v2.7.2" are parsed correctly without errors
   - `Docker::Version` is used instead of `Dependabot::Version`
3. The update command no longer raises ArgumentError for Docker images with v-prefixed version tags

The fix has been validated both through automated tests and manual verification with the original failing case.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
