### PR TITLE
Fetch release notes for the Gradle Wrapper

### DIFF
--- a/gradle/lib/dependabot/gradle/metadata_finder.rb
+++ b/gradle/lib/dependabot/gradle/metadata_finder.rb
@@ -26,7 +26,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        return nil if Distributions.distribution_requirements?(dependency.requirements)
+        return distributions_source if Distributions.distribution_requirements?(dependency.requirements)
 
         tmp_source = look_up_source_in_pom(dependency_pom_file)
         return tmp_source if tmp_source
@@ -40,6 +40,17 @@ module Dependabot
         return tmp_source if tmp_source.repo.end_with?(T.must(artifact))
 
         tmp_source if repo_has_subdir_for_dep?(tmp_source)
+      end
+
+      # The Gradle Wrapper does not have its own release notes.
+      # Instead, it shares the release notes of the matching Gradle version.
+      sig { returns(Dependabot::Source) }
+      def distributions_source
+        Source.new(
+          provider: "github",
+          repo: "gradle/gradle",
+          directory: "/"
+        )
       end
 
       sig { params(tmp_source: Dependabot::Source).returns(T::Boolean) }

--- a/gradle/spec/dependabot/gradle/metadata_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/metadata_finder_spec.rb
@@ -392,5 +392,27 @@ RSpec.describe Dependabot::Gradle::MetadataFinder do
 
       it { is_expected.to eq("https://github.com/mockito/mockito") }
     end
+
+    context "when it is the gradle wrapper" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "gradle-wrapper",
+          version: "9.3.1",
+          requirements: [{
+            requirement: "9.3.1",
+            file: "gradle/wrapper/gradle-wrapper.properties",
+            source: {
+              type: "gradle-distribution",
+              url: "https://services.gradle.org/distributions/gradle-9.3.1-bin.zip",
+              property: "distributionUrl"
+            },
+            groups: []
+          }],
+          package_manager: "gradle"
+        )
+      end
+
+      it { is_expected.to eq("https://github.com/gradle/gradle") }
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fetch release notes for the Gradle Wrapper by resolving its source to the main [Gradle repository](https://github.com/gradle/gradle).

The Gradle Wrapper does not publish standalone release notes. Instead, it follows the release notes of the corresponding Gradle version. With this change, Dependabot can correctly surface Gradle release notes for wrapper updates.

Fixes #13555

### Anything you want to highlight for special attention from reviewers?

- The Gradle Wrapper integration tests are expected to fail due to the newly enriched content. See https://github.com/dependabot/smoke-tests/pull/369 for the related test updates.
- To see the full test suite passing with this change, refer to: https://github.com/yeikel/dependabot-core/actions/runs/21807212156/job/62912534024?pr=247#step:6:2



<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

- Both existing and newer test work
- The Gradle wrapper updates contain release and commit information

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
