### PR TITLE
uv: Fix case-insensitive matching for package names in pyproject.toml

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -145,7 +145,7 @@ module Dependabot
           old_req = old_r[:requirement]
           escaped_name = escape_package_name(dep.name)
 
-          regex = /(["']#{escaped_name})([^"']+)(["'])/x
+          regex = /(["']#{escaped_name})([^"']+)(["'])/ix
 
           replaced = T.let(false, T::Boolean)
 

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -1339,6 +1339,47 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         end
       end
     end
+
+    context "with mixed case package name in source file" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "pyjwt",
+          version: "2.11.0",
+          requirements: [{
+            file: "pyproject.toml",
+            requirement: ">=2.11.0",
+            groups: [],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: "pyproject.toml",
+            requirement: ">=2.10.1",
+            groups: [],
+            source: nil
+          }],
+          previous_version: "2.10.1",
+          package_manager: "uv"
+        )
+      end
+
+      let(:new_req) { { requirement: ">=2.11.0" } }
+      let(:old_req) { { requirement: ">=2.10.1" } }
+
+      let(:content) do
+        <<~TOML
+          [project]
+          dependencies = [
+              "PyJWT>=2.10.1",
+          ]
+        TOML
+      end
+
+      it "matches case-insensitively and preserves original casing" do
+        result = replace_dep
+        expect(result).to include('"PyJWT>=2.11.0"')
+        expect(result).not_to include(">=2.10.1")
+      end
+    end
   end
 
   describe "#requirements_match?" do


### PR DESCRIPTION
## What

Fix `DependencyFileContentNotChanged` error when updating dependencies whose package name in `pyproject.toml` differs in case from the normalized name in `uv.lock`.

## Why

PEP 503 normalizes package names to lowercase (e.g., `PyJWT` → `pyjwt`). The `NameNormaliser` correctly applies this, so `dep.name` becomes `pyjwt`. However, `replace_dep` builds a regex from this lowercase name and tries to match it against the original `pyproject.toml` source which still has `PyJWT`. The regex uses the `/x` flag (extended format) but not `/i` (case-insensitive), so it never matches.

## How

Added the `/i` flag to the regex in `replace_dep`:
```ruby
# Before:
regex = /(["']#{escaped_name})([^"']+)(["'])/x
# After:
regex = /(["']#{escaped_name})([^"']+)(["'])/ix
```

The replacement uses `Regexp.last_match(1)` which preserves the original casing from the source file — so `PyJWT` stays as `PyJWT` in the output.

## Tests

1 new RSpec test added to `lock_file_updater_spec.rb`:
- Mixed case package name: `PyJWT` in source matched by normalized `pyjwt` ✅

Full test suite: **63 examples, 0 failures**

## Reproduction

`pyproject.toml`:
```toml
[project]
dependencies = [
    "PyJWT>=2.10.1",
]
```

Before: `dependency_file_content_not_changed` — regex `pyjwt` can't match `PyJWT`
After: Version correctly updated to `>=2.11.0`, preserving `PyJWT` casing

Fixes #14119