### PR TITLE
Remove `gradle_wrapper_updater` feature flag

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -182,8 +182,6 @@ module Dependabot
 
       sig { params(dir: String).returns(T::Array[DependencyFile]) }
       def wrapper_files(dir)
-        return [] unless Experiments.enabled?(:gradle_wrapper_updater)
-
         SUPPORTED_WRAPPER_FILES_PATH.filter_map do |filename|
           file = fetch_file_if_present(File.join(dir, filename))
           next unless file

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -60,10 +60,8 @@ module Dependabot
         script_plugin_files.each do |plugin_file|
           dependency_set += buildfile_dependencies(plugin_file)
         end
-        if Experiments.enabled?(:gradle_wrapper_updater)
-          wrapper_properties_file.each do |properties_file|
-            dependency_set += wrapper_properties_dependencies(properties_file)
-          end
+        wrapper_properties_file.each do |properties_file|
+          dependency_set += wrapper_properties_dependencies(properties_file)
         end
         version_catalog_file.each do |toml_file|
           dependency_set += version_catalog_dependencies(toml_file)

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -101,12 +101,10 @@ module Dependabot
         end
 
         # runs native updaters (e.g. wrapper, lockfile) on relevant build files updated
-        if Dependabot::Experiments.enabled?(:gradle_wrapper_updater)
-          buildfiles_processed.each_value do |buildfile|
-            wrapper_updater = WrapperUpdater.new(dependency_files: files, dependency: dependency)
-            updated_files = wrapper_updater.update_files(buildfile)
-            replace_updated_files(files, updated_files)
-          end
+        buildfiles_processed.each_value do |buildfile|
+          wrapper_updater = WrapperUpdater.new(dependency_files: files, dependency: dependency)
+          updated_files = wrapper_updater.update_files(buildfile)
+          replace_updated_files(files, updated_files)
         end
         if Dependabot::Experiments.enabled?(:gradle_lockfile_updater)
           buildfiles_processed.each_value do |buildfile|

--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -137,8 +137,6 @@ module Dependabot
 
         sig { returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
         def distribution_version_details
-          return nil unless Experiments.enabled?(:gradle_wrapper_updater)
-
           DistributionsFetcher.available_versions.map do |info|
             release_date = begin
               Time.parse(info[:build_time])

--- a/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
@@ -120,8 +120,6 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         def updated_distribution_requirements
-          return requirements unless Experiments.enabled?(:gradle_wrapper_updater)
-
           distribution_url = T.let(nil, T.nilable(String))
 
           requirements.map do |req|

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -832,14 +832,6 @@ RSpec.describe Dependabot::Gradle::FileParser do
             ]
           end
 
-          before do
-            Dependabot::Experiments.register(:gradle_wrapper_updater, true)
-          end
-
-          after do
-            Dependabot::Experiments.reset!
-          end
-
           its(:length) { is_expected.to eq(1) }
 
           describe "check dependency" do

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
         raise "Unexpected shell command: #{command}"
       end
 
-      Dependabot::Experiments.register(:gradle_wrapper_updater, true)
       Dependabot::Experiments.register(:gradle_lockfile_updater, true)
     end
 

--- a/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
@@ -321,17 +321,11 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
 
       context "when the details come from gradle distributions" do
         before do
-          Dependabot::Experiments.register(:gradle_wrapper_updater, true)
-
           stub_request(:get, "https://services.gradle.org/versions/all")
             .to_return(
               status: 200,
               body: fixture("gradle_distributions_metadata", "versions_all.json")
             )
-        end
-
-        after do
-          Dependabot::Experiments.reset!
         end
 
         describe "the last version" do

--- a/gradle/spec/dependabot/gradle/update_checker/requirements_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/requirements_updater_spec.rb
@@ -184,14 +184,8 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::RequirementsUpdater do
       end
 
       before do
-        Dependabot::Experiments.register(:gradle_wrapper_updater, true)
-
         stub_request(:get, "https://services.gradle.org/distributions/gradle-9.0.0-all.zip.sha256")
           .to_return(status: 200, body: "f759b8dd5204e2e3fa4ca3e73f452f087153cf81bac9561eeb854229cc2c5365")
-      end
-
-      after do
-        Dependabot::Experiments.reset!
       end
 
       it "updates url and checksum" do


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the `gradle_wrapper_updater` feature flag to enable Gradle wrapper updates for all users by default.

This completes the rollout after successful validation in production with healthy metrics.

Fixes #2223

### Anything you want to highlight for special attention from reviewers?

Test stubs were added for wrapper file requests in tests that didn't previously need them, since wrapper files are now always fetched.

### How will you know you've accomplished your goal?

- All existing tests pass
- No remaining references to `gradle_wrapper_updater` in the codebase

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.