### PR TITLE
Generate uv.lock using all project files

### DIFF
--- a/uv/lib/dependabot/uv/file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater.rb
@@ -64,7 +64,8 @@ module Dependabot
           dependencies: dependencies,
           dependency_files: dependency_files,
           credentials: credentials,
-          index_urls: pip_compile_index_urls
+          index_urls: pip_compile_index_urls,
+          repo_contents_path: repo_contents_path
         ).updated_dependency_files
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Previously, the UV lockfile updater only pulled in specific files it thought were needed to regenerate the lock file. This caused failures when projects had workspace members, local path dependencies, or other project files that UV needs during resolution.

This change uses `in_a_temporary_repo_directory` with `repo_contents_path` to copy the entire repository contents when regenerating the lock file, ensuring UV has access to all project files it needs.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The `repo_contents_path` parameter is now passed through to `updated_lockfile_content_for` and used with `SharedHelpers.in_a_temporary_repo_directory` to ensure the full project context is available during lock file regeneration.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

UV lock regeneration now works for projects with workspaces and local dependencies

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
