### PR TITLE
enable direct update of centrally managed transitive package

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1949,4 +1949,52 @@ public class XmlFileWriterTests : FileWriterTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task UpdatingAPinnedCentrallyManagedPackageUpdatesJustTheVersionNumberWhenDeclarationIsPresent()
+    {
+        await TestAsync(
+            useCentralPackageTransitivePinning: true,
+            files: [
+                ("src/project.csproj", """
+                    <?xml version="1.0"?>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Packages.props", """
+                    <?xml version="1.0"?>
+                    <Project>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Dependency" Version="1.0.0" />
+                        <PackageVersion Include="Unrelated.Dependency" Version="3.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/2.0.0"],
+            expectedFiles: [
+                ("src/project.csproj", """
+                    <?xml version="1.0"?>
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Packages.props", """
+                    <?xml version="1.0"?>
+                    <Project>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Dependency" Version="2.0.0" />
+                        <PackageVersion Include="Unrelated.Dependency" Version="3.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -253,21 +253,47 @@ public class XmlFileWriter : IFileWriter
                     .ToArray();
                 if (matchingPackageVersionElementsAndPaths.Length > 0)
                 {
-                    // found matching `<PackageVersion>` element; if `Version` attribute is appropriate we're done, otherwise set `VersionOverride` attribute on new element
+                    // found matching `<PackageVersion>` element
                     var (matchingPackageVersionElement, filePath) = matchingPackageVersionElementsAndPaths.First();
                     var versionAttribute = matchingPackageVersionElement.GetAttributeCaseInsensitive(VersionMetadataName);
+                    var isVersionOverrideNeeded = false;
                     if (versionAttribute is not null &&
-                        VersionRange.TryParse(versionAttribute.Value, out var existingVersionRange) &&
-                        existingVersionRange.MinVersion == requiredVersion)
+                        VersionRange.TryParse(versionAttribute.Value, out var existingVersionRange))
                     {
-                        // version matches; no update needed
-                        _logger.Info($"Dependency {requiredPackageVersion.Name} already set to {requiredVersion}; no override needed.");
+                        if (existingVersionRange.MinVersion == requiredVersion)
+                        {
+                            // version matches; no update needed
+                            _logger.Info($"Dependency {requiredPackageVersion.Name} already set to {requiredVersion} in file {filePath}; no update needed.");
+                        }
+                        else if (existingVersionRange.Satisfies(oldVersion))
+                        {
+                            // found matching old version; update the attribute directly
+                            _logger.Info($"Dependency {requiredPackageVersion.Name} updated from version {oldVersion} to {requiredVersion} in file {filePath}.");
+                            ReplaceNode(
+                                filePath,
+                                matchingPackageVersionElement.AsNode,
+                                matchingPackageVersionElement.ReplaceAttribute(
+                                    versionAttribute,
+                                    versionAttribute.WithValue(requiredVersion.ToString())
+                                ).AsNode
+                            );
+                        }
+                        else
+                        {
+                            // version doesn't match; use `VersionOverride` attribute on new element
+                            isVersionOverrideNeeded = true;
+                        }
                     }
                     else
                     {
-                        // version doesn't match; use `VersionOverride` attribute on new element
-                        _logger.Info($"Dependency {requiredPackageVersion.Name} set to {requiredVersion}; using `{VersionOverrideMetadataName}` attribute on new element.");
-                        newElement = (IXmlElementSyntax)ReplaceNode(
+                        // version not found; use `VersionOverride` attribute on new element
+                        isVersionOverrideNeeded = true;
+                    }
+
+                    if (isVersionOverrideNeeded)
+                    {
+                        _logger.Info($"Dependency {requiredPackageVersion.Name} set to {requiredVersion} using `{VersionOverrideMetadataName}` attribute on new element in file {projectRelativePath}.");
+                        ReplaceNode(
                             projectRelativePath,
                             newElement.AsNode,
                             newElement.WithAttribute(VersionOverrideMetadataName, requiredVersion.ToString()).AsNode


### PR DESCRIPTION
When attempting to update a pinned centrally managed package, the updater tried to make an impossible edit to a project's XML.  In most cases the result was a harmless noop but if a project file contained an XML declaration like `<?xml version="1.0"?>` then the bug would surface as `System.InvalidCastException: Unable to cast object of type 'Microsoft.Language.Xml.XmlDeclarationSyntax' to type 'Microsoft.Language.Xml.IXmlElementSyntax'.`

The fix was to add better detection to where this noop edit would occur and prevent it from happening by only directly updating the version attribute.

Fixes #14497