### PR TITLE
Add support for Julia additional dependencies in pre-commit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ PATH
       dependabot-cargo (= 0.362.0)
       dependabot-common (= 0.362.0)
       dependabot-go_modules (= 0.362.0)
+      dependabot-julia (= 0.362.0)
       dependabot-npm_and_yarn (= 0.362.0)
       dependabot-python (= 0.362.0)
 
@@ -465,6 +466,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-25
   x86_64-linux
 

--- a/julia/helpers/DependabotHelper.jl/src/DependabotHelper.jl
+++ b/julia/helpers/DependabotHelper.jl/src/DependabotHelper.jl
@@ -57,6 +57,8 @@ function run(input::String)
             expand_version_constraint(args["constraint"])
 
         # Package discovery and metadata
+        elseif func_name == "resolve_package_uuid"
+            resolve_package_uuid(args)
         elseif func_name == "get_latest_version"
             get_latest_version(args)
         elseif func_name == "get_package_metadata"

--- a/julia/helpers/DependabotHelper.jl/src/package_discovery.jl
+++ b/julia/helpers/DependabotHelper.jl/src/package_discovery.jl
@@ -49,7 +49,14 @@ end
     resolve_package_uuid(package_name::String)
 
 Resolve a package UUID from just its name by searching all reachable registries.
-Returns the UUID string if found, or nothing if the package is not registered.
+
+Returns a `Dict{String,Any}`. On success, the dict contains:
+  - `"uuid"`: the UUID string of the package
+  - `"name"`: the resolved package name
+
+On failure, the dict contains:
+  - `"error"`: a message describing why resolution failed (for example, if the
+    package is not found in any reachable registry or an internal error occurs).
 """
 function resolve_package_uuid(package_name::String)
     try

--- a/julia/lib/dependabot/julia/registry_client.rb
+++ b/julia/lib/dependabot/julia/registry_client.rb
@@ -21,6 +21,21 @@ module Dependabot
         @custom_registries = custom_registries
       end
 
+      sig { params(package_name: String).returns(T.nilable(String)) }
+      def resolve_package_uuid(package_name)
+        result = call_julia_helper(
+          function: "resolve_package_uuid",
+          args: { package_name: package_name }
+        )
+
+        return nil if result["error"]
+
+        result["uuid"]
+      rescue StandardError => e
+        Dependabot.logger.warn("Failed to resolve UUID for #{package_name}: #{e.message}")
+        nil
+      end
+
       sig { params(package_name: String, package_uuid: T.nilable(String)).returns(T.nilable(Gem::Version)) }
       def fetch_latest_version(package_name, package_uuid = nil)
         # Use custom registries if available

--- a/pre_commit/Dockerfile
+++ b/pre_commit/Dockerfile
@@ -5,19 +5,24 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER root
 
-COPY --from=go /usr/local/go /opt/go
-ENV PATH=/opt/go/bin:$PATH
-
-ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-
-COPY go_modules/helpers /opt/go_modules/helpers
-RUN bash /opt/go_modules/helpers/build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
 USER dependabot
 
-# Install bundler native helpers for Ruby additional_dependencies support
-COPY --chown=dependabot:dependabot bundler/helpers /opt/bundler/helpers
-RUN bash /opt/bundler/helpers/v2/build
+# Install Julia (required for Julia additional_dependency version lookups)
+RUN curl -fsSL https://install.julialang.org | sh -s -- -y \
+    && . ~/.bashrc
+
+ENV PATH="/home/dependabot/.juliaup/bin:$PATH"
+ENV JULIA_PKG_SERVER_REGISTRY_PREFERENCE="eager"
+
+# Build Julia native helpers
+ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
+COPY --chown=dependabot:dependabot julia/helpers /opt/julia/helpers
+RUN bash /opt/julia/helpers/build
 
 COPY --chown=dependabot:dependabot --parents go_modules cargo npm_and_yarn python pre_commit common bundler $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/pre_commit/Dockerfile
+++ b/pre_commit/Dockerfile
@@ -24,5 +24,5 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot julia/helpers /opt/julia/helpers
 RUN bash /opt/julia/helpers/build
 
-COPY --chown=dependabot:dependabot --parents go_modules cargo npm_and_yarn python pre_commit common bundler $DEPENDABOT_HOME/
+COPY --chown=dependabot:dependabot --parents go_modules cargo npm_and_yarn python julia pre_commit common bundler $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/pre_commit/dependabot-pre_commit.gemspec
+++ b/pre_commit/dependabot-pre_commit.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dependabot-cargo", Dependabot::VERSION
   spec.add_dependency "dependabot-common", Dependabot::VERSION
   spec.add_dependency "dependabot-go_modules", Dependabot::VERSION
+  spec.add_dependency "dependabot-julia", Dependabot::VERSION
   spec.add_dependency "dependabot-npm_and_yarn", Dependabot::VERSION
   spec.add_dependency "dependabot-python", Dependabot::VERSION
 

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/julia.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/julia.rb
@@ -1,0 +1,195 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "excon"
+require "sorbet-runtime"
+require "dependabot/dependency"
+require "dependabot/update_checkers"
+require "dependabot/julia/registry_client"
+require "dependabot/pre_commit/additional_dependency_checkers"
+require "dependabot/pre_commit/additional_dependency_checkers/base"
+
+module Dependabot
+  module PreCommit
+    module AdditionalDependencyCheckers
+      class Julia < Base
+        extend T::Sig
+
+        sig { override.returns(T.nilable(String)) }
+        def latest_version
+          return nil unless package_name
+
+          @latest_version ||= T.let(
+            fetch_latest_version_via_julia_checker,
+            T.nilable(String)
+          )
+        end
+
+        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        def updated_requirements(latest_version)
+          requirements.map do |original_req|
+            original_source = original_req[:source]
+            next original_req unless original_source.is_a?(Hash)
+            next original_req unless original_source[:type] == "additional_dependency"
+
+            original_requirement = original_req[:requirement]
+            new_requirement = build_updated_requirement(original_requirement, latest_version)
+
+            new_original_string = build_original_string(
+              package_name: original_source[:original_name] || original_source[:package_name],
+              requirement: new_requirement
+            )
+
+            new_source = original_source.merge(original_string: new_original_string)
+
+            original_req.merge(
+              requirement: new_requirement,
+              source: new_source
+            )
+          end
+        end
+
+        private
+
+        sig { returns(T.nilable(String)) }
+        def fetch_latest_version_via_julia_checker
+          checker = julia_update_checker
+          return nil unless checker
+
+          latest = checker.latest_version
+          Dependabot.logger.info("Julia UpdateChecker found latest version: #{latest || 'none'}")
+
+          latest&.to_s
+        rescue Dependabot::DependabotError, Excon::Error => e
+          Dependabot.logger.debug("Error checking Julia package #{package_name}: #{e.message}")
+          nil
+        end
+
+        sig { returns(T.nilable(Dependabot::UpdateCheckers::Base)) }
+        def julia_update_checker
+          @julia_update_checker ||= T.let(
+            build_julia_update_checker,
+            T.nilable(Dependabot::UpdateCheckers::Base)
+          )
+        end
+
+        sig { returns(T.nilable(Dependabot::UpdateCheckers::Base)) }
+        def build_julia_update_checker
+          julia_dependency = build_julia_dependency
+          return nil unless julia_dependency
+
+          Dependabot.logger.info("Delegating to julia UpdateChecker for package: #{julia_dependency.name}")
+
+          Dependabot::UpdateCheckers.for_package_manager("julia").new(
+            dependency: julia_dependency,
+            dependency_files: build_julia_dependency_files,
+            credentials: credentials,
+            ignored_versions: [],
+            security_advisories: [],
+            raise_on_ignored: false
+          )
+        end
+
+        sig { returns(T.nilable(Dependabot::Dependency)) }
+        def build_julia_dependency
+          return nil unless package_name
+
+          uuid = resolve_julia_uuid
+          return nil unless uuid
+
+          version = current_version || extract_version_from_requirement
+
+          Dependabot::Dependency.new(
+            name: T.must(package_name),
+            version: version,
+            requirements: [{
+              requirement: version,
+              groups: ["deps"],
+              file: "Project.toml",
+              source: nil
+            }],
+            package_manager: "julia",
+            metadata: { julia_uuid: uuid }
+          )
+        end
+
+        sig { returns(T.nilable(String)) }
+        def resolve_julia_uuid
+          @resolve_julia_uuid ||= T.let(
+            begin
+              client = Dependabot::Julia::RegistryClient.new(credentials: credentials)
+              uuid = client.resolve_package_uuid(T.must(package_name))
+              Dependabot.logger.info("Resolved Julia UUID for #{package_name}: #{uuid || 'not found'}")
+              uuid
+            rescue StandardError => e
+              Dependabot.logger.warn("Failed to resolve Julia UUID for #{package_name}: #{e.message}")
+              nil
+            end,
+            T.nilable(String)
+          )
+        end
+
+        sig { returns(T.nilable(String)) }
+        def extract_version_from_requirement
+          req_string = requirements.first&.dig(:requirement)
+          return nil unless req_string
+
+          version_part = req_string.sub(/\A(?:[~^]|[><=]+)\s*/, "")
+          return version_part if version_part.match?(/\A\d+(?:\.\d+)*\z/)
+
+          nil
+        end
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def build_julia_dependency_files
+          name = T.must(package_name)
+          uuid = resolve_julia_uuid || "00000000-0000-0000-0000-000000000000"
+          version = current_version || extract_version_from_requirement
+          content = <<~TOML
+            [deps]
+            #{name} = "#{uuid}"
+
+            [compat]
+            #{name} = "#{version || '*'}"
+          TOML
+
+          [
+            Dependabot::DependencyFile.new(
+              name: "Project.toml",
+              content: content
+            )
+          ]
+        end
+
+        sig do
+          params(
+            package_name: T.nilable(String),
+            requirement: T.nilable(String)
+          ).returns(String)
+        end
+        def build_original_string(package_name:, requirement:)
+          base = package_name.to_s
+          base = "#{base}@#{requirement}" if requirement
+          base
+        end
+
+        sig { params(original_requirement: T.nilable(String), new_version: String).returns(String) }
+        def build_updated_requirement(original_requirement, new_version)
+          return new_version unless original_requirement
+
+          operator_match = original_requirement.match(/\A(?<op>[~^]|[><=]+)\s*/)
+          if operator_match
+            "#{operator_match[:op]}#{new_version}"
+          else
+            new_version
+          end
+        end
+      end
+    end
+  end
+end
+
+Dependabot::PreCommit::AdditionalDependencyCheckers.register(
+  "julia",
+  Dependabot::PreCommit::AdditionalDependencyCheckers::Julia
+)

--- a/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/julia_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/julia_spec.rb
@@ -1,0 +1,213 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/julia/update_checker"
+require "dependabot/julia/registry_client"
+require "dependabot/pre_commit/additional_dependency_checkers/julia"
+
+RSpec.describe Dependabot::PreCommit::AdditionalDependencyCheckers::Julia do
+  let(:checker) do
+    described_class.new(
+      source: source,
+      credentials: credentials,
+      requirements: requirements,
+      current_version: current_version
+    )
+  end
+
+  let(:credentials) do
+    [Dependabot::Credential.new(
+      {
+        "type" => "git_source",
+        "host" => "github.com",
+        "username" => "x-access-token",
+        "password" => "token"
+      }
+    )]
+  end
+
+  let(:source) do
+    {
+      type: "additional_dependency",
+      language: "julia",
+      hook_id: "julia-lint",
+      hook_repo: "https://github.com/example/julia-lint",
+      package_name: "JSON",
+      original_name: "JSON",
+      original_string: "JSON@0.21.4"
+    }
+  end
+
+  let(:requirements) do
+    [{
+      requirement: "0.21.4",
+      groups: ["additional_dependencies"],
+      file: ".pre-commit-config.yaml",
+      source: source
+    }]
+  end
+
+  let(:current_version) { "0.21.4" }
+
+  let(:registry_client) { instance_double(Dependabot::Julia::RegistryClient) }
+  let(:resolved_uuid) { "682c06a0-de6a-54ab-a142-c8b1cf79cde6" }
+
+  before do
+    allow(Dependabot::Julia::RegistryClient).to receive(:new).and_return(registry_client)
+    allow(registry_client).to receive(:resolve_package_uuid).and_return(resolved_uuid)
+  end
+
+  describe "#latest_version" do
+    let(:julia_checker_class) { class_double(Dependabot::Julia::UpdateChecker) }
+    let(:julia_checker) { instance_double(Dependabot::UpdateCheckers::Base) }
+    let(:latest_version_obj) { Gem::Version.new("0.22.0") }
+
+    before do
+      allow(Dependabot::UpdateCheckers).to receive(:for_package_manager)
+        .with("julia")
+        .and_return(julia_checker_class)
+      allow(julia_checker_class).to receive(:new).and_return(julia_checker)
+      allow(julia_checker).to receive(:latest_version).and_return(latest_version_obj)
+    end
+
+    it "delegates to Julia UpdateChecker" do
+      result = checker.latest_version
+      expect(result).to eq("0.22.0")
+    end
+
+    it "creates a julia-compatible dependency" do
+      expect(julia_checker_class).to receive(:new) do |args|
+        dep = args[:dependency]
+        expect(dep.name).to eq("JSON")
+        expect(dep.package_manager).to eq("julia")
+        expect(dep.metadata[:julia_uuid]).to eq(resolved_uuid)
+        julia_checker
+      end
+
+      checker.latest_version
+    end
+
+    it "builds a synthetic Project.toml with resolved UUID" do
+      expect(julia_checker_class).to receive(:new) do |args|
+        files = args[:dependency_files]
+        expect(files.length).to eq(1)
+        expect(files.first.name).to eq("Project.toml")
+        expect(files.first.content).to include("JSON")
+        expect(files.first.content).to include("[deps]")
+        expect(files.first.content).to include("[compat]")
+        expect(files.first.content).to include(resolved_uuid)
+        julia_checker
+      end
+
+      checker.latest_version
+    end
+
+    context "when the registry is unreachable" do
+      before do
+        allow(registry_client).to receive(:resolve_package_uuid).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(checker.latest_version).to be_nil
+      end
+    end
+
+    context "when the package doesn't exist" do
+      before do
+        allow(julia_checker).to receive(:latest_version).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(checker.latest_version).to be_nil
+      end
+    end
+
+    context "when package_name is missing from source" do
+      let(:source) { { type: "additional_dependency", language: "julia" } }
+
+      it "returns nil" do
+        expect(checker.latest_version).to be_nil
+      end
+    end
+  end
+
+  describe "#updated_requirements" do
+    context "with exact version (no operator)" do
+      it "updates to the new exact version" do
+        updated = checker.updated_requirements("0.22.0")
+        expect(updated.first[:requirement]).to eq("0.22.0")
+        expect(updated.first[:source][:original_string]).to eq("JSON@0.22.0")
+      end
+    end
+
+    context "with caret range (^)" do
+      let(:source) do
+        {
+          type: "additional_dependency",
+          language: "julia",
+          hook_id: "julia-format",
+          hook_repo: "https://github.com/example/julia-format",
+          package_name: "JuliaFormatter",
+          original_name: "JuliaFormatter",
+          original_string: "JuliaFormatter@^1.0.0"
+        }
+      end
+
+      let(:requirements) do
+        [{
+          requirement: "^1.0.0",
+          groups: ["additional_dependencies"],
+          file: ".pre-commit-config.yaml",
+          source: source
+        }]
+      end
+
+      it "preserves the ^ operator" do
+        updated = checker.updated_requirements("1.1.0")
+        expect(updated.first[:requirement]).to eq("^1.1.0")
+        expect(updated.first[:source][:original_string]).to eq("JuliaFormatter@^1.1.0")
+      end
+    end
+
+    context "with tilde range (~)" do
+      let(:source) do
+        {
+          type: "additional_dependency",
+          language: "julia",
+          hook_id: "julia-format",
+          hook_repo: "https://github.com/example/julia-format",
+          package_name: "CSTParser",
+          original_name: "CSTParser",
+          original_string: "CSTParser@~3.3.0"
+        }
+      end
+
+      let(:requirements) do
+        [{
+          requirement: "~3.3.0",
+          groups: ["additional_dependencies"],
+          file: ".pre-commit-config.yaml",
+          source: source
+        }]
+      end
+
+      it "preserves the ~ operator" do
+        updated = checker.updated_requirements("3.4.0")
+        expect(updated.first[:requirement]).to eq("~3.4.0")
+        expect(updated.first[:source][:original_string]).to eq("CSTParser@~3.4.0")
+      end
+    end
+
+    it "preserves all requirement properties" do
+      updated = checker.updated_requirements("0.22.0")
+      expect(updated.first[:groups]).to eq(["additional_dependencies"])
+      expect(updated.first[:file]).to eq(".pre-commit-config.yaml")
+      expect(updated.first[:source][:type]).to eq("additional_dependency")
+      expect(updated.first[:source][:language]).to eq("julia")
+      expect(updated.first[:source][:hook_id]).to eq("julia-lint")
+      expect(updated.first[:source][:hook_repo]).to eq("https://github.com/example/julia-lint")
+      expect(updated.first[:source][:package_name]).to eq("JSON")
+    end
+  end
+end

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -170,6 +170,7 @@ PATH
       dependabot-cargo (= 0.362.0)
       dependabot-common (= 0.362.0)
       dependabot-go_modules (= 0.362.0)
+      dependabot-julia (= 0.362.0)
       dependabot-npm_and_yarn (= 0.362.0)
       dependabot-python (= 0.362.0)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Add support for Julia `additional_dependencies` in pre-commit configurations.

Pre-commit hooks with `language: julia` can specify crates as `additional_dependencies` (e.g., `JSON@0.21` `DataFrames@^1.6`). This PR enables Dependabot to parse, check for updates, and update these Julia dependencies.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

`Julia::Requirement.parse_dep_string` was added to handle splitting `name@version` strings using Julia's Pkg REPL add syntax. Version constraints like `^`, `~`, and `>=` are preserved in the `requirement` field while the bare version is extracted separately. Version validation delegates to `Julia::Version.correct?`. This mirrors how `NpmAndYarn::Requirement.parse_dep_string` and `Python::RequirementParser.parse` are used for their respective additional deps.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

We can parse Julia hooks in pre-commit, find new versions, and update them.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
