### PR TITLE
register msbuild upon entering clone command

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -25,6 +25,8 @@ public class CloneWorker
     // entrypoint for cli
     public async Task<int> RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath)
     {
+        MSBuildHelper.RegisterMSBuild(Environment.CurrentDirectory, Environment.CurrentDirectory, _logger);
+
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
 
         // only a limited set of errors can occur here


### PR DESCRIPTION
If bad arguments are given to `NuGetUpdater.Cli clone ...` then MSBuild types might need to be loaded for proper error reporting.  This PR registers MSBuild early in the command to allow the real error to be reported instead of `FileNotFoundException: Could not load file or assembly 'Microsoft.Buid...`