### PR TITLE
Consider JRE/JDK suffixes and semantics for Maven/Gradle

### DIFF
--- a/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
@@ -399,6 +399,73 @@ RSpec.describe Dependabot::Maven::Shared::SharedVersionFinder do
             it { is_expected.to be true }
           end
         end
+
+        describe "when JRE/JDK version qualifiers are used" do
+          context "when both versions are identical JREs" do
+            let(:dependency_version) { "13.2.1.jre8" }
+            let(:comparison_version) { "13.2.1.jre8" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when both versions are identical JREs(case insensitive)" do
+            let(:dependency_version) { "13.2.1.JRE8" }
+            let(:comparison_version) { "13.2.1.jre8" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when both versions are identical JDKs" do
+            let(:dependency_version) { "1.0.0-jdk11" }
+            let(:comparison_version) { "1.0.0-jdk11" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when upgrading from JRE to JDK (same major version)" do
+            let(:dependency_version) { "2.1.0.jre11" }
+            let(:comparison_version) { "2.1.0.jdk11" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when downgrading from JDK to JRE (forbidden capability loss)" do
+            # This would remove the compiler/tools from a library that might need them
+            let(:dependency_version) { "2.1.0.jdk11" }
+            let(:comparison_version) { "2.1.0.jre11" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when the Java major versions do not match" do
+            # Even if both are JREs, the java version mismatch is a failure
+            let(:dependency_version) { "13.2.1.jre8" }
+            let(:comparison_version) { "13.2.1.jre11" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when the comparison version is missing a suffix" do
+            let(:dependency_version) { "13.2.1.jre8" }
+            let(:comparison_version) { "13.2.1" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when the current version is missing the suffix" do
+            let(:dependency_version) { "13.2.1" }
+            let(:comparison_version) { "13.2.1-jre" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when using vendor-specific version strings (e.g., Guava style)" do
+            let(:dependency_version) { "33.0.0-jre" }
+            let(:comparison_version) { "33.0.0-jre" }
+
+            it { is_expected.to be true }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This change improves version compatibility checks for Maven and Gradle by taking JRE/JDK-specific suffixes into account when selecting versions.

Previously, version selection logic ignored JRE/JDK suffixes (e.g., `-jdk8`, `-jre11`), which could lead to selecting incompatible versions 

Fixes https://github.com/dependabot/dependabot-core/issues/13911

### How will you know you've accomplished your goal?

- The existing and new unit tests pass
- I was able to reproduce and confirm the defect and fix running the E2E test documented in #13911

Before: 

<img width="1289" height="134" alt="image" src="https://github.com/user-attachments/assets/cafcd294-7bca-4589-9802-5a7a4a432d76" />


After: 

<img width="1225" height="186" alt="image" src="https://github.com/user-attachments/assets/806c57ab-b3ba-4ed5-9a1f-b3a8ab5b644d" />


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
