### PR TITLE
improve project discovery merging

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1745,4 +1745,96 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         };
         AssertEx.Equal(expectedEntryPoints, actualEntryPoints);
     }
+
+    [Fact]
+    public void MergeProjectDiscovery()
+    {
+        // project discovery is frequently merged with prior results (e.g., `packages.config` followed by `<PackageReference>`)
+        // some of the groups getting merged are unlikely to happen in the wild, but it's still interesting just in case it shows up, e.g.,
+        // consider a hybrid project where one set of dependencies exists only in packages.config and another set only in PackageReference
+        var result1 = new ProjectDiscoveryResult()
+        {
+            FilePath = "src/project.csproj",
+            Dependencies = [new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net9.0"], IsDirect: true)],
+            IsSuccess = true,
+            Error = null,
+            Properties = [new("PropertyA", "Uno", "src/project.csproj")],
+            TargetFrameworks = ["net8.0"],
+            ReferencedProjectPaths = ["referenced/a.csproj"],
+            ImportedFiles = ["imported/a.props"],
+            AdditionalFiles = ["a/packages.config"],
+            CentralPackageTransitivePinningEnabled = false,
+        };
+        var result2 = new ProjectDiscoveryResult()
+        {
+            FilePath = "src/project.csproj",
+            Dependencies = [
+                new("Package.A", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true), // duplicate package; latest wins
+                new("Package.B", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["net9.0"], IsDirect: false, IsTransitive: true)
+            ],
+            IsSuccess = true,
+            Error = null,
+            Properties = [new("PropertyB", "Dos", "src/project.csproj")],
+            TargetFrameworks = ["net9.0"],
+            ReferencedProjectPaths = ["referenced/b.csproj"],
+            ImportedFiles = ["imported/b.props"],
+            AdditionalFiles = ["b/app.config"],
+            CentralPackageTransitivePinningEnabled = true,
+        };
+
+        // to make sure we're checking everything exactly, we'll explicitly check each item
+        var merged = DiscoveryWorker.MergeProjectDiscovery(result1, result2);
+        Assert.Equal("src/project.csproj", merged.FilePath);
+        Assert.Equal(2, merged.Dependencies.Length);
+
+        Assert.Equal("Package.A", merged.Dependencies[0].Name);
+        Assert.Equal("2.0.0", merged.Dependencies[0].Version);
+        Assert.Equal(DependencyType.PackageReference, merged.Dependencies[0].Type);
+        Assert.True(merged.Dependencies[0].IsDirect);
+        Assert.False(merged.Dependencies[0].IsTransitive);
+        AssertEx.Equal(["net9.0"], merged.Dependencies[0].TargetFrameworks);
+
+        Assert.Equal("Package.B", merged.Dependencies[1].Name);
+        Assert.Equal("3.0.0", merged.Dependencies[1].Version);
+        Assert.Equal(DependencyType.Unknown, merged.Dependencies[1].Type);
+        Assert.False(merged.Dependencies[1].IsDirect);
+        Assert.True(merged.Dependencies[1].IsTransitive);
+        AssertEx.Equal(["net9.0"], merged.Dependencies[1].TargetFrameworks);
+
+        Assert.True(merged.IsSuccess);
+        Assert.Null(merged.Error);
+
+        AssertEx.Equal(
+            [
+                new("PropertyA", "Uno", "src/project.csproj"),
+                new("PropertyB", "Dos", "src/project.csproj"),
+            ],
+            merged.Properties);
+
+        AssertEx.Equal(["net8.0", "net9.0"], merged.TargetFrameworks);
+        AssertEx.Equal(["referenced/a.csproj", "referenced/b.csproj"], merged.ReferencedProjectPaths);
+        AssertEx.Equal(["imported/a.props", "imported/b.props"], merged.ImportedFiles);
+        AssertEx.Equal(["a/packages.config", "b/app.config"], merged.AdditionalFiles);
+        Assert.True(merged.CentralPackageTransitivePinningEnabled);
+    }
+
+    [Fact]
+    public void MergeProjectDiscovery_ThrowsOnNotMatchingPaths()
+    {
+        var result1 = new ProjectDiscoveryResult()
+        {
+            FilePath = "src/project1.csproj",
+            Dependencies = [],
+            ImportedFiles = [],
+            AdditionalFiles = [],
+        };
+        var result2 = new ProjectDiscoveryResult()
+        {
+            FilePath = "src/project2.csproj",
+            Dependencies = [],
+            ImportedFiles = [],
+            AdditionalFiles = [],
+        };
+        Assert.Throws<InvalidOperationException>(() => DiscoveryWorker.MergeProjectDiscovery(result1, result2));
+    }
 }


### PR DESCRIPTION
NuGet dependency discovery can run in different contexts and the results need to be merged.  Previously we made the incorrect assumption that this could only happen if `packages.config` discovery was merged with `PackageReference` discovery, but in a multi-layered solution we can merge `PackageReference` results with `PackageReference` so we need to maintain all discovery properties, not just a few.

This PR does that and also extracts the merging to a separate function to make testing easier.