### PR TITLE
Add branch name prefix to PR titles for non-default branches

### DIFF
--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -847,6 +847,74 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
     end
 
+    context "when targeting a non-default branch" do
+      let(:builder) do
+        described_class.new(
+          source: source,
+          dependencies: dependencies,
+          files: files,
+          credentials: credentials,
+          pr_message_header: pr_message_header,
+          pr_message_footer: pr_message_footer,
+          commit_message_options: commit_message_options,
+          vulnerabilities_fixed: vulnerabilities_fixed,
+          github_redirection_service: github_redirection_service,
+          dependency_group: dependency_group,
+          ignore_conditions: ignore_conditions,
+          notices: notices,
+          target_branch: "develop",
+          default_branch: "main"
+        )
+      end
+
+      before do
+        stub_request(:get, watched_repo_url + "/commits?per_page=100")
+          .to_return(
+            status: 200,
+            body: fixture("github", "commits.json"),
+            headers: json_header
+          )
+      end
+
+      it "prefixes the PR name with the target branch" do
+        expect(pr_name).to eq("[develop] Bump business from 1.4.0 to 1.5.0")
+      end
+    end
+
+    context "when targeting the default branch" do
+      let(:builder) do
+        described_class.new(
+          source: source,
+          dependencies: dependencies,
+          files: files,
+          credentials: credentials,
+          pr_message_header: pr_message_header,
+          pr_message_footer: pr_message_footer,
+          commit_message_options: commit_message_options,
+          vulnerabilities_fixed: vulnerabilities_fixed,
+          github_redirection_service: github_redirection_service,
+          dependency_group: dependency_group,
+          ignore_conditions: ignore_conditions,
+          notices: notices,
+          target_branch: "main",
+          default_branch: "main"
+        )
+      end
+
+      before do
+        stub_request(:get, watched_repo_url + "/commits?per_page=100")
+          .to_return(
+            status: 200,
+            body: fixture("github", "commits.json"),
+            headers: json_header
+          )
+      end
+
+      it "does not prefix the PR name when targeting default branch" do
+        expect(pr_name).to eq("Bump business from 1.4.0 to 1.5.0")
+      end
+    end
+
     context "when dealing with a dependency group with one dependency" do
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })


### PR DESCRIPTION
### What are you trying to accomplish?

When creating a PR that targets a non-default branch, prefix the PR title with [branch-name] to make it clear which branch is being updated.

This helps distinguish PRs targeting feature branches, release branches, or other non-default branches from regular dependency updates.

Example: `[develop] Bump business from 1.4.0 to 1.5.0`

Changes:
- Add target_branch and default_branch parameters to MessageBuilder
- Add branch_name_prefix method to generate prefix when needed
- Add fetch_default_branch method to PullRequestCreator
- Add tests for branch prefix behavior


### Anything you want to highlight for special attention from reviewers?

Should it be opt-out?

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
