### PR TITLE
Set executable flag only for Unix version of the gradle wrapper

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -188,11 +188,12 @@ module Dependabot
           file = fetch_file_if_present(File.join(dir, filename))
           next unless file
 
-          if file.name.end_with?(".jar")
+          if File.basename(file.name) == "gradle-wrapper.jar"
             file.content = Base64.encode64(T.must(file.content)) if file.content
             file.content_encoding = DependencyFile::ContentEncoding::BASE64
           end
-          file.mode = DependencyFile::Mode::EXECUTABLE if file.name.end_with?("gradlew", "gradlew.bat")
+
+          file.mode = DependencyFile::Mode::EXECUTABLE if File.basename(file.name) == "gradlew"
           file
         rescue Dependabot::DependencyFileNotFound
           # Gradle itself doesn't worry about missing subprojects, so we don't


### PR DESCRIPTION
### What are you trying to accomplish?

As discussed in #14051, setting this flag does not make sense on Windows

Fixes #14051



### How will you know you've accomplished your goal?

- The existing tests pass

Smoke tests update: https://github.com/dependabot/smoke-tests/pull/368

Full suite running and passing(from my fork): https://github.com/yeikel/dependabot-core/actions/runs/21519219887/job/62005526856?pr=236

- This flag is no longer present for windows binaries

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
