### PR TITLE
fix(bazel): update FileFetcher to resolve import/try-import statements in .bazelrc (#13880)

### DIFF
--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -14,6 +14,7 @@ module Dependabot
       require_relative "file_fetcher/module_path_extractor"
       require_relative "file_fetcher/directory_tree_fetcher"
       require_relative "file_fetcher/downloader_config_fetcher"
+      require_relative "file_fetcher/bazelrc_import_fetcher"
       require_relative "file_fetcher/include_extractor"
 
       WORKSPACE_FILES = T.let(%w(WORKSPACE WORKSPACE.bazel).freeze, T::Array[String])
@@ -40,6 +41,7 @@ module Dependabot
         fetched_files += config_files
         fetched_files += referenced_files_from_modules
         fetched_files += downloader_config_files
+        fetched_files += bazelrc_import_files
 
         return fetched_files if fetched_files.any?
 
@@ -240,6 +242,12 @@ module Dependabot
       def downloader_config_files
         config_fetcher = DownloaderConfigFetcher.new(fetcher: self)
         config_fetcher.fetch_downloader_config_files
+      end
+
+      sig { returns(T::Array[DependencyFile]) }
+      def bazelrc_import_files
+        import_fetcher = BazelrcImportFetcher.new(fetcher: self)
+        import_fetcher.fetch_bazelrc_imports
       end
     end
   end

--- a/bazel/lib/dependabot/bazel/file_fetcher/bazelrc_import_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher/bazelrc_import_fetcher.rb
@@ -1,0 +1,94 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/bazel/file_fetcher"
+require "sorbet-runtime"
+
+module Dependabot
+  module Bazel
+    class FileFetcher < Dependabot::FileFetchers::Base
+      # Fetches files referenced by import/try-import statements in .bazelrc.
+      # Bazel's .bazelrc supports importing other rc files via:
+      #   import path/to/file
+      #   import %workspace%/path/to/file
+      #   try-import path/to/file
+      #   try-import %workspace%/path/to/file
+      # See: https://bazel.build/run/bazelrc#imports
+      class BazelrcImportFetcher
+        extend T::Sig
+
+        sig { params(fetcher: FileFetcher).void }
+        def initialize(fetcher:)
+          @fetcher = fetcher
+          @visited = T.let(Set.new, T::Set[String])
+        end
+
+        sig { returns(T::Array[DependencyFile]) }
+        def fetch_bazelrc_imports
+          bazelrc_file = @fetcher.send(:fetch_file_if_present, ".bazelrc")
+          return [] unless bazelrc_file
+
+          fetch_imports_from(bazelrc_file)
+        end
+
+        private
+
+        sig { returns(FileFetcher) }
+        attr_reader :fetcher
+
+        sig { params(bazelrc_file: DependencyFile).returns(T::Array[DependencyFile]) }
+        def fetch_imports_from(bazelrc_file)
+          content = T.must(bazelrc_file.content)
+          import_paths = extract_import_paths(content)
+          files = T.let([], T::Array[DependencyFile])
+
+          import_paths.each do |path|
+            next if @visited.include?(path)
+
+            @visited.add(path)
+
+            fetched_file = @fetcher.send(:fetch_file_if_present, path)
+            unless fetched_file
+              Dependabot.logger.warn(
+                "Imported bazelrc file '#{path}' referenced in .bazelrc but not found in repository"
+              )
+              next
+            end
+
+            files << fetched_file
+            files += fetch_imports_from(fetched_file)
+          rescue Dependabot::DependencyFileNotFound
+            Dependabot.logger.warn(
+              "Imported bazelrc file '#{path}' referenced in .bazelrc but not found in repository"
+            )
+          end
+
+          files
+        end
+
+        sig { params(content: String).returns(T::Array[String]) }
+        def extract_import_paths(content)
+          paths = T.let([], T::Array[String])
+
+          content.each_line do |line|
+            line = line.strip
+            next if line.empty? || line.start_with?("#")
+
+            match = line.match(/\A(?:try-)?import\s+(.+)\z/)
+            next unless match
+
+            path = T.must(match[1]).strip
+            path = path.delete_prefix("%workspace%/")
+
+            next if path.empty?
+            next if path.start_with?("/")
+
+            paths << path
+          end
+
+          paths.uniq
+        end
+      end
+    end
+  end
+end

--- a/bazel/spec/dependabot/bazel/file_fetcher/bazelrc_import_fetcher_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_fetcher/bazelrc_import_fetcher_spec.rb
@@ -1,0 +1,269 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bazel/file_fetcher"
+
+RSpec.describe Dependabot::Bazel::FileFetcher::BazelrcImportFetcher do
+  subject(:fetcher) { described_class.new(fetcher: file_fetcher) }
+
+  let(:file_fetcher) { instance_double(Dependabot::Bazel::FileFetcher) }
+
+  describe "#fetch_bazelrc_imports" do
+    context "when .bazelrc is not present" do
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(nil)
+      end
+
+      it "returns empty array" do
+        expect(fetcher.fetch_bazelrc_imports).to eq([])
+      end
+    end
+
+    context "when .bazelrc has no imports" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "build --java_runtime_version=remotejdk_11\ntest --test_output=all\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+      end
+
+      it "returns empty array" do
+        expect(fetcher.fetch_bazelrc_imports).to eq([])
+      end
+    end
+
+    context "when .bazelrc has import with %workspace% prefix" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "import %workspace%/tools/preset.bazelrc\nbuild --test_output=all\n"
+        )
+      end
+
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/preset.bazelrc",
+          content: "build --disk_cache=~/.cache/bazel\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/preset.bazelrc")
+                                             .and_return(imported_file)
+      end
+
+      it "fetches the imported file" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to eq(["tools/preset.bazelrc"])
+      end
+    end
+
+    context "when .bazelrc has import without %workspace% prefix" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "import tools/preset.bazelrc\n"
+        )
+      end
+
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/preset.bazelrc",
+          content: "build --disk_cache=~/.cache/bazel\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/preset.bazelrc")
+                                             .and_return(imported_file)
+      end
+
+      it "fetches the imported file" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to eq(["tools/preset.bazelrc"])
+      end
+    end
+
+    context "when .bazelrc has try-import" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "try-import %workspace%/user.bazelrc\n"
+        )
+      end
+
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "user.bazelrc",
+          content: "build --config=local\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "user.bazelrc")
+                                             .and_return(imported_file)
+      end
+
+      it "fetches the try-imported file" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to eq(["user.bazelrc"])
+      end
+    end
+
+    context "when try-imported file is missing" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "try-import %workspace%/user.bazelrc\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "user.bazelrc").and_return(nil)
+        allow(Dependabot.logger).to receive(:warn)
+      end
+
+      it "returns empty array and logs a warning" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result).to eq([])
+        expect(Dependabot.logger).to have_received(:warn).with(
+          "Imported bazelrc file 'user.bazelrc' referenced in .bazelrc but not found in repository"
+        )
+      end
+    end
+
+    context "with recursive imports" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "import %workspace%/tools/preset.bazelrc\n"
+        )
+      end
+
+      let(:preset_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/preset.bazelrc",
+          content: "import %workspace%/tools/ci.bazelrc\nbuild --disk_cache=~/.cache/bazel\n"
+        )
+      end
+
+      let(:ci_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/ci.bazelrc",
+          content: "build --remote_cache=grpc://cache.example.com\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/preset.bazelrc")
+                                             .and_return(preset_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/ci.bazelrc")
+                                             .and_return(ci_file)
+      end
+
+      it "fetches all transitively imported files" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to contain_exactly("tools/preset.bazelrc", "tools/ci.bazelrc")
+      end
+    end
+
+    context "with circular imports" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "import %workspace%/a.bazelrc\n"
+        )
+      end
+
+      let(:a_file) do
+        Dependabot::DependencyFile.new(
+          name: "a.bazelrc",
+          content: "import %workspace%/b.bazelrc\n"
+        )
+      end
+
+      let(:b_file) do
+        Dependabot::DependencyFile.new(
+          name: "b.bazelrc",
+          content: "import %workspace%/a.bazelrc\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "a.bazelrc").and_return(a_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "b.bazelrc").and_return(b_file)
+      end
+
+      it "does not loop infinitely and fetches both files" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to contain_exactly("a.bazelrc", "b.bazelrc")
+      end
+    end
+
+    context "with comments and empty lines in .bazelrc" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "# This is a comment\n\nimport %workspace%/tools/preset.bazelrc\n\n" \
+                   "# Another comment\nbuild --test_output=all\n"
+        )
+      end
+
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/preset.bazelrc",
+          content: "build --disk_cache=~/.cache/bazel\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/preset.bazelrc")
+                                             .and_return(imported_file)
+      end
+
+      it "correctly parses imports from lines with comments" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to eq(["tools/preset.bazelrc"])
+      end
+    end
+
+    context "with absolute path imports" do
+      let(:bazelrc_file) do
+        Dependabot::DependencyFile.new(
+          name: ".bazelrc",
+          content: "import /etc/bazel.bazelrc\nimport %workspace%/tools/preset.bazelrc\n"
+        )
+      end
+
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "tools/preset.bazelrc",
+          content: "build --disk_cache=~/.cache/bazel\n"
+        )
+      end
+
+      before do
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, ".bazelrc").and_return(bazelrc_file)
+        allow(file_fetcher).to receive(:send).with(:fetch_file_if_present, "tools/preset.bazelrc")
+                                             .and_return(imported_file)
+      end
+
+      it "skips absolute paths and fetches relative imports" do
+        result = fetcher.fetch_bazelrc_imports
+        expect(result.map(&:name)).to eq(["tools/preset.bazelrc"])
+      end
+    end
+  end
+end

--- a/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
@@ -1406,6 +1406,217 @@ RSpec.describe Dependabot::Bazel::FileFetcher do
     end
   end
 
+  describe "fetching bazelrc import files" do
+    subject(:fetched_files) { file_fetcher_instance.fetch_files }
+
+    context "with a .bazelrc containing import statements" do
+      before do
+        stub_request(:get, url + "?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_with_bazelrc_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "MODULE.bazel?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_module_file.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + ".bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_bazelrc_with_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # Mock the tools directory listing
+        stub_request(:get, url + "tools?ref=sha")
+          .to_return(
+            status: 200,
+            body: '[{"name": "preset.bazelrc", "type": "file"}]',
+            headers: { "content-type" => "application/json" }
+          )
+
+        # Mock the imported bazelrc file
+        stub_request(:get, url + "tools/preset.bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_imported_bazelrc.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # user.bazelrc is a try-import and not found
+        stub_request(:get, url + "user.bazelrc?ref=sha")
+          .to_return(status: 404)
+
+        # Stub other optional config files
+        stub_request(:get, url + "MODULE.bazel.lock?ref=sha").to_return(status: 404)
+        stub_request(:get, url + ".bazelversion?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "maven_install.json?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD.bazel?ref=sha").to_return(status: 404)
+      end
+
+      it "fetches the imported bazelrc file" do
+        expect(fetched_files.map(&:name)).to include("tools/preset.bazelrc")
+      end
+
+      it "includes MODULE.bazel and .bazelrc" do
+        expect(fetched_files.map(&:name)).to include("MODULE.bazel", ".bazelrc")
+      end
+
+      it "does not fail when try-import file is missing" do
+        expect(fetched_files.map(&:name)).not_to include("user.bazelrc")
+      end
+    end
+
+    context "with nested imports in bazelrc files" do
+      before do
+        stub_request(:get, url + "?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_with_bazelrc_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "MODULE.bazel?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_module_file.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + ".bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_bazelrc_with_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # Mock tools directory listing
+        stub_request(:get, url + "tools?ref=sha")
+          .to_return(
+            status: 200,
+            body: '[{"name": "preset.bazelrc", "type": "file"}, {"name": "ci.bazelrc", "type": "file"}]',
+            headers: { "content-type" => "application/json" }
+          )
+
+        # First imported file has a nested import
+        stub_request(:get, url + "tools/preset.bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_imported_bazelrc_nested.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # Nested import
+        stub_request(:get, url + "tools/ci.bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_ci_bazelrc.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # user.bazelrc not found
+        stub_request(:get, url + "user.bazelrc?ref=sha")
+          .to_return(status: 404)
+
+        # Stub other optional config files
+        stub_request(:get, url + "MODULE.bazel.lock?ref=sha").to_return(status: 404)
+        stub_request(:get, url + ".bazelversion?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "maven_install.json?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD.bazel?ref=sha").to_return(status: 404)
+      end
+
+      it "fetches recursively imported bazelrc files" do
+        expect(fetched_files.map(&:name)).to include(
+          "tools/preset.bazelrc",
+          "tools/ci.bazelrc"
+        )
+      end
+    end
+
+    context "when imported bazelrc file is missing" do
+      before do
+        stub_request(:get, url + "?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_with_bazelrc_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "MODULE.bazel?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_module_file.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + ".bazelrc?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_bazelrc_with_imports.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # Both imported files not found
+        stub_request(:get, url + "tools/preset.bazelrc?ref=sha")
+          .to_return(status: 404)
+        stub_request(:get, url + "tools?ref=sha")
+          .to_return(status: 404)
+        stub_request(:get, url + "user.bazelrc?ref=sha")
+          .to_return(status: 404)
+
+        # Stub other optional config files
+        stub_request(:get, url + "MODULE.bazel.lock?ref=sha").to_return(status: 404)
+        stub_request(:get, url + ".bazelversion?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "maven_install.json?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD?ref=sha").to_return(status: 404)
+        stub_request(:get, url + "BUILD.bazel?ref=sha").to_return(status: 404)
+      end
+
+      it "logs a warning when imported bazelrc file is not found" do
+        allow(Dependabot.logger).to receive(:warn)
+        fetched_files
+        expect(Dependabot.logger).to have_received(:warn).with(
+          "Imported bazelrc file 'tools/preset.bazelrc' referenced in .bazelrc but not found in repository"
+        )
+      end
+
+      it "continues fetching other files successfully" do
+        expect(fetched_files.map(&:name)).to include("MODULE.bazel", ".bazelrc")
+        expect(fetched_files.map(&:name)).not_to include("tools/preset.bazelrc")
+      end
+    end
+  end
+
+  describe "bazelrc imports (cloned repo)" do
+    subject(:fetched_files) { file_fetcher_instance.fetch_files }
+
+    let(:file_fetcher_instance) do
+      described_class.new(source: source, credentials: [], repo_contents_path: repo_contents_path)
+    end
+    let(:repo_contents_path) { build_tmp_repo(project_name) }
+    let(:directory) { "/" }
+
+    context "with .bazelrc containing import statements" do
+      let(:project_name) { "with_bazelrc_imports" }
+
+      it "fetches the imported bazelrc file from the local repo" do
+        names = fetched_files.map(&:name)
+        expect(names).to include("tools/preset.bazelrc")
+      end
+
+      it "includes the .bazelrc file" do
+        names = fetched_files.map(&:name)
+        expect(names).to include(".bazelrc")
+      end
+
+      it "does not fail when try-import target is missing" do
+        names = fetched_files.map(&:name)
+        expect(names).not_to include("user.bazelrc")
+      end
+    end
+  end
+
   describe "bzl file fetching (cloned repo)" do
     subject(:fetched_files) { file_fetcher_instance.fetch_files }
 

--- a/bazel/spec/fixtures/github/contents_bazel_bazelrc_with_imports.json
+++ b/bazel/spec/fixtures/github/contents_bazel_bazelrc_with_imports.json
@@ -1,0 +1,13 @@
+{
+  "name": ".bazelrc",
+  "path": ".bazelrc",
+  "sha": "def456",
+  "size": 150,
+  "url": "https://api.github.com/repos/example/repo/contents/.bazelrc?ref=sha",
+  "html_url": "https://github.com/example/repo/blob/sha/.bazelrc",
+  "git_url": "https://api.github.com/repos/example/repo/git/blobs/def456",
+  "download_url": "https://raw.githubusercontent.com/example/repo/sha/.bazelrc",
+  "type": "file",
+  "content": "IyBCYXplbCBjb25maWd1cmF0aW9uIGZpbGUKaW1wb3J0ICV3b3Jrc3BhY2Ul\nL3Rvb2xzL3ByZXNldC5iYXplbHJjCnRyeS1pbXBvcnQgJXdvcmtzcGFjZSUv\ndXNlci5iYXplbHJjCgpidWlsZCAtLWphdmFfcnVudGltZV92ZXJzaW9uPXJl\nbW90ZWpka18xMQp0ZXN0IC0tdGVzdF9vdXRwdXQ9YWxsCg==\n",
+  "encoding": "base64"
+}

--- a/bazel/spec/fixtures/github/contents_bazel_ci_bazelrc.json
+++ b/bazel/spec/fixtures/github/contents_bazel_ci_bazelrc.json
@@ -1,0 +1,13 @@
+{
+  "name": "ci.bazelrc",
+  "path": "tools/ci.bazelrc",
+  "sha": "def012",
+  "size": 60,
+  "url": "https://api.github.com/repos/example/repo/contents/tools/ci.bazelrc?ref=sha",
+  "html_url": "https://github.com/example/repo/blob/sha/tools/ci.bazelrc",
+  "git_url": "https://api.github.com/repos/example/repo/git/blobs/def012",
+  "download_url": "https://raw.githubusercontent.com/example/repo/sha/tools/ci.bazelrc",
+  "type": "file",
+  "content": "IyBDSSBjb25maWd1cmF0aW9uCmJ1aWxkIC0tcmVtb3RlX2NhY2hlPWdycGM6\nLy9jYWNoZS5leGFtcGxlLmNvbQo=\n",
+  "encoding": "base64"
+}

--- a/bazel/spec/fixtures/github/contents_bazel_imported_bazelrc.json
+++ b/bazel/spec/fixtures/github/contents_bazel_imported_bazelrc.json
@@ -1,0 +1,13 @@
+{
+  "name": "preset.bazelrc",
+  "path": "tools/preset.bazelrc",
+  "sha": "abc789",
+  "size": 100,
+  "url": "https://api.github.com/repos/example/repo/contents/tools/preset.bazelrc?ref=sha",
+  "html_url": "https://github.com/example/repo/blob/sha/tools/preset.bazelrc",
+  "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc789",
+  "download_url": "https://raw.githubusercontent.com/example/repo/sha/tools/preset.bazelrc",
+  "type": "file",
+  "content": "IyBQcmVzZXQgY29uZmlndXJhdGlvbgpidWlsZCAtLWRpc2tfY2FjaGU9fi8u\nY2FjaGUvYmF6ZWwKYnVpbGQgLS1yZXBvc2l0b3J5X2NhY2hlPX4vLmNhY2hl\nL2JhemVsLXJlcG8K\n",
+  "encoding": "base64"
+}

--- a/bazel/spec/fixtures/github/contents_bazel_imported_bazelrc_nested.json
+++ b/bazel/spec/fixtures/github/contents_bazel_imported_bazelrc_nested.json
@@ -1,0 +1,13 @@
+{
+  "name": "preset.bazelrc",
+  "path": "tools/preset.bazelrc",
+  "sha": "abc789",
+  "size": 80,
+  "url": "https://api.github.com/repos/example/repo/contents/tools/preset.bazelrc?ref=sha",
+  "html_url": "https://github.com/example/repo/blob/sha/tools/preset.bazelrc",
+  "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc789",
+  "download_url": "https://raw.githubusercontent.com/example/repo/sha/tools/preset.bazelrc",
+  "type": "file",
+  "content": "IyBQcmVzZXQgY29uZmlndXJhdGlvbgppbXBvcnQgJXdvcmtzcGFjZSUvdG9v\nbHMvY2kuYmF6ZWxyYwpidWlsZCAtLWRpc2tfY2FjaGU9fi8uY2FjaGUvYmF6\nZWwK\n",
+  "encoding": "base64"
+}

--- a/bazel/spec/fixtures/github/contents_bazel_with_bazelrc_imports.json
+++ b/bazel/spec/fixtures/github/contents_bazel_with_bazelrc_imports.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "MODULE.bazel",
+    "path": "MODULE.bazel",
+    "sha": "abc123",
+    "size": 1234,
+    "url": "https://api.github.com/repos/example/repo/contents/MODULE.bazel?ref=sha",
+    "html_url": "https://github.com/example/repo/blob/sha/MODULE.bazel",
+    "git_url": "https://api.github.com/repos/example/repo/git/blobs/abc123",
+    "download_url": "https://raw.githubusercontent.com/example/repo/sha/MODULE.bazel",
+    "type": "file"
+  },
+  {
+    "name": ".bazelrc",
+    "path": ".bazelrc",
+    "sha": "def456",
+    "size": 150,
+    "url": "https://api.github.com/repos/example/repo/contents/.bazelrc?ref=sha",
+    "html_url": "https://github.com/example/repo/blob/sha/.bazelrc",
+    "git_url": "https://api.github.com/repos/example/repo/git/blobs/def456",
+    "download_url": "https://raw.githubusercontent.com/example/repo/sha/.bazelrc",
+    "type": "file"
+  },
+  {
+    "name": "tools",
+    "path": "tools",
+    "sha": "xyz123",
+    "size": 0,
+    "url": "https://api.github.com/repos/example/repo/contents/tools?ref=sha",
+    "html_url": "https://github.com/example/repo/tree/sha/tools",
+    "git_url": "https://api.github.com/repos/example/repo/git/trees/xyz123",
+    "download_url": null,
+    "type": "dir"
+  }
+]

--- a/bazel/spec/fixtures/projects/with_bazelrc_imports/.bazelrc
+++ b/bazel/spec/fixtures/projects/with_bazelrc_imports/.bazelrc
@@ -1,0 +1,6 @@
+# Bazel configuration
+import %workspace%/tools/preset.bazelrc
+try-import %workspace%/user.bazelrc
+
+build --java_runtime_version=remotejdk_21
+test --test_output=all

--- a/bazel/spec/fixtures/projects/with_bazelrc_imports/MODULE.bazel
+++ b/bazel/spec/fixtures/projects/with_bazelrc_imports/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "test_project",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "rules_java", version = "7.3.2")

--- a/bazel/spec/fixtures/projects/with_bazelrc_imports/tools/preset.bazelrc
+++ b/bazel/spec/fixtures/projects/with_bazelrc_imports/tools/preset.bazelrc
@@ -1,0 +1,3 @@
+# Preset build configuration
+build --disk_cache=~/.cache/bazel
+build --repository_cache=~/.cache/bazel-repo


### PR DESCRIPTION
### What are you trying to accomplish?

Fix #13880.

Bazel's `.bazelrc` supports `import` and `try-import` directives that pull in other config files (e.g. `import %workspace%/tools/preset.bazelrc`). When dependabot updates a Bazel dependency, it fetches `.bazelrc` but never follows these import directives. The imported files are therefore missing from the temporary directory where `bazel mod tidy` runs, causing a fatal error:

```
[FATAL] Nonexistent path in import declaration in config file 'dependabot_tmp_dir/.bazelrc': 'import %workspace%/tools/preset.bazelrc'
```

### How will you know you've accomplished your goal?

- **10 unit tests** for `BazelrcImportFetcher` covering: no `.bazelrc`, no imports, `%workspace%` prefix, plain relative paths, `try-import`, missing files, recursive imports, circular imports, comments/empty lines, and absolute path skipping.
- **6 API-based integration tests** in `file_fetcher_spec.rb` covering: import fetching via GitHub API mocks, nested imports, and missing import with warning.
- **3 cloned-repo integration tests** using a real filesystem fixture (`spec/fixtures/projects/with_bazelrc_imports/`) that verifies the fix works with local repo checkouts.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
