### PR TITLE
Fix required_ruby_version in placeholder gemspec

### DIFF
--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.version = "0.95.1"
-  # Since a placeholder gem, no need to keep `required_ruby_version` up to date with `.ruby-version`
-  spec.required_ruby_version = ">= 3" # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = ">= 3.3.0"
 end


### PR DESCRIPTION
The placeholder `dependabot-core.gemspec` had `required_ruby_version` set to `">= 3"`. That's too loose. It lets `RubyRequirementSetter` pick Ruby 3.0.6 as the version to inject into the Gemfile during dependency resolution. Since `dependabot-common` requires `>= 3.3.0`, every bundler update job fails with `dependency_file_not_resolvable`.

Here's how that happens:

1. `UpdateChecker::FilePreparer` calls `RubyRequirementSetter` on the gemspec
2. `RubyRequirementSetter` finds the lowest Ruby from its hardcoded list satisfying `">= 3"` — that's `3.0.6`
3. It writes `ruby '3.0.6'` into the Gemfile used for resolution
4. The monkey patch's `ruby_version` method sees the Gemfile directive and never falls through to `.ruby-version`
5. Bundler tries to resolve with Ruby 3.0.6 and fails on anything requiring 3.1+

This bumps the constraint to `">= 3.3.0"` to match `dependabot-common.gemspec`, so `RubyRequirementSetter` picks `3.3.8` instead.