### PR TITLE
Add digest pinning for Docker images

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -14,6 +14,7 @@ require "dependabot/docker/requirement"
 require "dependabot/shared/utils/credentials_finder"
 require "dependabot/package/release_cooldown_options"
 require "dependabot/package/package_release"
+require "dependabot/experiments"
 
 module Dependabot
   module Docker
@@ -49,7 +50,7 @@ module Dependabot
           if tag
             updated_tag = latest_version_from(tag)
             updated_source[:tag] = updated_tag
-            updated_source[:digest] = digest_of(updated_tag) if digest
+            updated_source[:digest] = digest_of(updated_tag) if digest || pin_digests?
           elsif digest
             updated_source[:digest] = digest_of("latest")
           end
@@ -663,6 +664,11 @@ module Dependabot
       sig { returns(T::Boolean) }
       def cooldown_enabled?
         true
+      end
+
+      sig { returns(T::Boolean) }
+      def pin_digests?
+        Dependabot::Experiments.enabled?(:docker_pin_digests)
       end
 
       sig do

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -66,6 +66,9 @@ module Dependabot
         updated_content
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/MethodLength
       sig do
         params(
           previous_content: String,
@@ -73,7 +76,7 @@ module Dependabot
           new_source: T::Hash[Symbol, T.nilable(String)]
         ).returns(String)
       end
-      def update_digest_and_tag(previous_content, old_source, new_source) # rubocop:disable Metrics/PerceivedComplexity
+      def update_digest_and_tag(previous_content, old_source, new_source)
         old_digest = old_source[:digest]
         new_digest = new_source[:digest]
 
@@ -115,9 +118,16 @@ module Dependabot
 
           old_dec = old_dec.gsub(":#{old_tag}", ":#{new_tag}") unless old_tag.to_s.empty?
 
+          # Adding a digest to a tag-only image (digest pinning)
+          old_dec = "#{old_dec}@sha256:#{new_digest}" if old_digest.to_s.empty? && !new_digest.to_s.empty?
+
           old_dec
         end
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
+
       sig { params(escaped_declaration: String).returns(Regexp) }
       def build_old_declaration_regex(escaped_declaration)
         %r{^#{FROM_REGEX}\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)}


### PR DESCRIPTION
### What are you trying to accomplish?

Docker tags are mutable. If someone compromises a registry, they can swap out the image contents without changing the tag. Digests prevent this because they're content-addressed.

Right now, Dependabot only updates digests if you already have one:

```dockerfile
# Before
FROM ubuntu:22.04@sha256:abc123...
# After  
FROM ubuntu:24.04@sha256:def456...
```

But if you start with just a tag, you get just a tag back:

```dockerfile
# Before
FROM ubuntu:22.04
# After
FROM ubuntu:24.04
```

This PR adds an experiment flag (`docker_pin_digests`) that makes Dependabot add digests to tag-only images. When enabled:

```dockerfile
# Before
FROM ubuntu:22.04
# After
FROM ubuntu:24.04@sha256:def456...
```

Fixes #14065

### Anything you want to highlight for special attention from reviewers?

The code already knows how to fetch digests. `UpdateChecker#digest_of(tag)` does exactly this. The change is small:

1. `updated_requirements` now calls `digest_of(updated_tag)` when `pin_digests?` returns true (not just when there's an existing digest)
2. `SharedFileUpdater#update_digest_and_tag` appends `@sha256:...` when the old image had no digest but the new one does

I put it behind an experiment flag because it changes behavior for everyone using Docker.

### How will you know you've accomplished your goal?

Added tests for:
- `UpdateChecker#updated_requirements` returns a digest for tag-only images when the flag is on
- `UpdateChecker#updated_requirements` returns no digest when the flag is off (existing behavior)
- `FileUpdater` correctly appends `@sha256:...` to Dockerfiles
- `FileUpdater` correctly appends `@sha256:...` to YAML files (Kubernetes, Helm)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.