### PR TITLE
Default all Cargo crates to increase-if-necessary

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -108,8 +108,12 @@ module Dependabot
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy if @requirements_update_strategy
 
-        # Otherwise, widen ranges for libraries and bump versions for apps
-        library? ? RequirementsUpdateStrategy::BumpVersionsIfNecessary : RequirementsUpdateStrategy::BumpVersions
+        # Cargo resolves to the newest compatible version and a bare version is a
+        # caret-equivalent (compatible) requirement, so only raise the requirement
+        # when it doesn't already allow the new version. Avoids needless churn and
+        # MSRV bumps.
+        # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements
+        RequirementsUpdateStrategy::BumpVersionsIfNecessary
       end
 
       private
@@ -132,13 +136,12 @@ module Dependabot
         # present in other areas
         return unless preferred_resolvable_version
 
-        library? ? latest_version&.to_s : preferred_resolvable_version.to_s
+        # No lockfile: target the latest version. With one: the resolvable version.
+        no_lockfile? ? latest_version&.to_s : preferred_resolvable_version.to_s
       end
 
       sig { returns(T::Boolean) }
-      def library?
-        # If it has a lockfile, treat it as an application. Otherwise treat it
-        # as a library.
+      def no_lockfile?
         dependency_files.none? { |f| f.name == "Cargo.lock" }
       end
 

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -450,14 +450,15 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           requirements: requirements,
           updated_source: nil,
           target_version: "0.1.40",
-          update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
+          update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
         )
         .and_call_original
+      # "0.1.12" (caret) already allows 0.1.40, so the requirement is left as-is.
       expect(checker.updated_requirements)
         .to eq(
           [{
             file: "Cargo.toml",
-            requirement: "0.1.40",
+            requirement: "0.1.12",
             groups: [],
             source: nil
           }]
@@ -483,14 +484,15 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
             requirements: requirements,
             updated_source: nil,
             target_version: "0.1.39",
-            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions
+            update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
           )
           .and_call_original
+        # "0.1.12" already allows the 0.1.39 fix, so only the lockfile changes.
         expect(checker.updated_requirements)
           .to eq(
             [{
               file: "Cargo.toml",
-              requirement: "0.1.39",
+              requirement: "0.1.12",
               groups: [],
               source: nil
             }]
@@ -508,6 +510,39 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
       let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
 
       it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#requirements_update_strategy" do
+    subject(:strategy) { checker.requirements_update_strategy }
+
+    context "with no explicit strategy and a lockfile present" do
+      it "defaults to BumpVersionsIfNecessary" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary)
+      end
+    end
+
+    context "with no explicit strategy and no lockfile" do
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "Cargo.toml",
+            content: fixture("manifests", manifest_fixture_name)
+          )
+        ]
+      end
+
+      it "defaults to BumpVersionsIfNecessary" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary)
+      end
+    end
+
+    context "when an explicit strategy is passed" do
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
+
+      it "honours the explicit strategy" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::LockfileOnly)
+      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot keeps bumping `Cargo.toml` requirements when it doesn't need to. Cargo already resolves to the newest compatible version, and caret is implicit, so raising the lower bound mostly just causes churn and can drag the MSRV up with it. This makes `increase-if-necessary` the default for every Cargo crate, so a requirement only changes when it doesn't already allow the new version. It drops the old heuristic that assumed any crate with a `Cargo.lock` was an application. Fixes #4009.

### Anything you want to highlight for special attention from reviewers?

This PR started out detecting libraries from `[lib]`/`[[bin]]` sections in `Cargo.toml`. I scrapped that after @jonhoo and @Tamschi pointed out that `increase-if-necessary` is the saner default for binaries too (the lockfile pins the real version). Setting `versioning-strategy` explicitly still overrides the default.

### How will you know you've accomplished your goal?

Updated specs check the default both with and without a lockfile, and confirm an explicit strategy is still honored. Since the existing `0.1.12` caret already allows the target version, `Cargo.toml` is left untouched and the bump lands in `Cargo.lock`.

### Checklist
- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.