### PR TITLE
Fix ignore option for gitsubmodule

### DIFF
--- a/git_submodules/lib/dependabot/git_submodules/update_checker.rb
+++ b/git_submodules/lib/dependabot/git_submodules/update_checker.rb
@@ -62,8 +62,12 @@ module Dependabot
         T.let(
           LatestVersionFinder.new(
             dependency: dependency,
+            dependency_files: dependency_files,
             credentials: credentials,
-            cooldown_options: update_cooldown
+            ignored_versions: ignored_versions,
+            security_advisories: security_advisories,
+            cooldown_options: update_cooldown,
+            raise_on_ignored: raise_on_ignored
           ).latest_tag,
           T.nilable(String)
         )

--- a/git_submodules/lib/dependabot/git_submodules/update_checker/latest_version_finder.rb
+++ b/git_submodules/lib/dependabot/git_submodules/update_checker/latest_version_finder.rb
@@ -18,24 +18,12 @@ module Dependabot
       class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
 
-        sig do
-          params(
-            dependency: Dependabot::Dependency,
-            credentials: T::Array[Dependabot::Credential],
-            cooldown_options: T.nilable(Dependabot::Package::ReleaseCooldownOptions)
-          ).void
-        end
-        def initialize(dependency:, credentials:, cooldown_options:)
-          @dependency = dependency
-          @credentials = credentials
-          @cooldown_options = cooldown_options
-        end
-
         sig { returns(T.nilable(String)) }
         def latest_tag
           releases = version_list
 
           releases = filter_by_cooldown(T.must(releases))
+          releases = filter_ignored_versions(releases)
 
           # if there are no releases after applying filters, we fallback to the current tag to avoid empty results
           releases = apply_post_fetch_latest_versions_filter(releases)
@@ -115,15 +103,6 @@ module Dependabot
 
           releases
         end
-
-        sig { returns(Dependabot::Dependency) }
-        attr_reader :dependency
-
-        sig { returns(T::Array[Dependabot::Credential]) }
-        attr_reader :credentials
-
-        sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
-        attr_reader :cooldown_options
 
         sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def package_details; end

--- a/git_submodules/spec/dependabot/git_submodules/update_checker/latest_version_finder_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/update_checker/latest_version_finder_spec.rb
@@ -38,11 +38,18 @@ RSpec.describe Dependabot::GitSubmodules::UpdateChecker::LatestVersionFinder do
       "password" => "token"
     }]
   end
+  let(:ignored_versions) { [] }
+  let(:security_advisories) { [] }
+  let(:raise_on_ignored) { false }
   let(:checker) do
     described_class.new(
       dependency: dependency,
+      dependency_files: [],
       credentials: credentials,
-      cooldown_options: cooldown_options
+      ignored_versions: ignored_versions,
+      security_advisories: security_advisories,
+      cooldown_options: cooldown_options,
+      raise_on_ignored: raise_on_ignored
     )
   end
 
@@ -127,6 +134,59 @@ RSpec.describe Dependabot::GitSubmodules::UpdateChecker::LatestVersionFinder do
       end
 
       it { is_expected.to eq("95a470a557091cdbdc9f68a178b60bd19329942c") }
+    end
+  end
+
+  describe "#latest_tag with ignored_versions" do
+    subject { checker.latest_tag }
+
+    let(:tagged_sha) { "3c96b37d962e02d37f6b66b63af104c44249544d" }
+    let(:untagged_sha) { "50581639a03761c649e09e9618e26d3beb6a4198" }
+    let(:releases) do
+      [
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::GitSubmodules::Version.new("1.2.3"),
+          tag: tagged_sha
+        ),
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::GitSubmodules::Version.new("0.0.0-0.5"),
+          tag: untagged_sha
+        )
+      ]
+    end
+
+    before do
+      allow(checker).to receive(:version_list).and_return(releases)
+    end
+
+    context "when the user is ignoring all later versions" do
+      let(:ignored_versions) { ["> 0.0.0"] }
+
+      it { is_expected.to eq(untagged_sha) }
+    end
+
+    context "when the user has ignored all versions" do
+      let(:ignored_versions) { [">= 0"] }
+      let(:releases) do
+        [
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::GitSubmodules::Version.new("1.2.3"),
+            tag: tagged_sha
+          )
+        ]
+      end
+
+      it "returns nil" do
+        expect(checker.latest_tag).to be_nil
+      end
+
+      context "when raise_on_ignored is set" do
+        let(:raise_on_ignored) { true }
+
+        it "raises an error" do
+          expect { checker.latest_tag }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Dependabot has an `ignore` option to exclude certain version ranges from update proposals. However, for gitsubmodule ecosystem these options get ignored, effectively making it impossible to track the latest HEAD when release tags are present on the current branch.

With this fix, it becomes possible to opt out of release tracking:

```yaml
updates:
  - package-ecosystem: "gitsubmodule"
    directory: "/"
    schedule:
      interval: "daily"
    ignore:
      - dependency-name: "*"
        versions: ["> 0.0.0"]
```

### What are you trying to accomplish?

Fixes https://github.com/dependabot/dependabot-core/issues/1639#issuecomment-3974244759

### Anything you want to highlight for special attention from reviewers?

This is essentially a fix for pre-existing functionality of Dependabot that simply wasn't properly routed to gitsubmodule.

### How will you know you've accomplished your goal?

Added a new test that covers the "> 0.0.0" case specifically.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
