### PR TITLE
Strip UTF-8 BOM prefix from files read from cloned repos

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -233,7 +233,7 @@ module Dependabot
         repo_path = File.join(clone_repo_contents, path)
         raise Dependabot::DependencyFileNotFound, path unless File.exist?(repo_path)
 
-        content = File.read(repo_path)
+        content = decode_binary_string(Base64.encode64(File.read(repo_path)))
         type = if File.symlink?(repo_path)
                  symlink_target = File.readlink(repo_path)
                  "symlink"

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1471,6 +1471,23 @@ RSpec.describe Dependabot::FileFetchers::Base do
         end
       end
 
+      context "with a file containing UTF-8 BOM" do
+        let(:bom) { "\xEF\xBB\xBF" }
+        let(:fill_repo) do
+          # Write file with UTF-8 BOM prefix
+          File.binwrite("requirements.txt", "#{bom}#{contents}")
+        end
+
+        its(:length) { is_expected.to eq(1) }
+
+        describe "the file" do
+          subject { files.find { |file| file.name == "requirements.txt" } }
+
+          it { is_expected.to be_a(Dependabot::DependencyFile) }
+          its(:content) { is_expected.to eq(contents) }
+        end
+      end
+
       context "with an invalid source" do
         before do
           allow(source)


### PR DESCRIPTION
### What are you trying to accomplish?

Strip the UTF-8 BOM prefix from files read from cloned repos

This caused YAML parsing failures for files saved with UTF-8 BOM encoding when using cloned repositories.

<img width="924" height="327" alt="image" src="https://github.com/user-attachments/assets/7c2eaa36-3010-4948-93ee-01e7c7b6b58c" />

### Anything you want to highlight for special attention from reviewers?

The `decode_binary_string` method correctly strips the UTF-8 BOM for files fetched via API, but `load_cloned_file_if_present` was reading files directly from disk without BOM handling.

Fixed by reusing `decode_binary_string` for cloned repo file reads

### How will you know you've accomplished your goal?

Files that have a UTF-8 BOM encoding no longer raise an error for ecosystems that clone the repo, like GitHub Actions.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
