### PR TITLE
bun: Parse catalog dependencies from package.json

### DIFF
--- a/bun/lib/dependabot/bun/file_parser.rb
+++ b/bun/lib/dependabot/bun/file_parser.rb
@@ -59,6 +59,7 @@ module Dependabot
         dependency_set = DependencySet.new
         dependency_set += manifest_dependencies
         dependency_set += lockfile_dependencies
+        dependency_set += catalog_dependencies
 
         dependencies = Helpers.dependencies_with_all_versions_metadata(dependency_set)
 
@@ -198,6 +199,55 @@ module Dependabot
       sig { returns(Dependabot::FileParsers::Base::DependencySet) }
       def lockfile_dependencies
         lockfile_parser.parse_set
+      end
+
+      sig { returns(Dependabot::FileParsers::Base::DependencySet) }
+      def catalog_dependencies
+        dependency_set = DependencySet.new
+        catalogs = parsed_catalog_definitions
+        return dependency_set if catalogs.empty?
+
+        # Default catalog
+        catalogs.fetch("catalog", {}).each do |name, version|
+          dep = build_dependency(
+            file: package_json, type: "catalog", name: name, requirement: version
+          )
+          dependency_set << dep if dep
+        end
+
+        # Named catalogs
+        catalogs.fetch("catalogs", {}).each do |_group_name, group_deps|
+          next unless group_deps.is_a?(Hash)
+
+          group_deps.each do |name, version|
+            dep = build_dependency(
+              file: package_json, type: "catalogs", name: name, requirement: version
+            )
+            dependency_set << dep if dep
+          end
+        end
+
+        dependency_set
+      end
+
+      sig { returns(T::Hash[String, T.untyped]) }
+      def parsed_catalog_definitions
+        @parsed_catalog_definitions ||= T.let(
+          begin
+            json = parsed_package_json
+            result = T.let({}, T::Hash[String, T.untyped])
+
+            # Catalogs can be at top level or inside "workspaces"
+            catalog = json["catalog"] || json.dig("workspaces", "catalog")
+            catalogs = json["catalogs"] || json.dig("workspaces", "catalogs")
+
+            result["catalog"] = catalog if catalog.is_a?(Hash)
+            result["catalogs"] = catalogs if catalogs.is_a?(Hash)
+
+            result
+          end,
+          T.nilable(T::Hash[String, T.untyped])
+        )
       end
 
       sig do

--- a/bun/spec/dependabot/bun/file_parser_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser_spec.rb
@@ -61,6 +61,39 @@ RSpec.describe Dependabot::Bun::FileParser do
 
         its(:length) { is_expected.to eq(0) }
       end
+
+      context "with catalog dependencies" do
+        let(:files) { project_dependency_files("bun/catalog_workspace") }
+
+        it "parses dependencies from the default catalog" do
+          react = dependencies.find { |d| d.name == "react" }
+          expect(react).to be_a(Dependabot::Dependency)
+          expect(react.version).to eq("18.2.0")
+          expect(react.requirements).to include(
+            a_hash_including(
+              requirement: "^18.2.0",
+              groups: ["catalog"]
+            )
+          )
+        end
+
+        it "parses dependencies from named catalogs" do
+          jest = dependencies.find { |d| d.name == "jest" }
+          expect(jest).to be_a(Dependabot::Dependency)
+          expect(jest.version).to eq("29.6.2")
+          expect(jest.requirements).to include(
+            a_hash_including(
+              requirement: "^29.6.2",
+              groups: ["catalogs"]
+            )
+          )
+        end
+
+        it "includes all catalog dependencies" do
+          catalog_names = dependencies.map(&:name)
+          expect(catalog_names).to include("react", "react-dom", "jest", "testing-library")
+        end
+      end
     end
   end
 

--- a/bun/spec/fixtures/projects/bun/catalog_workspace/bun.lock
+++ b/bun/spec/fixtures/projects/bun/catalog_workspace/bun.lock
@@ -1,0 +1,35 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "my-monorepo",
+    },
+    "packages/app": {
+      "name": "app",
+      "dependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "jest": "catalog:testing",
+      },
+    },
+  },
+  "catalog": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+  },
+  "catalogs": {
+    "testing": {
+      "jest": "^29.6.2",
+      "testing-library": "^14.0.0",
+    },
+  },
+  "packages": {
+    "jest": ["jest@29.6.2", "", {}, "sha512-GOn61gOjEMhFhEx0V6rqfHJPmYNbMkduUOBW06n1In1zsCH/AOxAnFGfpmwzVlSJiFdPmI3HFQiLG5aEMOBiVQ=="],
+
+    "react": ["react@18.2.0", "", {}, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
+
+    "react-dom": ["react-dom@18.2.0", "", { "dependencies": { "react": "^18.2.0" } }, "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g=="],
+
+    "testing-library": ["testing-library@14.0.0", "", {}, "sha512-fakehash=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/catalog_workspace/package.json
+++ b/bun/spec/fixtures/projects/bun/catalog_workspace/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "my-monorepo",
+  "workspaces": {
+    "packages": ["packages/*"],
+    "catalog": {
+      "react": "^18.2.0",
+      "react-dom": "^18.2.0"
+    },
+    "catalogs": {
+      "testing": {
+        "jest": "^29.6.2",
+        "testing-library": "^14.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Add support for parsing Bun catalog and named catalog dependencies defined in the root `package.json`. Previously, dependencies using the `catalog:` specifier were silently skipped during parsing because `file_parser.rb` explicitly excluded them at line 175.

## Why

Bun supports [catalog](https://bun.sh/docs/install/workspaces#workspace-catalog) and [named catalogs](https://bun.sh/docs/install/workspaces#named-catalogs) (similar to pnpm's catalog feature) to share dependency versions across workspace packages. Without this fix, Dependabot cannot detect or update any dependencies defined in catalogs, leaving workspace monorepos with stale versions.

## How

- Added `catalog_dependencies` method that extracts dependencies from both the default `catalog` section and named `catalogs` sections
- Added `parsed_catalog_definitions` helper that reads catalog definitions from top-level or inside the `workspaces` key of `package.json`
- Dependencies get groups set to `["catalog"]` or `["catalogs"]` so `PackageJsonUpdater.update_package_json_sections` targets the correct JSON section during updates (this updater already supports arbitrary section names via the groups field)
- Pattern follows the existing pnpm catalog implementation in `npm_and_yarn`

## Tests

- Added RSpec tests covering default catalog parsing, named catalog parsing, and completeness check
- Added fixture project `bun/catalog_workspace` with `package.json` and `bun.lock` containing both catalog types
- All 16 existing + new tests pass

## Example

**package.json (root):**
```json
{
  "name": "my-monorepo",
  "workspaces": {
    "packages": ["packages/*"],
    "catalog": {
      "react": "^18.2.0",
      "react-dom": "^18.2.0"
    },
    "catalogs": {
      "testing": {
        "jest": "^29.6.2"
      }
    }
  }
}
```

**packages/app/package.json:**
```json
{
  "dependencies": {
    "react": "catalog:",
    "jest": "catalog:testing"
  }
}
```

Previously: `react` and `jest` silently ignored.
Now: Both parsed with correct versions from catalog definitions.

Fixes #14320