### PR TITLE
Test regenerated pip smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'main' }}
+  SMOKE_TEST_BRANCH: regenerate-test-pip-1773949143
 jobs:
   discover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Points the smoke test workflow at the `regenerate-test-pip-1773949143` branch from [dependabot/smoke-tests](https://github.com/dependabot/smoke-tests/tree/regenerate-test-pip-1773949143) to validate the regenerated pip ecosystem tests pass.

**This is a test PR — do not merge.** Revert the `SMOKE_TEST_BRANCH` change before merging, or close after validation.

Related Smoke Test PR: https://github.com/dependabot/smoke-tests/pull/430