### PR TITLE
honor update-types in grouped/ungrouped updater

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
@@ -1370,4 +1370,150 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task UngroupedPullRequestCanBeCreatedIfGroupAppliesToNonMatchedTypes()
+    {
+        // group only applies to minor and patch updates, but a major update is requested and gets generated separately
+        await TestAsync(
+            job: new Job()
+            {
+                Source = CreateJobSource("/src"),
+                DependencyGroups = [new()
+                {
+                    Name = "test-group",
+                    Rules = new()
+                    {
+                        ["patterns"] = new[] { "Some.Dependency" },
+                        ["update-types"] = new[] { "minor", "patch" }
+                    },
+                }]
+            },
+            files: [
+                ("src/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var repoRoot = input.Item1;
+                var discovery = input.Item2;
+                var dependencyInfo = input.Item3;
+                var newVersion = dependencyInfo.Name switch
+                {
+                    "Some.Dependency" => "2.0.0",
+                    _ => throw new NotImplementedException($"Test didn't expect to update dependency {dependencyInfo.Name}"),
+                };
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = newVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var previousVersion = input.Item4;
+                var newVersion = input.Item5;
+                var isTransitive = input.Item6;
+
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [new DirectUpdate() { DependencyName = dependencyName, NewVersion = NuGetVersion.Parse(newVersion), UpdatedFiles = [workspacePath] }],
+                };
+            }),
+            expectedUpdateHandler: GroupUpdateAllVersionsHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions",
+                    }
+                },
+                // discovery from group updater
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                // discovery from ungrouped updater
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src/project.csproj"],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
@@ -2,6 +2,8 @@ using System.Collections.Immutable;
 using System.IO.Enumeration;
 using System.Text.Json;
 
+using NuGet.Versioning;
+
 namespace NuGetUpdater.Core.Run.ApiModel;
 
 public record DependencyGroup
@@ -38,6 +40,32 @@ public class GroupMatcher
         var isExcluded = ExcludePatterns.Any(p => FileSystemName.MatchesSimpleExpression(p, dependencyName));
         var isMatch = isIncluded && !isExcluded;
         return isMatch;
+    }
+
+    public bool IsAllowedByVersion(NuGetVersion oldVersion, NuGetVersion newVersion)
+    {
+        var isMajorBump = newVersion.Major > oldVersion.Major;
+        var isMinorBump = newVersion.Major == oldVersion.Major && newVersion.Minor > oldVersion.Minor;
+        var isPatchBump = newVersion.Major == oldVersion.Major && newVersion.Minor == oldVersion.Minor && newVersion.Patch > oldVersion.Patch;
+
+        var allowedUpdateTypes = new HashSet<GroupUpdateType>(UpdateTypes);
+
+        if (isMajorBump && allowedUpdateTypes.Contains(GroupUpdateType.Major))
+        {
+            return true;
+        }
+
+        if (isMinorBump && allowedUpdateTypes.Contains(GroupUpdateType.Minor))
+        {
+            return true;
+        }
+
+        if (isPatchBump && allowedUpdateTypes.Contains(GroupUpdateType.Patch))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public static GroupMatcher FromRules(Dictionary<string, object> rules)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -1,5 +1,8 @@
 using System.Collections.Immutable;
 
+using NuGet.Versioning;
+
+using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Updater;
@@ -106,6 +109,13 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         continue;
                     }
 
+                    var isUpdateAllowed = groupMatcher.IsAllowedByVersion(NuGetVersion.Parse(dependency.Version!), NuGetVersion.Parse(analysisResult.UpdatedVersion));
+                    if (!isUpdateAllowed)
+                    {
+                        logger.Info($"Dependency {dependency.Name} skipped for group {group.Name} because update type was not allowed.");
+                        continue;
+                    }
+
                     var projectDiscovery = discoveryResult.GetProjectDiscoveryFromPath(projectPath);
                     var updaterResult = await updaterWorker.RunAsync(repoContentsPath.FullName, projectPath, dependency.Name, dependency.Version!, analysisResult.UpdatedVersion, dependency.IsTransitive);
                     if (updaterResult.Error is not null)
@@ -204,15 +214,6 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         continue;
                     }
 
-                    var matchingGroups = job.DependencyGroups
-                        .Where(group => group.GetGroupMatcher().IsMatch(dependency.Name))
-                        .ToImmutableArray();
-                    if (matchingGroups.Length > 0)
-                    {
-                        logger.Info($"Dependency {dependency.Name} skipped for ungrouped updates because it's a member of the following groups: {string.Join(", ", matchingGroups.Select(group => group.Name))}");
-                        continue;
-                    }
-
                     var dependencyInfo = RunWorker.GetDependencyInfo(job, dependency, groupMatchers: [], allowCooldown: true);
                     var analysisResult = await analyzeWorker.RunAsync(repoContentsPath.FullName, discoveryResult, dependencyInfo);
                     if (analysisResult.Error is not null)
@@ -225,6 +226,12 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     if (!analysisResult.CanUpdate)
                     {
                         logger.Info($"No updatable version found for {dependency.Name} in {projectPath}.");
+                        continue;
+                    }
+
+                    var isSkipped = IsUngroupedDependencySkipped(dependency, analysisResult, job.DependencyGroups, logger);
+                    if (isSkipped)
+                    {
                         continue;
                     }
 
@@ -292,5 +299,30 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             .GroupBy(o => $"{o.Dependency.Name}/{o.Dependency.Version}".ToLowerInvariant())
             .ToImmutableArray();
         return updateOperationsToPerformByDependency;
+    }
+
+    internal static bool IsUngroupedDependencySkipped(Dependency dependency, AnalysisResult dependencyAnalysis, ImmutableArray<DependencyGroup> dependencyGroups, ILogger logger)
+    {
+        var matcherGroups = dependencyGroups
+            .Select(group => (group.Name, Matcher: group.GetGroupMatcher()))
+            .Where(pair => pair.Matcher.IsMatch(dependency.Name))
+            .ToImmutableArray();
+        if (matcherGroups.Length > 0)
+        {
+            // update matches a group by name
+            // if any group allows the proposed version range, then it's not allowed in an ungrouped update
+            var oldVersion = NuGetVersion.Parse(dependency.Version!);
+            var newVersion = NuGetVersion.Parse(dependencyAnalysis.UpdatedVersion);
+            var matcherGroupsAllowingVersionRange = matcherGroups
+                .Where(pair => pair.Matcher.IsAllowedByVersion(oldVersion, newVersion))
+                .ToImmutableArray();
+            if (matcherGroupsAllowingVersionRange.Length > 0)
+            {
+                logger.Info($"Dependency {dependency.Name} skipped for ungrouped updates because it's a member of the following groups: {string.Join(", ", matcherGroupsAllowingVersionRange.Select(pair => pair.Name))}");
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #14470.

[The documentation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates) states that, e.g., an update group can allow only minor or patch updates but if a major update can be performed, that is to happen as a separate PR.

The functional change is to check if an update is to be skipped based on the new version number.  If processing a grouped update but the `update-type` doesn't allow for the requested update, then skip it.  The reverse is true in an ungrouped update: if a group matches but the update type isn't allowed in that group, then proceed as an ungrouped update.