### PR TITLE
bundler cooldown feature; Remove GPR special-casing, add fallback for registries that don't support the necessary API endpoint

### DIFF
--- a/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
@@ -62,11 +62,11 @@ module Dependabot
         sig { override.returns(T.nilable(String)) }
         attr_reader :repo_contents_path
 
-        sig { returns(Dependabot::Package::PackageDetails) }
+        sig { returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def fetch
           case source_type
           when GIT, OTHER
-            package_details([])
+            nil
           else
             rubygems_versions
           end
@@ -131,26 +131,6 @@ module Dependabot
         sig { returns(Dependabot::Package::PackageDetails) }
         def rubygems_versions
           registry_url = get_url_from_dependency(dependency) || replaces_base_registry_url || "https://rubygems.org"
-
-          # TODO: Github private registry support
-          # registry_url = "https://rubygems.pkg.github.com/#{OWNER_NAME}"
-          # Corresponding API URL:
-          # curl  -H "Accept: application/json" \
-          #       -H "Authorization: Bearer <<TOKEN>>" \
-          #       https://api.github.com/orgs/dsp-testing/packages/rubygems/json/version
-
-          validate_and_check_registry(registry_url)
-        end
-
-        sig { params(registry_url: String).returns(Dependabot::Package::PackageDetails) }
-        def validate_and_check_registry(registry_url)
-          parsed_url = begin
-            URI.parse(registry_url)
-          rescue URI::InvalidURIError
-            raise "Invalid registry URL: #{registry_url}"
-          end
-
-          return github_packages_versions(registry_url) if parsed_url.host == "rubygems.pkg.github.com"
 
           fetch_and_process_rubygems_response(registry_url)
         end
@@ -251,61 +231,6 @@ module Dependabot
             url: url,
             headers: { "Accept" => APPLICATION_JSON }
           )
-        end
-
-        sig { params(registry_url: String).returns(Dependabot::Package::PackageDetails) }
-        def github_packages_versions(registry_url)
-          # Extract org name from URL like "https://rubygems.pkg.github.com/dsp-testing/"
-          org_name = registry_url.split("/").last
-
-          # GitHub Packages API endpoint for RubyGems packages
-          api_url = "https://api.github.com/orgs/#{org_name}/packages/rubygems/#{dependency.name}/versions"
-
-          response = Dependabot::RegistryClient.get(
-            url: api_url,
-            headers: {
-              "Accept" => "application/vnd.github.v3+json",
-              "Authorization" => "Bearer #{github_token}"
-            }
-          )
-
-          unless response.status == 200
-            error_details = "Status: #{response.status}"
-            error_details += " (Package not found in GitHub Registry)" if response.status == 404
-            error_message = "Failed to fetch versions for '#{dependency.name}' from GitHub Packages. #{error_details}"
-            Dependabot.logger.info(error_message)
-            return package_details([])
-          end
-
-          begin
-            versions_data = JSON.parse(response.body)
-            package_releases = versions_data.map do |version_info|
-              # GitHub Packages API returns different structure than RubyGems
-              version_number = version_info["name"] # GitHub uses "name" for version
-              created_at = version_info["created_at"]
-
-              package_release(
-                version: version_number,
-                released_at: Time.parse(created_at),
-                downloads: 0, # GitHub Packages doesn't provide download counts
-                url: "#{registry_url}/gems/#{dependency.name}-#{version_number}.gem",
-                ruby_version: nil # GitHub Packages API doesn't provide ruby version requirements
-              )
-            end
-
-            package_details(package_releases)
-          rescue JSON::ParserError => e
-            Dependabot.logger.info("Failed to parse GitHub Packages response: #{e.message}")
-            package_details([])
-          end
-        end
-
-        sig { returns(T.nilable(String)) }
-        def github_token
-          github_credential = credentials.find do |cred|
-            cred["type"] == "rubygems_server" && cred["host"] == "rubygems.pkg.github.com"
-          end
-          github_credential&.fetch("token", nil)
         end
 
         sig { params(req_string: String).returns(Requirement) }

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -72,12 +72,17 @@ module Dependabot
 
         sig { override.returns(T.nilable(T::Array[Dependabot::Package::PackageRelease])) }
         def available_versions
-          return nil if package_details&.releases.nil?
+          releases = package_details&.releases
+          return nil if releases.nil?
 
           source_versions = releases_from_dependency_source
           return [] if source_versions.empty?
 
-          T.must(package_details).releases.select do |release|
+          # Some private registries don't support the versions API that we use for fetching release dates for cooldown.
+          # In that case, skip cooldown and just return all versions.
+          return source_versions if releases.empty?
+
+          releases.select do |release|
             source_versions.any? { |v| v.to_s == release.version.to_s }
           end
         end

--- a/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
@@ -93,11 +93,10 @@ RSpec.describe Dependabot::Bundler::Package::PackageDetailsFetcher do
           }
         end
 
-        it "returns an empty result" do
+        it "returns nil" do
           result = fetch
 
-          expect(result).to be_a(Dependabot::Package::PackageDetails)
-          expect(result.releases).to be_empty
+          expect(result).to be_nil
           expect(a_request(:get, json_url)).not_to have_been_made
         end
       end
@@ -180,273 +179,44 @@ RSpec.describe Dependabot::Bundler::Package::PackageDetailsFetcher do
       end
     end
 
-    describe "GitHub Package Registry support" do
-      let(:dependency_name) { "json" }
+    context "when registry does not support versions API" do
+      let(:dependency_name) { "my-private-gem" }
       let(:source) do
         {
           type: "rubygems",
-          url: "https://rubygems.pkg.github.com/dsp-testing/"
+          url: "https://gems.private-registry.example.com/"
         }
       end
-      let(:credentials) do
-        [
-          Dependabot::Credential.new(
-            {
-              "type" => "rubygems_server",
-              "host" => "rubygems.pkg.github.com",
-              "token" => "ghp_test_token_123"
-            }
-          )
-        ]
-      end
-      let(:github_api_url) { "https://api.github.com/orgs/dsp-testing/packages/rubygems/json/versions" }
-
-      context "when package exists in GitHub registry" do
-        let(:github_api_response) do
-          [
-            {
-              "id" => 123,
-              "name" => "2.12.2",
-              "created_at" => "2023-09-01T10:00:00Z",
-              "updated_at" => "2023-09-01T10:00:00Z"
-            },
-            {
-              "id" => 122,
-              "name" => "2.12.1",
-              "created_at" => "2023-08-15T09:30:00Z",
-              "updated_at" => "2023-08-15T09:30:00Z"
-            },
-            {
-              "id" => 121,
-              "name" => "2.11.0",
-              "created_at" => "2023-07-01T08:00:00Z",
-              "updated_at" => "2023-07-01T08:00:00Z"
-            }
-          ]
-        end
-
-        before do
-          stub_request(:get, github_api_url)
-            .with(
-              headers: {
-                "Accept" => "application/vnd.github.v3+json",
-                "Authorization" => "Bearer ghp_test_token_123"
-              }
-            )
-            .to_return(
-              status: 200,
-              body: github_api_response.to_json,
-              headers: { "Content-Type" => "application/json" }
-            )
-        end
-
-        it "returns package details with all versions" do
-          result = fetch
-
-          expect(result).to be_a(Dependabot::Package::PackageDetails)
-          expect(result.releases.length).to eq(3)
-
-          # Check versions are in correct order (oldest first)
-          versions = result.releases.map { |release| release.version.to_s }
-          expect(versions).to eq(["2.12.2", "2.12.1", "2.11.0"])
-        end
-
-        it "creates package releases with correct GitHub attributes" do
-          result = fetch
-          latest_release = result.releases.first
-
-          expect(latest_release.version.to_s).to eq("2.12.2")
-          expect(latest_release.released_at).to eq(Time.parse("2023-09-01T10:00:00Z"))
-          expect(latest_release.downloads).to eq(0) # GitHub doesn't provide download counts
-          expect(latest_release.url).to eq("https://rubygems.pkg.github.com/dsp-testing/gems/json-2.12.2.gem")
-          expect(latest_release.yanked).to be false
-          expect(latest_release.package_type).to eq("gem")
-          expect(latest_release.language.name).to eq("ruby")
-          expect(latest_release.language.requirement).to be_nil # GitHub doesn't provide ruby version
-        end
-
-        it "makes authenticated request to GitHub API" do
-          fetch
-
-          expect(
-            a_request(:get, github_api_url)
-                        .with(
-                          headers: {
-                            "Accept" => "application/vnd.github.v3+json",
-                            "Authorization" => "Bearer ghp_test_token_123"
-                          }
-                        )
-          ).to have_been_made.once
-        end
+      let(:private_versions_url) do
+        "https://gems.private-registry.example.com/api/v1/versions/my-private-gem.json"
       end
 
-      context "when package is not found in GitHub registry" do
-        before do
-          stub_request(:get, github_api_url)
-            .with(
-              headers: {
-                "Accept" => "application/vnd.github.v3+json",
-                "Authorization" => "Bearer ghp_test_token_123"
-              }
-            )
-            .to_return(status: 404, body: "Not Found")
-        end
-
-        it "returns empty package details" do
-          result = fetch
-
-          expect(result).to be_a(Dependabot::Package::PackageDetails)
-          expect(result.releases).to be_empty
-        end
-
-        it "logs package not found error" do
-          expect(Dependabot.logger).to receive(:info)
-            .with("Failed to fetch versions for 'json' from GitHub Packages. " \
-                  "Status: 404 (Package not found in GitHub Registry)")
-
-          fetch
-        end
+      before do
+        stub_request(:get, private_versions_url)
+          .to_return(status: 404, body: "Not Found")
       end
 
-      context "when GitHub API returns server error" do
-        before do
-          stub_request(:get, github_api_url)
-            .to_return(status: 500, body: "Internal Server Error")
-        end
+      it "returns empty package details" do
+        result = fetch
 
-        it "returns empty package details" do
-          result = fetch
-
-          expect(result).to be_a(Dependabot::Package::PackageDetails)
-          expect(result.releases).to be_empty
-        end
-
-        it "logs server error" do
-          expect(Dependabot.logger).to receive(:info)
-            .with("Failed to fetch versions for 'json' from GitHub Packages. Status: 500")
-
-          fetch
-        end
-      end
-
-      context "when GitHub API returns invalid JSON" do
-        before do
-          stub_request(:get, github_api_url)
-            .to_return(
-              status: 200,
-              body: "invalid json{",
-              headers: { "Content-Type" => "application/json" }
-            )
-        end
-
-        it "returns empty package details" do
-          result = fetch
-
-          expect(result).to be_a(Dependabot::Package::PackageDetails)
-          expect(result.releases).to be_empty
-        end
-
-        it "logs JSON parsing error" do
-          expect(Dependabot.logger).to receive(:info)
-            .with(/Failed to parse GitHub Packages response:/)
-
-          fetch
-        end
-      end
-
-      context "when no GitHub token is provided" do
-        let(:credentials) { [] }
-
-        before do
-          stub_request(:get, github_api_url)
-            .with(
-              headers: {
-                "Accept" => "application/vnd.github.v3+json",
-                "Authorization" => "Bearer "
-              }
-            )
-            .to_return(status: 401, body: "Unauthorized")
-        end
-
-        it "makes request with empty authorization header" do
-          fetch
-
-          expect(
-            a_request(:get, github_api_url)
-                        .with(
-                          headers: {
-                            "Accept" => "application/vnd.github.v3+json",
-                            "Authorization" => "Bearer "
-                          }
-                        )
-          ).to have_been_made.once
-        end
-      end
-    end
-
-    describe "#github_token" do
-      let(:credentials) do
-        [
-          Dependabot::Credential.new(
-            {
-              "type" => "rubygems_server",
-              "host" => "rubygems.pkg.github.com",
-              "token" => "ghp_test_token_123"
-            }
-          )
-        ]
-      end
-
-      it "extracts token from rubygems_server credentials" do
-        expect(fetcher.send(:github_token)).to eq("ghp_test_token_123")
-      end
-
-      context "when no matching credentials" do
-        let(:credentials) { [] }
-
-        it "returns nil" do
-          expect(fetcher.send(:github_token)).to be_nil
-        end
-      end
-
-      context "with multiple credential types" do
-        let(:credentials) do
-          [
-            Dependabot::Credential.new(
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "token" => "different_token"
-              }
-            ),
-            Dependabot::Credential.new(
-              {
-                "type" => "rubygems_server",
-                "host" => "rubygems.pkg.github.com",
-                "token" => "correct_token"
-              }
-            )
-          ]
-        end
-
-        it "returns the correct GitHub Package Registry token" do
-          expect(fetcher.send(:github_token)).to eq("correct_token")
-        end
+        expect(result).to be_a(Dependabot::Package::PackageDetails)
+        expect(result.releases).to be_empty
+        expect(a_request(:get, private_versions_url)).to have_been_made.once
       end
     end
 
     describe "#get_url_from_dependency" do
-      context "with GitHub Package Registry source URL" do
+      context "with a source URL with trailing slash" do
         let(:source) do
           {
             type: "rubygems",
-            url: "https://rubygems.pkg.github.com/dsp-testing/"
+            url: "https://gems.private-registry.example.com/"
           }
         end
 
         it "returns URL without trailing slash" do
           expect(fetcher.send(:get_url_from_dependency, dependency))
-            .to eq("https://rubygems.pkg.github.com/dsp-testing")
+            .to eq("https://gems.private-registry.example.com")
         end
       end
 

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -371,6 +371,59 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when registry does not support versions API" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: current_version,
+          requirements: requirements,
+          package_manager: "bundler"
+        )
+      end
+      let(:dependency_name) { "business" }
+      let(:current_version) { "1.3" }
+      let(:requirements) do
+        [{ requirement: "1.3",
+           groups: [:default],
+           source: { type: "rubygems", url: "https://gems.private-registry.example.com/" },
+           file: "Gemfile" }]
+      end
+
+      let(:private_versions_url) do
+        "https://gems.private-registry.example.com/api/v1/versions/business.json"
+      end
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 60) }
+
+      before do
+        stub_request(:get, private_versions_url)
+          .to_return(status: 404, body: "Not Found")
+
+        rubygems_response = fixture("ruby", "rubygems_response_versions.json")
+        stub_request(:get, rubygems_url + "versions/business.json")
+          .to_return(status: 200, body: rubygems_response)
+
+        allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess).and_return("rubygems")
+      end
+
+      context "with latest version details" do
+        subject(:result) { finder.latest_version_details }
+
+        it "falls back to bundler versions and resolves latest version" do
+          expect(result).to be_a(Hash)
+          expect(result).not_to be_empty
+          expect(result[:version]).to eq(Dependabot::Bundler::Version.new("1.5.0"))
+        end
+      end
+
+      context "with latest version" do
+        subject(:result) { finder.latest_version }
+
+        it "resolves the latest version" do
+          expect(result).to eq(Dependabot::Bundler::Version.new("1.5.0"))
+        end
+      end
+    end
+
     context "with a private rubygems source" do
       let(:dependency_files) { bundler_project_dependency_files("specified_source") }
       let(:subprocess_error) do


### PR DESCRIPTION
### What are you trying to accomplish?

Remove GitHub Packages Registry (GPR) special-casing from the bundler `PackageDetailsFetcher` and add a fallback in `LatestVersionFinder` so that private registries that don't support the RubyGems versions API still work correctly.

**Background:** The bundler cooldown feature needs release dates from a registry's `/api/v1/versions/<gem>.json` endpoint. PR #12465 initially excluded GPR entirely (returning empty package details), and PR #13155 attempted to fix this by routing GPR lookups through the GitHub REST API (`api.github.com/orgs/<org>/packages/rubygems/<gem>/versions`). However, this REST API returns 404 for packages linked to their source repository rather than the org — which is the default when publishing with `GITHUB_TOKEN`. When the REST API 404s, `latest_version` resolves to nil, which breaks **grouping for groups with `update-types` rules** (the `semver_rules_allow_grouping?` check returns false when `latest_version` is nil, so gems are excluded from the group and created as individual PRs instead) and produces noisy 404 log spam. Individual updates still work because the bundler subprocess resolution runs independently and resolves versions directly from GPR.

I don't think we should be special-casing a workaround if a registry doesn't implement well-known APIs for that ecosystem... instead, I submitted a PR to the GPR team inside GitHub that implements the standard `/api/v1/versions/<gem>.json` endpoint. If they choose to pull that in, then cooldown will work automatically with no further changes to dependabot-core.

### What does this PR do?

Two changes:

1. **Remove GPR special-casing from `PackageDetailsFetcher`** — Delete the `github_packages_versions` method, `github_token` helper, and the `rubygems.pkg.github.com` host check. GPR is now treated like any other private rubygems server. If GPR doesn't support `/api/v1/versions/<gem>.json`, it returns 404, which produces `package_details([])` — an empty releases list.

2. **Add fallback in `LatestVersionFinder#available_versions`** — When `package_details.releases` is empty (registry doesn't support the versions API) but bundler's native `dependency_source.versions` has versions, fall back to the bundler version list. This ensures `latest_version` resolves correctly (fixing grouping), while cooldown is gracefully skipped (no `released_at` data). This is a generic fix that helps any private registry missing the versions API, not just GPR.

### Anything you want to highlight for special attention from reviewers?

- The `in_cooldown_period?` method already handles nil `released_at` gracefully (`return false unless release.released_at`), so returning source versions without release dates is safe — cooldown is simply skipped.
- The GPR special-casing was the **only** provider-specific code in the bundler module. All other bundler code (version resolver, dependency source, native helpers) already treats GPR as a standard rubygems server.
- Individual gem updates from GPR still work without this PR (the bundler subprocess resolution finds versions independently). The main issue this fixes is that `latest_version` being nil breaks **grouping for groups with `update-types` rules** and produces unnecessary 404 log noise.
- There is a minor cooldown regression: cooldown previously worked for the rare case of GPR packages manually linked to an org by an admin. However, cooldown was already broken for the common case (packages published via `GITHUB_TOKEN`, which are repo-linked). If GPR implements the standard `/api/v1/versions/<gem>.json` endpoint, cooldown will work for all GPR packages with no further changes to dependabot-core.

### How will you know you've accomplished your goal?

- Existing tests pass
- New test: "when registry does not support versions API" verifies that `latest_version_details` still resolves the latest version when the registry returns 404 for the versions API
- GPR gems no longer produce 404 log noise from the REST API, and `latest_version` resolves correctly (fixing grouping for groups with `update-types` rules)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
