### PR TITLE
Fix Sorbet error when caret requirement has all zero segments

### DIFF
--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -400,7 +400,7 @@ module Dependabot
           version = req.requirements.first.last.release
 
           if req_string.strip.start_with?("^")
-            version.segments.index { |i| i != 0 }
+            version.segments.index { |i| i != 0 } || (version.segments.count - 1)
           elsif req_string.include?("*")
             version.segments.count - 1
           elsif req_string.strip.start_with?("~=", "==")

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -781,6 +781,13 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
                 its([:requirement]) { is_expected.to eq(">=0.0.3,<0.0.6") }
               end
 
+              context "when the version is all zeros" do
+                let(:pyproject_req_string) { "^0.0.0" }
+                let(:latest_resolvable_version) { "0.0.2" }
+
+                its([:requirement]) { is_expected.to eq(">=0.0.0,<0.0.3") }
+              end
+
               context "when dealing with a development dependency" do
                 let(:groups) { ["dev-dependencies"] }
 


### PR DESCRIPTION
## Summary

Fixes a Sorbet runtime error when processing caret requirements where all version segments are zero (e.g., `^0.0.0`).

## Problem

When a caret requirement like `^0.0.0` is used, the `index_to_update_for` method returns `nil` because `version.segments.index { |i| i != 0 }` finds no non-zero segments. This violates the method's return type signature of `Integer`, causing the error:

```
Dependabot::Sorbet::Runtime::InformationalError: Return value: Expected type Integer, got type NilClass
Caller: /home/dependabot/python/lib/dependabot/python/update_checker/requirements_updater.rb:369
Definition: /home/dependabot/python/lib/dependabot/python/update_checker/requirements_updater.rb:398
```

## Solution

Added a fallback to use the last segment index (`segments.count - 1`) when all segments are zero, matching the behavior in the composer ecosystem.

The fix changes:
```ruby
version.segments.index { |i| i != 0 }
```
to:
```ruby
version.segments.index { |i| i != 0 } || (version.segments.count - 1)
```

This ensures that for `^0.0.0`, the patch version (last segment) is used as the index to update, producing the expected range `>=0.0.0,<0.0.3` when updating to version `0.0.2`.

## Testing

Added a test case to verify the fix for `^0.0.0` requirements.