### PR TITLE
Fix: Use correct npm environment variable for private registry configuration

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -20,8 +20,8 @@ module Dependabot
       NPM_REGISTER_KEY_FOR_YARN = "npmRegistryServer"
 
       # Environment variable keys
-      COREPACK_NPM_REGISTRY_ENV = "COREPACK_NPM_REGISTRY"
-      COREPACK_NPM_TOKEN_ENV = "COREPACK_NPM_TOKEN"
+      COREPACK_NPM_REGISTRY_ENV = "npm_config_registry"
+      COREPACK_NPM_TOKEN_ENV = "NPM_CONFIG__AUTH"
 
       sig do
         params(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -1388,7 +1388,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             env_vars = Dependabot::NpmAndYarn::Helpers.send(:build_corepack_env_variables)
             expect(env_vars).to eq(
               {
-                "COREPACK_NPM_REGISTRY" => "https://npm.private.registry"
+                "npm_config_registry" => "https://npm.private.registry"
               }
             )
           end
@@ -1450,7 +1450,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             env_vars = Dependabot::NpmAndYarn::Helpers.send(:build_corepack_env_variables)
             expect(env_vars).to eq(
               {
-                "COREPACK_NPM_REGISTRY" => "https://custom.registry.com"
+                "npm_config_registry" => "https://custom.registry.com"
               }
             )
           end
@@ -1475,7 +1475,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             env_vars = Dependabot::NpmAndYarn::Helpers.send(:build_corepack_env_variables)
             expect(env_vars).to eq(
               {
-                "COREPACK_NPM_REGISTRY" => "https://yarn.registry.com"
+                "npm_config_registry" => "https://yarn.registry.com"
               }
             )
           end
@@ -1500,7 +1500,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             env_vars = Dependabot::NpmAndYarn::Helpers.send(:build_corepack_env_variables)
             expect(env_vars).to eq(
               {
-                "COREPACK_NPM_REGISTRY" => "https://yarn2.registry.com"
+                "npm_config_registry" => "https://yarn2.registry.com"
               }
             )
           end
@@ -1538,7 +1538,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             env_vars = Dependabot::NpmAndYarn::Helpers.send(:build_corepack_env_variables)
             expect(env_vars).to eq(
               {
-                "COREPACK_NPM_REGISTRY" => "https://creds.registry.com"
+                "npm_config_registry" => "https://creds.registry.com"
               }
             )
           end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -522,8 +522,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         env = described_class.send(:build_corepack_env_variables)
 
         expect(env).not_to be_nil
-        expect(env["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
-        expect(env["COREPACK_NPM_TOKEN"]).to be_nil
+        expect(env["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
       end
 
       context "when experiment flag is disabled" do
@@ -545,7 +544,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
           env = described_class.send(:build_corepack_env_variables)
           # Registry helper can still find registry from credentials even without files
           expect(env).not_to be_nil
-          expect(env["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
+          expect(env["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
         end
       end
 
@@ -556,7 +555,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
           env = described_class.send(:build_corepack_env_variables)
           # Can still extract registry from .npmrc even without credentials
           expect(env).not_to be_nil
-          expect(env["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
+          expect(env["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
         end
       end
 
@@ -576,7 +575,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
 
           # Returns env based on .npmrc content since credential doesn't replace base
           expect(env).not_to be_nil
-          expect(env["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
+          expect(env["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
         end
       end
 
@@ -596,8 +595,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
           env = described_class.send(:build_corepack_env_variables)
 
           expect(env).not_to be_nil
-          expect(env["COREPACK_NPM_REGISTRY"]).to eq("https://custom.registry.com")
-          expect(env["COREPACK_NPM_TOKEN"]).to be_nil
+          expect(env["npm_config_registry"]).to eq("https://custom.registry.com")
         end
       end
     end
@@ -609,8 +607,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         # Stub build_corepack_env_variables to return known values
         allow(described_class).to receive(:build_corepack_env_variables).and_return(
           {
-            "COREPACK_NPM_REGISTRY" => "https://test.registry.com",
-            "COREPACK_NPM_TOKEN" => "test-token"
+            "npm_config_registry" => "https://test.registry.com"
           }
         )
 
@@ -618,8 +615,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
 
         expect(merged["PATH"]).to eq("/usr/bin")
         expect(merged["NODE_ENV"]).to eq("test")
-        expect(merged["COREPACK_NPM_REGISTRY"]).to eq("https://test.registry.com")
-        expect(merged["COREPACK_NPM_TOKEN"]).to eq("test-token")
+        expect(merged["npm_config_registry"]).to eq("https://test.registry.com")
       end
 
       it "returns original env when corepack env is nil" do
@@ -644,8 +640,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
 
       it "returns corepack env when original env is nil" do
         corepack_env = {
-          "COREPACK_NPM_REGISTRY" => "https://test.registry.com",
-          "COREPACK_NPM_TOKEN" => "test-token"
+          "npm_config_registry" => "https://test.registry.com"
         }
 
         allow(described_class).to receive(:build_corepack_env_variables).and_return(corepack_env)
@@ -656,15 +651,15 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       end
 
       it "prefers provided env over corepack env for duplicate keys" do
-        original_env = { "COREPACK_NPM_TOKEN" => "override-token" }
+        original_env = { "npm_config_registry" => "https://override.registry.com" }
 
         allow(described_class).to receive(:build_corepack_env_variables).and_return(
-          { "COREPACK_NPM_TOKEN" => "default-token" }
+          { "npm_config_registry" => "https://default.registry.com" }
         )
 
         merged = described_class.send(:merge_corepack_env, original_env)
 
-        expect(merged["COREPACK_NPM_TOKEN"]).to eq("override-token")
+        expect(merged["npm_config_registry"]).to eq("https://override.registry.com")
       end
     end
 
@@ -672,8 +667,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       it "automatically injects corepack env variables with only registry" do
         expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_cmd, options|
           expect(options[:env]).not_to be_nil
-          expect(options[:env]["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
-          expect(options[:env]["COREPACK_NPM_TOKEN"]).to be_nil
+          expect(options[:env]["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
           ""
         end
 
@@ -683,7 +677,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       it "preserves manually provided env variables" do
         expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_cmd, options|
           expect(options[:env]["CUSTOM_VAR"]).to eq("custom-value")
-          expect(options[:env]["COREPACK_NPM_REGISTRY"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
+          expect(options[:env]["npm_config_registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/npm-virtual")
           ""
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com/"
+          "npm_config_registry" => "https://custom-registry.com/"
         )
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, credentials)
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://artifactory.example.com/npm"
+          "npm_config_registry" => "https://artifactory.example.com/npm"
         )
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com/"
+          "npm_config_registry" => "https://custom-registry.com/"
         )
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com/"
+          "npm_config_registry" => "https://yarn-registry.com/"
         )
       end
     end
@@ -142,7 +142,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com/"
+          "npm_config_registry" => "https://yarn-registry.com/"
         )
       end
     end
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com/"
+          "npm_config_registry" => "https://yarnrc-yml-registry.com/"
         )
       end
     end
@@ -166,7 +166,7 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com/"
+          "npm_config_registry" => "https://yarnrc-yml-registry.com/"
         )
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

The environment variable `COREPACK_NPM_REGISTRY` is not recognized by npm. `npm` uses `npm_config_registry` to override the registry configuration.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

**Issue Reproduction:**
I successfully reproduced the problem where `npm` was incorrectly accessing the public registry instead of the configured `private JFrog Artifactory registry`:
```
updater | 2026/01/08 15:11:00 INFO Process PID: 4883 completed with status: pid 4883 exit 0
updater | 2026/01/08 15:11:00 INFO Total execution time: 0.0 seconds
updater | 2026/01/08 15:11:00 INFO Started process PID: 4885 with command: {"COREPACK_NPM_REGISTRY" => "https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/", "registry" => "https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/"} corepack npm install lodash@4.17.2 --force --ignore-scripts --package-lock-only {}
  proxy | 2026/01/08 15:11:00 [017] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/01/08 15:11:00 [017] 200 https://registry.npmjs.org:443/lodash
updater | 2026/01/08 15:11:00 INFO Process PID: 4885 completed with status: pid 4885 exit 0
updater | 2026/01/08 15:11:00 INFO Total execution time: 0.86 seconds
```

**Fix Verification:**
After updating the environment variable to `npm_config_registry` (the correct `npm` configuration variable), npm now properly respects the private registry configuration:
```
updater | 2026/01/08 15:13:40 INFO Started process PID: 4887 with command: {"npm_config_registry" => "https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/", "registry" => "https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/"} corepack npm install lodash@4.17.2 --force --ignore-scripts --package-lock-only {}
updater | 2026/01/08 15:13:41 INFO Process PID: 4887 completed with status: pid 4887 exit 0
updater | 2026/01/08 15:13:41 INFO Total execution time: 0.74 seconds
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
