### PR TITLE
Add support for calendar-based versions for Maven and Gradle

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_version_finder.rb
@@ -5,7 +5,7 @@ require "sorbet-runtime"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/package/package_latest_version_finder"
-
+require "date"
 module Dependabot
   module Maven
     module Shared
@@ -67,6 +67,9 @@ module Dependabot
           return true if pre_release_compatible?(current, candidate)
 
           return true if upgrade_to_stable?(current, candidate)
+
+          # If either version contains a date, consider them compatible
+          return true if contains_date?(current) || contains_date?(candidate)
 
           suffix_compatible?(current, candidate)
         end
@@ -178,6 +181,8 @@ module Dependabot
 
           return true if contains_git_sha?(current_suffix) || contains_git_sha?(candidate_suffix)
 
+          return true if contains_date?(current_suffix) || contains_date?(candidate_suffix)
+
           # If both versions share the exact suffix or no suffix, they are compatible
           current_suffix == candidate_suffix
         end
@@ -234,6 +239,57 @@ module Dependabot
           version.split(/[-._]/).any? { |part| git_sha?(part) } ||
             # Check if removing delimiters reveals a SHA (e.g., "va_b_018a_a_6b_0d3")
             git_sha?(version.gsub(/[-._]/, ""))
+        end
+
+        # Determines whether a version string contains a date.
+        #
+        # This method checks if any part of a version string (when split by common
+        # delimiters like '-', '.', or '_') is a valid date.
+        #
+        # @example Standard delimiter-separated dates
+        #   contains_date?("2025-12-16-05-04") # => true
+        #   contains_date?("2025_12_16_05_04") # => true
+        #   contains_date?("1.0-2025_12_16_05_04") # => true
+        # @example Compact date formats
+        #   contains_date?("20251216") # => true
+        #
+        #   contains_date?("1.2.3-alpha")          # => false
+        #   contains_date?("abcdef123")            # => false
+        sig { params(version: T.nilable(String)).returns(T::Boolean) }
+        def contains_date?(version)
+          return false unless version
+
+          parts = T.let(T.cast(version.scan(/\d+/), T::Array[String]).map(&:to_i), T::Array[Integer])
+
+          case parts.length
+          when 2
+            # Example: "2024.1"
+            year, month = parts
+            valid_date_parts?(year, month, 1)
+          when 3
+            # Example: https://github.com/relizaio/versioning/releases/tag/versioning-2026.01.7
+            year, month, day = parts
+            valid_date_parts?(year, month, day)
+          when 4, 5
+            # Examples:
+            # https://github.com/relizaio/versioning/releases/tag/2019.05.Stable.3
+            # 2025_12_16_05_04 used in https://github.com/dependabot/dependabot-core/issues/14084
+            year, month, day, = parts
+            # Just validate the date part ignoring the build number
+            valid_date_parts?(year, month, day)
+          else
+            false
+          end
+        end
+
+        sig { params(year: T.nilable(Integer), month: T.nilable(Integer), day: T.nilable(Integer)).returns(T::Boolean) }
+        def valid_date_parts?(year, month, day)
+          # Require 4-digit year to avoid matching short version numbers like "1.2.3"
+          return false unless year && year > 999
+          return false unless month&.between?(1, 12)
+          return false unless day&.between?(1, 31)
+
+          Date.valid_date?(year, month, day)
         end
 
         # Determines whether two versions are compatible based on pre-release status.

--- a/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
@@ -707,6 +707,195 @@ RSpec.describe Dependabot::Maven::Shared::SharedVersionFinder do
           end
         end
       end
+
+      context "when the dependency versions uses dates for the delimiter" do
+        context "when the date is dot separated" do
+          let(:dependency_version) { "2025.12.16.05.04" }
+          let(:comparison_version) { "2026.12.16.05.06" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the date is dash separated" do
+          let(:dependency_version) { "2025-12-16-05-04" }
+          let(:comparison_version) { "2026-12-16-05-06" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the date is compact YYYYMMDD" do
+          let(:dependency_version) { "20251216" }
+          let(:comparison_version) { "20261216" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when it is a compact YYYYMMDD date" do
+          let(:dependency_version) { "1.0-20251216" }
+          let(:comparison_version) { "1.0-20261216" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the date is embedded in a version string" do
+          let(:dependency_version) { "1.0.0-2025_12_16_05_04" }
+          let(:comparison_version) { "1.0.0-2026_12_16_05_06" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the date has single digit month/day" do
+          let(:dependency_version) { "2025_1_6_05_04" }
+          let(:comparison_version) { "2026_1_6_05_06" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when date appears with prefix and suffix text" do
+          let(:dependency_version) { "release-2025_12_16_05_04-hotfix" }
+          let(:comparison_version) { "release-2026_12_16_05_06-hotfix" }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the dependency version uses dates for the delimiter" do
+          context "when the date is dot separated" do
+            let(:dependency_version) { "2025.12.16.05.04" }
+            let(:comparison_version) { "2026.12.16.05.06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is dash separated" do
+            let(:dependency_version) { "2025-12-16-05-04" }
+            let(:comparison_version) { "2026-12-16-05-06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is compact YYYYMMDD" do
+            let(:dependency_version) { "20251216" }
+            let(:comparison_version) { "20261216" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is a unix timestamp" do
+            # This test is not resolved via the date logic but the numeric suffix logic
+            # but it's worth testing that it doesn't cause a failure
+            let(:dependency_version) { "1.0-1766457600" }
+            let(:comparison_version) { "2.0-1766257600" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is embedded after a semver prefix" do
+            let(:dependency_version) { "1.0-20251216" }
+            let(:comparison_version) { "1.0-20261216" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is embedded in a version string" do
+            let(:dependency_version) { "1.0.0-2025_12_16_05_04" }
+            let(:comparison_version) { "1.0.0-2026_12_16_05_06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date has single digit month and day" do
+            let(:dependency_version) { "2025_1_6_05_04" }
+            let(:comparison_version) { "2026_1_6_05_06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when only current is a date" do
+            let(:dependency_version) { "2025-12-16" }
+            let(:comparison_version) { "1.0" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when comparison version is a date" do
+            let(:dependency_version) { "1.0" }
+            let(:comparison_version) { "2025-12-16" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date has a leading separator" do
+            let(:dependency_version) { "_2025_12_16_05_04" }
+            let(:comparison_version) { "_2026_12_16_05_06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the version has a single number" do
+            # May or may not be a date
+            let(:dependency_version) { "2024919191" }
+            let(:comparison_version) { "2024.1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date appears with prefix and suffix text" do
+            let(:dependency_version) { "release-2025_12_16_05_04-hotfix" }
+            let(:comparison_version) { "release-2026_12_16_05_06-hotfix" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the version contains an invalid date" do
+            let(:dependency_version) { "2025_13_16_05_04" }
+            let(:comparison_version) { "2026_13_16_05_06" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when the version contains an invalid day" do
+            let(:dependency_version) { "2025_12_32_05_04" }
+            let(:comparison_version) { "2026_12_32_05_06" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when candidate is a pre-release version" do
+            let(:dependency_version) { "2026_12_32_05_06" }
+            let(:comparison_version) { "23.0-RC1" }
+
+            it { is_expected.to be false }
+          end
+
+          context "when existing is a pre-release version" do
+            let(:dependency_version) { "23.0-RC1" }
+            let(:comparison_version) { "2026_12_32_05_06" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when the date is embedded in a non semantic version" do
+            let(:dependency_version) { "RELEASE-2025.07.3" }
+            let(:comparison_version) { "RELEASE-2025.08.3" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when it is missing the day" do
+            let(:dependency_version) { "RELEASE-2024.1" }
+            let(:comparison_version) { "RELEASE-2024.1" }
+
+            it { is_expected.to be true }
+          end
+
+          context "when there is a mix" do
+            let(:dependency_version) { "2019.05.Stable.3" }
+            let(:comparison_version) { "2019.05.Stable.4" }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This change adds support for detecting and matching date-based version formats when evaluating version compatibility.

Some Maven/Gradle projects use dates instead of semantic versioning (e.g. nightly builds, timestamped releases, calendar versioning). Previously, these versions could be treated as incompatible, causing Dependabot to skip valid upgrades.

Fixes #14084

### How will you know you've accomplished your goal?

- Existing and new unit tests pass
- Reproducer described in #14084 pases

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
