### PR TITLE
Extract pre-commit dependency version from comment in PR description

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -155,6 +155,7 @@ Metrics/AbcSize:
 # Offense count: 354/350
 Metrics/ClassLength:
   Exclude:
+    - 'common/lib/dependabot/dependency.rb'
     - 'opentofu/lib/dependabot/opentofu/file_parser.rb'
 
 # Offense count: 8

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -14,6 +14,10 @@ module Dependabot
     )
     @display_name_builders = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
     @name_normalisers = T.let({}, T::Hash[String, T.proc.params(arg0: String).returns(String)])
+    @humanized_previous_version_builders = T.let(
+      {},
+      T::Hash[String, T.proc.params(arg0: Dependency).returns(T.nilable(String))]
+    )
 
     sig do
       params(package_manager: String).returns(T.proc.params(arg0: T::Array[T.untyped]).returns(T::Boolean))
@@ -59,6 +63,25 @@ module Dependabot
     end
     def self.register_name_normaliser(package_manager, name_builder)
       @name_normalisers[package_manager] = name_builder
+    end
+
+    sig do
+      params(
+        package_manager: String
+      ).returns(T.nilable(T.proc.params(arg0: Dependency).returns(T.nilable(String))))
+    end
+    def self.humanized_previous_version_builder_for_package_manager(package_manager)
+      @humanized_previous_version_builders[package_manager]
+    end
+
+    sig do
+      params(
+        package_manager: String,
+        builder: T.proc.params(arg0: Dependency).returns(T.nilable(String))
+      ).void
+    end
+    def self.register_humanized_previous_version_builder(package_manager, builder)
+      @humanized_previous_version_builders[package_manager] = builder
     end
 
     sig { returns(String) }
@@ -225,24 +248,10 @@ module Dependabot
 
     sig { returns(T.nilable(String)) }
     def humanized_previous_version
-      # If we don't have a previous version, we *may* still be able to figure
-      # one out if a ref was provided and has been changed (in which case the
-      # previous ref was essentially the version).
-      if previous_version.nil?
-        return ref_changed? ? previous_ref : nil
-      end
+      custom_version = custom_humanized_previous_version
+      return custom_version if custom_version
 
-      if T.must(previous_version).match?(/^[0-9a-f]{40}/)
-        return previous_ref if ref_changed? && previous_ref
-
-        "`#{T.must(previous_version)[0..6]}`"
-      elsif version == previous_version &&
-            package_manager == "docker"
-        digest = docker_digest_from_reqs(T.must(previous_requirements))
-        "`#{T.must(T.must(digest).split(':').last)[0..6]}`"
-      else
-        previous_version
-      end
+      default_humanized_previous_version
     end
 
     sig { returns(T.nilable(String)) }
@@ -390,6 +399,40 @@ module Dependabot
     end
 
     private
+
+    sig { returns(T.nilable(String)) }
+    def custom_humanized_previous_version
+      builder = self.class.humanized_previous_version_builder_for_package_manager(package_manager)
+      return nil unless builder
+
+      builder.call(self)
+    end
+
+    sig { returns(T.nilable(String)) }
+    def default_humanized_previous_version
+      # If we don't have a previous version, we *may* still be able to figure
+      # one out if a ref was provided and has been changed (in which case the
+      # previous ref was essentially the version).
+      return (ref_changed? ? previous_ref : nil) if previous_version.nil?
+
+      return humanized_sha_previous_version if T.must(previous_version).match?(/^[0-9a-f]{40}/)
+      return humanized_docker_previous_version if version == previous_version && package_manager == "docker"
+
+      previous_version
+    end
+
+    sig { returns(T.nilable(String)) }
+    def humanized_sha_previous_version
+      return previous_ref if ref_changed? && previous_ref
+
+      "`#{T.must(previous_version)[0..6]}`"
+    end
+
+    sig { returns(String) }
+    def humanized_docker_previous_version
+      digest = docker_digest_from_reqs(T.must(previous_requirements))
+      "`#{T.must(T.must(digest).split(':').last)[0..6]}`"
+    end
 
     sig { void }
     def check_values

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -392,4 +392,112 @@ RSpec.describe Dependabot::Dependency do
       expect(dependency.all_versions).to eq(["1.0.0", "2.0.0"])
     end
   end
+
+  describe "#humanized_previous_version" do
+    context "with a registered humanized_previous_version_builder" do
+      before do
+        described_class.register_humanized_previous_version_builder(
+          "test_pm",
+          ->(dep) { dep.previous_requirements&.dig(0, :metadata, :comment_version) }
+        )
+      end
+
+      it "uses the registered builder when it returns a value" do
+        dependency = described_class.new(
+          name: "dep",
+          version: "abc123def456789012345678901234567890abcd",
+          previous_version: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e",
+          requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "abc123def456789012345678901234567890abcd" }
+          }],
+          previous_requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" },
+            metadata: { comment_version: "v2.2.1" }
+          }],
+          package_manager: "test_pm"
+        )
+
+        expect(dependency.humanized_previous_version).to eq("v2.2.1")
+      end
+
+      it "falls back to default behavior when builder returns nil" do
+        dependency = described_class.new(
+          name: "dep",
+          version: "abc123def456789012345678901234567890abcd",
+          previous_version: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e",
+          requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "abc123def456789012345678901234567890abcd" }
+          }],
+          previous_requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+          }],
+          package_manager: "test_pm"
+        )
+
+        # Falls back to previous_ref when ref changed and previous_ref exists
+        expect(dependency.humanized_previous_version).to eq("6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e")
+      end
+    end
+
+    context "without a registered builder" do
+      it "returns the previous_version when it's not a SHA" do
+        dependency = described_class.new(
+          name: "dep",
+          version: "v2.0.0",
+          previous_version: "v1.0.0",
+          requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: nil
+          }],
+          package_manager: "no_builder_pm"
+        )
+
+        expect(dependency.humanized_previous_version).to eq("v1.0.0")
+      end
+
+      it "returns previous_ref when previous_version is a SHA and ref changed" do
+        dependency = described_class.new(
+          name: "dep",
+          version: "abc123def456789012345678901234567890abcd",
+          previous_version: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e",
+          requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "abc123def456789012345678901234567890abcd" }
+          }],
+          previous_requirements: [{
+            file: "config.yaml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", ref: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+          }],
+          package_manager: "no_builder_pm"
+        )
+
+        # Returns previous_ref when ref changed and previous_ref exists
+        expect(dependency.humanized_previous_version).to eq("6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e")
+      end
+    end
+  end
 end

--- a/pre_commit/lib/dependabot/pre_commit.rb
+++ b/pre_commit/lib/dependabot/pre_commit.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 # These all need to be required so the various classes can be registered in a
@@ -11,6 +11,7 @@ require "dependabot/pre_commit/metadata_finder"
 require "dependabot/pre_commit/version"
 require "dependabot/pre_commit/requirement"
 require "dependabot/pre_commit/helpers"
+require "dependabot/pre_commit/comment_version_helper"
 
 require "dependabot/pull_request_creator/labeler"
 Dependabot::PullRequestCreator::Labeler
@@ -18,3 +19,21 @@ Dependabot::PullRequestCreator::Labeler
 
 require "dependabot/dependency"
 Dependabot::Dependency.register_production_check("pre_commit", ->(_) { true })
+
+# Register a humanized previous version builder for pre_commit that extracts
+# the version from the comment when using frozen SHA format (e.g., rev: <sha> # v2.2.1)
+Dependabot::Dependency.register_humanized_previous_version_builder(
+  "pre_commit",
+  lambda { |dep|
+    previous_reqs = dep.previous_requirements
+    return nil unless previous_reqs
+
+    comment = previous_reqs
+              .filter_map { |r| r.dig(:metadata, :comment) }
+              .first
+    return nil unless comment
+
+    match = comment.match(Dependabot::PreCommit::CommentVersionHelper::COMMENT_VERSION_PATTERN)
+    match&.[](0)
+  }
+)

--- a/pre_commit/spec/dependabot/pre_commit_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit_spec.rb
@@ -1,0 +1,166 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/pre_commit"
+
+RSpec.describe Dependabot::PreCommit do
+  describe "humanized_previous_version_builder registration" do
+    subject(:humanized_previous_version) { dependency.humanized_previous_version }
+
+    context "when previous_requirements contain a comment with version (frozen SHA format)" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/tofuutils/pre-commit-opentofu",
+          version: "10864545ddc58bd96330029b6bff16da3d072237",
+          previous_version: "04bfdda8eb902a604850282feec57563f388d71e",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/tofuutils/pre-commit-opentofu",
+              ref: "10864545ddc58bd96330029b6bff16da3d072237",
+              branch: nil
+            },
+            metadata: { comment_version: "v2.2.1", new_comment_version: "v2.2.2" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/tofuutils/pre-commit-opentofu",
+              ref: "04bfdda8eb902a604850282feec57563f388d71e",
+              branch: nil
+            },
+            metadata: { comment: "# v2.2.1" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      it "returns the version from the comment instead of the SHA" do
+        expect(humanized_previous_version).to eq("v2.2.1")
+      end
+    end
+
+    context "when previous_requirements contain a frozen comment format" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/example/hooks",
+          version: "abcdef1234567890abcdef1234567890abcdef12",
+          previous_version: "1234567890abcdef1234567890abcdef12345678",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/example/hooks",
+              ref: "abcdef1234567890abcdef1234567890abcdef12",
+              branch: nil
+            },
+            metadata: { comment_version: "7.3.0", new_comment_version: "8.0.0" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/example/hooks",
+              ref: "1234567890abcdef1234567890abcdef12345678",
+              branch: nil
+            },
+            metadata: { comment: "# frozen: 7.3.0" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      it "returns the version from the frozen comment" do
+        expect(humanized_previous_version).to eq("7.3.0")
+      end
+    end
+
+    context "when previous_requirements have no comment (tag-based version)" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/pre-commit/pre-commit-hooks",
+          version: "v4.5.0",
+          previous_version: "v4.4.0",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/pre-commit/pre-commit-hooks",
+              ref: "v4.5.0",
+              branch: nil
+            }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/pre-commit/pre-commit-hooks",
+              ref: "v4.4.0",
+              branch: nil
+            }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      it "falls back to the previous_version" do
+        expect(humanized_previous_version).to eq("v4.4.0")
+      end
+    end
+
+    context "when comment does not match version pattern" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/example/hooks",
+          version: "abcdef1234567890abcdef1234567890abcdef12",
+          previous_version: "1234567890abcdef1234567890abcdef12345678",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/example/hooks",
+              ref: "abcdef1234567890abcdef1234567890abcdef12",
+              branch: nil
+            }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: {
+              type: "git",
+              url: "https://github.com/example/hooks",
+              ref: "1234567890abcdef1234567890abcdef12345678",
+              branch: nil
+            },
+            metadata: { comment: "# some random comment" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      it "falls back to previous_ref (SHA in this case)" do
+        # When ref_changed? is true and previous_ref exists, it returns previous_ref
+        expect(humanized_previous_version).to eq("1234567890abcdef1234567890abcdef12345678")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes the issue where PR descriptions showed raw commit hashes instead of the version from comments when using frozen SHA format in `.pre-commit-config.yaml`.

**Problem:**
When users pin pre-commit hooks using SHA with a version comment:
```
repos:
  - repo: https://github.com/tofuutils/pre-commit-opentofu
    rev: 04bfdda8eb902a604850282feec57563f388d71e # v2.2.1
    hooks:
      - id: tofu_fmt
```
The PR description incorrectly displayed:
```
Bumps `https://github.com/tofuutils/pre-commit-opentofu` from 04bfdda8eb902a604850282feec57563f388d71e to 2.2.2
```
Instead of the expected:
```
Bumps `https://github.com/tofuutils/pre-commit-opentofu` from v2.2.1 to 2.2.2
```
<!-- Provide both a what and a _why_ for the change. -->
**Solution:**
Added a registration mechanism for ecosystems to customize how `humanized_previous_version` is computed, then registered a builder for `pre_commit` that extracts the version from the comment metadata.
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**Changes:**
`dependency.rb`:
 - Added `@humanized_previous_version_builders` class variable
 - Added `register_humanized_previous_version_builder` and `humanized_previous_version_builder_for_package_manager` class methods
 - Refactored `humanized_previous_version` to check for a registered builder before falling back to default behavior

`pre_commit.rb`:
 - Registered a `humanized_previous_version_builder` that extracts versions from comments using COMMENT_VERSION_PATTERN
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
If the PR description correctly shows the extracted version from comment.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
