### PR TITLE
feat(13926): use npm version shipped with nodejs

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -13,15 +13,10 @@ ARG PNPM_VERSION=10.16.0
 ARG YARN_VERSION=4.9.2
 
 # See https://github.com/nodesource/distributions#installation-instructions
-# Always update NODEJS_VERSION with a compatible NPM_VERSION
 # See https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch for more information
 # Note : Always use the Active LTS version
+# npm will use the default version that ships with Node.js
 ARG NODEJS_VERSION=24
-
-# Check for updates at https://github.com/npm/cli/releases
-# This version should be compatible with the NODEJS_VERSION version declared above. See https://nodejs.org/en/download/releases as well
-# With every major release update, also update npm_and_yarn/lib/dependabot/npm_and_yarn/npm_package_manager.rb (Section : Update instructions)
-ARG NPM_VERSION=11.7.0
 
 # Install Node and npm
 RUN mkdir -p /etc/apt/keyrings \
@@ -39,8 +34,8 @@ USER dependabot
 RUN <<EOF
   corepack install pnpm@$PNPM_VERSION --global
   corepack install yarn@$YARN_VERSION --global
-  corepack install npm@$NPM_VERSION --global
-  # Pre-cache popular older versions of npm for on-demand activation
+  # npm will use the default version that ships with Node.js
+  # Pre-cache popular older versions of npm for on-demand activation if needed
   corepack install -g --cache-only npm@10 npm@9 npm@8
 EOF
 


### PR DESCRIPTION
### What are you trying to accomplish?

- use default npm version that is shipped with nodejs (24)
- see https://github.com/dependabot/dependabot-core/issues/13926
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
