### PR TITLE
bundler: Move git source guard from PackageDetailsFetcher to LatestVersionFinder

### DIFF
--- a/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
@@ -27,8 +27,6 @@ module Dependabot
         PACKAGE_LANGUAGE = "ruby"
         APPLICATION_JSON = "application/json"
         RUBYGEMS = "rubygems"
-        GIT = "git"
-        OTHER = "other"
 
         sig do
           params(
@@ -42,7 +40,6 @@ module Dependabot
           @dependency_files = dependency_files
           @credentials = credentials
 
-          @source_type = T.let(nil, T.nilable(String))
           @options = T.let({}, T::Hash[Symbol, T.untyped])
           @repo_contents_path = T.let(nil, T.nilable(String))
         end
@@ -62,14 +59,9 @@ module Dependabot
         sig { override.returns(T.nilable(String)) }
         attr_reader :repo_contents_path
 
-        sig { returns(T.nilable(Dependabot::Package::PackageDetails)) }
+        sig { returns(Dependabot::Package::PackageDetails) }
         def fetch
-          case source_type
-          when GIT, OTHER
-            nil
-          else
-            rubygems_versions
-          end
+          rubygems_versions
         end
 
         private
@@ -236,16 +228,6 @@ module Dependabot
         sig { params(req_string: String).returns(Requirement) }
         def language_requirement(req_string)
           Requirement.new(req_string)
-        end
-
-        sig { returns(T.nilable(String)) }
-        def source_type
-          return nil unless dependency.requirements.any?
-
-          first_requirement = dependency.requirements.first
-          return nil unless first_requirement && first_requirement[:source]
-
-          first_requirement[:source][:type]
         end
 
         sig { override.returns(String) }

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -50,6 +50,8 @@ module Dependabot
 
         sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def package_details
+          return nil if dependency_source.git?
+
           @package_details ||= Package::PackageDetailsFetcher.new(
             dependency: dependency,
             dependency_files: dependency_files,

--- a/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/package/package_details_fetcher_spec.rb
@@ -84,22 +84,6 @@ RSpec.describe Dependabot::Bundler::Package::PackageDetailsFetcher do
         expect(first_result.language.name).to eq(latest_release.language.name)
         expect(first_result.language.requirement).to eq(latest_release.language.requirement)
       end
-
-      context "when dependency uses a git source" do
-        let(:source) do
-          {
-            type: "git",
-            url: "git@github.com/dependabot/dependabot-common"
-          }
-        end
-
-        it "returns nil" do
-          result = fetch
-
-          expect(result).to be_nil
-          expect(a_request(:get, json_url)).not_to have_been_made
-        end
-      end
     end
 
     context "with error responses" do

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -398,10 +398,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         stub_request(:get, private_versions_url)
           .to_return(status: 404, body: "Not Found")
 
-        rubygems_response = fixture("ruby", "rubygems_response_versions.json")
-        stub_request(:get, rubygems_url + "versions/business.json")
-          .to_return(status: 200, body: rubygems_response)
-
         allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess).and_return("rubygems")
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Refactor: make `PackageDetailsFetcher` purely a registry concern by moving the git/other source type guard to `LatestVersionFinder#package_details`.

**Stacked on #14551** — that PR fixes the GPR special-casing bug and adds the fallback for unsupported registries. This PR is a pure refactor with no behavior change.

### What does this PR do?

- Remove `source_type` method, `GIT`/`OTHER` constants, and `@source_type` instance variable from `PackageDetailsFetcher`
- `PackageDetailsFetcher#fetch` now always calls `rubygems_versions` — it no longer knows about git sources
- `LatestVersionFinder#package_details` returns `nil` early for git sources via the existing `dependency_source.git?` method
- Remove the git source test from `package_details_fetcher_spec.rb` (no longer the fetcher's responsibility)

### Why?

`PackageDetailsFetcher` had two concerns: deciding *whether* to fetch (source type check) and *how* to fetch (registry API call). The caller (`LatestVersionFinder`) already has source type awareness via `dependency_source.git?` and already handles `nil` package details. Moving the guard there simplifies the fetcher and makes the separation of concerns cleaner.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes.