### PR TITLE
fix(`npm_and_yarn`): preserve workspace package-lock manifest mirror for `bump_versions_if_necessary`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -1218,39 +1218,95 @@ module Dependabot
           packages = parsed_lockfile["packages"]
           return false unless packages.is_a?(Hash)
 
+          dependency_sections = %w(dependencies devDependencies peerDependencies optionalDependencies).freeze
+
+          changed = T.let(false, T::Boolean)
+          package_files.each do |file|
+            changed ||= sync_package_entry_dependencies_for_file(
+              packages: packages,
+              file: file,
+              dependency_sections: dependency_sections
+            )
+          end
+
+          changed
+        end
+
+        sig do
+          params(
+            packages: T::Hash[String, T.untyped],
+            file: Dependabot::DependencyFile,
+            dependency_sections: T::Array[String]
+          ).returns(T::Boolean)
+        end
+        def sync_package_entry_dependencies_for_file(packages:, file:, dependency_sections:)
+          manifest = manifest_hash_for_sync(file)
+          return false unless manifest
+
+          package_entry = package_entry_name(file)
+          return false unless package_entry
+
+          lockfile_package = packages[package_entry]
+          return false unless lockfile_package.is_a?(Hash)
+
+          sync_dependency_sections(
+            lockfile_package: lockfile_package,
+            manifest: manifest,
+            dependency_sections: dependency_sections
+          )
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[String, T.untyped])) }
+        def manifest_hash_for_sync(file)
+          manifest_content = T.must(updated_package_json_content(file) || file.content)
+          parsed_manifest = JSON.parse(manifest_content)
+          return parsed_manifest if parsed_manifest.is_a?(Hash)
+
+          nil
+        rescue JSON::ParserError => e
+          Dependabot.logger.warn(
+            "Failed to parse #{file.name} while syncing lockfile package entries: #{e.message}"
+          )
+          nil
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(T.nilable(String)) }
+        def package_entry_name(file)
+          lockfile_dir = Pathname.new(lockfile_directory).cleanpath
+          file_dir = Pathname.new(File.dirname(file.name)).cleanpath
+
+          return "" if file_dir == lockfile_dir
+
+          relative_dir = file_dir.relative_path_from(lockfile_dir).to_s
+          return nil if relative_dir.start_with?("..")
+
+          relative_dir
+        rescue ArgumentError
+          nil
+        end
+
+        sig do
+          params(
+            lockfile_package: T::Hash[String, T.untyped],
+            manifest: T::Hash[String, T.untyped],
+            dependency_sections: T::Array[String]
+          ).returns(T::Boolean)
+        end
+        def sync_dependency_sections(lockfile_package:, manifest:, dependency_sections:)
           changed = T.let(false, T::Boolean)
 
-          package_files.each do |file|
-            begin
-              manifest_content = T.must(updated_package_json_content(file) || file.content)
-              manifest = JSON.parse(manifest_content)
-            rescue JSON::ParserError => e
-              Dependabot.logger.warn("Failed to parse #{file.name} while syncing lockfile package entries: #{e.message}")
-              next
-            end
+          dependency_sections.each do |dep_type|
+            manifest_deps = manifest[dep_type]
 
-            next unless manifest.is_a?(Hash)
+            if manifest_deps
+              next unless manifest_deps.is_a?(Hash)
+              next if lockfile_package[dep_type] == manifest_deps
 
-            package_entry = File.dirname(file.name)
-            package_entry = "" if package_entry == "."
-
-            lockfile_package = packages[package_entry]
-            next unless lockfile_package.is_a?(Hash)
-
-            %w(dependencies devDependencies peerDependencies optionalDependencies).each do |dep_type|
-              manifest_deps = manifest[dep_type]
-
-              if manifest_deps
-                next unless manifest_deps.is_a?(Hash)
-
-                unless lockfile_package[dep_type] == manifest_deps
-                  lockfile_package[dep_type] = manifest_deps
-                  changed = true
-                end
-              elsif lockfile_package.key?(dep_type)
-                lockfile_package.delete(dep_type)
-                changed = true
-              end
+              lockfile_package[dep_type] = manifest_deps
+              changed = true
+            elsif lockfile_package.key?(dep_type)
+              lockfile_package.delete(dep_type)
+              changed = true
             end
           end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -242,10 +242,14 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     let(:files) { project_dependency_files("npm8/workspace_outdated_deps_not_in_root_package_json") }
 
     it "updates" do
-      expect(JSON.parse(updated_npm_lock_content)["packages"]["node_modules/@swc/core"]["version"])
+      parsed_lockfile = JSON.parse(updated_npm_lock_content)
+
+      expect(parsed_lockfile["packages"]["node_modules/@swc/core"]["version"])
         .to eq("1.3.44")
 
-      expect(JSON.parse(updated_npm_lock_content).dig("packages", "bump-version-for-cron", "devDependencies", "@swc/core"))
+      expect(
+        parsed_lockfile.dig("packages", "bump-version-for-cron", "devDependencies", "@swc/core")
+      )
         .to eq("^1.3.37")
     end
   end
@@ -288,6 +292,50 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       expect(nested_chokidar["version"]).to eq("3.6.0")
       expect(nested_chokidar["optional"]).to be(true)
       expect(nested_chokidar["peer"]).to be(true)
+    end
+  end
+
+  context "when syncing workspace package entries for a nested lockfile" do
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "cli/package-lock.json",
+          content: "{\"name\":\"cli\",\"lockfileVersion\":3,\"packages\":{\"\":{}}}"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "cli/package.json",
+          content: "{\"name\":\"@repro/cli\",\"workspaces\":[\"packages/*\"]}"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "cli/packages/app/package.json",
+          content: "{\"name\":\"@repro/app\",\"dependencies\":{\"pacote\":\"^21.4.0\"}}"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "package.json",
+          content: "{\"name\":\"repo-root\",\"dependencies\":{\"outside\":\"1.0.0\"}}"
+        )
+      ]
+    end
+
+    let(:dependencies) { [] }
+    let(:package_lock) { files.find { |f| f.name == "cli/package-lock.json" } }
+
+    it "uses lockfile-directory-relative package keys and ignores outside manifests" do
+      parsed_lockfile = {
+        "packages" => {
+          "" => { "name" => "@repro/cli" },
+          "packages/app" => {
+            "name" => "@repro/app",
+            "dependencies" => { "pacote" => "^21.5.0" }
+          }
+        }
+      }
+
+      changed = updater.send(:sync_package_entry_dependencies_with_manifests, parsed_lockfile)
+
+      expect(changed).to be(true)
+      expect(parsed_lockfile.dig("packages", "packages/app", "dependencies", "pacote")).to eq("^21.4.0")
+      expect(parsed_lockfile.dig("packages", "", "dependencies")).to be_nil
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Keep npm workspace lockfile mirror entries in sync with unchanged [package.json](https://github.com/thavaahariharangit/errorneous-lock-update-recreation/blob/main/cli/package.json) ranges for non-breaking updates, so only resolved lock data changes (fixes pacote 21.4.0 -> 21.5.0 case).

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Recreated the error: https://github.com/thavaahariharangit/errorneous-lock-update-recreation/actions/runs/23341454944/job/67895829530

[Below part of PR](https://github.com/thavaahariharangit/errorneous-lock-update-recreation/pull/2/changes) update should not be happening, As it should be mirroring real [cli/package.json](https://github.com/thavaahariharangit/errorneous-lock-update-recreation/blob/main/cli/package.json)
<img width="1546" height="196" alt="image" src="https://github.com/user-attachments/assets/74ccd6ec-a485-456f-92e1-174888a8fc5b" />

```
{
  "name": "repro-14460",
  "lockfileVersion": 3,
  "requires": true,
  "packages": {
    "": {
      "name": "repro-14460",
      "workspaces": [
        "cli"
      ]
    },
    "cli": {
      "name": "@repro/cli",
      "version": "1.0.0",
      "dependencies": {
        "pacote": "^21.4.0" # Before fix this is updated, now(with this PR changes) it's synced with cli/package.json
      }
    },
```

Tested with dependabot-cli run in local

Fixes the issue: https://github.com/dependabot/dependabot-core/issues/14460

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
