### PR TITLE
nix: fix permission denied on /nix/var/nix/db/big-lock

### DIFF
--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/nixos/nix:2.34.1 AS nix
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Copy Nix from the official image
-COPY --from=nix /nix /nix
+COPY --from=nix --chown=dependabot:dependabot /nix /nix
 
 # Configure Nix for single-user mode with flakes enabled
 RUN mkdir -p /etc/nix \


### PR DESCRIPTION
### What are you trying to accomplish?

The nix container image copies `/nix` from `nixos/nix` with root ownership, but the updater runs as the `dependabot` user. When `nix flake update` tries to write to the Nix store and SQLite database, it fails with:

```
error: opening lock file "/nix/var/nix/db/big-lock": Permission denied
```

Found while adding nix smoke tests: https://github.com/dependabot/smoke-tests/pull/445 ([failed run](https://github.com/dependabot/smoke-tests/actions/runs/23658887376/job/68926112184?pr=445))

### Anything you want to highlight for special attention from reviewers?

The fix is `--chown=dependabot:dependabot` on the `COPY --from=nix` line. This gives the `dependabot` user ownership of the entire `/nix` tree at copy time, which is how single-user Nix is supposed to work -- the running user owns `/nix`. No extra Docker layer needed compared to a separate `RUN chown -R`.

### How will you know you've accomplished your goal?

Built the image locally and verified:
- `/nix/var/nix/db/big-lock` and `/nix/store` are owned by `dependabot`
- `nix --version` runs without error
- `nix flake update` against a test flake completes and produces a `flake.lock`

The smoke test in https://github.com/dependabot/smoke-tests/pull/445 should pass once this lands.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.