### PR TITLE
npm: Warn when attestation/provenance is lost between versions

### DIFF
--- a/common/lib/dependabot/metadata_finders/base.rb
+++ b/common/lib/dependabot/metadata_finders/base.rb
@@ -167,6 +167,11 @@ module Dependabot
         nil
       end
 
+      sig { overridable.returns(T.nilable(String)) }
+      def attestation_changes
+        nil
+      end
+
       private
 
       sig { overridable.returns(T.nilable(String)) }

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -27,6 +27,7 @@ module Dependabot
         attr_reader :github_redirection_service
 
         def_delegators :metadata_finder,
+                       :attestation_changes,
                        :changelog_url,
                        :changelog_text,
                        :commits_url,
@@ -73,6 +74,7 @@ module Dependabot
           msg += commits_cascade
           msg += maintainer_changes_cascade
           msg += install_script_changes_cascade
+          msg += attestation_changes_cascade
           msg += break_tag unless msg == ""
           "\n" + sanitize_links_and_mentions(msg, unsafe: true)
         end
@@ -190,6 +192,16 @@ module Dependabot
           build_details_tag(
             summary: "Install script changes",
             body: sanitize_links_and_mentions(install_script_changes) + "\n"
+          )
+        end
+
+        sig { returns(String) }
+        def attestation_changes_cascade
+          return "" unless attestation_changes
+
+          build_details_tag(
+            summary: "Attestation changes",
+            body: sanitize_links_and_mentions(attestation_changes) + "\n"
           )
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe namespace::MetadataPresenter do
   let(:metadata_finder) do
     instance_double(
       Dependabot::MetadataFinders::Base,
+      attestation_changes: "",
       changelog_url: "http://localhost/changelog.md",
       changelog_text: "",
       commits_url: "http://localhost/commits",
@@ -96,6 +97,19 @@ RSpec.describe namespace::MetadataPresenter do
       it "includes install script changes section" do
         expect(presenter.to_s).to include("Install script changes")
         expect(presenter.to_s).to include("postinstall")
+      end
+    end
+
+    context "with attestation changes" do
+      before do
+        allow(metadata_finder)
+          .to receive(:attestation_changes)
+          .and_return("This version has no provenance attestation, while the previous version (1.0.0) was attested.")
+      end
+
+      it "includes attestation changes section" do
+        expect(presenter.to_s).to include("Attestation changes")
+        expect(presenter.to_s).to include("provenance attestation")
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -657,6 +657,146 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
     end
   end
 
+  describe "#attestation_changes" do
+    subject(:attestation_changes) { finder.attestation_changes }
+
+    let(:dependency_name) { "attestation-pkg" }
+    let(:npm_url) { "https://registry.npmjs.org/attestation-pkg" }
+    let(:npm_all_versions_response) do
+      fixture("npm_responses", "attestation_changes.json")
+    end
+
+    before do
+      stub_request(:get, npm_url)
+        .to_return(status: 200, body: npm_all_versions_response)
+    end
+
+    context "when there is no previous version" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.1.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when attestation is lost between versions" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.2.0",
+          previous_version: "1.1.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it "returns a warning about lost attestation" do
+        expect(attestation_changes).to eq(
+          "This version has no provenance attestation, while the previous version " \
+          "(1.1.0) was attested. Review the " \
+          "[package versions](https://www.npmjs.com/package/attestation-pkg?activeTab=versions) " \
+          "before updating."
+        )
+      end
+    end
+
+    context "when both versions are attested" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.3.0",
+          previous_version: "1.1.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when neither version is attested" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.2.0",
+          previous_version: "1.0.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when attestation is gained" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.1.0",
+          previous_version: "1.0.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when using a non-standard registry" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.2.0",
+          previous_version: "1.1.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^1.0",
+            groups: [],
+            source: { type: "registry", url: "https://npm.pkg.github.com" }
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      before do
+        stub_request(:get, "https://npm.pkg.github.com/attestation-pkg")
+          .to_return(status: 200, body: npm_all_versions_response)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "#dependency_url" do
     subject(:dependency_url) { finder.send(:dependency_url) }
 

--- a/npm_and_yarn/spec/fixtures/npm_responses/attestation_changes.json
+++ b/npm_and_yarn/spec/fixtures/npm_responses/attestation_changes.json
@@ -1,0 +1,114 @@
+{
+  "_id": "attestation-pkg",
+  "name": "attestation-pkg",
+  "description": "Test package with attestation changes",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "time": {
+    "1.0.0": "2026-01-01T00:00:00.000Z",
+    "1.1.0": "2026-02-01T00:00:00.000Z",
+    "1.2.0": "2026-03-01T00:00:00.000Z",
+    "1.3.0": "2026-04-01T00:00:00.000Z",
+    "created": "2026-01-01T00:00:00.000Z",
+    "modified": "2026-04-01T00:00:00.000Z"
+  },
+  "versions": {
+    "1.0.0": {
+      "_id": "attestation-pkg@1.0.0",
+      "_npmUser": {
+        "email": "maintainer@example.com",
+        "name": "maintainer"
+      },
+      "name": "attestation-pkg",
+      "version": "1.0.0",
+      "description": "Test package with attestation changes",
+      "scripts": {
+        "test": "echo test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/example/attestation-pkg"
+      },
+      "dist": {
+        "shasum": "abc123",
+        "tarball": "http://registry.npmjs.org/attestation-pkg/-/attestation-pkg-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "_id": "attestation-pkg@1.1.0",
+      "_npmUser": {
+        "email": "maintainer@example.com",
+        "name": "maintainer"
+      },
+      "name": "attestation-pkg",
+      "version": "1.1.0",
+      "description": "Test package with attestation changes",
+      "scripts": {
+        "test": "echo test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/example/attestation-pkg"
+      },
+      "dist": {
+        "shasum": "def456",
+        "tarball": "http://registry.npmjs.org/attestation-pkg/-/attestation-pkg-1.1.0.tgz",
+        "attestations": {
+          "url": "https://registry.npmjs.org/-/npm/v1/attestations/attestation-pkg@1.1.0",
+          "provenance": {
+            "predicateType": "https://slsa.dev/provenance/v1"
+          }
+        }
+      }
+    },
+    "1.2.0": {
+      "_id": "attestation-pkg@1.2.0",
+      "_npmUser": {
+        "email": "maintainer@example.com",
+        "name": "maintainer"
+      },
+      "name": "attestation-pkg",
+      "version": "1.2.0",
+      "description": "Test package with attestation changes",
+      "scripts": {
+        "test": "echo test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/example/attestation-pkg"
+      },
+      "dist": {
+        "shasum": "ghi789",
+        "tarball": "http://registry.npmjs.org/attestation-pkg/-/attestation-pkg-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "_id": "attestation-pkg@1.3.0",
+      "_npmUser": {
+        "email": "maintainer@example.com",
+        "name": "maintainer"
+      },
+      "name": "attestation-pkg",
+      "version": "1.3.0",
+      "description": "Test package with attestation changes",
+      "scripts": {
+        "test": "echo test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/example/attestation-pkg"
+      },
+      "dist": {
+        "shasum": "jkl012",
+        "tarball": "http://registry.npmjs.org/attestation-pkg/-/attestation-pkg-1.3.0.tgz",
+        "attestations": {
+          "url": "https://registry.npmjs.org/-/npm/v1/attestations/attestation-pkg@1.3.0",
+          "provenance": {
+            "predicateType": "https://slsa.dev/provenance/v1"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

During the eslint-config-prettier compromise (CVE-2025-54313), the malicious versions had no provenance attestation while all prior releases did. This adds a warning to PR descriptions when that happens, the same way we already warn about new maintainers and install script changes.

Closes #12765

### Anything you want to highlight for special attention from reviewers?

Reads `dist.attestations` from the packument that `npm_listing` already fetches. No extra HTTP requests. Skips private registries since they may not support attestations.

### How will you know you've accomplished your goal?

All tests pass. Cases covered: no previous version, attestation lost, both attested, neither attested, attestation gained, private registry.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.