### PR TITLE
feat: add `semantic-versioning` option

### DIFF
--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -32,8 +32,14 @@ module Dependabot
         @exclude_paths = exclude_paths
       end
 
-      sig { params(dependency: Dependency, security_updates_only: T::Boolean).returns(T::Array[String]) }
-      def ignored_versions_for(dependency, security_updates_only: false)
+      sig do
+        params(
+          dependency: Dependency,
+          security_updates_only: T::Boolean,
+          semantic_versioning: String
+        ).returns(T::Array[String])
+      end
+      def ignored_versions_for(dependency, security_updates_only: false, semantic_versioning: "relaxed")
         normalizer = name_normaliser_for(dependency)
         dep_name = T.must(normalizer).call(dependency.name)
 
@@ -43,7 +49,7 @@ module Dependabot
 
         @ignore_conditions
           .select { |ic| self.class.wildcard_match?(T.must(normalizer).call(ic.dependency_name), dep_name) }
-          .map { |ic| ic.ignored_versions(dependency, security_updates_only) }
+          .map { |ic| ic.ignored_versions(dependency, security_updates_only, semantic_versioning: semantic_versioning) }
           .flatten
           .compact
           .uniq

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -74,6 +74,32 @@ module Dependabot
       "a"
     end
 
+    # Mode-aware methods that respect semantic-versioning option
+    # When semantic_versioning is "strict", 0.x versions are treated differently:
+    # - 0.0.z: any change is breaking (major)
+    # - 0.y.z: minor changes are breaking (major)
+
+    sig { params(semantic_versioning: String).returns(T::Array[String]) }
+    def ignored_patch_versions_for_mode(semantic_versioning = "relaxed")
+      return strict_ignored_patch_versions if semantic_versioning == "strict"
+
+      ignored_patch_versions
+    end
+
+    sig { params(semantic_versioning: String).returns(T::Array[String]) }
+    def ignored_minor_versions_for_mode(semantic_versioning = "relaxed")
+      return strict_ignored_minor_versions if semantic_versioning == "strict"
+
+      ignored_minor_versions
+    end
+
+    sig { params(semantic_versioning: String).returns(T::Array[String]) }
+    def ignored_major_versions_for_mode(semantic_versioning = "relaxed")
+      return strict_ignored_major_versions if semantic_versioning == "strict"
+
+      ignored_major_versions
+    end
+
     sig { returns(T.nilable([Integer, Integer, Integer])) }
     def semver_parts
       # Extracts only the numeric major.minor.patch part of the version, ensuring it starts with a number
@@ -85,6 +111,57 @@ module Dependabot
 
       major, minor, patch = first_match.split(".").map(&:to_i)
       [major || 0, minor || 0, patch || 0]
+    end
+
+    private
+
+    # Strict semver: for 0.0.z versions, patch changes are breaking
+    sig { returns(T::Array[String]) }
+    def strict_ignored_patch_versions
+      parts = to_semver.split(".")
+      major = parts[0].to_i
+      minor = parts[1].to_i
+
+      # For 0.0.z versions, patch changes are breaking, so treat as major
+      return strict_ignored_major_versions if major.zero? && minor.zero?
+
+      ignored_patch_versions
+    end
+
+    # Strict semver: for 0.y.z versions, minor changes are breaking
+    sig { returns(T::Array[String]) }
+    def strict_ignored_minor_versions
+      parts = to_semver.split(".")
+      major = parts[0].to_i
+
+      # For 0.y.z versions, minor changes are breaking, so treat as major
+      return strict_ignored_major_versions if major.zero?
+
+      ignored_minor_versions
+    end
+
+    # Strict semver: for 0.x versions, returns range starting from next breaking version
+    sig { returns(T::Array[String]) }
+    def strict_ignored_major_versions
+      parts = to_semver.split(".")
+      major = parts[0].to_i
+      minor = parts[1].to_i
+
+      # For 0.0.z versions, any patch change is breaking
+      if major.zero? && minor.zero?
+        patch = parts[2].to_i
+        lower_parts = [0, 0, patch + 1] + [lowest_prerelease_suffix]
+        return [">= #{lower_parts.join('.')}"]
+      end
+
+      # For 0.y.z versions (y > 0), minor changes are breaking
+      if major.zero?
+        lower_parts = [0, minor + 1] + [lowest_prerelease_suffix]
+        return [">= #{lower_parts.join('.')}"]
+      end
+
+      # For 1.y.z+ versions, use standard semantic versioning
+      ignored_major_versions
     end
   end
 end

--- a/common/spec/dependabot/version_spec.rb
+++ b/common/spec/dependabot/version_spec.rb
@@ -38,4 +38,139 @@ RSpec.describe Dependabot::Version do
 
     it { is_expected.to eq(["> #{version_string}, < 1.3"]) }
   end
+
+  describe "#ignored_patch_versions_for_mode" do
+    let(:version_string) { "0.2.3" }
+
+    context "with relaxed mode (default)" do
+      subject(:ignored_versions) { version.ignored_patch_versions_for_mode("relaxed") }
+
+      it "uses standard semver" do
+        expect(ignored_versions).to eq(["> 0.2.3, < 0.3"])
+      end
+    end
+
+    context "with strict mode" do
+      subject(:ignored_versions) { version.ignored_patch_versions_for_mode("strict") }
+
+      context "with 0.y.z versions (y > 0)" do
+        let(:version_string) { "0.2.3" }
+
+        it "uses standard semver for patch changes (patch is still patch)" do
+          expect(ignored_versions).to eq(["> 0.2.3, < 0.3"])
+        end
+      end
+
+      context "with 0.0.z versions" do
+        let(:version_string) { "0.0.3" }
+
+        it "treats patch changes as major (breaking)" do
+          expect(ignored_versions).to eq([">= 0.0.4.a"])
+        end
+      end
+    end
+  end
+
+  describe "#ignored_minor_versions_for_mode" do
+    let(:version_string) { "0.2.3" }
+
+    context "with relaxed mode (default)" do
+      subject(:ignored_versions) { version.ignored_minor_versions_for_mode("relaxed") }
+
+      it "uses standard semver" do
+        expect(ignored_versions).to eq([">= 0.3.a, < 1"])
+      end
+    end
+
+    context "with strict mode" do
+      subject(:ignored_versions) { version.ignored_minor_versions_for_mode("strict") }
+
+      context "with 1.y.z versions" do
+        let(:version_string) { "1.2.3" }
+
+        it "uses standard semver" do
+          expect(ignored_versions).to eq([">= 1.3.a, < 2"])
+        end
+      end
+
+      context "with 0.y.z versions" do
+        let(:version_string) { "0.2.3" }
+
+        it "treats minor changes as major (breaking)" do
+          expect(ignored_versions).to eq([">= 0.3.a"])
+        end
+      end
+    end
+  end
+
+  describe "#ignored_major_versions_for_mode" do
+    let(:version_string) { "0.2.3" }
+
+    context "with relaxed mode (default)" do
+      subject(:ignored_versions) { version.ignored_major_versions_for_mode("relaxed") }
+
+      it "uses standard semver (ignores 1.0.0+)" do
+        expect(ignored_versions).to eq([">= 1.a"])
+      end
+    end
+
+    context "with strict mode" do
+      subject(:ignored_versions) { version.ignored_major_versions_for_mode("strict") }
+
+      context "with 1.y.z versions" do
+        let(:version_string) { "1.2.3" }
+
+        it "uses standard semver" do
+          expect(ignored_versions).to eq([">= 2.a"])
+        end
+      end
+
+      context "with 0.y.z versions (y > 0)" do
+        let(:version_string) { "0.2.3" }
+
+        it "treats minor changes as major (breaking)" do
+          expect(ignored_versions).to eq([">= 0.3.a"])
+        end
+      end
+
+      context "with 0.0.z versions" do
+        let(:version_string) { "0.0.3" }
+
+        it "treats patch changes as major (breaking)" do
+          expect(ignored_versions).to eq([">= 0.0.4.a"])
+        end
+      end
+    end
+  end
+
+  describe "strict mode integration with ignore conditions" do
+    # These tests verify that the *_for_mode methods work correctly
+    # when used by Dependabot::Config::IgnoreCondition for filtering
+
+    context "with strict mode for 0.y.z packages" do
+      let(:version_string) { "0.15.5" }
+
+      it "correctly ignores breaking minor version bumps" do
+        ignored = version.ignored_major_versions_for_mode("strict")
+        req = Gem::Requirement.new(ignored.first)
+
+        expect(req.satisfied_by?(described_class.new("0.15.6"))).to be(false) # patch is allowed
+        expect(req.satisfied_by?(described_class.new("0.16.0"))).to be(true)  # minor bump is ignored
+        expect(req.satisfied_by?(described_class.new("1.0.0"))).to be(true)   # major bump is ignored
+      end
+    end
+
+    context "with relaxed mode for 0.y.z packages" do
+      let(:version_string) { "0.15.5" }
+
+      it "treats minor changes as minor, not major" do
+        ignored = version.ignored_major_versions_for_mode("relaxed")
+        req = Gem::Requirement.new(ignored.first)
+
+        expect(req.satisfied_by?(described_class.new("0.15.6"))).to be(false) # patch is allowed
+        expect(req.satisfied_by?(described_class.new("0.16.0"))).to be(false) # minor is allowed
+        expect(req.satisfied_by?(described_class.new("1.0.0"))).to be(true)   # only actual major is ignored
+      end
+    end
+  end
 end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -47,6 +47,7 @@ module Dependabot
         requirements_update_strategy
         security_advisories
         security_updates_only
+        semantic_versioning
         source
         update_subdependencies
         updating_a_pull_request
@@ -116,6 +117,9 @@ module Dependabot
 
     sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
     attr_reader :cooldown
+
+    sig { returns(String) }
+    attr_reader :semantic_versioning
 
     sig { returns(Dependabot::Config::UpdateConfig) }
     attr_reader :update_config
@@ -210,6 +214,7 @@ module Dependabot
         build_cooldown(attributes.fetch(:cooldown, nil)),
         T.nilable(Dependabot::Package::ReleaseCooldownOptions)
       )
+      @semantic_versioning            = T.let(attributes.fetch(:semantic_versioning, "relaxed"), String)
       @multi_ecosystem_update         = T.let(attributes.fetch(:multi_ecosystem_update, false), T::Boolean)
       # TODO: Make this hash required
       #
@@ -432,7 +437,8 @@ module Dependabot
     def ignore_conditions_for(dependency)
       update_config.ignored_versions_for(
         dependency,
-        security_updates_only: security_updates_only?
+        security_updates_only: security_updates_only?,
+        semantic_versioning: semantic_versioning
       )
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Adds `semantic-versioning` option that defaults to `relaxed` for current behavior, and supports `strict` value that causes 0.y.z and 0.0.z releases to be considered major updates according to https://semver.org/.

Fixes https://github.com/dependabot/dependabot-core/issues/8685.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
