### PR TITLE
nuget: switch NuGetUpdater target framework to net10.0

### DIFF
--- a/nuget/helpers/build
+++ b/nuget/helpers/build
@@ -32,7 +32,7 @@ cd "$install_dir/lib/NuGetUpdater/NuGetUpdater.Cli"
 dotnet publish \
     --configuration Release \
     --output "$install_dir/NuGetUpdater" \
-    --framework net9.0 \
+    --framework net10.0 \
     --runtime "$os-$arch"
 dotnet clean
 

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Common.props
@@ -9,7 +9,7 @@
             NuGetUpdater\NuGetUpdater.Core\FrameworkChecker\SupportedFrameworks.cs
       2. Update tests as needed at `NuGetUpdater\NuGetUpdater.Core.Test\FrameworkChecker\CompatibilityCheckerFacts.cs`
     -->
-    <CommonTargetFramework>net9.0</CommonTargetFramework>
+    <CommonTargetFramework>net10.0</CommonTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts\$(OS)</ArtifactsPath>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -48,6 +48,7 @@ namespace NuGetGallery.Frameworks
 
         public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8);
         public static readonly NuGetFramework Net80Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "android", EmptyVersion);
+        public static readonly NuGetFramework Net80Browser = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "browser", EmptyVersion);
         public static readonly NuGetFramework Net80Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "ios", EmptyVersion);
         public static readonly NuGetFramework Net80MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "macos", EmptyVersion);
         public static readonly NuGetFramework Net80MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "maccatalyst", EmptyVersion);
@@ -56,6 +57,7 @@ namespace NuGetGallery.Frameworks
 
         public static readonly NuGetFramework Net90 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9);
         public static readonly NuGetFramework Net90Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "android", EmptyVersion);
+        public static readonly NuGetFramework Net90Browser = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "browser", EmptyVersion);
         public static readonly NuGetFramework Net90Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "ios", EmptyVersion);
         public static readonly NuGetFramework Net90MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "macos", EmptyVersion);
         public static readonly NuGetFramework Net90MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "maccatalyst", EmptyVersion);
@@ -64,6 +66,7 @@ namespace NuGetGallery.Frameworks
 
         public static readonly NuGetFramework Net100 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10);
         public static readonly NuGetFramework Net100Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "android", EmptyVersion);
+        public static readonly NuGetFramework Net100Browser = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "browser", EmptyVersion);
         public static readonly NuGetFramework Net100Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "ios", EmptyVersion);
         public static readonly NuGetFramework Net100MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "macos", EmptyVersion);
         public static readonly NuGetFramework Net100MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "maccatalyst", EmptyVersion);
@@ -97,9 +100,9 @@ namespace NuGetGallery.Frameworks
                 Net50, Net50Windows,
                 Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows, Net60Windows7,
                 Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows, Net70Windows7,
-                Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
-                Net90, Net90Android, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
-                Net100, Net100Android, Net100Ios, Net100MacCatalyst, Net100MacOs, Net100TvOs, Net100Windows, Net100Windows7,
+                Net80, Net80Android, Net80Browser, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
+                Net90, Net90Android, Net90Browser, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
+                Net100, Net100Android, Net100Browser, Net100Ios, Net100MacCatalyst, Net100MacOs, Net100TvOs, Net100Windows, Net100Windows7,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,


### PR DESCRIPTION
### What are you trying to accomplish?

The SDK was already at 10.0 but the project still targeted net9.0, so this catches the target framework up and pulls in the latest SupportedFrameworks.cs (which adds the browser platform TFMs upstream missed locally).

### Anything you want to highlight for special attention from reviewers?

The test files still reference net9.0 in their fixture data -- that's intentional since those represent projects Dependabot is analyzing, not the tool itself.

### How will you know you've accomplished your goal?

CI builds green; `dotnet build NuGetUpdater.sln` compiles with zero errors on net10.0.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.