### PR TITLE
Fix git-lfs installation by using Ubuntu repositories

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -63,21 +63,10 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     # needed to run add-apt-repository
     software-properties-common \
-    # Used to download the git-lfs GPG key as well as dev dependencies for CI
+    # Used to download dev dependencies for CI
     curl \
     # Add git core ppa to get a more recent git version than the one provided by ubuntu
     && add-apt-repository -y ppa:git-core/ppa \
-    # Install the git-lfs mirror. See https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md
-    # We need this because the version of git-lfs provided by Ubuntu is outdated
-    # apt-transport-https is a temporary dependency to install the git-lfs apt source
-    && apt-get install -y --no-install-recommends apt-transport-https \
-    && mkdir -p /etc/apt/keyrings \
-           && curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg \
-           && release=$( . /etc/os-release && echo "$VERSION_CODENAME" ) \
-           && echo "deb [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ $release main" \
-              > /etc/apt/sources.list.d/github_git-lfs.list \
-           && echo "deb-src [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ $release main" \
-              >> /etc/apt/sources.list.d/github_git-lfs.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     # dev dependencies for CI
@@ -89,6 +78,7 @@ RUN apt-get update \
     zstd \
     # VCS section
     git \
+    # Install git-lfs from Ubuntu repos (packagecloud.io is blocking access)
     git-lfs \
     bzr \
     mercurial \
@@ -104,8 +94,8 @@ RUN apt-get update \
     libyaml-dev \
     locales \
   && locale-gen en_US.UTF-8 \
-  # No longer needed post git-core ppa addition and git-lfs install
-  && apt purge software-properties-common apt-transport-https -y && apt-get autoremove -y \
+  # No longer needed post git-core ppa addition
+  && apt purge software-properties-common -y && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 ARG USER_UID=1000


### PR DESCRIPTION
### What are you trying to accomplish?

`packagecloud.io` returns 403 Forbidden, breaking `script/build python` builds. Install `git-lfs` from Ubuntu repos instead to avoid the external dependency.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Before this change, `script/build python` fails with a 403 Forbidden error from packagecloud.io. After this change, the Docker image builds successfully without errors.


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
