### PR TITLE
fix(uv): grapher not preferring lockfile

### DIFF
--- a/uv/lib/dependabot/uv/dependency_grapher.rb
+++ b/uv/lib/dependabot/uv/dependency_grapher.rb
@@ -32,12 +32,10 @@ module Dependabot
 
       sig { override.returns(Dependabot::DependencyFile) }
       def relevant_dependency_file
-        # This cannot realistically happen as the parser will throw a runtime error
-        # on init without a pyproject.toml file,
-        # but this will avoid surprises if anything changes.
-        raise DependabotError, "No pyproject.toml present in dependency files." unless pyproject_toml
+        return T.must(uv_lock) if uv_lock
+        return T.must(pyproject_toml) if pyproject_toml
 
-        T.must(pyproject_toml)
+        raise DependabotError, "No uv.lock or pyproject.toml present."
       end
 
       private

--- a/uv/spec/dependabot/uv/dependency_grapher_spec.rb
+++ b/uv/spec/dependabot/uv/dependency_grapher_spec.rb
@@ -33,8 +33,26 @@ RSpec.describe Dependabot::Uv::DependencyGrapher do
   let(:uv_tree_output) { fixture("dependency_grapher", "uv_tree_output.txt") }
 
   describe "#relevant_dependency_file" do
-    it "specifies the pyproject.toml as the relevant dependency file" do
-      expect(grapher.relevant_dependency_file).to eql(pyproject_toml)
+    context "when uv.lock is not present" do
+      it "falls back to pyproject.toml" do
+        expect(grapher.relevant_dependency_file).to eql(pyproject_toml)
+      end
+    end
+
+    context "when uv.lock is present" do
+      let(:uv_lock_file) do
+        Dependabot::DependencyFile.new(
+          name: "uv.lock",
+          content: fixture("dependency_grapher", "uv_lock_with_relationships.lock"),
+          directory: "/"
+        )
+      end
+
+      let(:dependency_files) { [pyproject_toml, uv_lock_file] }
+
+      it "specifies the uv.lock as the relevant dependency file" do
+        expect(grapher.relevant_dependency_file).to eql(uv_lock_file)
+      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot must match Dependency Graph behavior and prefer the lockfile over the manifest. It was already parsing the lockfile, we just needed to return it in this method as well.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Pretty straight forward.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

I was expecting to see the uv smoke test failing due to this change but looks like uv's smoke tests were never set up. I will create a PR for that afterwards. 

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
