### PR TITLE
Add docker pull to backup registry in latest-images workflow

### DIFF
--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -1,6 +1,7 @@
 name: Latest images
 env:
   UPDATER_IMAGE: "ghcr.io/dependabot/dependabot-updater-"
+  BACKUP_REGISTRY: "dependabot-acr-apim-production.azure-api.net"
 on: # yamllint disable-line rule:truthy
   push:
     branches:
@@ -97,6 +98,12 @@ jobs:
           docker push --all-tags "${UPDATER_IMAGE}${ECOSYSTEM}"
           # All tags should resolve to the same digest so we only need to look up one of them
           cosign sign --yes $(cosign triangulate --type=digest "${UPDATER_IMAGE}${ECOSYSTEM}:latest")
+
+      - name: Pull images through backup registry
+        run: |
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}${ECOSYSTEM}:$COMMIT_SHA"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}${ECOSYSTEM}:latest"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}${ECOSYSTEM}:${{ needs.date-version.outputs.date }}"
 
       - name: Set summary
         run: |


### PR DESCRIPTION
### What are you trying to accomplish?

In an effort to reduce the single point of failure of the GHCR public registry, a "backup" registry in Azure has been created. This registry acts as a pull through cache of the GHCR registry. To populate images, we only need to pull them from the Azure registry once they're available in GHCR.

This PR adds to the `latest-image` workflow such that after images are uploaded to GHCR, we then immediately pull them from the Azure backup registry which will populate them in the cache.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Runs of the `images-latest` workflow will continue to be successful, and we can observe in the Azure portal (private) that the registry is populated with new images.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
