### PR TITLE
Upgrade Node.js version to 22 in `devcontainers/Dockerfile`

### DIFF
--- a/devcontainers/Dockerfile
+++ b/devcontainers/Dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update \
     curl \
   && mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-  && NODE_MAJOR=18 \
+  && NODE_MAJOR=22 \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update -y \
-  && apt-get install -y nodejs \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g @devcontainers/cli
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g @devcontainers/cli \
+  && rm -rf ~/.npm
 
 USER dependabot
 


### PR DESCRIPTION
v20 and 22 are the current LTS versions.

So let's go to v22.

I also:

* Added `--no-install-recommends`
* Restructured so that the `npm` install command happens within the nodejs install. This isn't strictly necessary, but that was breaking when i was experimenting with bumping to Ubuntu 25.04... so it makes sense to do it here. Plus it's one less docker layer to pull from the docker registry.

This should help unblock:
* https://github.com/dependabot/dependabot-core/pull/14061
* https://github.com/dependabot/dependabot-core/issues/13433