### PR TITLE
Upgrade Erlang OTP major version to 27

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   gnupg2 sudo curl apt-transport-https
 
-ARG ERLANG_MAJOR_VERSION=26
+ARG ERLANG_MAJOR_VERSION=27
 
 # This is using https://www.rabbitmq.com/docs/install-debian#apt-launchpad-erlang to install erlang. Previously, esl-erlang was used, but it does not
 # contain arm architecture packages. The base `apt` erlang version should not be used--it is too old.
@@ -30,7 +30,7 @@ RUN apt-get update \
 # Install Elixir
 # https://github.com/elixir-lang/elixir/releases
 ARG ELIXIR_VERSION=v1.19.5
-ARG ELIXIR_CHECKSUM=db6701f2232be899190ecb8dbf280104fe2434675093c2b5935e563a08052afb
+ARG ELIXIR_CHECKSUM=1ab3154ec19adcd4b764cf96badecbe44df5ec6f358dc0fbe29c3749ff6c08de
 RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \


### PR DESCRIPTION
### What are you trying to accomplish?

OTP 27 introduces `:json` as a natve Erlang module and some elixir projects started using it in their `mix.exs` which means when they are fetched as git repos and dependabot tries to evaluate them, it fails.

Dependabot encountered the following error:
```
Failed to update lockfile: Error while loading project :electric at dependabot_tmp_dir/deps/electric/packages/sync-service
** (UndefinedFunctionError) function :json.decode/1 is undefined (module :json is not available). Did you mean:

      * :elixir_json.decode/1

    :json.decode("{\n  \"name\": \"@core/sync-service\",\n  \"private\": true,\n  \"version\": \"1.2.6\",\n  \"scripts\": {\n    \"publish:hex\": \"mix do deps.get + hex.publish --yes || true\",\n    \"changeset\": \"pushd ../..; pnpm changeset; popd\"\n  }\n}\n")
    dependabot_tmp_dir/deps/electric/packages/sync-service/mix.exs:196: Electric.MixProject.version_from_package_json/0
    dependabot_tmp_dir/deps/electric/packages/sync-service/mix.exs:181: Electric.MixProject.version/1
    dependabot_tmp_dir/deps/electric/packages/sync-service/mix.exs:16: Electric.MixProject.project/0
    (mix 1.19.5) lib/mix/project.ex:1093: Mix.Project.get_project_config/1
    (mix 1.19.5) lib/mix/project.ex:299: Mix.Project.push_config/2
    (mix 1.19.5) lib/mix/project.ex:262: Mix.Project.push/3
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
