### PR TITLE
Handle unhandled uv errors prefixed with `CPython interpreter` info

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_error_handler.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_error_handler.rb
@@ -65,8 +65,8 @@ module Dependabot
           Regexp
         )
         # uv prefixes errors with interpreter info that should be stripped
-        USING_CPYTHON_REGEX = T.let(
-          /Using CPython \S+ interpreter at: /,
+        USING_CPYTHON_LINE_REGEX = T.let(
+          /\AUsing CPython \S+ interpreter at: [^\n]+\n?/,
           Regexp
         )
         PYPROJECT_SCHEMA_ERROR_REGEX = T.let(
@@ -301,9 +301,7 @@ module Dependabot
 
         sig { params(message: String).void }
         def handle_uv_fallback_error(message)
-          anchored_using_cpython_regex =
-            Regexp.new("\\A#{USING_CPYTHON_REGEX.source}", USING_CPYTHON_REGEX.options)
-          return unless message.match?(anchored_using_cpython_regex)
+          return unless message.match?(USING_CPYTHON_LINE_REGEX)
 
           raise Dependabot::DependencyFileNotResolvable, clean_error_message(message)
         end
@@ -326,7 +324,7 @@ module Dependabot
         sig { params(message: String).returns(String) }
         def clean_error_message(message)
           message
-            .gsub(/\AUsing CPython \S+ interpreter at: [^\n]+\n?/, "")
+            .sub(USING_CPYTHON_LINE_REGEX, "")
             .gsub(/#{Regexp.escape(Utils::BUMP_TMP_DIR_PATH)}[^\s]*/o, "")
             .lines
             .reject { |line| line.strip.empty? }

--- a/uv/spec/dependabot/uv/file_updater/lock_file_error_handler_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_error_handler_spec.rb
@@ -530,6 +530,19 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileErrorHandler do
       end
     end
 
+    context "when error contains 'Using CPython' mid-message (not at start)" do
+      let(:error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: "some other error\nUsing CPython 3.11.14 interpreter at: /usr/bin/python3.11\ndetails",
+          error_context: {}
+        )
+      end
+
+      it "re-raises the original error" do
+        expect { handle_uv_error }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      end
+    end
+
     context "when error is unknown" do
       let(:error) do
         Dependabot::SharedHelpers::HelperSubprocessFailed.new(


### PR DESCRIPTION
### What are you trying to accomplish?

Catch unhandled `uv` errors that start with Using `CPython <version> interpreter at:` and surface them as `DependencyFileNotResolvable` instead of letting them propagate as raw `HelperSubprocessFailed` / `unknown_error`.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

- Unit tests: Added tests in `lock_file_error_handler_spec.rb` covering both error scenarios — `uv` conflicting URLs resolution failure and uv.lock parse failure — both prefixed with Using CPython. Tests verify the correct exception type (`DependencyFileNotResolvable`) is raised and that the Using `CPython prefix` is stripped from the error message.
- All existing tests pass: The 30 existing handler tests continue to pass, confirming that more-specific handlers (git errors, auth errors, build failures, etc.) still take priority over the new fallback.
- Sentry validation: After deployment, the ~1867 unknown_error events with Using `CPython` prefix should stop appearing and instead be recorded as `dependency_file_not_resolvable`, which is an expected/actionable error type.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
