### PR TITLE
don't fail if nuget feed returns unexpected 404

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -1446,4 +1446,62 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
         Assert.Equal("< 1.0.1", dependencyInfo.IgnoredVersions.Single().ToString());
         Assert.Empty(dependencyInfo.Vulnerabilities);
     }
+
+    [Fact]
+    public async Task MisbehavingNuGetFeedDoesNotTakeDownURLDiscovery()
+    {
+        using var http = TestHttpServer.CreateTestStringServer(url =>
+        {
+            var uri = new Uri(url, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                "/index.json" => (200, $$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """),
+                // registration index returns a range with @id but no inlined items;
+                // this causes the URL specified in @id to be queried but if that isn't present, the NuGet libraries will eventually throw
+                "/registrations/some.package/index.json" => (200, $$"""
+                    {
+                        "count": 1,
+                        "items": [
+                            {
+                                "@id": "{{baseUrl}}/registrations/some.package/page1.json",
+                                "lower": "1.0.0",
+                                "upper": "2.0.0"
+                            }
+                        ]
+                    }
+                    """),
+                _ => (404, "")
+            };
+        });
+        var feedUrl = $"{http.BaseUrl.TrimEnd('/')}/index.json";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+            ("NuGet.Config", $"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="private_feed" value="{feedUrl}" allowInsecureConnections="true" />
+                  </packageSources>
+                </configuration>
+                """)
+        );
+
+        var context = new NuGetContext(tempDir.DirectoryPath);
+        var infoUrl = await context.GetPackageInfoUrlAsync("some.package", "1.0.0", CancellationToken.None);
+        Assert.Null(infoUrl);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
@@ -458,4 +458,73 @@ public class VersionFinderTests : TestBase
         var actual = versions.Select(v => v.ToString()).ToArray();
         AssertEx.Equal(expected, actual);
     }
+
+    [Fact]
+    public async Task MisbehavingNuGetFeedDoesNotPreventFindingVersions()
+    {
+        using var http = TestHttpServer.CreateTestStringServer(url =>
+        {
+            var uri = new Uri(url, UriKind.Absolute);
+            var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return uri.PathAndQuery switch
+            {
+                "/index.json" => (200, $$"""
+                    {
+                        "version": "3.0.0",
+                        "resources": [
+                            {
+                                "@id": "{{baseUrl}}/download",
+                                "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                                "@id": "{{baseUrl}}/registrations",
+                                "@type": "RegistrationsBaseUrl"
+                            }
+                        ]
+                    }
+                    """),
+                // registration index returns a range with @id but no inlined items;
+                // this causes the URL specified in @id to be queried but if that isn't present, the NuGet libraries will eventually throw
+                "/registrations/some.package/index.json" => (200, $$"""
+                    {
+                        "count": 1,
+                        "items": [
+                            {
+                                "@id": "{{baseUrl}}/registrations/some.package/page1.json",
+                                "lower": "1.0.0",
+                                "upper": "2.0.0"
+                            }
+                        ]
+                    }
+                    """),
+                _ => (404, "")
+            };
+        });
+        var feedUrl = $"{http.BaseUrl.TrimEnd('/')}/index.json";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+            ("NuGet.Config", $"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="private_feed" value="{feedUrl}" allowInsecureConnections="true" />
+                  </packageSources>
+                </configuration>
+                """)
+        );
+
+        var context = new NuGetContext(tempDir.DirectoryPath);
+
+        var projectTfm = NuGetFramework.Parse("net9.0");
+        var dependencyInfo = new DependencyInfo()
+        {
+            Name = "Some.Package",
+            Version = "1.0.0",
+            IsVulnerable = false,
+        };
+        var currentVersion = NuGetVersion.Parse(dependencyInfo.Version);
+        var versionsResult = await VersionFinder.GetVersionsAsync([projectTfm], dependencyInfo, currentVersion, DateTime.Now, context, new TestLogger(), CancellationToken.None);
+        Assert.NotNull(versionsResult);
+        var versions = versionsResult.GetVersions();
+        Assert.Empty(versions);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -111,6 +111,11 @@ internal record NuGetContext : IDisposable
                 // if anything goes wrong here, the package source obviously doesn't contain the requested package
                 continue;
             }
+            catch (InvalidDataException)
+            {
+                // this usually means the feed returns an unexpected 404 when paging results; nothing we can do about it here
+                continue;
+            }
 
             var downloadResource = await sourceRepository.GetResourceAsync<DownloadResource>(cancellationToken);
             using var downloadResult = await downloadResource.GetDownloadResourceResultAsync(packageIdentity, PackageDownloadContext, globalPackagesFolder, Logger, cancellationToken);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -141,6 +141,11 @@ internal static class VersionFinder
                 // if anything goes wrong here, the package source obviously doesn't contain the requested package
                 continue;
             }
+            catch (InvalidDataException)
+            {
+                // this usually means the feed returns an unexpected 404 when paging results; nothing we can do about it here
+                continue;
+            }
             catch (JsonReaderException ex)
             {
                 // unable to parse server response


### PR DESCRIPTION
If a NuGet feed is returning results as paged and one of those page URLs returns a 404 then NuGet will throw a `System.IO.InvalidDataException`.  A real log was found with the following pattern:

```
GET https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/3.0.0-preview9.19424.4/5.0.12.json
200 https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/3.0.0-preview9.19424.4/5.0.12.json
GET https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/5.0.13/7.0.5.json
200 https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/5.0.13/7.0.5.json
GET https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/7.0.7/9.0.7.json
404 https://api.nuget.org:443/v3/registration5-gz-semver2/microsoft.aspnetcore.components.authorization/page/7.0.7/9.0.7.json
```

From analyzing call stacks, this appears to happen in two scenarios: (1) when enumerating package versions and (2) when fetching a package's info URL.

Both unit tests mimic a V3 feed that returns paged results where a page results in a 404.  Note that the URLs queried come directly from a prior call to the NuGet feed, so this is something entirely on the feed owner and not on this project or the NuGet libraries.  It appears to be transient, but often enough that it shows up in the logs.