### PR TITLE
Maven: Ignore repositories from profiles that are not activated

### DIFF
--- a/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
@@ -348,5 +348,21 @@ RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
         end
       end
     end
+
+    context "when there are repository declarations in profiles" do
+      let(:base_pom_fixture_name) { "custom_repositories_pom_with_profiles.xml" }
+
+      it "does not include repositories from profiles that are not activated by default" do
+        expect(repository_urls).to eq(
+          %w(
+            https://repo.jenkins-ci.org/public
+            https://repo.jenkins-ci.org/incrementals-activated
+            https://repo.jenkins-ci.org/incrementals-activated-2
+            https://repo.jenkins-ci.org/another-activated
+            https://repo.maven.apache.org/maven2
+          )
+        )
+      end
+    end
   end
 end

--- a/maven/spec/fixtures/poms/custom_repositories_pom_with_profiles.xml
+++ b/maven/spec/fixtures/poms/custom_repositories_pom_with_profiles.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This POM demonstrates a project that declares repositories in two places:
+
+  1) Top-level <repositories>
+     - Always active.
+     - Dependabot should always consider these repositories.
+
+  2) Repositories within profiles:
+     - They are conditionally active depending on profile activation.
+     - Only profiles that are "active by default" should be considered
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>demo</groupId>
+  <artifactId>demo</artifactId>
+  <version>0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <profiles>
+    <!--- The repositories in this profile should NOT be considered because the profile is not activated (lack of activation defaults to false)-->
+    <profile>
+      <id>consume-incrementals</id>
+      <repositories>
+        <repository>
+          <id>incrementals-not-activated</id>
+          <url>https://repo.jenkins-ci.org/incrementals-disabled/</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <!--- The repositories in this profile should be considered because the profile is activated by default -->
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <id>incrementals-activated</id>
+      <repositories>
+        <repository>
+          <id>incrementals-activated</id>
+          <url>https://repo.jenkins-ci.org/incrementals-activated/</url>
+        </repository>
+        <repository>
+          <id>incrementals-activated-2</id>
+          <url>https://repo.jenkins-ci.org/incrementals-activated-2/</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <!--- The repositories in this profile should be considered because the profile is activated by default -->
+      <activation>
+        <!-- Parsing should be case-insensitive because this is also allowed in Maven -->
+        <activeByDefault>TRUE</activeByDefault>
+      </activation>
+      <id>another-activated</id>
+      <repositories>
+        <repository>
+          <id>another-activated</id>
+          <url>https://repo.jenkins-ci.org/another-activated/</url>
+        </repository>
+      </repositories>
+    </profile>
+    <profile>
+      <!--- The repositories in this profile should NOT be considered because the profile is disabled explicitly -->
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <id>Another profile</id>
+      <repositories>
+        <repository>
+          <id>incrementals</id>
+          <url>https://repo.jenkins-ci.org/some other repo/</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

In #13747, we updated Dependabot to consider all repositories defined in a project rather than only the first match. 

Unfortunately, this revealed a gap in Dependabot’s repository parsing: repositories that were expected to be disabled via Maven profiles were still being extracted. As a result, Dependabot started to query repositories that users had explicitly disabled in their Maven configuration leading to unexpected updates

With this change, we now respect the user’s configuration and only include repositories that are:

1. Defined at the top level of the project
2. Defined in profiles that are explicitly activated

Profiles that are explicitly deactivated, or that lack activation configuration, are treated as disabled to match native Maven behavior.


Fixes #14148

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The diff looks larger than it is because I had to reduce the code complexity as per  `rubocop`

### How will you know you've accomplished your goal?

#### Both new and existing spec pass

The new specs focused on parsing the profile and show how it should ignore profiles that are not activated

#### Validated using the provided reproducer

I ran this version against the reproducer documented in #14148 and produces the expected output (only `https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave/` is consulted)

<details>
  <summary>Logs</summary>
  
```
    cli | 2026/02/11 01:22:18 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/02/11 01:22:19 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/02/11 01:22:19 using image ghcr.io/dependabot/proxy:latest at sha256:01973f1077a283381e979987aae6e70fbe1104f04186863985539e4d2472f019
    cli | 2026/02/11 01:22:19 digest sha256:ce2b5f94e3b0ea3ac519c6fe593a2e3a7200100e7e7283f1ab92dbefefe4b8e4 for image ghcr.io/dependabot/dependabot-updater-maven does not exist remotely
  proxy | 2026/02/11 01:22:20 proxy starting, commit: c1aef7567fe8d0d42a65ac01dd05b2504af53a3b
  proxy | 2026/02/11 01:22:20 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | Processing triggers for ca-certificates-java (20240118) ...
updater | Adding debian:dbot-ca.pem
updater | done.
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/02/11 01:22:33 INFO Starting job processing
updater | 2026/02/11 01:22:33 INFO Job definition: {"job":{"command":"version","package-manager":"maven","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":null,"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"avoid-duplicate-updates-package-json":true,"deprecate-cancel-merge-command":true,"deprecate-close-command":true,"deprecate-merge-command":true,"deprecate-reopen-command":true,"deprecate-squash-merge-command":true,"disable-cancel-merge-command":true,"disable-close-command":true,"disable-merge-command":true,"disable-reopen-command":true,"disable-squash-merge-command":true,"enable-corepack-for-npm-and-yarn":true,"enable-dependabot-setting-up-cronjob":true,"enable-engine-version-detection":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"enable-record-ecosystem-meta":true,"enable-shared-helpers-command-timeout":true,"gradle-lockfile-updater":true,"gradle-wrapper-updater":true,"group-membership-enforcement":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"jglick/dependabot-14148-demo","directory":"/.","hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
updater | 2026/02/11 01:22:33 INFO Started process PID: 1132 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1132 completed with status: pid 1132 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1141 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1141 completed with status: pid 1141 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1149 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1149 completed with status: pid 1149 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1157 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1157 completed with status: pid 1157 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1164 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1171 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1171 completed with status: pid 1171 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1178 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1178 completed with status: pid 1178 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1185 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1185 completed with status: pid 1185 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1192 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1192 completed with status: pid 1192 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1200 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1200 completed with status: pid 1200 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.02 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1207 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:33 INFO Process PID: 1207 completed with status: pid 1207 exit 0
updater | 2026/02/11 01:22:33 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:33 INFO Started process PID: 1214 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/jglick/dependabot-14148-demo /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/02/11 01:22:33 [002] GET https://github.com:443/jglick/dependabot-14148-demo/info/refs?service=git-upload-pack
  proxy | 2026/02/11 01:22:33 [002] * authenticating git server request (host: github.com)
  proxy | 2026/02/11 01:22:34 [002] 200 https://github.com:443/jglick/dependabot-14148-demo/info/refs?service=git-upload-pack
  proxy | 2026/02/11 01:22:34 [004] POST https://github.com:443/jglick/dependabot-14148-demo/git-upload-pack
  proxy | 2026/02/11 01:22:34 [004] * authenticating git server request (host: github.com)
  proxy | 2026/02/11 01:22:34 [004] 200 https://github.com:443/jglick/dependabot-14148-demo/git-upload-pack
  proxy | 2026/02/11 01:22:34 [006] POST https://github.com:443/jglick/dependabot-14148-demo/git-upload-pack
  proxy | 2026/02/11 01:22:34 [006] * authenticating git server request (host: github.com)
  proxy | 2026/02/11 01:22:34 [006] 200 https://github.com:443/jglick/dependabot-14148-demo/git-upload-pack
updater | 2026/02/11 01:22:34 INFO Process PID: 1214 completed with status: pid 1214 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.79 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1254 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1254 completed with status: pid 1254 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1271 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1271 completed with status: pid 1271 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1279 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1279 completed with status: pid 1279 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1286 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1286 completed with status: pid 1286 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1293 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1293 completed with status: pid 1293 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1300 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1300 completed with status: pid 1300 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1307 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1307 completed with status: pid 1307 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1314 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1314 completed with status: pid 1314 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1321 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1321 completed with status: pid 1321 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1328 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1328 completed with status: pid 1328 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1335 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1335 completed with status: pid 1335 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1342 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1342 completed with status: pid 1342 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1350 with command: {} git rev-parse HEAD {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1350 completed with status: pid 1350 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1365 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1365 completed with status: pid 1365 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1373 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1373 completed with status: pid 1373 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1380 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1380 completed with status: pid 1380 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1387 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1387 completed with status: pid 1387 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1394 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1394 completed with status: pid 1394 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1402 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1402 completed with status: pid 1402 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1409 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1409 completed with status: pid 1409 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1416 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1416 completed with status: pid 1416 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1424 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1424 completed with status: pid 1424 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1431 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1431 completed with status: pid 1431 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1438 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1438 completed with status: pid 1438 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO Started process PID: 1445 with command: {} git rev-parse HEAD {}
updater | 2026/02/11 01:22:34 INFO Process PID: 1445 completed with status: pid 1445 exit 0
updater | 2026/02/11 01:22:34 INFO Total execution time: 0.01 seconds
updater | 2026/02/11 01:22:34 INFO DEBUG filter_excluded: entries=4, exclude_paths=[]
updater | 2026/02/11 01:22:34 INFO Base commit SHA: 86efedd3ca70f02b7220af511074547036385bb8
updater | 2026/02/11 01:22:34 INFO Finished job processing
updater | 2026/02/11 01:22:34 INFO Starting job processing
  proxy | 2026/02/11 01:22:34 [007] POST http://host.docker.internal:59308/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"org.jenkins-ci.plugins:mock-slave","requirements":[{"file":"pom.xml","groups":[],"metadata":{"packaging_type":"jar"},"requirement":"193.v88c279d0c584","source":null}],"version":"193.v88c279d0c584"}],"dependency_files":["/pom.xml"]},"type":"update_dependency_list"}
  proxy | 2026/02/11 01:22:34 [007] 200 http://host.docker.internal:59308/update_jobs/cli/update_dependency_list
  proxy | 2026/02/11 01:22:34 [008] POST http://host.docker.internal:59308/update_jobs/cli/increment_metric
{"data":{"metric":"updater.started","tags":{"operation":"group_update_all_versions"}},"type":"increment_metric"}
  proxy | 2026/02/11 01:22:34 [008] 200 http://host.docker.internal:59308/update_jobs/cli/increment_metric
updater | 2026/02/11 01:22:34 INFO Starting update job for jglick/dependabot-14148-demo
updater | 2026/02/11 01:22:34 INFO Checking all dependencies for version updates...
updater | 2026/02/11 01:22:34 INFO Checking if org.jenkins-ci.plugins:mock-slave 193.v88c279d0c584 needs updating
  proxy | 2026/02/11 01:22:34 [010] GET https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave/maven-metadata.xml
  proxy | 2026/02/11 01:22:35 [010] 200 https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave/maven-metadata.xml
  proxy | 2026/02/11 01:22:35 [012] GET https://repo.maven.apache.org/maven2/org/jenkins-ci/plugins/mock-slave/maven-metadata.xml
  proxy | 2026/02/11 01:22:35 [012] 404 https://repo.maven.apache.org/maven2/org/jenkins-ci/plugins/mock-slave/maven-metadata.xml
  proxy | 2026/02/11 01:22:36 [014] GET https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave
  proxy | 2026/02/11 01:22:36 [014] 302 https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave
  proxy | 2026/02/11 01:22:36 [016] GET https://repo.jenkins-ci.org/artifactory/public/org/jenkins-ci/plugins/mock-slave/
  proxy | 2026/02/11 01:22:36 [016] 200 https://repo.jenkins-ci.org/artifactory/public/org/jenkins-ci/plugins/mock-slave/
  proxy | 2026/02/11 01:22:36 [018] GET https://repo.maven.apache.org/maven2/org/jenkins-ci/plugins/mock-slave
  proxy | 2026/02/11 01:22:36 [018] 404 https://repo.maven.apache.org/maven2/org/jenkins-ci/plugins/mock-slave
updater | 2026/02/11 01:22:36 INFO Filtered out 1 pre-release versions
updater | 2026/02/11 01:22:36 INFO Filtered out 5 non-v88c279d0c584 classifier versions
  proxy | 2026/02/11 01:22:36 [020] HEAD https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave/193.v88c279d0c584/mock-slave-193.v88c279d0c584.jar
  proxy | 2026/02/11 01:22:36 [020] 200 https://repo.jenkins-ci.org/public/org/jenkins-ci/plugins/mock-slave/193.v88c279d0c584/mock-slave-193.v88c279d0c584.jar
updater | 2026/02/11 01:22:36 INFO Latest version is 193.v88c279d0c584
updater | 2026/02/11 01:22:36 INFO Filtered out 1 pre-release versions
updater | 2026/02/11 01:22:36 INFO Filtered out 5 non-v88c279d0c584 classifier versions
updater | 2026/02/11 01:22:36 INFO Filtered out 1 pre-release versions
updater | 2026/02/11 01:22:36 INFO Filtered out 5 non-v88c279d0c584 classifier versions
updater | 2026/02/11 01:22:36 INFO Filtered out 1 pre-release versions
updater | 2026/02/11 01:22:36 INFO Filtered out 5 non-v88c279d0c584 classifier versions
updater | 2026/02/11 01:22:36 INFO No update needed for org.jenkins-ci.plugins:mock-slave 193.v88c279d0c584
  proxy | 2026/02/11 01:22:36 [021] POST http://host.docker.internal:59308/update_jobs/cli/record_ecosystem_meta
{"data":[{"ecosystem":{"name":"maven","package_manager":{"name":"maven","version":"NOT-AVAILABLE","raw_version":"NOT-AVAILABLE"},"language":{"name":"java","version":"NOT-AVAILABLE","raw_version":"NOT-AVAILABLE"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/02/11 01:22:36 [021] 200 http://host.docker.internal:59308/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/02/11 01:22:36 [022] PATCH http://host.docker.internal:59308/update_jobs/cli/mark_as_processed
{"data":{"base-commit-sha":"86efedd3ca70f02b7220af511074547036385bb8"},"type":"mark_as_processed"}
  proxy | 2026/02/11 01:22:36 [022] 200 http://host.docker.internal:59308/update_jobs/cli/mark_as_processed
updater | 2026/02/11 01:22:36 INFO Finished job processing
  proxy | 2026/02/11 01:22:37 Skipping sending metrics because api endpoint is empty
  proxy | 2026/02/11 01:22:37 0/9 calls cached (0%)
```

  
</details>

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
