### PR TITLE
fix(bundler): support multiple requirements in required_ruby_version eval

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -92,7 +92,12 @@ module Dependabot
           return unless requirement_node
 
           begin
-            eval(requirement_node.children[2].loc.expression.source)
+            dependency_requirement_node = requirement_node.children[2]
+            if dependency_requirement_node.type == :array
+              dependency_requirement_node.children.map { |child| eval(child.loc.expression.source) }
+            else
+              eval(dependency_requirement_node.loc.expression.source)
+            end
           rescue StandardError
             nil # If we can't evaluate the expression just return nil
           end

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         it { is_expected.to include(%(gem "statesman", "~> 1.2.0")) }
       end
 
+      context "with a required ruby version range multiple requirements" do
+        let(:gemspec) do
+          bundler_project_dependency_file(
+            "gemspec_required_ruby_version_multiple_requirements",
+            filename: "example.gemspec"
+          )
+        end
+        let(:content) do
+          bundler_project_dependency_file(
+            "gemspec_required_ruby_version_multiple_requirements",
+            filename: "Gemfile"
+          ).content
+        end
+
+        it { is_expected.to include("ruby '3.0.6'\n") }
+        it { is_expected.to include(%(gem "statesman", "~> 1.2.0")) }
+      end
+
       context "with a required ruby version requirement class" do
         let(:gemspec) do
           bundler_project_dependency_file(

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_multiple_requirements/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_multiple_requirements/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_multiple_requirements/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_multiple_requirements/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = '>= 3.0', '< 3.2'
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end


### PR DESCRIPTION

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->
#### What
Handle required_ruby_version in gemspec when multiple version constraints are specified with comma-separated arguments (without array brackets).


#### Why

<!-- What issues does this affect or fix? -->
Fixes https://github.com/dependabot/dependabot-core/issues/13848

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

The bracket-less syntax '>= 3.0', '< 4' is also parsed as an :array node, just like the explicit bracket syntax ['>= 3.0', '< 4']. The original code called eval on the entire source expression of the node, which works for a single :str node but fails for an :array node — eval("'>= 3.0', '< 4'") raises a SyntaxError because a comma-separated expression without an assignment target is not valid Ruby. The fix detects the :array type and evaluates each child node individually.

### How will you know you've accomplished your goal?

- Existing tests for single-argument, range and bracket-array required_ruby_version continue to pass
- New test for bracket-less comma-separated required_ruby_version (e.g. '>= 3.0', '< 3.2') passes and resolves to the correct Ruby version
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
