### PR TITLE
Revert "Fix python incorrect version selection issue"

### DIFF
--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -27,8 +27,7 @@ module Dependabot
       PRE_INSTALLED_PYTHON_VERSIONS = T.let(
         PRE_INSTALLED_PYTHON_VERSIONS_RAW.map do |v|
           Version.new(v)
-        end.sort.reverse, # installed versions is sorted in descending order as highest available version is preferred
-        # over the lower ones
+        end.sort,
         T::Array[Dependabot::Python::Version]
       )
 

--- a/python/spec/dependabot/python/language_spec.rb
+++ b/python/spec/dependabot/python/language_spec.rb
@@ -16,28 +16,6 @@ RSpec.describe Dependabot::Python::Language do
   let(:detected_version) { "3.11" }
   let(:raw_version) { "3.13.1" }
 
-  describe "PRE_INSTALLED_PYTHON_VERSIONS" do
-    it "is sorted in descending order" do
-      versions = described_class::PRE_INSTALLED_PYTHON_VERSIONS
-      expect(versions).to eq(versions.sort.reverse)
-    end
-
-    it "has the highest version first" do
-      versions = described_class::PRE_INSTALLED_PYTHON_VERSIONS
-      expect(versions.first).to eq(versions.max)
-    end
-
-    it "has the lowest version last" do
-      versions = described_class::PRE_INSTALLED_PYTHON_VERSIONS
-      expect(versions.last).to eq(versions.min)
-    end
-
-    it "matches PRE_INSTALLED_HIGHEST_VERSION with the first element" do
-      expect(described_class::PRE_INSTALLED_PYTHON_VERSIONS.first)
-        .to eq(described_class::PRE_INSTALLED_HIGHEST_VERSION)
-    end
-  end
-
   describe "#deprecated?" do
     it "returns false" do
       expect(language.deprecated?).to be false


### PR DESCRIPTION
## Revert PR #13862: Python dependency resolution regression

This reverts #13862, which caused Dependabot to fail resolving Python dependencies with `uv` when pinned version constraints are incompatible (see #13886).  
Latest runs: [example error](https://github.com/dsp-testing/dependabot-all-updates-test-staging/actions/runs/20724834701).

Restores previous dependency update logic to fix breakages in uv-based Python projects.