### PR TITLE
Fix pnpm lockfileVersion 9.0 parsing error with optional chaining

### DIFF
--- a/bun/helpers/lib/pnpm/lockfile-parser.js
+++ b/bun/helpers/lib/pnpm/lockfile-parser.js
@@ -72,7 +72,7 @@ function nameVerDevFromPkgSnapshot(depPath, pkgSnapshot, projectSnapshots) {
   return {
     name: name,
     version: version,
-    resolved: pkgSnapshot.resolution.tarball,
+    resolved: pkgSnapshot.resolution?.tarball,
     dev: pkgSnapshot.dev,
     specifiers: specifiers,
     aliased: aliased

--- a/bun/helpers/test/pnpm/fixtures/parser/lockfile_v9/pnpm-lock.yaml
+++ b/bun/helpers/test/pnpm/fixtures/parser/lockfile_v9/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      etag:
+        specifier: ^1.0.0
+        version: 1.8.1
+
+packages:
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+snapshots:
+
+  etag@1.8.1: {}

--- a/bun/helpers/test/pnpm/lockfile-parser.test.js
+++ b/bun/helpers/test/pnpm/lockfile-parser.test.js
@@ -59,4 +59,21 @@ describe("generates an updated pnpm lock for the original file", () => {
         expect(result.length).toEqual(9);
     })
 
+    // pnpm v9+ lockfiles don't have resolution.tarball for npm packages
+    it("that uses lockfileVersion 9.0 format without resolution.tarball", async () =>{
+        copyDependencies("lockfile_v9", tempDir);
+        const result = await parseLockfile(tempDir);
+
+        expect(result).toEqual([
+            {
+                name: 'etag',
+                version: '1.8.1',
+                resolved: undefined,
+                dev: undefined,
+                specifiers: [ '^1.0.0' ],
+                aliased: false
+            }
+        ]);
+    })
+
 })


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes the `dependency_file_not_parseable` error that occurs when parsing pnpm lockfiles with `lockfileVersion: 9.0` (pnpm v10+).

The issue is that pnpm v9+ lockfiles have a fundamentally different structure where the `resolution.tarball` field is no longer present for regular npm packages - only for non-npm sources (git, GitHub tarballs). The code was crashing when trying to access `pkgSnapshot.resolution.tarball` without optional chaining.

**Why:** Users with pnpm v10+ were unable to use Dependabot at all due to this parsing error.

Fixes #13920

### Anything you want to highlight for special attention from reviewers?

The fix uses optional chaining (`pkgSnapshot.resolution?.tarball`) to safely access the tarball field, returning `undefined` when it doesn't exist. 

**Impact of `resolved: undefined` for v9+ lockfiles:**

| Scenario | Impact | Mitigation |
|----------|--------|------------|
| Public npm packages | ✅ Low | Falls back to `registry.npmjs.org` |
| Git dependencies | ✅ Low | Version field contains commit SHA as fallback |
| Private registries (configured in .npmrc) | ✅ Low | Explicit config takes precedence |
| Private registries (NOT in .npmrc) | ⚠️ Medium | May fail to detect correct registry |

Users with private registries should ensure explicit `.npmrc` configuration with scoped registry entries.

### How will you know you've accomplished your goal?

- The parsing error no longer occurs for pnpm v9+ lockfiles
- Existing tests continue to pass (the `npm_and_yarn` helper tests already expect `resolved: undefined` for many cases)
- Users can successfully run Dependabot on repositories using pnpm v10+

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.