### PR TITLE
fix(hex): correct tuple order for Hex.Repo.get_public_key response

### DIFF
--- a/hex/helpers/lib/run.exs
+++ b/hex/helpers/lib/run.exs
@@ -6,6 +6,7 @@ defmodule DependencyHelper do
     |> case do
       {output, 0} ->
         output = try_decode(output)
+
         if output =~ "No authenticated organization found" do
           {:error, output}
         else
@@ -121,14 +122,14 @@ defmodule DependencyHelper do
 
   defp fetch_public_key(repo, repo_url, auth_key, fingerprint) do
     case Hex.Repo.get_public_key(%{trusted: true, url: repo_url, auth_key: auth_key}) do
-      {:ok, {200, key, _}} ->
+      {:ok, {200, _headers, key}} ->
         if public_key_matches?(key, fingerprint) do
           {:ok, key}
         else
           {:error, "Public key fingerprint mismatch for repo \"#{repo}\""}
         end
 
-      {:ok, {code, _, _}} ->
+      {:ok, {code, _headers, _body}} ->
         {:error, "Downloading public key for repo \"#{repo}\" failed with code: #{inspect(code)}"}
 
       other ->


### PR DESCRIPTION
Fixes #14291

In hex 2.2.x, `Hex.Repo.get_public_key/1` had a `handle_response/1` wrapper that reordered the Erlang return into `{status, body, headers}`. In hex 2.3.0 that wrapper was removed, so the raw `:mix_hex_repo` format `{status, headers, body}` now comes through directly.

The helper script still destructures it the old way, so `key` captures the HTTP headers map instead of the actual PEM public key. This causes a `FunctionClauseError` in `:mix_hex_registry.key/1` for every project using a private hex repository (like Oban Pro).

The bug was introduced in #14002 which bumped hex from 2.2.2 to 2.3.1.

**hex ≤ 2.2.x** (with `handle_response` wrapper):
```elixir
{:ok, {status, body, headers}}
```

**hex 2.3.0+** (raw `:mix_hex_repo` return):
```erlang
{:ok, {status, headers, body}}
```