### PR TITLE
Revert "Include PR title and body in update_pull_request API calls"

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -59,6 +59,7 @@ module Dependabot
     end
 
     # TODO: Make `base_commit_sha` part of Dependabot::DependencyChange
+    # TODO: Determine if we should regenerate the PR message within core for updates
     sig { params(dependency_change: Dependabot::DependencyChange, base_commit_sha: String).void }
     def update_pull_request(dependency_change, base_commit_sha)
       ::Dependabot::OpenTelemetry.tracer.in_span("update_pull_request", kind: :internal) do |span|
@@ -67,14 +68,14 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::DEPENDENCY_NAMES, dependency_change.humanized)
 
         api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/update_pull_request"
-        data = {
-          "dependency-names": dependency_change.updated_dependencies.map(&:name),
-          "updated-dependency-files": dependency_change.updated_dependency_files_hash,
-          "base-commit-sha": base_commit_sha,
-          "pr-title": dependency_change.pr_message.pr_name,
-          "pr-body": dependency_change.pr_message.pr_message
+        body = {
+          data: {
+            "dependency-names": dependency_change.updated_dependencies.map(&:name),
+            "updated-dependency-files": dependency_change.updated_dependency_files_hash,
+            "base-commit-sha": base_commit_sha
+          }
         }
-        response = http_client.post(path: api_url, body: { data: data }.to_json)
+        response = http_client.post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -285,8 +285,7 @@ RSpec.describe Dependabot::ApiClient do
         source: source,
         credentials: [],
         commit_message_options: [],
-        updating_a_pull_request?: true,
-        ignore_conditions: []
+        updating_a_pull_request?: true
       )
     end
     let(:dependency) do
@@ -317,21 +316,12 @@ RSpec.describe Dependabot::ApiClient do
         )
       ]
     end
-    let(:message) do
-      Dependabot::PullRequestCreator::Message.new(
-        pr_name: "PR name",
-        pr_message: "PR message",
-        commit_message: "Commit message"
-      )
-    end
     let(:update_pull_request_url) do
       "http://example.com/update_jobs/1/update_pull_request"
     end
     let(:base_commit) { "sha" }
 
     before do
-      allow(Dependabot::PullRequestCreator::MessageBuilder)
-        .to receive_message_chain(:new, :message).and_return(message)
       stub_request(:post, update_pull_request_url)
         .to_return(status: 204, headers: headers)
     end
@@ -344,7 +334,9 @@ RSpec.describe Dependabot::ApiClient do
         .with(headers: { "Authorization" => "token" })
     end
 
-    it "encodes the pull request fields" do
+    it "does not encode the pull request fields" do
+      expect(Dependabot::PullRequestCreator::MessageBuilder).not_to receive(:new)
+
       client.update_pull_request(dependency_change, base_commit)
 
       expect(WebMock)
@@ -376,8 +368,9 @@ RSpec.describe Dependabot::ApiClient do
               )
               expect(data["base-commit-sha"]).to eql("sha")
               expect(data).not_to have_key("commit-message")
-              expect(data["pr-title"]).to eq("PR name")
-              expect(data["pr-body"]).to eq("PR message")
+              expect(data).not_to have_key("pr-title")
+              expect(data).not_to have_key("pr-body")
+              expect(data).not_to have_key("grouped-update")
             end)
     end
   end


### PR DESCRIPTION
Reverts dependabot/dependabot-core#14492

The related dependabot-api should have been merged before. Currently it is in the queue. Still checking if sentry error is related.