### PR TITLE
Fix GitHub Actions SHA-pinned refs being downgraded when mixed with tag refs

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -158,7 +158,7 @@ module Dependabot
 
         # Return the pinned git commit if one is available
         if source_git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           (new_commit_sha = latest_commit_sha)
+           (new_commit_sha = latest_commit_sha(source_git_commit_checker))
           return new_commit_sha
         end
 
@@ -166,12 +166,12 @@ module Dependabot
         nil
       end
 
-      sig { returns(T.nilable(String)) }
-      def latest_commit_sha
+      sig { params(source_checker: Dependabot::GitCommitChecker).returns(T.nilable(String)) }
+      def latest_commit_sha(source_checker)
         new_tag = T.must(latest_version_finder).latest_version_tag
         return unless new_tag
 
-        if git_commit_checker.local_tag_for_pinned_sha
+        if source_checker.local_tag_for_pinned_sha
           new_tag.fetch(:commit_sha)
         else
           latest_commit_for_pinned_ref

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -1193,6 +1193,94 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
     end
 
+    context "with mixed tag and SHA requirements across files" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "actions/checkout",
+          version: "2",
+          package_manager: "github_actions",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow1.yml",
+            metadata: { declaration_string: "actions/checkout@v2" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "v2",
+              branch: nil
+            }
+          }, {
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow2.yml",
+            metadata: { declaration_string: "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+              branch: nil
+            }
+          }, {
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow3.yml",
+            metadata: { declaration_string: "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "8f4b7f84864484a7bf31766abe9204da3cbe65b3",
+              branch: nil
+            }
+          }]
+        )
+      end
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow1.yml",
+          metadata: { declaration_string: "actions/checkout@v2" },
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v3",
+            branch: nil
+          }
+        }, {
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow2.yml",
+          metadata: { declaration_string: "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab" },
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+            branch: nil
+          }
+        }, {
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow3.yml",
+          metadata: { declaration_string: "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3" },
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+            branch: nil
+          }
+        }]
+      end
+
+      it "updates tag ref to latest version and SHA refs to latest version SHA" do
+        expect(updated_requirements).to eq(expected_requirements)
+      end
+    end
+
     context "when a dependency has a path based tag reference with semver" do
       let(:service_pack_url) do
         "https://github.com/gopidesupavan/monorepo-actions.git/info/refs" \


### PR DESCRIPTION
## Problem

When a repository references the same GitHub Action with a mix of tag refs (`@v4`) and SHA-pinned refs (`@<sha> # v6`), the SHA-pinned refs get downgraded instead of upgraded.

For example, given three workflow files:

| File | Reference | Expected update |
|------|-----------|-----------------|
| `codeql-rust.yml` | `actions/checkout@v4` | `@v6` |
| `rust.yml` | `actions/checkout@<sha> # v6.0.1` | `@<sha> # v6.0.2` |
| `security-workflow.yml` | `actions/checkout@<sha> # v6.0.2` | no change (already latest) |

Dependabot was updating the SHA-pinned v6 refs to the v4 branch HEAD SHA (v4.3.1), effectively downgrading them.

## Root cause

`DependencySet.combined_version` picks the lowest version across all requirements, so the combined dependency version becomes "4" rather than "6.0.1". The `UpdateChecker` creates a source-specific `git_commit_checker` per requirement (correct), but `latest_commit_sha` used the shared `git_commit_checker` which gets its ref from the first requirement's source: `ref: "v4"` (a tag, not a SHA).

Since "v4" is not a SHA, `local_tag_for_pinned_sha` returns nil, and the code falls through to `latest_commit_for_pinned_ref`, which follows the v4 ref and returns the v4.3.1 SHA. That wrong SHA then gets applied to all SHA-pinned requirements.

## Fix

Pass the source-specific `git_commit_checker` (which has the actual SHA ref for each requirement) to `latest_commit_sha`, so `local_tag_for_pinned_sha` correctly resolves the tag from the SHA and returns the right commit.

4 lines changed in production code.

Fixes https://github.com/dependabot/dependabot-core/issues/13677.