### PR TITLE
Maven: skip unresolvable properties

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -127,7 +127,7 @@ module Dependabot
               callsite_pom: callsite_pom,
               seen_properties: seen_properties
             )
-            T.must(resolved)[:value]
+            resolved[:value] if resolved
           end
 
           { file: pom.name, node: node, value: resolved_value }

--- a/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe Dependabot::Maven::FileParser::PropertyValueFinder do
         its([:value]) { is_expected.to eq("org.reproducer.channels2") }
       end
 
+      context "when the nested property is undefined" do
+        let(:base_pom_fixture_name) { "pom_with_undefined_property.xml" }
+        let(:property_name) { "os.detected.classifier" }
+
+        its([:value]) { is_expected.to eq("") }
+      end
+
       context "when the property name starts with 'project' but not an attribute of the project" do
         let(:base_pom_fixture_name) { "property_name_starts_with_project_pom.xml" }
         let(:property_name) { "project.dependency.spring-boot.version" }

--- a/maven/spec/fixtures/poms/pom_with_undefined_property.xml
+++ b/maven/spec/fixtures/poms/pom_with_undefined_property.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.reproducer</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <!-- Property intentionally left unresolved in this fixture:
+         ${nisse.os.classifier} is undefined in the test environment.
+         Dependabot should not fail the entire job if this happens
+    -->
+    <os.detected.classifier>${nisse.os.classifier}</os.detected.classifier>
+  </properties>
+
+
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

This change makes `PropertyValueFinder#resolve_property_placeholder` tolerant of unresolvable nested properties.

Previously, we assumed that recursive resolution would always return a value but If a nested property could not be resolved, this would raise due to `T.must`, causing parsing to fail.

Fixes #14330

### How will you know you've accomplished your goal?

- The existing and new test cases pass
- The reproducer documented in #14330 runs successfully after this change 


<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
