### PR TITLE
cargo: restore placeholder tokens for private registry auth (Option B)

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -217,7 +217,7 @@ module Dependabot
         def run_cargo_command(command, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.bypass_cargo_credential_providers
+          Helpers.setup_credentials_in_environment(credentials)
           # Pass through any cargo registry configuration via environment variables
           # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
           env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -6,15 +6,34 @@ module Dependabot
     module Helpers
       extend T::Sig
 
-      sig { void }
-      def self.bypass_cargo_credential_providers
-        # Disable Cargo's built-in credential providers entirely so that Cargo does not attempt to look up registry
-        # tokens on its own. The dependabot proxy (https://github.com/dependabot/proxy/) handles all registry
-        # authentication transparently by intercepting HTTP requests and injecting the appropriate credentials.
-        #
-        # Uses ||= so developers can override by setting CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token in their
-        # shell (along with the appropriate CARGO_REGISTRIES_{NAME}_TOKEN vars) for local development without the proxy.
-        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= ""
+      sig { params(credentials: T::Array[Dependabot::Credential]).void }
+      def self.setup_credentials_in_environment(credentials)
+        credentials.each do |cred|
+          next if cred["type"] != "cargo_registry"
+          next if cred["registry"].nil? # org-level registries won't have this; the proxy handles them
+
+          # Build the CARGO_REGISTRIES_{NAME}_TOKEN env var that Cargo uses to authenticate with the registry.
+          token_env_var = "CARGO_REGISTRIES_#{T.must(cred['registry']).upcase.tr('-', '_')}_TOKEN"
+
+          if cred["token"]
+            # Token is present — use it directly. This is the case for repo-level configs with explicit tokens
+            # and for the dependabot-action when it passes credentials directly (not through the proxy).
+            Dependabot.logger.info(
+              "Token found for #{cred['registry']}, setting #{token_env_var} to provided token value"
+            )
+            ENV[token_env_var] ||= cred["token"]
+          else
+            # No token means we are running behind the dependabot proxy, which strips tokens from credentials
+            # and re-injects them by intercepting HTTP requests. We still need to set a placeholder so that
+            # Cargo believes the registry is configured and proceeds to make the HTTP request (which the proxy
+            # will then authenticate). Without this, Cargo fails with "no token found for <registry>".
+            Dependabot.logger.info("No token found for #{cred['registry']}, proxy will inject credentials")
+            ENV[token_env_var] ||= "placeholder_token"
+          end
+        end
+
+        # Tell Cargo to use token-based auth for all registries.
+        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= "cargo:token"
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -186,7 +186,7 @@ module Dependabot
         def run_cargo_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.bypass_cargo_credential_providers
+          Helpers.setup_credentials_in_environment(credentials)
           # Pass through any cargo registry configuration via environment variables
           # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
           env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }

--- a/cargo/spec/dependabot/cargo/helpers_spec.rb
+++ b/cargo/spec/dependabot/cargo/helpers_spec.rb
@@ -5,32 +5,132 @@ require "spec_helper"
 require "dependabot/cargo/helpers"
 
 RSpec.describe Dependabot::Cargo::Helpers do
-  describe ".bypass_cargo_credential_providers" do
+  describe ".setup_credentials_in_environment" do
     after do
+      ENV.delete("CARGO_REGISTRIES_MY_REGISTRY_TOKEN")
+      ENV.delete("CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN")
       ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
     end
 
-    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is not set" do
-      before do
-        ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
+    context "when credentials array is empty" do
+      let(:credentials) { [] }
+
+      it "does not set any token environment variables" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to be_nil
       end
 
-      it "sets it to an empty string to disable credential providers" do
-        described_class.bypass_cargo_credential_providers
+      it "sets the global credential providers to cargo:token" do
+        described_class.setup_credentials_in_environment(credentials)
 
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("")
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("cargo:token")
       end
     end
 
-    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is already set" do
+    context "when credential type is not cargo_registry" do
+      let(:credentials) do
+        [Dependabot::Credential.new({ "type" => "git_source", "registry" => "my-registry", "token" => "secret" })]
+      end
+
+      it "does not set any token environment variables" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to be_nil
+      end
+    end
+
+    context "when registry is nil (org-level config)" do
+      let(:credentials) do
+        [Dependabot::Credential.new({ "type" => "cargo_registry", "token" => "secret" })]
+      end
+
+      it "skips the credential (proxy handles org-level registries)" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES__TOKEN", nil)).to be_nil
+      end
+    end
+
+    context "when token is nil (running behind proxy)" do
+      let(:credentials) do
+        [Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry" })]
+      end
+
+      it "sets a placeholder token so Cargo proceeds to make HTTP requests" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("placeholder_token")
+      end
+    end
+
+    context "when registry and token are both present" do
+      let(:credentials) do
+        [Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry", "token" => "secret" })]
+      end
+
+      it "sets the token environment variable with uppercase registry name and hyphens replaced with underscores" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("secret")
+      end
+
+      it "sets the global credential providers to cargo:token" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("cargo:token")
+      end
+    end
+
+    context "when multiple cargo_registry credentials are provided" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry", "token" => "token1" }),
+          Dependabot::Credential.new(
+            { "type" => "cargo_registry", "registry" => "another-registry", "token" => "token2" }
+          )
+        ]
+      end
+
+      it "sets token environment variables for all registries" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("token1")
+        expect(ENV.fetch("CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN", nil)).to eq("token2")
+      end
+    end
+
+    context "when environment variable is already set" do
+      let(:credentials) do
+        [Dependabot::Credential.new(
+          { "type" => "cargo_registry", "registry" => "my-registry", "token" => "new-token" }
+        )]
+      end
+
       before do
-        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] = "cargo:token"
+        ENV["CARGO_REGISTRIES_MY_REGISTRY_TOKEN"] = "existing-token"
       end
 
       it "does not overwrite the existing value" do
-        described_class.bypass_cargo_credential_providers
+        described_class.setup_credentials_in_environment(credentials)
 
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("cargo:token")
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("existing-token")
+      end
+    end
+
+    context "when mixing registries with and without tokens (proxy mode)" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "my-registry", "token" => "real" }),
+          Dependabot::Credential.new({ "type" => "cargo_registry", "registry" => "another-registry" })
+        ]
+      end
+
+      it "uses the real token for one and placeholder for the other" do
+        described_class.setup_credentials_in_environment(credentials)
+
+        expect(ENV.fetch("CARGO_REGISTRIES_MY_REGISTRY_TOKEN", nil)).to eq("real")
+        expect(ENV.fetch("CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN", nil)).to eq("placeholder_token")
       end
     end
   end


### PR DESCRIPTION
## Summary

Restore placeholder token injection for Cargo private registries, reverting the bypass approach from #14340.

Fixes #14354
Related: #14094, #14030

## Problem

PR #14340 tried to fix #14094 by disabling Cargo's credential providers entirely (`CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=""`). This works for the global case but fails when `.cargo/config.toml` contains per-registry `credential-provider` settings:

```toml
[registries.artifactory]
index = "sparse+https://example.com/api/cargo/cargo-local/index/"
credential-provider = "cargo:token"
```

Per-registry settings override the global env var, so Cargo still invokes `cargo:token` for that registry, looks for `CARGO_REGISTRIES_{NAME}_TOKEN`, finds nothing, and fails.

## Solution

Work **with** Cargo's auth system rather than trying to disable it. Restore `setup_credentials_in_environment` which sets:
- `CARGO_REGISTRIES_{NAME}_TOKEN` for each registry (real token if available, `placeholder_token` if running behind the proxy)
- `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token`

This way Cargo finds a token for every configured registry and proceeds to make HTTP requests. The dependabot proxy intercepts those requests and replaces the placeholder with the real credential.

### Why this is robust
- Works regardless of what's in `.cargo/config.toml` — satisfies Cargo's auth rather than fighting it
- Handles per-registry `credential-provider` settings, global settings, and any future Cargo auth features
- Battle-tested design from #8719 that worked until #14030 broke it
- The key fix from #14030 is preserved: `next if cred['registry'].nil?` correctly skips org-level registries

### Trade-off vs Option A (PR #14356, strip config lines)
Option A strips `credential-provider` lines from config files, which is fragile (regex against TOML, doesn't handle env var overrides). This approach is more robust because it satisfies Cargo's auth expectations rather than trying to remove them.

### Changes

- **`helpers.rb`**: Replaced `bypass_cargo_credential_providers` with `setup_credentials_in_environment(credentials)` that injects per-registry tokens (real or placeholder) and sets `cargo:token` as the global credential provider
- **`lockfile_updater.rb`**: Updated to call `setup_credentials_in_environment(credentials)`
- **`version_resolver.rb`**: Same
- **`helpers_spec.rb`**: 10 tests covering: empty creds, wrong type, nil registry (org-level), nil token (proxy mode), real token, multiple registries, existing env var, mixed real/placeholder

## Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.