### PR TITLE
additional unparseable file message

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -634,5 +634,17 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new UnknownError(new Exception("Multiple project files found for single packages.config"), "TEST-JOB-ID"),
         ];
+
+        yield return
+        [
+            // output
+            """
+            Error parsing packages.config file at /path/to/packages.config: Unexpected XML declaration. The XML declaration must be the first node in the document, and no whitespace characters are allowed to appear before it. Line 1, position 5.
+
+            ^^^ this blank line is necessary to force a newline at the end of the output
+            """,
+            // expectedError
+            new DependencyFileNotParseable("/path/to/packages.config", "Unexpected XML declaration. The XML declaration must be the first node in the document, and no whitespace characters are allowed to appear before it. Line 1, position 5.")
+        ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -728,6 +728,7 @@ internal static partial class MSBuildHelper
         {
             new Regex(@"\nAn error occurred while reading file '(?<FilePath>[^']+)': (?<Message>[^\n]*)\n"),
             new Regex(@"NuGet\.Config is not valid XML\. Path: '(?<FilePath>[^']+)'\.\n\s*(?<Message>[^\n]*)(\n|$)"),
+            new Regex(@"Error parsing packages\.config file at (?<FilePath>[^:]+): (?<Message>[^\n]*)\n"),
         };
         var match = patterns.Select(p => p.Match(output)).Where(m => m.Success).FirstOrDefault();
         if (match is not null)


### PR DESCRIPTION
From scanning the error reporting, I found a scenario where it was really easy to pull out the error of an unparsable `packages.config` file.