### PR TITLE
strip extras from Python PURLs in DG payload

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -53,6 +53,13 @@ module Dependabot
         "pypi"
       end
 
+      # Strip extras (e.g. "[filecache]") from the dependency name for PURLs,
+      # since the PURL should reference the base package only.
+      sig { override.params(dependency: Dependabot::Dependency).returns(String) }
+      def purl_name_for(dependency)
+        NameNormaliser.normalise(dependency.name)
+      end
+
       sig { returns(T::Hash[String, T::Array[String]]) }
       def package_relationships
         @package_relationships ||= T.let(

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -174,6 +174,22 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
         expect(grapher.relevant_dependency_file).to eql(setup_py)
       end
     end
+
+    context "when a requirements.txt contains dependencies with extras" do
+      let(:requirements_txt_with_extras) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "cachecontrol[filecache]==0.14.2\nrequests==2.32.5\n",
+          directory: "/"
+        )
+      end
+
+      let(:dependency_files) { [requirements_txt_with_extras] }
+
+      it "falls back to requirements.txt" do
+        expect(grapher.relevant_dependency_file).to eql(requirements_txt_with_extras)
+      end
+    end
   end
 
   describe "#resolved_dependencies" do
@@ -412,6 +428,26 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
             "pkg:pypi/urllib3@2.2.1"
           ]
         )
+      end
+    end
+
+    context "when dependencies have extras in their names" do
+      let(:requirements_txt_with_extras) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "cachecontrol[filecache]==0.14.2\nrequests==2.32.5\n",
+          directory: "/"
+        )
+      end
+
+      let(:dependency_files) { [requirements_txt_with_extras] }
+
+      it "strips extras from PURL names" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        purl_keys = resolved_dependencies.keys
+        expect(purl_keys).to include("pkg:pypi/cachecontrol@0.14.2")
+        expect(purl_keys).not_to include("pkg:pypi/cachecontrol[filecache]@0.14.2")
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Python can specify dependency extras like `cachecontrol[filecache]==0.14.2` where `filecache` specifies a set of transitive dependencies that are optionally specified. 

Dependabot carries this extra data in the Dependency name (e.g. `cachecontrol[filecache]`) probably so when it bumps it preserves the extras.

For submitting this data to Dependency Graph we need to strip it, because the package is just `cachecontrol`.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

We'll see correct names show up in Dependency Graph.

Running this in Dependabot CLI shows it's working now. This used to be `coverage[toml]`

```
$ dependabot graph pip encode/httpx
...
updater |         "pkg:pypi/coverage@7.10.6": {
...
```

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
