### PR TITLE
Disable scheduled CI workflow in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'dependabot/dependabot-core'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What are you trying to accomplish?

Disable scheduled CI workflow in forks to match other similarly-disabled workflows.

Otherwise if a workflow fails it generates notification noise, as well as just being wasteful of compute resources.

### Anything you want to highlight for special attention from reviewers?

No.

### How will you know you've accomplished your goal?

Scheduled workflows stop running daily in forks of this repository.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
