### PR TITLE
fix(github_actions): use most specific version tag when updating comments

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -110,8 +110,12 @@ module Dependabot
         previous_version_tags = git_checker.most_specific_version_tags_for_sha(old_ref)
         return unless previous_version_tags.any? # There's no tag for this commit
 
+        # Use the most specific (longest) matching version to avoid partial replacements.
+        # Tags are sorted ascending, so ["v1", "v1.0", "v1.0.1"] maps to ["1", "1.0", "1.0.1"].
+        # Without this, "1" could match the end of "v1.0.1", causing gsub("1", "1.1") => "v1.1.0.1.1".
         previous_version = previous_version_tags.map { |tag| version_class.new(tag).to_s }
-                                                .find { |version| comment.end_with? version }
+                                                .select { |version| comment.end_with?(version) }
+                                                .max_by(&:length)
         return unless previous_version
 
         new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -485,6 +485,69 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         end
       end
 
+      context "with pinned SHA where shorter tag version is a suffix of comment version" do
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+        let(:workflow_file_body) do
+          fixture("workflow_files", "pinned_source_multiple_tags_substring_versions.yml")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "advanced-security/filter-sarif",
+            version: "1.1",
+            package_manager: "github_actions",
+            previous_version: "1.0.1",
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/advanced-security/filter-sarif",
+                ref: "f3b8118a9349d88f7b1c0c488476411145b6270d",
+                branch: nil
+              },
+              metadata: {
+                declaration_string:
+                  "advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d"
+              }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/advanced-security/filter-sarif",
+                ref: "2da736ff05ef065cb2894ac6892e47b5eac2c3c0",
+                branch: nil
+              },
+              metadata: {
+                declaration_string:
+                  "advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0"
+              }
+            }]
+          )
+        end
+
+        it "uses the most specific matching tag to avoid partial gsub replacements" do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          # The old SHA has multiple tags where "1" (from v1) is a suffix of "1.0.1"
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha)
+            .with("f3b8118a9349d88f7b1c0c488476411145b6270d")
+            .and_return(["v1", "v1.0", "v1.0.1"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha)
+            .with("2da736ff05ef065cb2894ac6892e47b5eac2c3c0")
+            .and_return("v1.1")
+
+          expect(updated_workflow_file.content).to include(
+            "advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1"
+          )
+          # Must NOT contain the buggy result where gsub("1", "1.1") mangled the comment
+          expect(updated_workflow_file.content).not_to include("v1.1.0.1.1")
+        end
+      end
+
       context "with pinned SHA hash matching multiple tags and version in comment different from latest matching tag" do
         let(:service_pack_url) do
           "https://github.com/github/codeql-action.git/info/refs" \

--- a/github_actions/spec/fixtures/workflow_files/pinned_source_multiple_tags_substring_versions.yml
+++ b/github_actions/spec/fixtures/workflow_files/pinned_source_multiple_tags_substring_versions.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Integration
+jobs:
+  chore:
+    steps:
+    - uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1


### PR DESCRIPTION
## Summary

When a pinned SHA has multiple version tags (e.g. `v1`, `v1.0`, `v1.0.1`), the version comment update logic in `FileUpdater#updated_version_comment` used `.find` to pick the first tag whose version string was a suffix of the comment. Because tags are sorted ascending by version, this could pick a short version like `"1"` that is a substring of the actual comment version `"1.0.1"`. The subsequent `gsub("1", "1.1")` then mangled the entire comment:

- **Before (bug):** `# v1.0.1` → `# v1.1.0.1.1`
- **After (fix):** `# v1.0.1` → `# v1.1`

## Root Cause

In `updated_version_comment`, the code:
```ruby
previous_version = previous_version_tags.map { |tag| version_class.new(tag).to_s }
                                        .find { |version| comment.end_with? version }
```

With tags `["v1", "v1.0", "v1.0.1"]`, this maps to `["1", "1.0", "1.0.1"]` and `.find` returns `"1"` because `"v1.0.1".end_with?("1")` is true. Then `comment.gsub("1", "1.1")` replaces every `"1"` in the comment.

## Fix

Changed `.find` to `.select { ... }.max_by(&:length)` so the longest (most specific) matching version string is used. This correctly picks `"1.0.1"` over `"1"`, and `gsub("1.0.1", "1.1")` produces the correct result.

## Test

Added a test case that reproduces the exact scenario from https://github.com/cli/cli/pull/12918 — multiple tags (`v1`, `v1.0`, `v1.0.1`) on the same SHA where a shorter version is a suffix of the version in the comment.

## References

- Observed in: https://github.com/cli/cli/pull/12918