### PR TITLE
Bump silent/tests go.mod to Go 1.26

### DIFF
--- a/silent/tests/go.mod
+++ b/silent/tests/go.mod
@@ -1,8 +1,7 @@
 module github.com/dependabot/dependabot-core/example
 
-go 1.22
+go 1.26
 
-require (
-	golang.org/x/tools v0.14.0 // indirect
-	rsc.io/script v0.0.2-0.20231205190631-334f6c18cff3 // indirect
-)
+require rsc.io/script v0.0.2-0.20231205190631-334f6c18cff3
+
+require golang.org/x/tools v0.14.0 // indirect


### PR DESCRIPTION
## What

Bumps the `go` directive in `silent/tests/go.mod` from 1.22 to 1.26.

## Why

The `dependabot/cli` now requires Go >= 1.26.0. The `setup-go` action in CI reads `go-version-file: 'silent/tests/go.mod'` to determine which Go version to install, and sets `GOTOOLCHAIN=local`. With `go 1.22`, `go install github.com/dependabot/cli/cmd/dependabot@latest` fails because the CLI requires a newer Go version.

## Related PRs

- #14400 — switches from `gh release download` to `go install` for the Dependabot CLI (blocked on this)