### PR TITLE
Bump to Ubuntu 25.04 base image

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM docker.io/library/ubuntu:24.04
+FROM docker.io/library/ubuntu:25.04
 
 ARG TARGETARCH
 


### PR DESCRIPTION
I'm pretty doubtful this will work, but opening to see what CI says... 

We do have the swift image pinned to installing swift from a 24.04 build... I couldn't bump that because Swift doesn't offer a 25.04 build. Similarly, our devcontainer.json doesn't have a 25.04 build and probably won't. Those will likely wait til 26.04 lands in April.

But maybe things will still work with 25.04 as the base image??

The downside is that `25.04` is EOL'd as of January, so we'd have Feb/March/April of unsupported til we hit `26.04`...

This may be too big of a security/instability risk, in which case we'll need to wait on this til April and jump straight to 26.04.

* Fix: https://github.com/dependabot/dependabot-core/issues/13433