### PR TITLE
Add scanned_manifests_path metadata to snapshots

### DIFF
--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -108,10 +108,17 @@ module GithubApi
           url: SNAPSHOT_DETECTOR_URL
         },
         manifests: manifests,
+        # TODO: Move use of metadata to a Dependabot-specific object
+        #
+        # We are using the existing job metadata as a bag-of-values for error handling
+        # and job tracking that is specific to Dependabot-created submissions.
+        #
+        # In future, we should extend the public API schema with a validated object to
+        # harden this contract.
         metadata: {
           status: status.serialize,
           reason: reason,
-          scanned_manifest_paths: scanned_manifest_paths
+          scanned_manifest_path: scanned_manifest_path
         }.compact
       }
     end
@@ -181,23 +188,15 @@ module GithubApi
       }
     end
 
-    # Returns the manifest paths this snapshot scanned.
+    # Returns a synopsis of the scan performed in the format `ecosystem::manifest_path`, e.g.
+    # - `golang::/`
+    # - `rubygems::rails_app/`
     #
-    # This allows the snapshot service to check the snapshot against those requested
-    # even if the `manifests` property is empty.
-    #
-    # Note: We currently submit each manifest path separately, but we use an array
-    #       to align with the `manifests` property and allow flexibility in future.
     sig do
-      returns(T::Array[T::Hash[Symbol, String]])
+      returns(String)
     end
-    def scanned_manifest_paths
-      [
-        {
-          ecosystem: GithubApi::EcosystemMapper.ecosystem_for(package_manager),
-          manifest_path: File.dirname(manifest_file.path)
-        }
-      ]
+    def scanned_manifest_path
+      "#{GithubApi::EcosystemMapper.ecosystem_for(package_manager)}::#{File.dirname(manifest_file.path)}"
     end
   end
 end

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
           # It should contain the expected metadata
           expect(payload[:metadata][:status]).to eql(GithubApi::DependencySubmission::SnapshotStatus::FAILED.serialize)
           expect(payload[:metadata][:reason]).to eql("dependency_file_not_evaluatable")
-          expect(payload[:metadata][:scanned_manifest_paths]).to eql([{ ecosystem: "rubygems", manifest_path: "/" }])
+          expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
         end
 
         it "correctly snapshots the second directory" do
@@ -419,10 +419,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
           # We should have metadata indicating a successful snapshot
           expect(payload[:metadata][:status]).to eql(GithubApi::DependencySubmission::SnapshotStatus::SUCCESS.serialize)
           expect(payload[:metadata][:reason]).to be_nil
-          expect(payload[:metadata][:scanned_manifest_paths]).to eql(
-            [{ ecosystem: "rubygems",
-               manifest_path: "/subproject" }]
-          )
+          expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/subproject")
         end
       end
     end
@@ -562,7 +559,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         # It should contain the expected metadata
         expect(payload[:metadata][:status]).to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED.serialize)
         expect(payload[:metadata][:reason]).to eq(GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS)
-        expect(payload[:metadata][:scanned_manifest_paths]).to eql([{ ecosystem: "rubygems", manifest_path: "/" }])
+        expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
       end
 
       update_graph_processor.run
@@ -671,7 +668,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
           # We should have metadata indicating a successful snapshot
           expect(payload[:metadata][:status]).to eql(GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize)
           expect(payload[:metadata][:reason]).to eql(GithubApi::DependencySubmission::DEGRADED_REASON_SUBDEPENDENCY_ERR)
-          expect(payload[:metadata][:scanned_manifest_paths]).to eql([{ ecosystem: "rubygems", manifest_path: "/" }])
+          expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
         end
 
         expect(service).to receive(:record_update_job_warning) do |args|

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -115,7 +115,7 @@ RSpec.shared_examples "dependency_submission" do |empty|
       # Check dependabot-specific metadata keys
       expect(payload[:metadata][:status]).to eql("ok")
       expect(payload[:metadata][:reason]).to be_nil
-      expect(payload[:metadata][:scanned_manifest_paths]).to eql([{ ecosystem: "rubygems", manifest_path: "/" }])
+      expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
     end
 
     it "affixes to use the updater sha if available" do


### PR DESCRIPTION
### What are you trying to accomplish?

We have started to track the snapshots received vs those requested from Dependabot in the service using the `manifest[].ecosystem` and `manifest[].file.source_location` but this only allows us to track 'happy path' outcomes.

In case where a manifest has been deleted or there was a fatal error processing the project, we will have an empty `manifests` collection in the snapshot.

To solve this problem, let's start adding an explicit `scanned_manifest_path` inventory to the metadata that will **always be populated** regardless of the snapshot outcome.

### Anything you want to highlight for special attention from reviewers?

This is using the current pattern of attaching these values to the snapshots top-level `metadata` key, in future we will extend the JSON definition with a Dependabot-specific object to validate and track the values a little more concretely, but for now this is good enough.

### How will you know you've accomplished your goal?

I will see the new `scanned_manifest_path` appear in any snapshots I generate from my test repos.

I will also see the smoke tests for graph jobs fail on this PR until I generate an updated test expectation.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
