### PR TITLE
Replace `CGI.parse` with `URI.decode_www_form` for Ruby 4.0 compatibility

### DIFF
--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "cgi"
 require "excon"
 require "nokogiri"
 require "open3"
@@ -314,7 +313,7 @@ module Dependabot
           type: "git",
           url: git_url,
           branch: nil,
-          ref: CGI.parse(querystr.to_s)["ref"].first&.split(%r{(?<!:)//})&.first
+          ref: URI.decode_www_form(querystr.to_s).to_h["ref"]&.split(%r{(?<!:)//})&.first
         }
       end
 

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "cgi"
 require "excon"
 require "nokogiri"
 require "open3"
@@ -309,7 +308,7 @@ module Dependabot
           type: "git",
           url: git_url,
           branch: nil,
-          ref: CGI.parse(querystr.to_s)["ref"].first&.split(%r{(?<!:)//})&.first
+          ref: URI.decode_www_form(querystr.to_s).to_h["ref"]&.split(%r{(?<!:)//})&.first
         }
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Ruby 4.0 retires the CGI library ([Feature #21258](https://bugs.ruby-lang.org/issues/21258)), removing most CGI functionality including `CGI.parse` while keeping only the escape/unescape methods in `cgi/escape`.

This PR replaces usage of `CGI.parse` with `URI.decode_www_form.to_h` in preparation for Ruby 4.0 compatibility. The `URI` module is part of Ruby's standard library and provides equivalent functionality for parsing query strings.

**Files changed:**
- `terraform/lib/dependabot/terraform/file_parser.rb`
- `opentofu/lib/dependabot/opentofu/file_parser.rb`

### Anything you want to highlight for special attention from reviewers?

`CGI.parse` returns values as arrays (e.g., `{"ref" => ["v1.0.0"]}`), while `URI.decode_www_form(...).to_h` returns scalar values (e.g., `{"ref" => "v1.0.0"}`).

Since the original code used `.first` to extract the first element from the array, and query strings in Terraform/OpenTofu modules typically only have a single value per key, the `.first` accessor was removed and the behavior remains equivalent.

This is a forward-compatible change that works with both Ruby 3.x and Ruby 4.0.

### How will you know you've accomplished your goal?

- The terraform and opentofu test suites pass
- The code no longer depends on `CGI.parse`, which is removed in Ruby 4.0

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.