### PR TITLE
honor ranges in transitive pinning

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -261,6 +261,48 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
+    public async Task SingleDependency_CentralPackageManagement_RangeContainsNewVersion()
+    {
+        // in this scenario, a prior pass updated `[1.0.0]` to `[1.1.0]` for a direct dependency and now in a higher
+        // level project we need to ensure the version matches when pinning a transitive dependency
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Dependency" Version="[1.1.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Dependency" Version="[1.1.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ]
+        );
+    }
+
+    [Fact]
     public async Task SingleDependency_SingleFile_AttributeDirectUpdate_ExactMatchVersionRangeFromPropertyValue()
     {
         await TestAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -257,8 +257,8 @@ public class XmlFileWriter : IFileWriter
                     var (matchingPackageVersionElement, filePath) = matchingPackageVersionElementsAndPaths.First();
                     var versionAttribute = matchingPackageVersionElement.GetAttributeCaseInsensitive(VersionMetadataName);
                     if (versionAttribute is not null &&
-                        NuGetVersion.TryParse(versionAttribute.Value, out var existingVersion) &&
-                        existingVersion == requiredVersion)
+                        VersionRange.TryParse(versionAttribute.Value, out var existingVersionRange) &&
+                        existingVersionRange.MinVersion == requiredVersion)
                     {
                         // version matches; no update needed
                         _logger.Info($"Dependency {requiredPackageVersion.Name} already set to {requiredVersion}; no override needed.");


### PR DESCRIPTION
Packages are updated bottom-up and if the lowest project had a direct reference on a package with a range, the subsequent projects were unable to determine that the range was already updated and incorrectly added a `VersionOverride` attribute.

This fixes that by updating the existing version check from a static version to a range and checks the minimum version.