### PR TITLE
Preserve file mode when updating pull requests

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -207,7 +207,7 @@ module Dependabot
 
             {
               path: file.realpath,
-              mode: Dependabot::DependencyFile::Mode::FILE,
+              mode: file.mode || Dependabot::DependencyFile::Mode::FILE,
               type: "blob"
             }.merge(content)
           end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14027 - Gradle wrapper permissions are downgraded during upgrade.

When updating pull requests (during `@dependabot rebase` or `@dependabot recreate` operations), the executable file mode (100755) was being lost and replaced with the regular file mode (100644). This caused gradlew files to lose their executable permissions, breaking builds.

**Root Cause:** In `PullRequestUpdater::Github#create_tree`, the file mode was hardcoded as `Mode::FILE` (100644), ignoring the actual file's mode attribute. Meanwhile, `PullRequestCreator::Github` correctly used `file.mode || Mode::FILE`.

### Anything you want to highlight for special attention from reviewers?

The fix is a one-line change that mirrors the existing pattern in `PullRequestCreator::Github`:

```ruby
# Before (always used 100644):
mode: Dependabot::DependencyFile::Mode::FILE,

# After (respects file.mode, falls back to 100644):
mode: file.mode || Dependabot::DependencyFile::Mode::FILE,
```

### How will you know you've accomplished your goal?

- Added a new test case that verifies executable files (like gradlew) preserve their 100755 mode when pushing commits to GitHub during PR updates
- The test fails without the fix (demonstrates the bug) and passes with the fix

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Fixes #14027
