### PR TITLE
gradle: fix wrapper updater crash when only some wrapper files define checksum

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -120,7 +120,7 @@ module Dependabot
         sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]], network_timeout: T.nilable(String)).returns(T::Array[String]) }
         def command_args(requirements, network_timeout)
           version = T.let(requirements[0]&.[](:requirement), String)
-          checksum = T.let(requirements[1]&.[](:requirement), String) if dependency.requirements.size > 1
+          checksum = T.let(requirements[1]&.[](:requirement), T.nilable(String)) if requirements.size > 1
           distribution_url = T.let(requirements[0]&.[](:source), T::Hash[Symbol, String])[:url]
           distribution_type = distribution_url&.match(/\b(bin|all)\b/)&.captures&.first
 

--- a/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
@@ -1,0 +1,70 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/gradle/file_updater"
+
+RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
+  subject(:command_args) { updater.send(:command_args, target_requirements, nil) }
+
+  let(:updater) do
+    described_class.new(
+      dependency_files: [],
+      dependency: dependency
+    )
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "gradle-wrapper",
+      version: "9.0.0",
+      requirements: [
+        {
+          file: "gradle/wrapper/gradle-wrapper.properties",
+          requirement: "9.0.0",
+          groups: [],
+          source: {
+            type: "gradle-distribution",
+            url: "https://services.gradle.org/distributions/gradle-9.0.0-bin.zip",
+            property: "distributionUrl"
+          }
+        },
+        {
+          file: "subproject/gradle/wrapper/gradle-wrapper.properties",
+          requirement: "9.0.0",
+          groups: [],
+          source: {
+            type: "gradle-distribution",
+            url: "https://services.gradle.org/distributions/gradle-9.0.0-all.zip",
+            property: "distributionUrl"
+          }
+        },
+        {
+          file: "subproject/gradle/wrapper/gradle-wrapper.properties",
+          requirement: "f759b8dd5204e2e3fa4ca3e73f452f087153cf81bac9561eeb854229cc2c5365",
+          groups: [],
+          source: {
+            type: "gradle-distribution",
+            url: "https://services.gradle.org/distributions/gradle-9.0.0-all.zip.sha256",
+            property: "distributionSha256Sum"
+          }
+        }
+      ],
+      package_manager: "gradle"
+    )
+  end
+
+  context "when the current wrapper file has no checksum requirement" do
+    let(:target_requirements) do
+      dependency.requirements.select do |req|
+        req[:file] == "gradle/wrapper/gradle-wrapper.properties"
+      end
+    end
+
+    it "does not crash and does not include a checksum argument from another wrapper file" do
+      expect(command_args).not_to include("--gradle-distribution-sha256-sum")
+      expect(command_args).to include("--distribution-type", "bin")
+    end
+  end
+end


### PR DESCRIPTION
## Problem
Dependabot crashes updating `gradle-wrapper` in repositories with multiple `gradle-wrapper.properties` files when only some files include `distributionSha256Sum`.

Error:
- `Error processing gradle-wrapper (TypeError)`
- `T.let: Expected type String, got type NilClass`

## Root cause
`WrapperUpdater#command_args` used a global guard:
- `dependency.requirements.size > 1`

but indexed into the local per-file slice:
- `requirements[1]`

In mixed multi-wrapper scenarios, a local file can have only one requirement (`distributionUrl`), so `requirements[1]` is `nil` and Sorbet raises.

## Fix
Use a local guard and nullable type for checksum extraction:
- `checksum = T.let(requirements[1]&.[](:requirement), T.nilable(String)) if requirements.size > 1`

This keeps behavior for single-wrapper repositories unchanged and prevents the crash for mixed multi-wrapper repositories.

## Test coverage
Added a focused regression spec:
- `gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb`

Scenario covered:
- dependency has merged requirements for two wrapper files
- current file has only `distributionUrl`
- another file has `distributionUrl` + `distributionSha256Sum`

Assertion:
- no checksum argument is added for the file without checksum and no crash occurs.

## Testing
```bash
bin/test gradle spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb spec/dependabot/gradle/file_updater_spec.rb --example wrapper
```

Result:
- `5 examples, 0 failures`
