### PR TITLE
fix(uv): use env var auth for all matching pyproject.toml indexes, not just explicit ones

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -3,6 +3,7 @@
 
 require "toml-rb"
 require "open3"
+require "uri"
 require "dependabot/dependency"
 require "dependabot/shared_helpers"
 require "dependabot/uv/language_version_manager"
@@ -399,9 +400,12 @@ module Dependabot
             .reject { |cred| skip_lock_index_credential?(cred) }
         end
 
+        # Skip credentials whose index is already declared in pyproject.toml; those are
+        # authenticated via UV_INDEX_<NAME>_* env vars (see #pyproject_index_env_vars) so uv
+        # uses the pyproject.toml index entry directly, avoiding a duplicate --index flag.
         sig { params(credential: Dependabot::Credential).returns(T::Boolean) }
         def skip_lock_index_credential?(credential)
-          credential.replaces_base? ? defined_in_pyproject?(credential) : explicit_index?(credential)
+          defined_in_pyproject?(credential)
         end
 
         sig do
@@ -504,16 +508,6 @@ module Dependabot
           []
         end
 
-        sig { params(credential: Dependabot::Credential).returns(T::Boolean) }
-        def explicit_index?(credential)
-          return false if credential.replaces_base?
-
-          cred_url = normalize_index_url(credential["index-url"].to_s)
-          uv_indices.any? do |_name, config|
-            config["explicit"] == true && normalize_index_url(config["url"].to_s) == cred_url
-          end
-        end
-
         # Checks if a credential's index URL matches any index defined in pyproject.toml.
         # When true, authentication is provided via env vars so uv uses the pyproject.toml URL,
         # preserving URL format alignment between pyproject.toml and uv.lock.
@@ -522,8 +516,15 @@ module Dependabot
           !find_index_name_for_credential(credential).nil?
         end
 
+        # Strips trailing slashes and any embedded userinfo so a pyproject.toml URL like
+        # https://oauth2accesstoken@host/path matches a credential URL like https://host/path.
         sig { params(url: String).returns(String) }
         def normalize_index_url(url)
+          uri = URI.parse(url.chomp("/"))
+          uri.user = nil
+          uri.password = nil
+          uri.to_s
+        rescue URI::InvalidURIError
           url.chomp("/")
         end
 
@@ -545,8 +546,7 @@ module Dependabot
             next unless name
 
             result[name] = {
-              "url" => index["url"],
-              "explicit" => index["explicit"] == true
+              "url" => index["url"]
             }
           end
         rescue TomlRB::ParseError

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -690,10 +690,10 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "includes --index flag only for non-explicit indices" do
+      it "omits --index flags for all indices defined in pyproject.toml" do
         options = lock_index_options.join(" ")
-        expect(options).not_to include("https://explicit_token@private-pypi.example.com/simple")
-        expect(options).to include("--index https://fallback_token@fallback-pypi.example.com/simple")
+        expect(options).not_to include("--index")
+        expect(options).not_to include("--default-index")
       end
     end
 
@@ -713,9 +713,9 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "includes --index flag for non-explicit indices defined in pyproject.toml" do
+      it "omits --index flag when the credential matches a non-explicit pyproject.toml index" do
         options = lock_index_options.join(" ")
-        expect(options).to include("--index https://token@private-pypi.example.com/simple")
+        expect(options).not_to include("--index")
         expect(options).not_to include("--default-index")
       end
     end
@@ -956,6 +956,29 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         expect(lock_index_options).to include("--index https://root_token@pypi.example.com/pypi")
       end
     end
+
+    context "with a pyproject.toml index URL containing embedded userinfo" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_index_with_userinfo.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple",
+              "token" => "secret_token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "matches URLs ignoring userinfo in the pyproject.toml URL" do
+        options = lock_index_options.join(" ")
+        expect(options).not_to include("--index")
+        expect(options).not_to include("--default-index")
+      end
+    end
   end
 
   describe "#pyproject_index_env_vars" do
@@ -1136,6 +1159,31 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         )
       end
     end
+
+    context "with a pyproject.toml index URL containing embedded userinfo" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_index_with_userinfo.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple",
+              "username" => "oauth2accesstoken",
+              "password" => "my_token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "matches URLs ignoring userinfo and returns environment variables" do
+        expect(pyproject_index_env_vars).to include(
+          "UV_INDEX_COMPANY_PYPI_USERNAME" => "oauth2accesstoken",
+          "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_token"
+        )
+      end
+    end
   end
 
   describe "#uv_indices" do
@@ -1146,7 +1194,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
 
       it "parses index configuration correctly" do
         expect(uv_indices).to include(
-          "company_pypi" => { "url" => "https://private-pypi.example.com/simple", "explicit" => true }
+          "company_pypi" => { "url" => "https://private-pypi.example.com/simple" }
         )
       end
     end
@@ -1154,17 +1202,21 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
     context "with mixed indices in pyproject.toml" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_mixed_explicit_indices.toml") }
 
-      it "parses both explicit and non-explicit indices" do
-        expect(uv_indices["company_pypi"]["explicit"]).to be true
-        expect(uv_indices["fallback_pypi"]["explicit"]).to be_falsey
+      it "parses all named indices regardless of explicit flag" do
+        expect(uv_indices).to include(
+          "company_pypi" => { "url" => "https://private-pypi.example.com/simple" },
+          "fallback_pypi" => { "url" => "https://fallback-pypi.example.com/simple" }
+        )
       end
     end
 
     context "with non-explicit index in pyproject.toml" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_non_explicit_index.toml") }
 
-      it "parses index without explicit flag as non-explicit" do
-        expect(uv_indices["company_pypi"]["explicit"]).to be_falsey
+      it "parses the index URL" do
+        expect(uv_indices).to include(
+          "company_pypi" => { "url" => "https://private-pypi.example.com/simple" }
+        )
       end
     end
 

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -1229,6 +1229,44 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
     end
   end
 
+  describe "#normalize_index_url" do
+    subject(:normalized) { updater.send(:normalize_index_url, url) }
+
+    context "with a trailing slash" do
+      let(:url) { "https://private-pypi.example.com/simple/" }
+
+      it "strips the trailing slash" do
+        expect(normalized).to eq("https://private-pypi.example.com/simple")
+      end
+    end
+
+    context "with embedded userinfo" do
+      let(:url) { "https://oauth2accesstoken@private-pypi.example.com/simple/" }
+
+      it "strips both the userinfo and trailing slash" do
+        expect(normalized).to eq("https://private-pypi.example.com/simple")
+      end
+    end
+
+    context "with embedded username and password" do
+      let(:url) { "https://user:secret@private-pypi.example.com/simple" }
+
+      it "strips the full userinfo" do
+        expect(normalized).to eq("https://private-pypi.example.com/simple")
+      end
+    end
+
+    context "when the URL cannot be parsed by URI.parse" do
+      # A userinfo password containing an unencoded slash raises URI::InvalidURIError;
+      # the method must fall back to trailing-slash normalization without raising.
+      let(:url) { "https://user:pa/ss@private-pypi.example.com/simple/" }
+
+      it "falls back to chomping the trailing slash" do
+        expect(normalized).to eq("https://user:pa/ss@private-pypi.example.com/simple")
+      end
+    end
+  end
+
   describe "#lock_options_fingerprint" do
     subject(:lock_options_fingerprint) { updater.send(:lock_options_fingerprint, options) }
 

--- a/uv/spec/fixtures/pyproject_files/uv_index_with_userinfo.toml
+++ b/uv/spec/fixtures/pyproject_files/uv_index_with_userinfo.toml
@@ -1,0 +1,17 @@
+[project]
+name = "userinfo-index-project"
+version = "0.1.0"
+description = "Test UV index URL containing embedded userinfo"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0",
+    "private-package>=1.0.0",
+]
+
+[[tool.uv.index]]
+name = "company_pypi"
+url = "https://oauth2accesstoken@private-pypi.example.com/simple"
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14478


This PR fixes credential injection for `uv` private registry indexes declared in `pyproject.toml`, extending the env var authentication approach (introduced in #13798 for `explicit = true` indexes) to **all** matching `[[tool.uv.index]]` entries.

### The Problem

PR #13798 (fixing #13094) correctly identified that passing `--index` flags to `uv lock` for indexes already declared in `pyproject.toml` causes undesirable behavior (rewriting all package sources to the private index). The fix was to use `UV_INDEX_{NAME}_USERNAME/PASSWORD` env vars instead of `--index` -- but only when the `pyproject.toml` index had `explicit = true`.

This left two gaps:

**1. Non-explicit indexes still get duplicate `--index` injection**

When a `[[tool.uv.index]]` entry exists in `pyproject.toml` but doesn't have `explicit = true`, Dependabot still injects a duplicate `--index` flag. `uv` then sees two entries for the same registry, which can cause source rewriting and auth conflicts. There's no reason to add `--index` when the index is already declared in the project -- env vars authenticate the existing entry without duplication.

**2. URL matching doesn't strip userinfo, breaking GCP Artifact Registry (and similar)**

`normalize_index_url` only stripped trailing slashes. Many private registries embed a username in the `pyproject.toml` URL for local keyring-based auth:

```toml
[[tool.uv.index]]
name = "qs-python"
url = "https://oauth2accesstoken@us-central1-python.pkg.dev/my-project/my-repo/simple/"
```

While `dependabot.yml` provides the bare URL:

```yaml
registries:
  my-registry:
    type: python-index
    url: "https://us-central1-python.pkg.dev/my-project/my-repo/simple/"
    username: "oauth2accesstoken"
    password: ${{ secrets.TOKEN }}
```

These URLs never matched because `oauth2accesstoken@` was not stripped during comparison. The credential fell through to `--index`, creating a duplicate entry with different auth. The `pyproject.toml` entry (relying on a keyring subprocess that doesn't exist in Dependabot's sandbox) would get a 401, which `uv` treats as fatal -- blocking resolution of **all** packages, including public ones like `hatchling` from PyPI.

### The Fix

1. **Use env vars for ANY matching `[[tool.uv.index]]`**, not just `explicit = true`. If the index is already in `pyproject.toml`, there's no need to add `--index` -- just authenticate the existing entry. If the credential URL doesn't match any `pyproject.toml` index, `--index` is still used (the only way to tell `uv` about an index not in the project).

2. **Strip userinfo from URLs** during comparison using `URI.parse`, so `https://oauth2accesstoken@host/path` matches `https://host/path`.

### Anything you want to highlight for special attention from reviewers?

**Why removing the `explicit` check is safe:** The `explicit` flag in `uv` controls which packages an index is queried for -- it has nothing to do with how authentication is provided. Env var auth (`UV_INDEX_{NAME}_USERNAME/PASSWORD`) works identically for explicit and non-explicit indexes. The previous `explicit`-only gate was a scoping decision for #13798, not an architectural requirement.

**Backward compatibility:** Credentials for indexes NOT declared in `pyproject.toml` still use `--index`/`--default-index` flags, exactly as before. The only behavioral change is for credentials whose URL matches an existing `[[tool.uv.index]]` -- these now get env vars instead of a duplicate `--index`.

**The `replaces_base?` escape hatch is preserved:** Credentials with `replaces-base: true` always go through `--default-index`, unchanged.

### How will you know you've accomplished your goal?

- Private registries with `[[tool.uv.index]]` entries (both `explicit = true` and without) authenticate correctly via env vars
- Index URLs with embedded userinfo (e.g., GCP Artifact Registry with `oauth2accesstoken@`) match credential URLs without userinfo
- Public packages (e.g., `hatchling`) resolve from PyPI without being blocked by a 401 on a private index
- No source rewriting in `uv.lock` for packages that should come from PyPI

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.