### PR TITLE
Add workflow to auto-update RBI files on Dependabot bundler PRs

### DIFF
--- a/.github/workflows/update-rbi.yml
+++ b/.github/workflows/update-rbi.yml
@@ -1,0 +1,58 @@
+name: Update RBI files
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  fetch-dependabot-metadata:
+    runs-on: ubuntu-latest
+    # Only check metadata on pull_request events from Dependabot itself.
+    # Subsequent pushes to the PR skip this step to avoid commit loops.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    outputs:
+      package-ecosystem: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
+    steps:
+      - name: Fetch dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  update-rbi-files:
+    runs-on: ubuntu-latest
+    needs: [fetch-dependabot-metadata]
+    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'bundler'
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_CORE_ACTION_AUTOMATION_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1.290.0
+        with:
+          bundler-cache: true
+
+      - name: Update RBI files
+        run: |
+          bundle exec tapioca gem
+          bundle exec tapioca todo
+
+      - name: Commit updated RBI files
+        run: |
+          git add sorbet/rbi/
+          git config user.name "github-actions[bot]"
+          # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "[dependabot skip] Update sorbet/rbi with changes for dependency update" || exit 0
+          git push


### PR DESCRIPTION
## Summary

When Dependabot opens a PR to update bundler dependencies, the gem RBI files in `sorbet/rbi/gems/` are not regenerated. This causes stale RBI files to accumulate (currently 27 gems with multiple versioned RBI files) and can lead to Sorbet check failures when a gem update introduces a class/module definition that conflicts with a stub in `todo.rbi`.

## Changes

Adds a new `update-rbi.yml` workflow that:
- Triggers on `pull_request` events
- Uses `dependabot/fetch-metadata` to detect the package ecosystem
- Only runs on Dependabot bundler PRs
- Runs `bundle exec tapioca gem` to regenerate gem RBIs (cleans up old versions, generates new ones)
- Runs `bundle exec tapioca todo` to regenerate `todo.rbi` (removes stale entries)
- Commits and pushes any changes back to the PR branch
- Uses the existing `DEPENDABOT_CORE_ACTION_AUTOMATION` app token for push access
- Includes `[dependabot skip]` in the commit message to prevent retriggering Dependabot

Closes #14465