### PR TITLE
uv: Allow lockfile updates for build-system deps that also appear in uv.lock

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -84,8 +84,20 @@ module Dependabot
 
           groups = T.must(dependency).requirements.flat_map { |req| req[:groups] || [] }.compact.uniq
           return false if groups.empty?
+          return false unless groups.all?("build-system")
 
-          groups.all?("build-system")
+          # A build-system dependency that also appears in the lockfile as a
+          # transitive/runtime package still needs lockfile updates
+          !dependency_in_lockfile?
+        end
+
+        sig { returns(T::Boolean) }
+        def dependency_in_lockfile?
+          lockfile_content = lockfile&.content
+          return false unless lockfile_content
+
+          dep_name = normalise(T.must(dependency).name)
+          lockfile_content.match?(/^name = "#{Regexp.escape(dep_name)}"$/m)
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -364,6 +364,51 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
     end
 
+    context "when updating a build-system dependency that also appears in the lockfile" do
+      let(:pyproject_content) { fixture("pyproject_files", "build_system_also_transitive.toml") }
+      let(:lockfile_content) { fixture("uv_locks", "build_system_also_transitive.lock") }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "setuptools",
+          version: "80.10.2",
+          requirements: [{
+            file: "pyproject.toml",
+            requirement: ">=70",
+            groups: ["build-system"],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: "pyproject.toml",
+            requirement: ">=70",
+            groups: ["build-system"],
+            source: nil
+          }],
+          previous_version: "80.9.0",
+          package_manager: "uv"
+        )
+      end
+
+      it "updates the lockfile" do
+        updated_lockfile_content = lockfile_content.sub(
+          'version = "80.9.0"',
+          'version = "80.10.2"'
+        )
+
+        allow(updater).to receive(:updated_lockfile_content).and_return(updated_lockfile_content)
+
+        updated_dependency_files = updater.updated_dependency_files
+
+        # Should NOT include pyproject.toml (requirement didn't change)
+        expect(updated_dependency_files.map(&:name)).not_to include("pyproject.toml")
+
+        # Should include the lockfile with updated version
+        lock = updated_dependency_files.find { |f| f.name == "uv.lock" }
+        expect(lock).not_to be_nil
+        expect(lock.content).to include('version = "80.10.2"')
+      end
+    end
+
     context "when updating a regular dependency" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
       let(:lockfile_content) { fixture("uv_locks", "simple.lock") }

--- a/uv/spec/fixtures/pyproject_files/build_system_also_transitive.toml
+++ b/uv/spec/fixtures/pyproject_files/build_system_also_transitive.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dummy-project"
+version = "0.1.0"
+description = ""
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0",
+]

--- a/uv/spec/fixtures/uv_locks/build_system_also_transitive.lock
+++ b/uv/spec/fixtures/uv_locks/build_system_also_transitive.lock
@@ -1,0 +1,35 @@
+version = 1
+requires-python = ">=3.9"
+
+[[package]]
+name = "certifi"
+version = "2025.1.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/certifi-2025.1.31.tar.gz", hash = "sha256:abc123" }
+
+[[package]]
+name = "dummy-project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "requests", specifier = ">=2.31.0" }]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/requests-2.32.3.tar.gz", hash = "sha256:abc123" }
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/setuptools-80.9.0.tar.gz", hash = "sha256:abc123" }


### PR DESCRIPTION
## What

Fix `"No files have changed!"` error when updating dependencies that are both a build-system dependency (in `[build-system].requires`) and a transitive runtime dependency (appearing in `uv.lock` via another package's extras like `moto[server]`).

## Why

PR #13760 added `build_system_only_dependency?` to skip lockfile updates for build-system-only deps, since they don't appear in `uv.lock` by design. But when a package like `setuptools` is in `[build-system].requires` AND also exists in `uv.lock` as a transitive dep, the check incorrectly blocks the lockfile update:

1. `build_system_only_dependency?` returns `true` (all groups are `"build-system"`)
2. Lockfile update is skipped
3. `file_changed?` returns `false` (build-system requirement didn't change)
4. No files updated → `"No files have changed!"`

## How

Modified `build_system_only_dependency?` to check whether the dependency also appears as a `[[package]]` entry in `uv.lock`. If it does, the dependency is not truly build-system-only — it's also a runtime/transitive package that needs lockfile updates.

Added `dependency_in_lockfile?` helper that matches `name = "dep_name"` in the lockfile content using a line-anchored regex.

The existing build-system-only test (`hatchling`) continues to pass because `hatchling` does NOT appear as a `[[package]]` in the test lockfile — it's truly build-system-only.

## Tests

1 new RSpec test added to `lock_file_updater_spec.rb`:
- Build-system dependency that also appears in the lockfile: `setuptools` with `groups: ["build-system"]` and present in `uv.lock` as a transitive package — verifies the lockfile IS updated ✅

Existing test preserved:
- Build-system-only dependency: `hatchling` NOT in lockfile — verifies the lockfile is NOT updated (regression) ✅

Full test suite: **63 examples, 0 failures**
Transitive dep spec: **1 example, 0 failures**

## Reproduction

`pyproject.toml`:
```toml
[build-system]
requires = ["setuptools>=70"]

[project]
dependencies = ["moto[server]>=5.0"]
```

`setuptools` ends up in `uv.lock` as a transitive dep of `moto[server]`.

Before: `RuntimeError: No files have changed!`
After: `uv.lock` correctly updated with new `setuptools` version

Fixes #14118