### PR TITLE
cargo: Bypass Cargo credential providers, rely on proxy for registry auth

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -217,8 +217,10 @@ module Dependabot
         def run_cargo_command(command, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.setup_credentials_in_environment(credentials)
-          env = ENV.select { |key, _value| key.match(/^CARGO_REGISTRIES_/) }
+          Helpers.bypass_cargo_credential_providers
+          # Pass through any cargo registry configuration via environment variables
+          # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
+          env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }
           stdout, process = Open3.capture2e(env, command)
           time_taken = Time.now - start
 

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -1,28 +1,20 @@
 # typed: strong
 # frozen_string_literal: true
 
-require "yaml"
-
 module Dependabot
   module Cargo
     module Helpers
       extend T::Sig
 
-      sig { params(credentials: T::Array[Dependabot::Credential]).void }
-      def self.setup_credentials_in_environment(credentials)
-        credentials.each do |cred|
-          next if cred["type"] != "cargo_registry"
-          next if cred["registry"].nil? # this will not be present for org-level registries
-          next if cred["token"].nil?
-
-          # If there is a 'token' property, then apply it.
-          # In production Dependabot-Action or Dependabot-CLI will inject the real token via the Proxy.
-          token_env_var = "CARGO_REGISTRIES_#{T.must(cred['registry']).upcase.tr('-', '_')}_TOKEN"
-          ENV[token_env_var] ||= cred["token"]
-        end
-
-        # And set CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS here as well, so Cargo will expect tokens
-        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= "cargo:token"
+      sig { void }
+      def self.bypass_cargo_credential_providers
+        # Disable Cargo's built-in credential providers entirely so that Cargo does not attempt to look up registry
+        # tokens on its own. The dependabot proxy (https://github.com/dependabot/proxy/) handles all registry
+        # authentication transparently by intercepting HTTP requests and injecting the appropriate credentials.
+        #
+        # Uses ||= so developers can override by setting CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token in their
+        # shell (along with the appropriate CARGO_REGISTRIES_{NAME}_TOKEN vars) for local development without the proxy.
+        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= ""
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -186,10 +186,10 @@ module Dependabot
         def run_cargo_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.setup_credentials_in_environment(credentials)
-          # Pass through any registry tokens supplied via CARGO_REGISTRIES_...
-          # environment variables, and also any CARGO_REGISTRY_... configuration.
-          env = ENV.select { |key, _value| key.match(/^(CARGO_REGISTRY|CARGO_REGISTRIES)_/) }
+          Helpers.bypass_cargo_credential_providers
+          # Pass through any cargo registry configuration via environment variables
+          # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
+          env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }
 
           stdout, process = Open3.capture2e(env, command)
           time_taken = Time.now - start

--- a/cargo/spec/dependabot/cargo/helpers_spec.rb
+++ b/cargo/spec/dependabot/cargo/helpers_spec.rb
@@ -5,121 +5,32 @@ require "spec_helper"
 require "dependabot/cargo/helpers"
 
 RSpec.describe Dependabot::Cargo::Helpers do
-  describe ".setup_credentials_in_environment" do
+  describe ".bypass_cargo_credential_providers" do
     after do
-      # Clean up environment variables set during tests
-      ENV.delete("CARGO_REGISTRIES_MY_REGISTRY_TOKEN")
-      ENV.delete("CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN")
       ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
     end
 
-    context "when credentials array is empty" do
-      let(:credentials) { [] }
-
-      it "does not set any token environment variables" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to be_nil
-      end
-
-      it "sets the global credential providers" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("cargo:token")
-      end
-    end
-
-    context "when credential type is not cargo_registry" do
-      let(:credentials) do
-        [Dependabot::Credential.new({ "type" => "git_source", "registry" => "my-registry", "token" => "secret" })]
-      end
-
-      it "does not set any token environment variables" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to be_nil
-      end
-    end
-
-    context "when registry is nil" do
-      let(:credentials) do
-        [Dependabot::Credential.new({ "type" => "cargo_registry", "token" => "secret" })]
-      end
-
-      it "does not set any token environment variables" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES__TOKEN", nil)).to be_nil
-      end
-    end
-
-    context "when token is nil" do
-      let(:credentials) do
-        [Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry" })]
-      end
-
-      it "does not set any token environment variables" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to be_nil
-      end
-    end
-
-    context "when registry and token are present" do
-      let(:credentials) do
-        [Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry", "token" => "secret" })]
-      end
-
-      it "sets the token environment variable with uppercase registry name and hyphens replaced with underscores" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("secret")
-      end
-
-      it "sets the global credential providers" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("cargo:token")
-      end
-    end
-
-    context "when multiple cargo_registry credentials are provided" do
-      let(:credentials) do
-        [
-          Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry", "token" => "token1" }),
-          Dependabot::Credential.new(
-            {
-              "type" => "cargo_registry", "registry" => "another-registry", "token" => "token2"
-            }
-          )
-        ]
-      end
-
-      it "sets token environment variables for all registries" do
-        described_class.setup_credentials_in_environment(credentials)
-
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("token1")
-        expect(ENV.fetch("CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN", nil)).to eq("token2")
-      end
-    end
-
-    context "when environment variable is already set" do
-      let(:credentials) do
-        [Dependabot::Credential.new(
-          {
-            "type" => "cargo_registry", "registry" => "my-registry", "token" => "new-token"
-          }
-        )]
-      end
-
+    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is not set" do
       before do
-        ENV["CARGO_REGISTRIES_MY_REGISTRY_TOKEN"] = "existing-token"
+        ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
+      end
+
+      it "sets it to an empty string to disable credential providers" do
+        described_class.bypass_cargo_credential_providers
+
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("")
+      end
+    end
+
+    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is already set" do
+      before do
+        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] = "cargo:token"
       end
 
       it "does not overwrite the existing value" do
-        described_class.setup_credentials_in_environment(credentials)
+        described_class.bypass_cargo_credential_providers
 
-        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("existing-token")
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("cargo:token")
       end
     end
   end


### PR DESCRIPTION
## Summary

Bypass Cargo's built-in credential providers entirely and rely on the [dependabot proxy](https://github.com/dependabot/proxy/) for all private registry authentication.

## Problem

PR #14030 removed the placeholder token logic for private cargo registries but kept `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token`, which tells Cargo to look up tokens via `CARGO_REGISTRIES_{NAME}_TOKEN` environment variables. Since those tokens are no longer being injected, Cargo fails with `no token found` errors when resolving dependencies from private registries.

Fixes #14094

## Solution

Instead of injecting per-registry tokens into environment variables, set `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS` to an empty string (`""`). This disables Cargo's credential lookup entirely, so Cargo makes plain HTTP requests which the dependabot proxy intercepts and decorates with the appropriate credentials.

### Changes

- **`helpers.rb`**: Replaced `setup_credentials_in_environment(credentials)` with `bypass_cargo_credential_providers`. Removed all per-registry token iteration/injection logic. Sets `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS ||= ""` (using `||=` so developers can override for local development without the proxy).
- **`lockfile_updater.rb`**: Updated to call `Helpers.bypass_cargo_credential_providers` and broadened the env var filter to pass through both `CARGO_REGISTRY_*` and `CARGO_REGISTRIES_*` variables.
- **`version_resolver.rb`**: Same changes as lockfile_updater.rb.

## Developer Override

Developers running without the proxy (e.g. via `dry-run.rb`) can still authenticate by setting environment variables in their shell:

```bash
export CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token
export CARGO_REGISTRIES_MY_REGISTRY_TOKEN=mytoken
```

The `||=` assignment ensures these take precedence over the empty-string default.