### PR TITLE
Fix ArgumentError for devcontainer features without version constraint

### DIFF
--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -34,11 +34,14 @@ module Dependabot
       sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
       def updated_requirements
         dependency.requirements.map do |requirement|
-          required_version = T.cast(version_class.new(requirement[:requirement]), Dependabot::Devcontainers::Version)
-          updated_requirement = remove_precision_changes(
-            T.cast(release_versions, T::Array[Dependabot::Devcontainers::Version]),
-            required_version
-          ).last
+          req_string = requirement[:requirement]
+          updated_requirement = unless req_string.nil? || req_string.empty?
+                                  required_version = T.cast(version_class.new(req_string), Dependabot::Devcontainers::Version)
+                                  remove_precision_changes(
+                                    T.cast(release_versions, T::Array[Dependabot::Devcontainers::Version]),
+                                    required_version
+                                  ).last
+                                end
           {
             file: requirement[:file],
             requirement: updated_requirement,

--- a/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
@@ -118,6 +118,50 @@ RSpec.describe Dependabot::Devcontainers::UpdateChecker do
     end
   end
 
+  describe "#updated_requirements" do
+    context "when feature has no version constraint (trailing colon only)" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "ghcr.io/devcontainers/features/docker-in-docker",
+          version: "2.12.3",
+          requirements: [{
+            requirement: nil,
+            file: ".devcontainer/devcontainer.json",
+            groups: ["feature"],
+            source: nil
+          }],
+          package_manager: "devcontainers"
+        )
+      end
+      let(:project_name) { "config_in_root" }
+      let(:directory) { "/" }
+
+      before do
+        allow(checker).to receive(:release_versions).and_return(
+          [
+            Dependabot::Devcontainers::Version.new("2.12.3"),
+            Dependabot::Devcontainers::Version.new("2.16.1")
+          ]
+        )
+      end
+
+      it "does not raise an ArgumentError" do
+        expect { checker.updated_requirements }.not_to raise_error
+      end
+
+      it "preserves nil requirement so the feature reference stays unchanged" do
+        expect(checker.updated_requirements).to eq(
+          [{
+            file: ".devcontainer/devcontainer.json",
+            requirement: nil,
+            groups: ["feature"],
+            source: nil
+          }]
+        )
+      end
+    end
+  end
+
   describe "#latest_version with cooldown filter" do
     subject(:latest_version) { checker.latest_version.to_s }
 


### PR DESCRIPTION
resolve https://github.com/dependabot/dependabot-core/issues/11185

### What are you trying to accomplish?

When a devcontainer.json feature has no version specified (trailing colon only, e.g. "ghcr.io/foo/bar:"), the requirement is parsed as nil. Passing nil to Gem::Version.new raises ArgumentError.

Skip version processing for nil/empty requirements so the feature reference stays unchanged in devcontainer.json while still allowing the lockfile to be updated.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Run dry-run.rb against a repo with an unversioned feature (e.g. "ghcr.io/devcontainers/features/docker-in-docker:") and verify that devcontainer.json has no diff while devcontainer-lock.json is updated.

For dependencies with a version constraint (e.g. "1", "2.1"), the code path is unchanged — version_class.new(req_string) and remove_precision_changes run exactly as before. The new nil/empty guard only adds an early return for the previously-crashing case. Existing tests for versioned features continue to pass, confirming no regression.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
