### PR TITLE
Promote Nix ecosystem from beta to GA

### DIFF
--- a/nix/lib/dependabot/nix/file_fetcher.rb
+++ b/nix/lib/dependabot/nix/file_fetcher.rb
@@ -22,13 +22,6 @@ module Dependabot
 
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files
-        unless allow_beta_ecosystems?
-          raise Dependabot::DependencyFileNotFound.new(
-            nil,
-            "Nix support is currently in beta. Set ALLOW_BETA_ECOSYSTEMS=true to enable it."
-          )
-        end
-
         fetched_files = []
         fetched_files << flake_nix
         fetched_files << flake_lock

--- a/nix/spec/dependabot/nix/file_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/file_fetcher_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Dependabot::Nix::FileFetcher do
   end
 
   before do
-    allow(file_fetcher_instance).to receive_messages(commit: "sha", allow_beta_ecosystems?: true)
+    allow(file_fetcher_instance).to receive_messages(commit: "sha")
   end
 
   describe ".required_files_in?" do
@@ -75,17 +75,6 @@ RSpec.describe Dependabot::Nix::FileFetcher do
     it "fetches both flake.nix and flake.lock" do
       expect(file_fetcher_instance.files.count).to eq(2)
       expect(file_fetcher_instance.files.map(&:name)).to match_array(%w(flake.nix flake.lock))
-    end
-
-    context "when beta ecosystems are not allowed" do
-      before do
-        allow(file_fetcher_instance).to receive(:allow_beta_ecosystems?).and_return(false)
-      end
-
-      it "raises a DependencyFileNotFound error" do
-        expect { file_fetcher_instance.files }
-          .to raise_error(Dependabot::DependencyFileNotFound)
-      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Removes the beta gate from the Nix file fetcher so Nix is available to all users without needing `ALLOW_BETA_ECOSYSTEMS=true`.

### Anything you want to highlight for special attention from reviewers?

The only change is removing the `allow_beta_ecosystems?` guard in `FileFetcher#fetch_files` and the corresponding test. No behavioral changes otherwise.

### How will you know you've accomplished your goal?

Nix dependency updates work without setting `ALLOW_BETA_ECOSYSTEMS`. Existing file fetcher tests pass.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.