### PR TITLE
Replace `gh release download` with `go install` for Dependabot CLI

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
-tar xzvf ./*.tar.gz >/dev/null 2>&1
-sudo mv dependabot /usr/local/bin
-rm ./*.tar.gz
+go install github.com/dependabot/cli/cmd/dependabot@latest
 
 bundle install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,17 +160,10 @@ jobs:
         with:
           go-version-file: 'silent/tests/go.mod'
 
-      - name: Download Dependabot CLI
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
-          tar xzvf *.tar.gz >/dev/null 2>&1
-          ./dependabot --version
+      - name: Install Dependabot CLI
+        run: go install github.com/dependabot/cli/cmd/dependabot@latest
 
       - name: Run integration tests
-        env:
-          PATH: ${{ github.workspace }}:$PATH
         run: |
           cd silent/tests
           go test ./...

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -57,15 +57,9 @@ jobs:
 
           # Set the step output
           echo "suites=$(cat suites.json)" >> $GITHUB_OUTPUT
-  download-cli:
-    uses: dependabot/smoke-tests/.github/workflows/download-cli.yml@main
-    permissions:
-      contents: read
-    secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   e2e:
-    needs: [discover, download-cli]
+    needs: [discover]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -78,15 +72,13 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Download CLI artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          name: dependabot-cli
+          go-version-file: 'go_modules/helpers/go.mod'
 
-      - name: Make CLI executable
-        run: |
-          chmod +x dependabot
-          ./dependabot --version
+      - name: Install Dependabot CLI
+        run: go install github.com/dependabot/cli/cmd/dependabot@latest
 
       - name: Restore Smoke Test
         id: cache-smoke-test
@@ -98,8 +90,7 @@ jobs:
       - name: Download test
         if: steps.cache-smoke-test.outputs.cache-hit != 'true'
         run: |
-          URL=https://api.github.com/repos/${{ vars.SMOKE_TEST_REPO || 'dependabot/smoke-tests' }}/contents/tests/${{ matrix.suite.name }}?ref=${{ env.SMOKE_TEST_BRANCH }}
-          curl $(gh api $URL --jq .download_url) -o smoke.yaml
+          gh api "repos/${{ vars.SMOKE_TEST_REPO || 'dependabot/smoke-tests' }}/contents/tests/${{ matrix.suite.name }}?ref=${{ env.SMOKE_TEST_BRANCH }}" -H "Accept: application/vnd.github.raw" > smoke.yaml
 
       - name: Cache Smoke Test
         if: steps.cache-smoke-test.outputs.cache-hit != 'true'
@@ -131,7 +122,7 @@ jobs:
           LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
-          ./dependabot test \
+          dependabot test \
             -f=smoke.yaml \
             -o=result.yaml \
             --cache=cache \

--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/Masterminds/vcs v1.13.3


### PR DESCRIPTION
## What

Replaces all usages of `gh release download` for obtaining the Dependabot CLI with `go install github.com/dependabot/cli/cmd/dependabot@latest`.

## Why

In Go module semantics, `@latest` resolves to the highest semver-tagged release — it's equivalent to downloading the latest GitHub release binary. Using `go install` is simpler and doesn't require `gh` authentication or artifact upload/download workflows.

Go is pre-installed on `ubuntu-latest` runners and in the dev container, so there's no additional setup cost.

## Changes

- **`.devcontainer/post-create.sh`** — replaced `gh release download` + `tar` + `sudo mv` with a single `go install`
- **`.github/workflows/ci.yml`** — replaced "Download Dependabot CLI" step with `go install`, removed unnecessary `PATH` override
- **`.github/workflows/smoke.yml`** — removed the `download-cli` reusable workflow job (going away upstream), replaced artifact download steps with `go install`, replaced `curl $(gh api ...)` with single `gh api` raw call

## Related PRs

- dependabot/smoke-tests#404 — same change in smoke-tests repo
- dependabot/cli#594 — `gh api` raw header approach for downloading smoke test files