### PR TITLE
report package as compatible if it contains no assemblies

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -114,10 +114,22 @@ internal static class CompatibilityChecker
             }
         }
 
-        var refItems = await readers.ContentReader.GetReferenceItemsAsync(cancellationToken);
+        var refItems = (await readers.ContentReader.GetReferenceItemsAsync(cancellationToken)).ToArray();
         foreach (var refItem in refItems)
         {
             tfms.Add(refItem.TargetFramework);
+        }
+
+        var libItems = (await readers.ContentReader.GetLibItemsAsync(cancellationToken)).ToArray();
+        foreach (var libItem in libItems)
+        {
+            tfms.Add(libItem.TargetFramework);
+        }
+
+        // if a package contains no assemblies that need to be referenced, we can consider it compatible with all frameworks
+        if (refItems.Length == 0 && libItems.Length == 0)
+        {
+            tfms.Clear();
         }
 
         if (!tfms.Any())


### PR DESCRIPTION
When determining NuGet package compatibility with the project's target framework, we previously assumed the dependency groups from the `.nuspec` were absolute, but a situation was found where a package says it has a dependency on .NET Framework 4.7.2, but this appears to only be a build-time dependency for some auto-injected tasks.  This specific package doesn't contain any build time or runtime references so it's technically allowed during a restore operation.

Normally this would be classified as a development dependency, but the `.nuspec` didn't explicitly state that, so this is a manual inference of that.

This PR checks for that specific scenario where if both the `ref/` and `lib/` directories are empty, assume the package _is_ compatible.