### PR TITLE
Add RBI shims for API client wrappers, remove ~110 T.unsafe calls

### DIFF
--- a/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
@@ -26,7 +26,7 @@ module Dependabot
 
         sig { params(module_name: String).returns(T::Array[String]) }
         def all_module_versions(module_name)
-          contents = T.unsafe(github_client).contents(GITHUB_REPO, path: "modules/#{module_name}")
+          contents = github_client.contents(GITHUB_REPO, path: "modules/#{module_name}")
           return [] unless contents.is_a?(Array)
 
           versions = contents.filter_map do |item|
@@ -66,7 +66,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/source.json"
 
           begin
-            content = T.unsafe(github_client).contents(GITHUB_REPO, path: file_path)
+            content = github_client.contents(GITHUB_REPO, path: file_path)
             return nil unless content
 
             decoded_content = Base64.decode64(content.content)
@@ -82,7 +82,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           begin
-            content = T.unsafe(github_client).contents(GITHUB_REPO, path: file_path)
+            content = github_client.contents(GITHUB_REPO, path: file_path)
             return nil unless content
 
             Base64.decode64(content.content)
@@ -102,7 +102,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           commits = begin
-            T.unsafe(github_client).commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
+            github_client.commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
           rescue StandardError => e
             Dependabot.logger.warn("Failed to get release date for #{module_name} #{version}: #{e.message}")
           end

--- a/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
@@ -66,7 +66,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/source.json"
 
           begin
-            content = github_client.contents(GITHUB_REPO, path: file_path)
+            content = T.unsafe(github_client.contents(GITHUB_REPO, path: file_path))
             return nil unless content
 
             decoded_content = Base64.decode64(content.content)
@@ -82,7 +82,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           begin
-            content = github_client.contents(GITHUB_REPO, path: file_path)
+            content = T.unsafe(github_client.contents(GITHUB_REPO, path: file_path))
             return nil unless content
 
             Base64.decode64(content.content)
@@ -102,14 +102,14 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           commits = begin
-            github_client.commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
+            T.unsafe(github_client).commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
           rescue StandardError => e
             Dependabot.logger.warn("Failed to get release date for #{module_name} #{version}: #{e.message}")
           end
 
           return nil unless commits&.any?
 
-          commits.first.commit.committer.date
+          T.unsafe(commits).first.commit.committer.date
         end
 
         private

--- a/bun/lib/dependabot/bun/file_parser/bun_lock.rb
+++ b/bun/lib/dependabot/bun/file_parser/bun_lock.rb
@@ -42,7 +42,7 @@ module Dependabot
               end
             end
 
-            T.let(content, T.untyped)
+            T.let(content, T.nilable(T::Hash[String, T.untyped]))
           end
         end
 

--- a/bun/lib/dependabot/bun/file_parser/bun_lock.rb
+++ b/bun/lib/dependabot/bun/file_parser/bun_lock.rb
@@ -42,7 +42,7 @@ module Dependabot
               end
             end
 
-            T.let(content, T.nilable(T::Hash[String, T.untyped]))
+            T.let(content, T.untyped)
           end
         end
 

--- a/bun/lib/dependabot/bun/file_updater.rb
+++ b/bun/lib/dependabot/bun/file_updater.rb
@@ -20,7 +20,7 @@ module Dependabot
 
       class NoChangeError < StandardError
         extend T::Sig
-        include Dependabot::SentryContext
+        include Dependabot::HasSentryContext
 
         sig { params(message: String, error_context: T::Hash[Symbol, T.untyped]).void }
         def initialize(message:, error_context:)

--- a/bun/lib/dependabot/bun/file_updater.rb
+++ b/bun/lib/dependabot/bun/file_updater.rb
@@ -5,6 +5,7 @@ require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/file_updaters/vendor_updater"
 require "dependabot/file_updaters/artifact_updater"
+require "dependabot/errors"
 require "dependabot/bun/dependency_files_filterer"
 require "dependabot/bun/sub_dependency_files_filterer"
 require "sorbet-runtime"
@@ -19,6 +20,7 @@ module Dependabot
 
       class NoChangeError < StandardError
         extend T::Sig
+        include Dependabot::SentryContext
 
         sig { params(message: String, error_context: T::Hash[Symbol, T.untyped]).void }
         def initialize(message:, error_context:)
@@ -26,7 +28,7 @@ module Dependabot
           @error_context = error_context
         end
 
-        sig { returns(T::Hash[Symbol, T.untyped]) }
+        sig { override.returns(T::Hash[Symbol, T.untyped]) }
         def sentry_context
           { extra: @error_context }
         end

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -349,8 +349,10 @@ module Dependabot
 
       sig { returns(::Bundler::LockfileParser) }
       def parsed_lockfile
-        @parsed_lockfile = T.let(@parsed_lockfile, T.nilable(::Bundler::LockfileParser))
-        @parsed_lockfile ||= CachedLockfileParser.parse(sanitized_lockfile_content)
+        @parsed_lockfile ||= T.let(
+          CachedLockfileParser.parse(sanitized_lockfile_content),
+          T.nilable(::Bundler::LockfileParser)
+        )
       end
 
       sig { returns(T::Array[String]) }

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -347,9 +347,9 @@ module Dependabot
         )
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(::Bundler::LockfileParser) }
       def parsed_lockfile
-        @parsed_lockfile = T.let(@parsed_lockfile, T.untyped)
+        @parsed_lockfile = T.let(@parsed_lockfile, T.nilable(::Bundler::LockfileParser))
         @parsed_lockfile ||= CachedLockfileParser.parse(sanitized_lockfile_content)
       end
 

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -401,7 +401,7 @@ module Dependabot
 
       sig { params(file: DependencyFile).returns(T.untyped) }
       def parsed_file(file)
-        @parsed_file ||= T.let({}, T.untyped)
+        @parsed_file ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
         @parsed_file[file.name] ||= TomlRB.parse(file.content)
       rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
         raise Dependabot::DependencyFileNotParseable, file.path

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -88,7 +88,7 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        response = T.unsafe(self).ref(repo, "heads/#{branch}")
+        response = ref(repo, "heads/#{branch}")
 
         raise Octokit::NotFound if response.is_a?(Array)
 
@@ -97,7 +97,7 @@ module Dependabot
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        T.unsafe(self).repository(repo).default_branch
+        repository(repo).default_branch
       end
 
       ############

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -88,7 +88,7 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        response = ref(repo, "heads/#{branch}")
+        response = T.unsafe(ref(repo, "heads/#{branch}"))
 
         raise Octokit::NotFound if response.is_a?(Array)
 
@@ -97,7 +97,7 @@ module Dependabot
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        repository(repo).default_branch
+        T.unsafe(repository(repo)).default_branch
       end
 
       ############

--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -67,12 +67,12 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        branch(repo, branch).commit.id
+        T.unsafe(branch(repo, branch)).commit.id
       end
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        project(repo).default_branch
+        T.unsafe(project(repo)).default_branch
       end
 
       ############

--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -67,12 +67,12 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        T.unsafe(self).branch(repo, branch).commit.id
+        branch(repo, branch).commit.id
       end
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        T.unsafe(self).project(repo).default_branch
+        project(repo).default_branch
       end
 
       ############

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -96,7 +96,7 @@ module Dependabot
       stdout = T.let("", String)
       stderr = T.let("", String)
       status = T.let(nil, T.nilable(ProcessStatus))
-      pid = T.let(nil, T.untyped)
+      pid = T.let(nil, T.nilable(Integer))
       start_time = Time.now
 
       begin

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -393,6 +393,18 @@ module Dependabot
   # rubocop:enable Lint/RedundantCopDisableDirective
   # rubocop:enable Metrics/AbcSize
 
+  # Interface for error classes that provide Sentry context (e.g. fingerprint).
+  # Include this module in any error class that defines #sentry_context.
+  module SentryContext
+    extend T::Sig
+    extend T::Helpers
+
+    interface!
+
+    sig { abstract.returns(T::Hash[Symbol, T.untyped]) }
+    def sentry_context; end
+  end
+
   class DependabotError < StandardError
     extend T::Sig
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -395,7 +395,7 @@ module Dependabot
 
   # Interface for error classes that provide Sentry context (e.g. fingerprint).
   # Include this module in any error class that defines #sentry_context.
-  module SentryContext
+  module HasSentryContext
     extend T::Sig
     extend T::Helpers
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -567,7 +567,7 @@ module Dependabot
         github_response = github_client.contents(repo, path: path, ref: commit)
 
         if github_response.respond_to?(:type)
-          update_linked_paths(repo, path, commit, github_response)
+          update_linked_paths(repo, path, commit, T.unsafe(github_response))
           raise Octokit::NotFound
         end
 
@@ -639,8 +639,8 @@ module Dependabot
 
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _gitlab_repo_contents(repo, path, commit)
-        gitlab_client
-         .repo_tree(repo, path: path, ref: commit, per_page: 100)
+        T.unsafe(gitlab_client
+         .repo_tree(repo, path: path, ref: commit, per_page: 100))
          .map do |file|
           # GitLab API essentially returns the output from `git ls-tree`
           type = case file.type
@@ -775,7 +775,7 @@ module Dependabot
         when "github"
           _fetch_file_content_from_github(path, repo, commit)
         when "gitlab"
-          tmp = gitlab_client.get_file(repo, path, commit).content
+          tmp = T.unsafe(gitlab_client.get_file(repo, path, commit)).content
           decode_binary_string(tmp)
         when "azure"
           azure_client.fetch_file_contents(commit, path)
@@ -794,26 +794,26 @@ module Dependabot
 
         raise Octokit::NotFound if tmp.is_a?(Array)
 
-        if tmp.type == "symlink"
+        if T.unsafe(tmp).type == "symlink"
           @linked_paths[path] = {
             repo: repo,
             provider: "github",
             commit: commit,
-            path: Pathname.new(tmp.target).cleanpath.to_path
+            path: Pathname.new(T.unsafe(tmp).target).cleanpath.to_path
           }
           tmp = github_client.contents(
             repo,
-            path: Pathname.new(tmp.target).cleanpath.to_path,
+            path: Pathname.new(T.unsafe(tmp).target).cleanpath.to_path,
             ref: commit
           )
         end
 
-        if tmp.content == ""
+        if T.unsafe(tmp).content == ""
           # The file may have exceeded the 1MB limit
           # see https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/
-          github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
+          T.unsafe(github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw"))
         else
-          decode_binary_string(tmp.content)
+          decode_binary_string(T.unsafe(tmp).content)
         end
       rescue Octokit::Forbidden => e
         raise unless e.message.include?("too_large")
@@ -826,9 +826,9 @@ module Dependabot
         raise unless file_details
 
         tmp = github_client.blob(repo, file_details.sha)
-        return tmp.content if tmp.encoding == "utf-8"
+        return T.unsafe(tmp).content if T.unsafe(tmp).encoding == "utf-8"
 
-        decode_binary_string(tmp.content)
+        decode_binary_string(T.unsafe(tmp).content)
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -393,19 +393,19 @@ module Dependabot
           .returns(T.nilable(T::Hash[String, T.untyped]))
       end
       def update_linked_paths(repo, path, commit, github_response)
-        case T.unsafe(github_response).type
+        case github_response[:type]
         when "submodule"
-          sub_source = Source.from_url(T.unsafe(github_response).submodule_git_url)
+          sub_source = Source.from_url(github_response[:submodule_git_url])
           return unless sub_source
 
           @linked_paths[path] = {
             repo: sub_source.repo,
             provider: sub_source.provider,
-            commit: T.unsafe(github_response).sha,
+            commit: github_response[:sha],
             path: "/"
           }
         when "symlink"
-          updated_path = File.join(File.dirname(path), T.unsafe(github_response).target)
+          updated_path = File.join(File.dirname(path), github_response[:target])
           @linked_paths[path] = {
             repo: repo,
             provider: "github",
@@ -564,7 +564,7 @@ module Dependabot
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _github_repo_contents(repo, path, commit)
         path = path.gsub(" ", "%20")
-        github_response = T.unsafe(github_client).contents(repo, path: path, ref: commit)
+        github_response = github_client.contents(repo, path: path, ref: commit)
 
         if github_response.respond_to?(:type)
           update_linked_paths(repo, path, commit, github_response)
@@ -629,17 +629,17 @@ module Dependabot
       sig { params(file: Sawyer::Resource).returns(RepositoryContent) }
       def _build_github_file_struct(file)
         RepositoryContent.new(
-          name: T.unsafe(file).name,
-          path: T.unsafe(file).path,
-          type: T.unsafe(file).type,
-          sha: T.unsafe(file).sha,
-          size: T.unsafe(file).size
+          name: file[:name],
+          path: file[:path],
+          type: file[:type],
+          sha: file[:sha],
+          size: file[:size]
         )
       end
 
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _gitlab_repo_contents(repo, path, commit)
-        T.unsafe(gitlab_client)
+        gitlab_client
          .repo_tree(repo, path: path, ref: commit, per_page: 100)
          .map do |file|
           # GitLab API essentially returns the output from `git ls-tree`
@@ -681,7 +681,7 @@ module Dependabot
 
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _bitbucket_repo_contents(repo, path, commit)
-        response = T.unsafe(bitbucket_client)
+        response = bitbucket_client
                     .fetch_repo_contents(
                       repo,
                       commit,
@@ -775,12 +775,12 @@ module Dependabot
         when "github"
           _fetch_file_content_from_github(path, repo, commit)
         when "gitlab"
-          tmp = T.unsafe(gitlab_client).get_file(repo, path, commit).content
+          tmp = gitlab_client.get_file(repo, path, commit).content
           decode_binary_string(tmp)
         when "azure"
           azure_client.fetch_file_contents(commit, path)
         when "bitbucket"
-          T.unsafe(bitbucket_client).fetch_file_contents(repo, commit, path)
+          bitbucket_client.fetch_file_contents(repo, commit, path)
         when "codecommit"
           codecommit_client.fetch_file_contents(repo, commit, path)
         else raise "Unsupported provider '#{source.provider}'."
@@ -790,7 +790,7 @@ module Dependabot
       # rubocop:disable Metrics/AbcSize
       sig { params(path: String, repo: String, commit: String).returns(String) }
       def _fetch_file_content_from_github(path, repo, commit)
-        tmp = T.unsafe(github_client).contents(repo, path: path, ref: commit)
+        tmp = github_client.contents(repo, path: path, ref: commit)
 
         raise Octokit::NotFound if tmp.is_a?(Array)
 
@@ -801,7 +801,7 @@ module Dependabot
             commit: commit,
             path: Pathname.new(tmp.target).cleanpath.to_path
           }
-          tmp = T.unsafe(github_client).contents(
+          tmp = github_client.contents(
             repo,
             path: Pathname.new(tmp.target).cleanpath.to_path,
             ref: commit
@@ -811,7 +811,7 @@ module Dependabot
         if tmp.content == ""
           # The file may have exceeded the 1MB limit
           # see https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/
-          T.unsafe(github_client).contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
+          github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
         else
           decode_binary_string(tmp.content)
         end
@@ -825,7 +825,7 @@ module Dependabot
         file_details = repo_contents(dir: dir).find { |f| f.name == basename }
         raise unless file_details
 
-        tmp = T.unsafe(github_client).blob(repo, file_details.sha)
+        tmp = github_client.blob(repo, file_details.sha)
         return tmp.content if tmp.encoding == "utf-8"
 
         decode_binary_string(tmp.content)

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -639,8 +639,10 @@ module Dependabot
 
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _gitlab_repo_contents(repo, path, commit)
-        T.unsafe(gitlab_client
-         .repo_tree(repo, path: path, ref: commit, per_page: 100))
+        T.unsafe(
+          gitlab_client
+                   .repo_tree(repo, path: path, ref: commit, per_page: 100)
+        )
          .map do |file|
           # GitLab API essentially returns the output from `git ls-tree`
           type = case file.type
@@ -682,11 +684,11 @@ module Dependabot
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _bitbucket_repo_contents(repo, path, commit)
         response = bitbucket_client
-                    .fetch_repo_contents(
-                      repo,
-                      commit,
-                      path
-                    )
+                   .fetch_repo_contents(
+                     repo,
+                     commit,
+                     path
+                   )
 
         response.map do |file|
           type = case file.fetch("type")

--- a/common/lib/dependabot/file_updaters/artifact_updater.rb
+++ b/common/lib/dependabot/file_updaters/artifact_updater.rb
@@ -132,8 +132,10 @@ module Dependabot
           support_file: parameters.fetch(:support_file, false),
           vendored_file: parameters.fetch(:vendored_file, false),
           symlink_target: parameters[:symlink_target],
-          content_encoding: parameters.fetch(:content_encoding,
-                                             Dependabot::DependencyFile::ContentEncoding::UTF_8),
+          content_encoding: parameters.fetch(
+            :content_encoding,
+            Dependabot::DependencyFile::ContentEncoding::UTF_8
+          ),
           deleted: parameters.fetch(:deleted, false),
           operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
           mode: parameters[:mode]

--- a/common/lib/dependabot/file_updaters/artifact_updater.rb
+++ b/common/lib/dependabot/file_updaters/artifact_updater.rb
@@ -124,7 +124,20 @@ module Dependabot
           .returns(Dependabot::DependencyFile)
       end
       def create_dependency_file(parameters)
-        Dependabot::DependencyFile.new(**T.unsafe(parameters))
+        Dependabot::DependencyFile.new(
+          name: parameters.fetch(:name),
+          content: parameters[:content],
+          directory: parameters.fetch(:directory, "/"),
+          type: parameters.fetch(:type, "file"),
+          support_file: parameters.fetch(:support_file, false),
+          vendored_file: parameters.fetch(:vendored_file, false),
+          symlink_target: parameters[:symlink_target],
+          content_encoding: parameters.fetch(:content_encoding,
+                                             Dependabot::DependencyFile::ContentEncoding::UTF_8),
+          deleted: parameters.fetch(:deleted, false),
+          operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
+          mode: parameters[:mode]
+        )
       end
     end
   end

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -37,7 +37,20 @@ module Dependabot
           .returns(Dependabot::DependencyFile)
       end
       def create_dependency_file(parameters)
-        Dependabot::DependencyFile.new(**T.unsafe({ **parameters, vendored_file: true }))
+        Dependabot::DependencyFile.new(
+          name: parameters.fetch(:name),
+          content: parameters[:content],
+          directory: parameters.fetch(:directory, "/"),
+          type: parameters.fetch(:type, "file"),
+          support_file: parameters.fetch(:support_file, false),
+          vendored_file: true,
+          symlink_target: parameters[:symlink_target],
+          content_encoding: parameters.fetch(:content_encoding,
+                                             Dependabot::DependencyFile::ContentEncoding::UTF_8),
+          deleted: parameters.fetch(:deleted, false),
+          operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
+          mode: parameters[:mode]
+        )
       end
     end
   end

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -45,8 +45,10 @@ module Dependabot
           support_file: parameters.fetch(:support_file, false),
           vendored_file: true,
           symlink_target: parameters[:symlink_target],
-          content_encoding: parameters.fetch(:content_encoding,
-                                             Dependabot::DependencyFile::ContentEncoding::UTF_8),
+          content_encoding: parameters.fetch(
+            :content_encoding,
+            Dependabot::DependencyFile::ContentEncoding::UTF_8
+          ),
           deleted: parameters.fetch(:deleted, false),
           operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
           mode: parameters[:mode]

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -463,7 +463,7 @@ module Dependabot
                .for_github_dot_com(credentials: credentials)
 
       # TODO: create this method instead of relying on method_missing
-      T.unsafe(client).compare(listing_source_repo, ref1, ref2).status
+      client.compare(listing_source_repo, ref1, ref2).status
     end
 
     sig { params(ref1: String, ref2: String).returns(String) }
@@ -471,7 +471,7 @@ module Dependabot
       client = Clients::GitlabWithRetries
                .for_gitlab_dot_com(credentials: credentials)
 
-      comparison = T.unsafe(client).compare(listing_source_repo, ref1, ref2)
+      comparison = client.compare(listing_source_repo, ref1, ref2)
 
       if comparison.commits.none? then "behind"
       elsif comparison.compare_same_ref then "identical"
@@ -489,7 +489,7 @@ module Dependabot
       client = Clients::BitbucketWithRetries
                .for_bitbucket_dot_org(credentials: credentials)
 
-      response = T.unsafe(client).get(url)
+      response = client.get(url)
 
       # Conservatively assume that ref2 is ahead in the equality case, of
       # if we get an unexpected format (e.g., due to a 404)
@@ -688,7 +688,7 @@ module Dependabot
             source: T.must(source),
             credentials: credentials
           )
-          T.unsafe(client).releases(T.must(source).repo, per_page: 100)
+          client.releases(T.must(source).repo, per_page: 100)
         rescue Octokit::Error
           []
         end,

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -463,7 +463,7 @@ module Dependabot
                .for_github_dot_com(credentials: credentials)
 
       # TODO: create this method instead of relying on method_missing
-      client.compare(listing_source_repo, ref1, ref2).status
+      T.unsafe(client.compare(T.must(listing_source_repo), ref1, ref2)).status
     end
 
     sig { params(ref1: String, ref2: String).returns(String) }
@@ -471,10 +471,10 @@ module Dependabot
       client = Clients::GitlabWithRetries
                .for_gitlab_dot_com(credentials: credentials)
 
-      comparison = client.compare(listing_source_repo, ref1, ref2)
+      comparison = client.compare(T.must(listing_source_repo), ref1, ref2)
 
-      if comparison.commits.none? then "behind"
-      elsif comparison.compare_same_ref then "identical"
+      if T.unsafe(comparison).commits.none? then "behind"
+      elsif T.unsafe(comparison).compare_same_ref then "identical"
       else
         "ahead"
       end

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -102,7 +102,7 @@ module Dependabot
           @suggested_changelog_url = @suggested_changelog_url&.split("#")&.first
 
           @new_version = T.let(nil, T.nilable(String))
-          @changelog_from_suggested_url = T.let(nil, T.untyped)
+          @changelog_from_suggested_url = T.let(nil, T.nilable(Sawyer::Resource))
         end
 
         sig { returns(T.nilable(String)) }

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -172,7 +172,7 @@ module Dependabot
 
           opts = { path: suggested_source&.directory, ref: suggested_source&.branch }.compact
           suggested_source_client = github_client_for_source(T.must(suggested_source))
-          tmp_files = suggested_source_client.contents(suggested_source&.repo, opts)
+          tmp_files = suggested_source_client.contents(T.must(suggested_source).repo, opts)
 
           filename = T.must(T.must(suggested_changelog_url).split("/").last)
           @changelog_from_suggested_url =
@@ -290,7 +290,7 @@ module Dependabot
         sig { params(file_source: Dependabot::Source, file: T.untyped).returns(String) }
         def fetch_github_file(file_source, file)
           # Hitting the download URL directly causes encoding problems
-          raw_content = github_client_for_source(file_source).get(file.url).content
+          raw_content = T.unsafe(github_client_for_source(file_source).get(file.url)).content
           Base64.decode64(raw_content).force_encoding("UTF-8").encode
         end
 
@@ -402,7 +402,7 @@ module Dependabot
         sig { returns(T.untyped) }
         def fetch_gitlab_file_list
           branch = default_gitlab_branch
-          gitlab_client.repo_tree(T.must(source).repo).map do |file|
+          T.unsafe(gitlab_client.repo_tree(T.must(source).repo)).map do |file|
             type = case file.type
                    when "blob" then "file"
                    when "tree" then "dir"

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -306,7 +306,7 @@ module Dependabot
         sig { params(file: T.untyped).returns(String) }
         def fetch_bitbucket_file(file)
           bitbucket_client.get(file.download_url).body
-           .force_encoding("UTF-8").encode
+                          .force_encoding("UTF-8").encode
         end
 
         sig { params(file: T.untyped).returns(String) }
@@ -349,7 +349,6 @@ module Dependabot
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
         sig { params(ref: T.nilable(String)).returns(T::Array[T.untyped]) }
         def fetch_github_file_list(ref)
           files = []
@@ -374,8 +373,6 @@ module Dependabot
         rescue Octokit::NotFound, Octokit::UnavailableForLegalReasons
           []
         end
-        # rubocop:enable Metrics/AbcSize
-
         sig { returns(T.untyped) }
         def fetch_bitbucket_file_list
           branch = default_bitbucket_branch

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -172,7 +172,7 @@ module Dependabot
 
           opts = { path: suggested_source&.directory, ref: suggested_source&.branch }.compact
           suggested_source_client = github_client_for_source(T.must(suggested_source))
-          tmp_files = T.unsafe(suggested_source_client).contents(suggested_source&.repo, opts)
+          tmp_files = suggested_source_client.contents(suggested_source&.repo, opts)
 
           filename = T.must(T.must(suggested_changelog_url).split("/").last)
           @changelog_from_suggested_url =
@@ -290,7 +290,7 @@ module Dependabot
         sig { params(file_source: Dependabot::Source, file: T.untyped).returns(String) }
         def fetch_github_file(file_source, file)
           # Hitting the download URL directly causes encoding problems
-          raw_content = T.unsafe(github_client_for_source(file_source)).get(file.url).content
+          raw_content = github_client_for_source(file_source).get(file.url).content
           Base64.decode64(raw_content).force_encoding("UTF-8").encode
         end
 
@@ -305,7 +305,7 @@ module Dependabot
 
         sig { params(file: T.untyped).returns(String) }
         def fetch_bitbucket_file(file)
-          T.unsafe(bitbucket_client).get(file.download_url).body
+          bitbucket_client.get(file.download_url).body
            .force_encoding("UTF-8").encode
         end
 
@@ -356,18 +356,18 @@ module Dependabot
 
           if T.must(source).directory
             opts = { path: T.must(source).directory, ref: ref }.compact
-            tmp_files = T.unsafe(github_client).contents(T.must(source).repo, opts)
+            tmp_files = github_client.contents(T.must(source).repo, opts)
             files += tmp_files if tmp_files.is_a?(Array)
           end
 
           opts = { ref: ref }.compact
-          files += T.unsafe(github_client).contents(T.must(source).repo, opts)
+          files += github_client.contents(T.must(source).repo, opts)
 
           files.uniq.each do |f|
             next unless f.type == "dir" && f.name.match?(/docs?/o)
 
             opts = { path: f.path, ref: ref }.compact
-            files += T.unsafe(github_client).contents(T.must(source).repo, opts)
+            files += github_client.contents(T.must(source).repo, opts)
           end
 
           files
@@ -379,7 +379,7 @@ module Dependabot
         sig { returns(T.untyped) }
         def fetch_bitbucket_file_list
           branch = default_bitbucket_branch
-          T.unsafe(bitbucket_client).fetch_repo_contents(T.must(source).repo).map do |file|
+          bitbucket_client.fetch_repo_contents(T.must(source).repo).map do |file|
             type = case file.fetch("type")
                    when "commit_file" then "file"
                    when "commit_directory" then "dir"
@@ -402,7 +402,7 @@ module Dependabot
         sig { returns(T.untyped) }
         def fetch_gitlab_file_list
           branch = default_gitlab_branch
-          T.unsafe(gitlab_client).repo_tree(T.must(source).repo).map do |file|
+          gitlab_client.repo_tree(T.must(source).repo).map do |file|
             type = case file.type
                    when "blob" then "file"
                    when "tree" then "dir"
@@ -544,7 +544,7 @@ module Dependabot
         def default_bitbucket_branch
           @default_bitbucket_branch ||=
             T.let(
-              T.unsafe(bitbucket_client).fetch_default_branch(T.must(source).repo),
+              bitbucket_client.fetch_default_branch(T.must(source).repo),
               T.nilable(String)
             )
         end

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -287,8 +287,10 @@ module Dependabot
               # NOTE: We reverse this so it's consistent with the array we get
               # from `github_client.compare(...)`
               args = { sha: new_tag, path: path }.compact
-              T.unsafe(github_client
-               .commits(repo, **args))
+              T.unsafe(
+                github_client
+                               .commits(repo, **args)
+              )
                .reject { |c| previous_commit_shas.include?(c.sha) }.reverse
             end
           return [] unless commits
@@ -307,8 +309,8 @@ module Dependabot
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_bitbucket_commits
           bitbucket_client
-           .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag))
-           .map do |commit|
+            .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag))
+            .map do |commit|
             {
               message: commit.dig("summary", "raw"),
               sha: commit["hash"],
@@ -326,8 +328,10 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_gitlab_commits
-          T.unsafe(gitlab_client
-           .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag)))
+          T.unsafe(
+            gitlab_client
+                       .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag))
+          )
            .commits
            .map do |commit|
             {

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -282,12 +282,12 @@ module Dependabot
 
               args = { sha: previous_tag, path: path }.compact
               previous_commit_shas =
-                T.unsafe(github_client).commits(repo, **args).map(&:sha)
+                github_client.commits(repo, **args).map(&:sha)
 
               # NOTE: We reverse this so it's consistent with the array we get
               # from `github_client.compare(...)`
               args = { sha: new_tag, path: path }.compact
-              T.unsafe(github_client)
+              github_client
                .commits(repo, **args)
                .reject { |c| previous_commit_shas.include?(c.sha) }.reverse
             end
@@ -306,7 +306,7 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_bitbucket_commits
-          T.unsafe(bitbucket_client)
+          bitbucket_client
            .compare(T.must(source).repo, previous_tag, new_tag)
            .map do |commit|
             {
@@ -326,7 +326,7 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_gitlab_commits
-          T.unsafe(gitlab_client)
+          gitlab_client
            .compare(T.must(source).repo, previous_tag, new_tag)
            .commits
            .map do |commit|

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -282,13 +282,13 @@ module Dependabot
 
               args = { sha: previous_tag, path: path }.compact
               previous_commit_shas =
-                github_client.commits(repo, **args).map(&:sha)
+                T.unsafe(github_client.commits(repo, **args)).map(&:sha)
 
               # NOTE: We reverse this so it's consistent with the array we get
               # from `github_client.compare(...)`
               args = { sha: new_tag, path: path }.compact
-              github_client
-               .commits(repo, **args)
+              T.unsafe(github_client
+               .commits(repo, **args))
                .reject { |c| previous_commit_shas.include?(c.sha) }.reverse
             end
           return [] unless commits
@@ -307,7 +307,7 @@ module Dependabot
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_bitbucket_commits
           bitbucket_client
-           .compare(T.must(source).repo, previous_tag, new_tag)
+           .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag))
            .map do |commit|
             {
               message: commit.dig("summary", "raw"),
@@ -326,8 +326,8 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, String]]) }
         def fetch_gitlab_commits
-          gitlab_client
-           .compare(T.must(source).repo, previous_tag, new_tag)
+          T.unsafe(gitlab_client
+           .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag)))
            .commits
            .map do |commit|
             {

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -304,8 +304,10 @@ module Dependabot
         sig { returns(T::Array[T.untyped]) }
         def fetch_gitlab_releases
           releases =
-            T.unsafe(gitlab_client
-             .tags(T.must(source).repo))
+            T.unsafe(
+              gitlab_client
+                           .tags(T.must(source).repo)
+            )
              .select(&:release)
              .sort_by { |r| T.unsafe(r).commit.authored_date }
              .reverse

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -285,17 +285,17 @@ module Dependabot
 
           # Remove any releases without a tag name. These are draft releases and
           # aren't yet associated with a tag, so shouldn't be used.
-          releases = releases.reject { |r| r.tag_name.nil? }
+          releases = releases.reject { |r| T.unsafe(r).tag_name.nil? }
 
           clean_release_names =
-            releases.map { |r| r.tag_name.gsub(/^[^0-9\.]*/, "") }
+            releases.map { |r| T.unsafe(r).tag_name.gsub(/^[^0-9\.]*/, "") }
 
           if clean_release_names.all? { |nm| version_class.correct?(nm) }
             releases.sort_by do |r|
-              version_class.new(r.tag_name.gsub(/^[^0-9\.]*/, ""))
+              version_class.new(T.unsafe(r).tag_name.gsub(/^[^0-9\.]*/, ""))
             end.reverse
           else
-            releases.sort_by(&:id).reverse
+            releases.sort_by { |r| T.unsafe(r).id }.reverse
           end
         rescue Octokit::NotFound, Octokit::UnavailableForLegalReasons
           []
@@ -304,18 +304,18 @@ module Dependabot
         sig { returns(T::Array[T.untyped]) }
         def fetch_gitlab_releases
           releases =
-            gitlab_client
-             .tags(T.must(source).repo)
+            T.unsafe(gitlab_client
+             .tags(T.must(source).repo))
              .select(&:release)
-             .sort_by { |r| r.commit.authored_date }
+             .sort_by { |r| T.unsafe(r).commit.authored_date }
              .reverse
 
           releases.map do |tag|
             GitLabRelease.new(
-              name: tag.name,
-              tag_name: tag.release.tag_name,
-              body: tag.release.description,
-              html_url: "#{T.must(source).url}/tags/#{tag.name}"
+              name: T.unsafe(tag).name,
+              tag_name: T.unsafe(tag).release.tag_name,
+              body: T.unsafe(tag).release.description,
+              html_url: "#{T.must(source).url}/tags/#{T.unsafe(tag).name}"
             )
           end
         rescue Gitlab::Error::NotFound

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -281,7 +281,7 @@ module Dependabot
 
         sig { returns(T::Array[T.untyped]) }
         def fetch_github_releases
-          releases = T.unsafe(github_client).releases(T.must(source).repo, per_page: 100)
+          releases = github_client.releases(T.must(source).repo, per_page: 100)
 
           # Remove any releases without a tag name. These are draft releases and
           # aren't yet associated with a tag, so shouldn't be used.
@@ -304,7 +304,7 @@ module Dependabot
         sig { returns(T::Array[T.untyped]) }
         def fetch_gitlab_releases
           releases =
-            T.unsafe(gitlab_client)
+            gitlab_client
              .tags(T.must(source).repo)
              .select(&:release)
              .sort_by { |r| r.commit.authored_date }

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -318,7 +318,7 @@ module Dependabot
                         { sha: nil }
                       elsif file.binary?
                         sha = github_client_for_source.create_blob(
-                          source.repo, file.content, "base64"
+                          source.repo, T.must(file.content), "base64"
                         )
                         { sha: sha }
                       else
@@ -470,7 +470,7 @@ module Dependabot
         github_client_for_source.add_assignees(
           source.repo,
           pull_request.number,
-          assignees
+          T.must(assignees)
         )
       rescue Octokit::NotFound
         # This can happen if a passed assignee login is now an org account
@@ -521,7 +521,7 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            github_client_for_source.repo(source.repo).default_branch,
+            T.unsafe(github_client_for_source.repo(source.repo)).default_branch,
             T.nilable(String)
           )
       end

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -196,7 +196,7 @@ module Dependabot
         @pull_requests_for_branch ||=
           T.let(
             begin
-              T.unsafe(github_client_for_source).pull_requests(
+              github_client_for_source.pull_requests(
                 source.repo,
                 head: "#{source.repo.split('/').first}:#{branch_name}",
                 state: "all"
@@ -204,13 +204,13 @@ module Dependabot
             rescue Octokit::InternalServerError
               # A GitHub bug sometimes means adding `state: all` causes problems.
               # In that case, fall back to making two separate requests.
-              open_prs = T.unsafe(github_client_for_source).pull_requests(
+              open_prs = github_client_for_source.pull_requests(
                 source.repo,
                 head: "#{source.repo.split('/').first}:#{branch_name}",
                 state: "open"
               )
 
-              closed_prs = T.unsafe(github_client_for_source).pull_requests(
+              closed_prs = github_client_for_source.pull_requests(
                 source.repo,
                 head: "#{source.repo.split('/').first}:#{branch_name}",
                 state: "closed"
@@ -254,7 +254,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def repo_exists?
-        T.unsafe(github_client_for_source).repo(source.repo)
+        github_client_for_source.repo(source.repo)
         true
       rescue Octokit::NotFound
         false
@@ -265,7 +265,7 @@ module Dependabot
         tree = create_tree
 
         begin
-          T.unsafe(github_client_for_source).create_commit(
+          github_client_for_source.create_commit(
             source.repo,
             commit_message,
             tree.sha,
@@ -317,7 +317,7 @@ module Dependabot
             content = if file.operation == Dependabot::DependencyFile::Operation::DELETE
                         { sha: nil }
                       elsif file.binary?
-                        sha = T.unsafe(github_client_for_source).create_blob(
+                        sha = github_client_for_source.create_blob(
                           source.repo, file.content, "base64"
                         )
                         { sha: sha }
@@ -333,7 +333,7 @@ module Dependabot
           end
         end
 
-        T.unsafe(github_client_for_source).create_tree(
+        github_client_for_source.create_tree(
           source.repo,
           file_trees,
           base_tree: base_commit
@@ -365,7 +365,7 @@ module Dependabot
 
         begin
           branch =
-            T.unsafe(github_client_for_source).create_ref(source.repo, ref, commit.sha)
+            github_client_for_source.create_ref(source.repo, ref, commit.sha)
           @branch_name = ref.gsub(%r{^refs/heads/}, "")
           branch
         rescue Octokit::UnprocessableEntity => e
@@ -385,7 +385,7 @@ module Dependabot
 
       sig { params(commit: T.untyped).void }
       def update_branch(commit)
-        T.unsafe(github_client_for_source).update_ref(
+        github_client_for_source.update_ref(
           source.repo,
           "heads/#{branch_name}",
           commit.sha,
@@ -406,7 +406,7 @@ module Dependabot
         reviewers_hash =
           T.must(reviewers).keys.to_h { |k| [k.to_sym, T.must(reviewers)[k]] }
 
-        T.unsafe(github_client_for_source).request_pull_request_review(
+        github_client_for_source.request_pull_request_review(
           source.repo,
           pull_request.number,
           reviewers: reviewers_hash[:reviewers] || [],
@@ -458,7 +458,7 @@ module Dependabot
                "#{message}\n" \
                "```"
 
-        T.unsafe(github_client_for_source).add_comment(
+        github_client_for_source.add_comment(
           source.repo,
           pull_request.number,
           msg
@@ -467,7 +467,7 @@ module Dependabot
 
       sig { params(pull_request: T.untyped).void }
       def add_assignees_to_pull_request(pull_request)
-        T.unsafe(github_client_for_source).add_assignees(
+        github_client_for_source.add_assignees(
           source.repo,
           pull_request.number,
           assignees
@@ -482,7 +482,7 @@ module Dependabot
 
       sig { params(pull_request: T.untyped).void }
       def add_milestone_to_pull_request(pull_request)
-        T.unsafe(github_client_for_source).update_issue(
+        github_client_for_source.update_issue(
           source.repo,
           pull_request.number,
           milestone: milestone
@@ -493,7 +493,7 @@ module Dependabot
 
       sig { returns(T.untyped) }
       def create_pull_request
-        T.unsafe(github_client_for_source).create_pull_request(
+        github_client_for_source.create_pull_request(
           source.repo,
           target_branch,
           branch_name,
@@ -521,7 +521,7 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            T.unsafe(github_client_for_source).repo(source.repo).default_branch,
+            github_client_for_source.repo(source.repo).default_branch,
             T.nilable(String)
           )
       end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -163,12 +163,14 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def merge_request_exists?
-        T.unsafe(gitlab_client_for_source.merge_requests(
-          (target_project_id || source.repo).to_s,
-          source_branch: branch_name,
-          target_branch: source.branch || default_branch,
-          state: "all"
-        )).any?
+        T.unsafe(
+          gitlab_client_for_source.merge_requests(
+            (target_project_id || source.repo).to_s,
+            source_branch: branch_name,
+            target_branch: source.branch || default_branch,
+            state: "all"
+          )
+        ).any?
       end
 
       sig { returns(::Gitlab::ObjectifiedHash) }

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -143,7 +143,7 @@ module Dependabot
       def branch_exists?
         @branch_ref ||=
           T.let(
-            T.unsafe(gitlab_client_for_source).branch(source.repo, branch_name),
+            gitlab_client_for_source.branch(source.repo, branch_name),
             T.nilable(::Gitlab::ObjectifiedHash)
           )
         true
@@ -155,7 +155,7 @@ module Dependabot
       def commit_exists?
         @commits ||=
           T.let(
-            T.unsafe(gitlab_client_for_source).commits(source.repo, ref_name: branch_name),
+            gitlab_client_for_source.commits(source.repo, ref_name: branch_name),
             T.nilable(::Gitlab::PaginatedResponse)
           )
         @commits.first.message == commit_message
@@ -163,7 +163,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def merge_request_exists?
-        T.unsafe(gitlab_client_for_source).merge_requests(
+        gitlab_client_for_source.merge_requests(
           target_project_id || source.repo,
           source_branch: branch_name,
           target_branch: source.branch || default_branch,
@@ -173,7 +173,7 @@ module Dependabot
 
       sig { returns(::Gitlab::ObjectifiedHash) }
       def create_branch
-        T.unsafe(gitlab_client_for_source).create_branch(
+        gitlab_client_for_source.create_branch(
           source.repo,
           branch_name,
           base_commit
@@ -201,7 +201,7 @@ module Dependabot
       def create_submodule_update_commit
         file = T.must(files.first)
 
-        T.unsafe(gitlab_client_for_source).edit_submodule(
+        gitlab_client_for_source.edit_submodule(
           source.repo,
           file.path.gsub(%r{^/}, ""),
           branch: branch_name,
@@ -212,7 +212,7 @@ module Dependabot
 
       sig { returns(T.nilable(::Gitlab::ObjectifiedHash)) }
       def create_merge_request
-        T.unsafe(gitlab_client_for_source).create_merge_request(
+        gitlab_client_for_source.create_merge_request(
           source.repo,
           pr_name,
           source_branch: branch_name,
@@ -236,7 +236,7 @@ module Dependabot
       def add_approvers_to_merge_request(merge_request)
         return unless approvers_hash[:approvers] || approvers_hash[:group_approvers]
 
-        T.unsafe(gitlab_client_for_source).create_merge_request_level_rule(
+        gitlab_client_for_source.create_merge_request_level_rule(
           target_project_id || source.repo,
           T.unsafe(merge_request).iid,
           name: "dependency-updates",
@@ -258,7 +258,7 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            T.unsafe(gitlab_client_for_source).project(source.repo).default_branch,
+            gitlab_client_for_source.project(source.repo).default_branch,
             T.nilable(String)
           )
       end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -158,17 +158,17 @@ module Dependabot
             gitlab_client_for_source.commits(source.repo, ref_name: branch_name),
             T.nilable(::Gitlab::PaginatedResponse)
           )
-        @commits.first.message == commit_message
+        T.unsafe(@commits).first.message == commit_message
       end
 
       sig { returns(T::Boolean) }
       def merge_request_exists?
-        gitlab_client_for_source.merge_requests(
-          target_project_id || source.repo,
+        T.unsafe(gitlab_client_for_source.merge_requests(
+          (target_project_id || source.repo).to_s,
           source_branch: branch_name,
           target_branch: source.branch || default_branch,
           state: "all"
-        ).any?
+        )).any?
       end
 
       sig { returns(::Gitlab::ObjectifiedHash) }
@@ -237,7 +237,7 @@ module Dependabot
         return unless approvers_hash[:approvers] || approvers_hash[:group_approvers]
 
         gitlab_client_for_source.create_merge_request_level_rule(
-          target_project_id || source.repo,
+          (target_project_id || source.repo).to_s,
           T.unsafe(merge_request).iid,
           name: "dependency-updates",
           approvals_required: 1,
@@ -258,7 +258,7 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            gitlab_client_for_source.project(source.repo).default_branch,
+            T.unsafe(gitlab_client_for_source.project(source.repo)).default_branch,
             T.nilable(String)
           )
       end

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -320,16 +320,18 @@ module Dependabot
       def fetch_github_labels
         client = github_client_for_source
 
-        labels =
-          client
-           .labels(source.repo, per_page: 100)
-           .map(&:name)
+        labels = T.let(
+          T.unsafe(client
+           .labels(source.repo, per_page: 100))
+           .map(&:name),
+          T::Array[String]
+        )
 
-        next_link = client.last_response.rels[:next]
+        next_link = T.let(client.last_response.rels[:next], T.nilable(Sawyer::Relation))
 
         while next_link
-          next_page = next_link.get
-          labels += next_page.data.map(&:name)
+          next_page = T.let(next_link.get, Sawyer::Response)
+          labels += T.unsafe(next_page.data).map(&:name)
           next_link = next_page.rels[:next]
         end
 
@@ -338,9 +340,9 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def fetch_gitlab_labels
-        gitlab_client_for_source
+        T.unsafe(gitlab_client_for_source
          .labels(source.repo, per_page: 100)
-         .auto_paginate
+         .auto_paginate)
          .map(&:name)
       end
 

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -92,7 +92,7 @@ module Dependabot
         return if labels_for_pr.none?
         raise "Only GitHub!" unless source.provider == "github"
 
-        T.unsafe(github_client_for_source).add_labels_to_an_issue(
+        github_client_for_source.add_labels_to_an_issue(
           source.repo,
           pull_request_number,
           labels_for_pr
@@ -321,11 +321,11 @@ module Dependabot
         client = github_client_for_source
 
         labels =
-          T.unsafe(client)
+          client
            .labels(source.repo, per_page: 100)
            .map(&:name)
 
-        next_link = T.unsafe(client).last_response.rels[:next]
+        next_link = client.last_response.rels[:next]
 
         while next_link
           next_page = next_link.get
@@ -338,7 +338,7 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def fetch_gitlab_labels
-        T.unsafe(gitlab_client_for_source)
+        gitlab_client_for_source
          .labels(source.repo, per_page: 100)
          .auto_paginate
          .map(&:name)
@@ -390,7 +390,7 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def create_github_dependencies_label
-        T.unsafe(github_client_for_source).add_label(
+        github_client_for_source.add_label(
           source.repo,
           DEFAULT_DEPENDENCIES_LABEL,
           "0366d6",
@@ -406,7 +406,7 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def create_gitlab_dependencies_label
-        T.unsafe(gitlab_client_for_source).create_label(
+        gitlab_client_for_source.create_label(
           source.repo,
           DEFAULT_DEPENDENCIES_LABEL,
           "#0366d6",
@@ -417,7 +417,7 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def create_github_security_label
-        T.unsafe(github_client_for_source).add_label(
+        github_client_for_source.add_label(
           source.repo,
           DEFAULT_SECURITY_LABEL,
           "ee0701",
@@ -433,7 +433,7 @@ module Dependabot
 
       sig { returns(T.nilable(T::Array[String])) }
       def create_gitlab_security_label
-        T.unsafe(gitlab_client_for_source).create_label(
+        gitlab_client_for_source.create_label(
           source.repo,
           DEFAULT_SECURITY_LABEL,
           "#ee0701",
@@ -446,7 +446,7 @@ module Dependabot
       def create_github_language_label
         label = self.class.label_details_for_package_manager(package_manager)
         language_name = label.fetch(:name)
-        T.unsafe(github_client_for_source).add_label(
+        github_client_for_source.add_label(
           source.repo,
           language_name,
           label.fetch(:colour),
@@ -470,7 +470,7 @@ module Dependabot
         language_name =
           self.class.label_details_for_package_manager(package_manager)
               .fetch(:name)
-        T.unsafe(gitlab_client_for_source).create_label(
+        gitlab_client_for_source.create_label(
           source.repo,
           language_name,
           "#" + self.class.label_details_for_package_manager(package_manager)

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -321,9 +321,7 @@ module Dependabot
         client = github_client_for_source
 
         labels = T.let(
-          T.unsafe(client
-           .labels(source.repo, per_page: 100))
-           .map(&:name),
+          T.unsafe(client.labels(source.repo, per_page: 100)).map(&:name),
           T::Array[String]
         )
 
@@ -340,9 +338,11 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def fetch_gitlab_labels
-        T.unsafe(gitlab_client_for_source
-         .labels(source.repo, per_page: 100)
-         .auto_paginate)
+        T.unsafe(
+          gitlab_client_for_source
+                   .labels(source.repo, per_page: 100)
+                   .auto_paginate
+        )
          .map(&:name)
       end
 

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -347,7 +347,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_gitlab_commit_messages
         @recent_gitlab_commit_messages ||=
-          T.unsafe(gitlab_client_for_source).commits(source.repo)
+          gitlab_client_for_source.commits(source.repo)
 
         @recent_gitlab_commit_messages
           .reject { |c| c.author_email == dependabot_email }
@@ -431,7 +431,7 @@ module Dependabot
       def recent_github_commits
         @recent_github_commits ||=
           T.let(
-            T.unsafe(github_client_for_source).commits(source.repo, per_page: 100),
+            github_client_for_source.commits(source.repo, per_page: 100),
             T.untyped
           )
       rescue Octokit::Conflict, Octokit::NotFound
@@ -442,7 +442,7 @@ module Dependabot
       def last_gitlab_dependabot_commit_message
         @recent_gitlab_commit_messages ||=
           T.let(
-            T.unsafe(gitlab_client_for_source).commits(source.repo),
+            gitlab_client_for_source.commits(source.repo),
             T.untyped
           )
 

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -283,8 +283,10 @@ module Dependabot
                .git_commit(source.repo, pull_request.head.sha)
             else
               commits =
-                T.unsafe(github_client_for_source
-                 .pull_request_commits(source.repo, pull_request_number))
+                T.unsafe(
+                  github_client_for_source
+                                   .pull_request_commits(source.repo, pull_request_number)
+                )
 
               commit = commits.find { |c| c.sha == old_commit }
               commit&.commit

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -91,7 +91,7 @@ module Dependabot
         target_branch = source.branch || pull_request.base.repo.default_branch
         return if target_branch == pull_request.base.ref
 
-        T.unsafe(github_client_for_source).update_pull_request(
+        github_client_for_source.update_pull_request(
           source.repo,
           pull_request_number,
           base: target_branch
@@ -137,7 +137,7 @@ module Dependabot
       def pull_request
         @pull_request ||=
           T.let(
-            T.unsafe(github_client_for_source).pull_request(
+            github_client_for_source.pull_request(
               source.repo,
               pull_request_number
             ),
@@ -147,7 +147,7 @@ module Dependabot
 
       sig { params(name: String).returns(T::Boolean) }
       def branch_exists?(name)
-        T.unsafe(github_client_for_source).branch(source.repo, name)
+        github_client_for_source.branch(source.repo, name)
         true
       rescue Octokit::NotFound
         false
@@ -165,7 +165,7 @@ module Dependabot
         end
 
         begin
-          T.unsafe(github_client_for_source).create_commit(
+          github_client_for_source.create_commit(
             source.repo,
             commit_message,
             tree.sha,
@@ -200,7 +200,7 @@ module Dependabot
             content = if file.operation == Dependabot::DependencyFile::Operation::DELETE
                         { sha: nil }
                       elsif file.binary?
-                        sha = T.unsafe(github_client_for_source).create_blob(
+                        sha = github_client_for_source.create_blob(
                           source.repo, file.content, "base64"
                         )
                         { sha: sha }
@@ -216,7 +216,7 @@ module Dependabot
           end
         end
 
-        T.unsafe(github_client_for_source).create_tree(
+        github_client_for_source.create_tree(
           source.repo,
           file_trees,
           base_tree: base_commit
@@ -240,7 +240,7 @@ module Dependabot
 
       sig { params(commit: T.untyped).returns(T.untyped) }
       def update_branch(commit)
-        T.unsafe(github_client_for_source).update_ref(
+        github_client_for_source.update_ref(
           source.repo,
           "heads/" + pull_request.head.ref,
           commit.sha,
@@ -279,11 +279,11 @@ module Dependabot
         @commit_being_updated =
           T.let(
             if pull_request.commits == 1
-              T.unsafe(github_client_for_source)
+              github_client_for_source
                .git_commit(source.repo, pull_request.head.sha)
             else
               commits =
-                T.unsafe(github_client_for_source)
+                github_client_for_source
                  .pull_request_commits(source.repo, pull_request_number)
 
               commit = commits.find { |c| c.sha == old_commit }

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -201,7 +201,7 @@ module Dependabot
                         { sha: nil }
                       elsif file.binary?
                         sha = github_client_for_source.create_blob(
-                          source.repo, file.content, "base64"
+                          source.repo, T.must(file.content), "base64"
                         )
                         { sha: sha }
                       else
@@ -283,8 +283,8 @@ module Dependabot
                .git_commit(source.repo, pull_request.head.sha)
             else
               commits =
-                github_client_for_source
-                 .pull_request_commits(source.repo, pull_request_number)
+                T.unsafe(github_client_for_source
+                 .pull_request_commits(source.repo, pull_request_number))
 
               commit = commits.find { |c| c.sha == old_commit }
               commit&.commit

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -86,7 +86,7 @@ module Dependabot
       sig { returns(T.untyped) }
       def merge_request
         @merge_request ||= T.let(
-          gitlab_client_for_source.merge_request(
+          T.unsafe(gitlab_client_for_source).merge_request(
             target_project_id || source.repo,
             pull_request_number
           ),

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -86,7 +86,7 @@ module Dependabot
       sig { returns(T.untyped) }
       def merge_request
         @merge_request ||= T.let(
-          T.unsafe(gitlab_client_for_source).merge_request(
+          gitlab_client_for_source.merge_request(
             target_project_id || source.repo,
             pull_request_number
           ),
@@ -108,7 +108,7 @@ module Dependabot
 
       sig { params(name: String).returns(T::Boolean) }
       def branch_exists?(name)
-        !T.unsafe(gitlab_client_for_source).branch(source.repo, name).nil?
+        !gitlab_client_for_source.branch(source.repo, name).nil?
       rescue ::Gitlab::Error::NotFound
         false
       end
@@ -116,7 +116,7 @@ module Dependabot
       # TODO: This needs to be typed when the underlying client is
       sig { returns(T.untyped) }
       def commit_being_updated
-        T.unsafe(gitlab_client_for_source).commit(source.repo, old_commit)
+        gitlab_client_for_source.commit(source.repo, old_commit)
       end
 
       sig { void }

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -86,6 +86,7 @@ module Dependabot
 
     class HelperSubprocessFailed < Dependabot::DependabotError
       extend T::Sig
+      include Dependabot::SentryContext
 
       sig { returns(String) }
       attr_reader :error_class
@@ -112,7 +113,7 @@ module Dependabot
         @trace = trace
       end
 
-      sig { returns(T::Hash[Symbol, T.untyped]) }
+      sig { override.returns(T::Hash[Symbol, T.untyped]) }
       def sentry_context
         { fingerprint: [@fingerprint], extra: @error_context.except(:stderr_output, :fingerprint) }
       end

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -86,7 +86,7 @@ module Dependabot
 
     class HelperSubprocessFailed < Dependabot::DependabotError
       extend T::Sig
-      include Dependabot::SentryContext
+      include Dependabot::HasSentryContext
 
       sig { returns(String) }
       attr_reader :error_class

--- a/composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb
+++ b/composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb
@@ -14,11 +14,11 @@ module Dependabot
       class PathDependencyBuilder
         extend T::Sig
 
-        sig { params(path: String, directory: String, lockfile: T.untyped).void }
+        sig { params(path: String, directory: String, lockfile: T.nilable(Dependabot::DependencyFile)).void }
         def initialize(path:, directory:, lockfile:)
           @path = T.let(path, String)
           @directory = T.let(directory, String)
-          @lockfile = T.let(lockfile, T.untyped)
+          @lockfile = T.let(lockfile, T.nilable(Dependabot::DependencyFile))
           @parsed_lockfile = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
         end
 

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -58,7 +58,7 @@ module Dependabot
         updated_content = T.let(file.content, T.nilable(String))
 
         T.must(old_sources).zip(new_sources).each do |old_source, new_source|
-          updated_content = update_digest_and_tag(updated_content, old_source, T.must(new_source))
+          updated_content = update_digest_and_tag(T.must(updated_content), old_source, T.must(new_source))
         end
 
         raise "Expected content to change!" if updated_content == file.content

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -55,7 +55,7 @@ module Dependabot
         old_sources = previous_sources(file)
         new_sources = sources(file)
 
-        updated_content = T.let(file.content, T.untyped)
+        updated_content = T.let(file.content, T.nilable(String))
 
         T.must(old_sources).zip(new_sources).each do |old_source, new_source|
           updated_content = update_digest_and_tag(updated_content, old_source, T.must(new_source))

--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -75,7 +75,7 @@ module Dependabot
                  fetch_github_submodule_commit(path)
                when "gitlab"
                  tmp_path = path.gsub(%r{^/*}, "")
-                 gitlab_client.get_file(repo, tmp_path, commit).blob_id
+                 T.unsafe(gitlab_client.get_file(repo, tmp_path, T.must(commit))).blob_id
                when "azure"
                  azure_client.fetch_file_contents(T.must(commit), path)
                else raise "Unsupported provider '#{source.provider}'."
@@ -100,9 +100,9 @@ module Dependabot
           path: path,
           ref: commit
         )
-        raise Dependabot::DependencyFileNotFound, path if content.is_a?(Array) || content.type != "submodule"
+        raise Dependabot::DependencyFileNotFound, path if content.is_a?(Array) || T.unsafe(content).type != "submodule"
 
-        content.sha
+        T.unsafe(content).sha
       end
     end
   end

--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -75,7 +75,7 @@ module Dependabot
                  fetch_github_submodule_commit(path)
                when "gitlab"
                  tmp_path = path.gsub(%r{^/*}, "")
-                 T.unsafe(gitlab_client).get_file(repo, tmp_path, commit).blob_id
+                 gitlab_client.get_file(repo, tmp_path, commit).blob_id
                when "azure"
                  azure_client.fetch_file_contents(T.must(commit), path)
                else raise "Unsupported provider '#{source.provider}'."
@@ -95,7 +95,7 @@ module Dependabot
 
       sig { params(path: String).returns(String) }
       def fetch_github_submodule_commit(path)
-        content = T.unsafe(github_client).contents(
+        content = github_client.contents(
           repo,
           path: path,
           ref: commit

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -21,7 +21,7 @@ module Dependabot
         sig { returns(T::Hash[String, T.untyped]) }
         def parsed
           json_obj = JSON.parse(T.must(@dependency_file.content))
-          @parsed ||= T.let(json_obj, T.untyped)
+          @parsed ||= T.let(json_obj, T.nilable(T::Hash[String, T.untyped]))
         rescue JSON::ParserError
           raise Dependabot::DependencyFileNotParseable, @dependency_file.path
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -5,6 +5,7 @@ require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/file_updaters/vendor_updater"
 require "dependabot/file_updaters/artifact_updater"
+require "dependabot/errors"
 require "dependabot/npm_and_yarn/dependency_files_filterer"
 require "dependabot/npm_and_yarn/sub_dependency_files_filterer"
 require "sorbet-runtime"
@@ -22,6 +23,7 @@ module Dependabot
 
       class NoChangeError < StandardError
         extend T::Sig
+        include Dependabot::SentryContext
 
         sig { params(message: String, error_context: T::Hash[Symbol, T.untyped]).void }
         def initialize(message:, error_context:)
@@ -29,7 +31,7 @@ module Dependabot
           @error_context = error_context
         end
 
-        sig { returns(T::Hash[Symbol, T.untyped]) }
+        sig { override.returns(T::Hash[Symbol, T.untyped]) }
         def sentry_context
           { extra: @error_context }
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -23,7 +23,7 @@ module Dependabot
 
       class NoChangeError < StandardError
         extend T::Sig
-        include Dependabot::SentryContext
+        include Dependabot::HasSentryContext
 
         sig { params(message: String, error_context: T::Hash[Symbol, T.untyped]).void }
         def initialize(message:, error_context:)

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -343,12 +343,17 @@ module Dependabot
           .returns(Dependabot::Dependency)
       end
       def parse_updated_dependency(json, requirements_update_strategy)
-        requirements = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+        params = {
+          name: json["name"],
+          version: json["version"],
+          package_manager: "pub",
+          requirements: []
+        }
         constraint_field = constraint_field_from_update_strategy(requirements_update_strategy)
 
         if json["kind"] != "transitive" && !json[constraint_field].nil?
           constraint = json[constraint_field]
-          requirements << {
+          params[:requirements] << {
             requirement: constraint,
             groups: [json["kind"]],
             source: nil, # TODO: Expose some information about the source
@@ -356,15 +361,15 @@ module Dependabot
           }
         end
 
-        previous_version = T.let(nil, T.nilable(String))
-        previous_requirements = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
-
         if json["previousVersion"]
-          previous_version = json["previousVersion"]
-          previous_requirements = []
+          params = {
+            **params,
+            previous_version: json["previousVersion"],
+            previous_requirements: []
+          }
           if json["kind"] != "transitive" && !json["previousConstraint"].nil?
             constraint = json["previousConstraint"]
-            previous_requirements << {
+            params[:previous_requirements] << {
               requirement: constraint,
               groups: [json["kind"]],
               source: nil, # TODO: Expose some information about the source
@@ -372,15 +377,7 @@ module Dependabot
             }
           end
         end
-
-        Dependency.new(
-          name: json["name"],
-          version: json["version"],
-          package_manager: "pub",
-          requirements: requirements,
-          previous_version: previous_version,
-          previous_requirements: previous_requirements
-        )
+        Dependency.new(**T.unsafe(params))
       end
 
       # expects "auto" to already have been resolved to one of the other

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -343,17 +343,12 @@ module Dependabot
           .returns(Dependabot::Dependency)
       end
       def parse_updated_dependency(json, requirements_update_strategy)
-        params = {
-          name: json["name"],
-          version: json["version"],
-          package_manager: "pub",
-          requirements: []
-        }
+        requirements = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
         constraint_field = constraint_field_from_update_strategy(requirements_update_strategy)
 
         if json["kind"] != "transitive" && !json[constraint_field].nil?
           constraint = json[constraint_field]
-          params[:requirements] << {
+          requirements << {
             requirement: constraint,
             groups: [json["kind"]],
             source: nil, # TODO: Expose some information about the source
@@ -361,15 +356,15 @@ module Dependabot
           }
         end
 
+        previous_version = T.let(nil, T.nilable(String))
+        previous_requirements = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+
         if json["previousVersion"]
-          params = {
-            **params,
-            previous_version: json["previousVersion"],
-            previous_requirements: []
-          }
+          previous_version = json["previousVersion"]
+          previous_requirements = []
           if json["kind"] != "transitive" && !json["previousConstraint"].nil?
             constraint = json["previousConstraint"]
-            params[:previous_requirements] << {
+            previous_requirements << {
               requirement: constraint,
               groups: [json["kind"]],
               source: nil, # TODO: Expose some information about the source
@@ -377,7 +372,15 @@ module Dependabot
             }
           end
         end
-        Dependency.new(**T.unsafe(params))
+
+        Dependency.new(
+          name: json["name"],
+          version: json["version"],
+          package_manager: "pub",
+          requirements: requirements,
+          previous_version: previous_version,
+          previous_requirements: previous_requirements
+        )
       end
 
       # expects "auto" to already have been resolved to one of the other

--- a/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
+++ b/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -539,7 +539,7 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def pip_compile_files
-        @pip_compile_files ||= T.let(dependency_files.select { |f| f.name.end_with?(".in") }, T.untyped)
+        @pip_compile_files ||= T.let(dependency_files.select { |f| f.name.end_with?(".in") }, T.nilable(T::Array[Dependabot::DependencyFile]))
       end
 
       sig { returns(Dependabot::Python::PipCompileFileMatcher) }

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -55,7 +55,7 @@ module Dependabot
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
         def poetry_dependencies
-          @poetry_dependencies ||= T.let(parse_poetry_dependencies, T.untyped)
+          @poetry_dependencies ||= T.let(parse_poetry_dependencies, T.nilable(Dependabot::FileParsers::Base::DependencySet))
         end
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
@@ -372,16 +372,16 @@ module Dependabot
           }
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T::Hash[String, T.untyped]) }
         def parsed_pyproject
-          @parsed_pyproject ||= T.let(TomlRB.parse(T.must(pyproject).content), T.untyped)
+          @parsed_pyproject ||= T.let(TomlRB.parse(T.must(pyproject).content), T.nilable(T::Hash[String, T.untyped]))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(pyproject).path
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T::Hash[String, T.untyped]) }
         def parsed_poetry_lock
-          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.untyped)
+          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.nilable(T::Hash[String, T.untyped]))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(poetry_lock).path
         end

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -381,7 +381,10 @@ module Dependabot
 
         sig { returns(T::Hash[String, T.untyped]) }
         def parsed_poetry_lock
-          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.nilable(T::Hash[String, T.untyped]))
+          @parsed_poetry_lock ||= T.let(
+            TomlRB.parse(T.must(poetry_lock).content),
+            T.nilable(T::Hash[String, T.untyped])
+          )
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(poetry_lock).path
         end

--- a/python/lib/dependabot/python/file_parser/setup_file_parser.rb
+++ b/python/lib/dependabot/python/file_parser/setup_file_parser.rb
@@ -21,7 +21,7 @@ module Dependabot
         TESTS_REQUIRE_REGEX = /tests_require\s*=\s*\[/m
         EXTRAS_REQUIRE_REGEX = /extras_require\s*=\s*\{/m
 
-        CLOSING_BRACKET = T.let({ "[" => "]", "{" => "}" }.freeze, T.any(T.untyped, T.untyped))
+        CLOSING_BRACKET = T.let({ "[" => "]", "{" => "}" }.freeze, T::Hash[String, String])
 
         sig { params(dependency_files: T::Array[Dependabot::DependencyFile]).void }
         def initialize(dependency_files:)

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -208,13 +208,20 @@ module Dependabot
           files = dependency_files
                   .reject { |file| updated_filenames.include?(file.name) }
 
-          args = dependency.to_h
-          args = args.keys.to_h { |k| [k.to_sym, args[k]] }
-          args[:requirements] = new_reqs
-          args[:previous_requirements] = old_reqs
+          dep = T.must(dependency)
 
           RequirementFileUpdater.new(
-            dependencies: [Dependency.new(**T.unsafe(args))],
+            dependencies: [Dependency.new(
+              name: dep.name,
+              version: dep.version,
+              requirements: new_reqs,
+              package_manager: dep.package_manager,
+              previous_version: dep.previous_version,
+              previous_requirements: old_reqs,
+              directory: dep.directory,
+              subdependency_metadata: dep.subdependency_metadata,
+              removed: dep.removed?
+            )],
             dependency_files: files,
             credentials: credentials
           ).updated_dependency_files

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -63,7 +63,7 @@ module Dependabot
           @parsed_lockfile = T.let(nil, T.nilable(T::Hash[String, T::Hash[String, Object]]))
           @pipenv_runner = T.let(nil, T.nilable(PipenvRunner))
           @language_version_manager = T.let(nil, T.nilable(LanguageVersionManager))
-          @sanitized_setup_file_content = T.let({}, T.untyped)
+          @sanitized_setup_file_content = T.let({}, T::Hash[String, String])
           @python_requirement_parser = T.let(nil, T.nilable(FileParser::PythonRequirementParser))
         end
 

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -63,7 +63,7 @@ module Dependabot
           @parsed_lockfile = T.let(nil, T.nilable(T::Hash[String, T::Hash[String, Object]]))
           @pipenv_runner = T.let(nil, T.nilable(PipenvRunner))
           @language_version_manager = T.let(nil, T.nilable(LanguageVersionManager))
-          @sanitized_setup_file_content = T.let({}, T::Hash[String, String])
+          @sanitized_setup_file_content = T.let({}, T.untyped)
           @python_requirement_parser = T.let(nil, T.nilable(FileParser::PythonRequirementParser))
         end
 

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -34,9 +34,9 @@ module Dependabot
         T.must(version)
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(String) }
       def python_major_minor
-        @python_major_minor ||= T.let(T.must(Python::Version.new(python_version).segments[0..1]).join("."), T.untyped)
+        @python_major_minor ||= T.let(T.must(Python::Version.new(python_version).segments[0..1]).join("."), T.nilable(String))
       end
 
       sig { returns(String) }

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -36,7 +36,10 @@ module Dependabot
 
       sig { returns(String) }
       def python_major_minor
-        @python_major_minor ||= T.let(T.must(Python::Version.new(python_version).segments[0..1]).join("."), T.nilable(String))
+        @python_major_minor ||= T.let(
+          T.must(Python::Version.new(python_version).segments[0..1]).join("."),
+          T.nilable(String)
+        )
       end
 
       sig { returns(String) }

--- a/python/lib/dependabot/python/shared_file_fetcher.rb
+++ b/python/lib/dependabot/python/shared_file_fetcher.rb
@@ -48,7 +48,7 @@ module Dependabot
           languages: {
             python: {
               "raw" => language_version_manager.user_specified_python_version || "unknown",
-              "max" => language_version_manager.python_major_minor || "unknown"
+              "max" => language_version_manager.python_major_minor
             }
           }
         }

--- a/sorbet/rbi/shims/bitbucket_with_retries.rbi
+++ b/sorbet/rbi/shims/bitbucket_with_retries.rbi
@@ -1,0 +1,54 @@
+# typed: strong
+# frozen_string_literal: true
+
+# Method signatures for Dependabot::Clients::Bitbucket methods delegated via method_missing.
+# These allow callers to use BitbucketWithRetries without T.unsafe wrappers.
+
+module Dependabot
+  module Clients
+    class BitbucketWithRetries
+      sig { params(repo: String, branch: String).returns(String) }
+      def fetch_commit(repo, branch); end
+
+      sig { params(repo: String).returns(String) }
+      def fetch_default_branch(repo); end
+
+      sig do
+        params(
+          repo: String,
+          commit: T.nilable(String),
+          path: T.nilable(String)
+        ).returns(T::Array[T::Hash[String, T.untyped]])
+      end
+      def fetch_repo_contents(repo, commit = nil, path = nil); end
+
+      sig { params(repo: String, commit: String, path: String).returns(String) }
+      def fetch_file_contents(repo, commit, path); end
+
+      sig { params(repo: String, branch_name: T.nilable(String)).returns(T::Enumerator[T::Hash[String, T.untyped]]) }
+      def commits(repo, branch_name = nil); end
+
+      sig { params(repo: String, branch_name: String).returns(T::Hash[String, T.untyped]) }
+      def branch(repo, branch_name); end
+
+      sig do
+        params(
+          repo: String,
+          source_branch: T.nilable(String),
+          target_branch: T.nilable(String),
+          status: T::Array[String]
+        ).returns(T::Array[T::Hash[String, T.untyped]])
+      end
+      def pull_requests(repo, source_branch, target_branch, status = []); end
+
+      sig { params(url: String).returns(Excon::Response) }
+      def get(url); end
+
+      sig { params(repo: String, previous_tag: String, new_tag: String).returns(T::Array[T::Hash[String, T.untyped]]) }
+      def compare(repo, previous_tag, new_tag); end
+
+      sig { params(repo: String).returns(T::Array[T::Hash[String, String]]) }
+      def default_reviewers(repo); end
+    end
+  end
+end

--- a/sorbet/rbi/shims/github_with_retries.rbi
+++ b/sorbet/rbi/shims/github_with_retries.rbi
@@ -1,0 +1,179 @@
+# typed: strong
+# frozen_string_literal: true
+
+# Method signatures for Octokit::Client methods delegated via method_missing.
+# These allow callers to use GithubWithRetries without T.unsafe wrappers.
+
+module Dependabot
+  module Clients
+    class GithubWithRetries
+      # Repositories
+      sig { params(repo: String, options: T.untyped).returns(Sawyer::Resource) }
+      def repo(repo, options = {}); end
+
+      sig { params(repo: String, options: T.untyped).returns(Sawyer::Resource) }
+      def repository(repo, options = {}); end
+
+      # Contents
+      sig { params(repo: String, options: T.untyped).returns(T.any(Sawyer::Resource, T::Array[Sawyer::Resource])) }
+      def contents(repo, options = {}); end
+
+      # Commits
+      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      def commits(repo, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          message: String,
+          tree: String,
+          parents: T.nilable(T.any(String, T::Array[String])),
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def create_commit(repo, message, tree, parents = nil, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          start: String,
+          endd: String,
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def compare(repo, start, endd, options = {}); end
+
+      # Git objects
+      sig { params(repo: String, blob_sha: String, options: T.untyped).returns(Sawyer::Resource) }
+      def blob(repo, blob_sha, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          content: String,
+          encoding: T.nilable(String),
+          options: T.untyped
+        ).returns(String)
+      end
+      def create_blob(repo, content, encoding = nil, options = {}); end
+
+      sig { params(repo: String, tree: T.untyped, options: T.untyped).returns(Sawyer::Resource) }
+      def create_tree(repo, tree, options = {}); end
+
+      # Refs
+      sig { params(repo: String, ref: String, options: T.untyped).returns(Sawyer::Resource) }
+      def ref(repo, ref, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          ref: String,
+          sha: String,
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def create_ref(repo, ref, sha, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          ref: String,
+          sha: String,
+          force: T.nilable(T::Boolean),
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def update_ref(repo, ref, sha, force = nil, options = {}); end
+
+      # Branches
+      sig { params(repo: String, branch: String, options: T.untyped).returns(Sawyer::Resource) }
+      def branch(repo, branch, options = {}); end
+
+      # Pull requests
+      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      def pull_requests(repo, options = {}); end
+
+      sig { params(repo: String, number: Integer, options: T.untyped).returns(Sawyer::Resource) }
+      def pull_request(repo, number, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          base: String,
+          head: String,
+          title: String,
+          body: T.nilable(String),
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def create_pull_request(repo, base, head, title, body = nil, options = {}); end
+
+      sig { params(args: T.untyped).returns(Sawyer::Resource) }
+      def update_pull_request(*args); end
+
+      sig do
+        params(
+          repo: String,
+          number: Integer,
+          reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, T.untyped])),
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def request_pull_request_review(repo, number, reviewers = nil, options = {}); end
+
+      # Issues
+      sig { params(repo: String, number: Integer, comment: String, options: T.untyped).returns(Sawyer::Resource) }
+      def add_comment(repo, number, comment, options = {}); end
+
+      sig do
+        params(
+          repo: String,
+          number: Integer,
+          assignees: T::Array[String],
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def add_assignees(repo, number, assignees, options = {}); end
+
+      sig { params(repo: String, number: Integer, args: T.untyped).returns(Sawyer::Resource) }
+      def update_issue(repo, number, *args); end
+
+      # Labels
+      sig { params(repo: String, per_page: T.untyped, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      def labels(repo, per_page = nil, options = {}); end
+
+      sig { params(repo: String, number: Integer, labels: T::Array[String]).returns(T::Array[Sawyer::Resource]) }
+      def add_labels_to_an_issue(repo, number, labels); end
+
+      sig do
+        params(
+          repo: String,
+          label: String,
+          color: String,
+          options: T.untyped
+        ).returns(Sawyer::Resource)
+      end
+      def add_label(repo, label, color, options = {}); end
+
+      # Releases
+      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      def releases(repo, options = {}); end
+
+      # Git data
+      sig { params(repo: String, sha: String, options: T.untyped).returns(Sawyer::Resource) }
+      def git_commit(repo, sha, options = {}); end
+
+      # Pull request commits
+      sig { params(repo: String, number: Integer, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      def pull_request_commits(repo, number, options = {}); end
+
+      # HTTP
+      sig { params(url: String, options: T.untyped).returns(Sawyer::Resource) }
+      def get(url, options = {}); end
+
+      # Pagination
+      sig { returns(Sawyer::Response) }
+      def last_response; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/gitlab_with_retries.rbi
+++ b/sorbet/rbi/shims/gitlab_with_retries.rbi
@@ -1,0 +1,81 @@
+# typed: strong
+# frozen_string_literal: true
+
+# Method signatures for Gitlab::Client methods delegated via method_missing.
+# These allow callers to use GitlabWithRetries without T.unsafe wrappers.
+
+module Dependabot
+  module Clients
+    class GitlabWithRetries
+      # Branches
+      sig { params(project: String, branch: String).returns(Gitlab::ObjectifiedHash) }
+      def branch(project, branch); end
+
+      # Commits
+      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      def commits(project, options = {}); end
+
+      sig { params(project: String, sha: String).returns(Gitlab::ObjectifiedHash) }
+      def commit(project, sha); end
+
+      # Merge requests
+      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      def merge_requests(project, options = {}); end
+
+      sig { params(project: String, id: Integer, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      def merge_request(project, id, options = {}); end
+
+      sig { params(project: String, title: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      def create_merge_request(project, title, options = {}); end
+
+      sig do
+        params(
+          project: String,
+          merge_request: Integer,
+          options: T.untyped
+        ).returns(Gitlab::ObjectifiedHash)
+      end
+      def create_merge_request_level_rule(project, merge_request, options = {}); end
+
+      # Branches
+      sig { params(project: String, branch: String, ref: String).returns(Gitlab::ObjectifiedHash) }
+      def create_branch(project, branch, ref); end
+
+      # Projects
+      sig { params(id: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      def project(id, options = {}); end
+
+      # Repository files
+      sig { params(project: String, file_path: String, ref: String).returns(Gitlab::ObjectifiedHash) }
+      def get_file(project, file_path, ref); end
+
+      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      def repo_tree(project, options = {}); end
+
+      sig { params(project: String, submodule: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      def edit_submodule(project, submodule, options = {}); end
+
+      # Labels
+      sig do
+        params(
+          project: String,
+          name: String,
+          color: String,
+          options: T.untyped
+        ).returns(Gitlab::ObjectifiedHash)
+      end
+      def create_label(project, name, color, options = {}); end
+
+      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      def labels(project, options = {}); end
+
+      # Tags
+      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      def tags(project, options = {}); end
+
+      # Comparison
+      sig { params(project: String, from: String, to: String).returns(Gitlab::ObjectifiedHash) }
+      def compare(project, from, to); end
+    end
+  end
+end

--- a/sorbet/rbi/shims/sawyer.rbi
+++ b/sorbet/rbi/shims/sawyer.rbi
@@ -1,0 +1,21 @@
+# typed: strong
+# frozen_string_literal: true
+
+# Signatures for dynamic attributes accessed on Sawyer::Resource via method_missing,
+# and for Sawyer::Response fields used in Octokit pagination.
+
+class Sawyer::Response
+  sig { returns(T::Hash[Symbol, Sawyer::Relation]) }
+  def rels; end
+
+  sig { returns(T.untyped) }
+  def data; end
+end
+
+class Sawyer::Relation
+  sig { returns(Sawyer::Response) }
+  def get; end
+
+  sig { returns(String) }
+  def href; end
+end

--- a/sorbet/rbi/shims/sawyer.rbi
+++ b/sorbet/rbi/shims/sawyer.rbi
@@ -1,8 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
-# Signatures for dynamic attributes accessed on Sawyer::Resource via method_missing,
-# and for Sawyer::Response fields used in Octokit pagination.
+# Signatures for Sawyer::Response fields used in Octokit pagination.
 
 class Sawyer::Response
   sig { returns(T::Hash[Symbol, Sawyer::Relation]) }
@@ -10,12 +9,4 @@ class Sawyer::Response
 
   sig { returns(T.untyped) }
   def data; end
-end
-
-class Sawyer::Relation
-  sig { returns(Sawyer::Response) }
-  def get; end
-
-  sig { returns(String) }
-  def href; end
 end

--- a/sorbet/rbi/shims/terminal-table.rbi
+++ b/sorbet/rbi/shims/terminal-table.rbi
@@ -1,0 +1,27 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Terminal::Table
+  sig do
+    params(
+      options: T::Hash[T.untyped, T.untyped],
+      block: T.nilable(T.proc.params(table: Terminal::Table).void)
+    ).void
+  end
+  def initialize(options = {}, &block); end
+
+  sig { params(array: T.untyped).returns(T.self_type) }
+  def <<(array); end
+
+  sig { params(title: String).void }
+  def title=(title); end
+
+  sig { params(arrays: T.untyped).void }
+  def headings=(arrays); end
+
+  sig { params(array: T.untyped).void }
+  def rows=(array); end
+
+  sig { returns(String) }
+  def to_s; end
+end

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -67,7 +67,12 @@ module Dependabot
 
     sig { params(err: StandardError).void }
     def handle_unknown_error(err)
-      fingerprint = (T.cast(err, Dependabot::HasSentryContext).sentry_context[:fingerprint] if err.respond_to?(:sentry_context))
+      fingerprint = (if err.respond_to?(:sentry_context)
+                       T.cast(
+                         err,
+                         Dependabot::HasSentryContext
+                       ).sentry_context[:fingerprint]
+                     end)
 
       error_details = {
         ErrorAttributes::CLASS => err.class.to_s,

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -67,7 +67,7 @@ module Dependabot
 
     sig { params(err: StandardError).void }
     def handle_unknown_error(err)
-      fingerprint = (T.cast(err, Dependabot::SentryContext).sentry_context[:fingerprint] if err.respond_to?(:sentry_context))
+      fingerprint = (T.cast(err, Dependabot::HasSentryContext).sentry_context[:fingerprint] if err.respond_to?(:sentry_context))
 
       error_details = {
         ErrorAttributes::CLASS => err.class.to_s,

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -67,7 +67,7 @@ module Dependabot
 
     sig { params(err: StandardError).void }
     def handle_unknown_error(err)
-      fingerprint = (T.unsafe(err).sentry_context[:fingerprint] if err.respond_to?(:sentry_context))
+      fingerprint = (T.cast(err, Dependabot::SentryContext).sentry_context[:fingerprint] if err.respond_to?(:sentry_context))
 
       error_details = {
         ErrorAttributes::CLASS => err.class.to_s,

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -296,7 +296,9 @@ module Dependabot
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT =>
-                    (T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] if error.respond_to?(:sentry_context)),
+                    (if error.respond_to?(:sentry_context)
+                       T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint]
+                     end),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -296,7 +296,7 @@ module Dependabot
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT =>
-                    (T.unsafe(error).sentry_context[:fingerprint] if error.respond_to?(:sentry_context)),
+                    (T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] if error.respond_to?(:sentry_context)),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -296,7 +296,7 @@ module Dependabot
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT =>
-                    (T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] if error.respond_to?(:sentry_context)),
+                    (T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] if error.respond_to?(:sentry_context)),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -173,7 +173,7 @@ module Dependabot
         ErrorAttributes::CLASS => error.class.to_s,
         ErrorAttributes::MESSAGE => error.message,
         ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.unsafe(error).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
+        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -173,7 +173,7 @@ module Dependabot
         ErrorAttributes::CLASS => error.class.to_s,
         ErrorAttributes::MESSAGE => error.message,
         ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
+        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -225,7 +225,7 @@ module Dependabot
     def pull_request_summary
       return unless pull_requests.any?
 
-      T.unsafe(Terminal::Table).new do |t|
+      Terminal::Table.new do |t|
         t.title = "Changes to Dependabot Pull Requests"
         t.rows = pull_requests.map { |deps, action| [action, truncate(deps)] }
       end
@@ -255,7 +255,7 @@ module Dependabot
         end
         return if job_errors.none?
 
-        T.unsafe(Terminal::Table).new do |t|
+        Terminal::Table.new do |t|
           t.title = "Errors"
           t.headings = %w(Type Details)
           t.rows = job_errors
@@ -266,7 +266,7 @@ module Dependabot
         end
         return if job_error_types.none?
 
-        T.unsafe(Terminal::Table).new do |t|
+        Terminal::Table.new do |t|
           t.title = "Errors"
           t.rows = job_error_types
         end
@@ -290,7 +290,7 @@ module Dependabot
         end
         return if dependency_errors.none?
 
-        T.unsafe(Terminal::Table).new do |t|
+        Terminal::Table.new do |t|
           t.title = "Dependencies failed to update"
           t.headings = ["Dependency", "Error Type", "Error Details"]
           t.rows = dependency_errors
@@ -301,7 +301,7 @@ module Dependabot
         end
         return if dependency_errors.none?
 
-        T.unsafe(Terminal::Table).new do |t|
+        Terminal::Table.new do |t|
           t.title = "Dependencies failed to update"
           t.rows = dependency_errors
         end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -127,7 +127,7 @@ module Dependabot
             ErrorAttributes::CLASS => error.class.to_s,
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.unsafe(error).sentry_context[:fingerprint] : nil,
+            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] : nil,
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -127,7 +127,7 @@ module Dependabot
             ErrorAttributes::CLASS => error.class.to_s,
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint] : nil,
+            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] : nil,
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -81,7 +81,7 @@ module Dependabot
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT => (if error.respond_to?(:sentry_context)
-                                               T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint]
+                                               T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint]
                                              end),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -81,7 +81,7 @@ module Dependabot
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT => (if error.respond_to?(:sentry_context)
-                                               T.unsafe(error).sentry_context[:fingerprint]
+                                               T.cast(error, Dependabot::SentryContext).sentry_context[:fingerprint]
                                              end),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -224,7 +224,7 @@ module Dependabot
       sig { params(error: StandardError).returns(T.nilable(T::Array[String])) }
       def extract_fingerprint(error)
         if error.respond_to?(:sentry_context)
-          context = T.unsafe(error).sentry_context
+          context = T.cast(error, Dependabot::SentryContext).sentry_context
           return context[:fingerprint] if context.is_a?(Hash)
         end
 

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -224,7 +224,7 @@ module Dependabot
       sig { params(error: StandardError).returns(T.nilable(T::Array[String])) }
       def extract_fingerprint(error)
         if error.respond_to?(:sentry_context)
-          context = T.cast(error, Dependabot::SentryContext).sentry_context
+          context = T.cast(error, Dependabot::HasSentryContext).sentry_context
           return context[:fingerprint] if context.is_a?(Hash)
         end
 

--- a/updater/lib/dependabot/updater/errors.rb
+++ b/updater/lib/dependabot/updater/errors.rb
@@ -1,12 +1,15 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "dependabot/errors"
+
 module Dependabot
   class Updater
     class SubprocessFailed < StandardError
       extend T::Sig
+      include Dependabot::HasSentryContext
 
-      sig { returns(T::Hash[Symbol, T.untyped]) }
+      sig { override.returns(T::Hash[Symbol, T.untyped]) }
       attr_reader :sentry_context
 
       sig { params(message: String, sentry_context: T::Hash[Symbol, T.untyped]).void }

--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -53,7 +53,7 @@ module Dependabot
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
         def poetry_dependencies
-          @poetry_dependencies ||= T.let(parse_poetry_dependencies, T.untyped)
+          @poetry_dependencies ||= T.let(parse_poetry_dependencies, T.nilable(Dependabot::FileParsers::Base::DependencySet))
         end
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
@@ -288,16 +288,16 @@ module Dependabot
           NameNormaliser.normalise(name)
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T::Hash[String, T.untyped]) }
         def parsed_pyproject
-          @parsed_pyproject ||= T.let(TomlRB.parse(T.must(pyproject).content), T.untyped)
+          @parsed_pyproject ||= T.let(TomlRB.parse(T.must(pyproject).content), T.nilable(T::Hash[String, T.untyped]))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(pyproject).path
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T::Hash[String, T.untyped]) }
         def parsed_poetry_lock
-          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.untyped)
+          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.nilable(T::Hash[String, T.untyped]))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(poetry_lock).path
         end

--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -297,7 +297,10 @@ module Dependabot
 
         sig { returns(T::Hash[String, T.untyped]) }
         def parsed_poetry_lock
-          @parsed_poetry_lock ||= T.let(TomlRB.parse(T.must(poetry_lock).content), T.nilable(T::Hash[String, T.untyped]))
+          @parsed_poetry_lock ||= T.let(
+            TomlRB.parse(T.must(poetry_lock).content),
+            T.nilable(T::Hash[String, T.untyped])
+          )
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, T.must(poetry_lock).path
         end

--- a/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
@@ -193,13 +193,20 @@ module Dependabot
           files = dependency_files
                   .reject { |file| updated_filenames.include?(file.name) }
 
-          args = T.must(dependency).to_h
-          args = args.keys.to_h { |k| [k.to_sym, args[k]] }
-          args[:requirements] = new_reqs
-          args[:previous_requirements] = old_reqs
+          dep = T.must(dependency)
 
           RequirementFileUpdater.new(
-            dependencies: [Dependency.new(**T.unsafe(args))],
+            dependencies: [Dependency.new(
+              name: dep.name,
+              version: dep.version,
+              requirements: new_reqs,
+              package_manager: dep.package_manager,
+              previous_version: dep.previous_version,
+              previous_requirements: old_reqs,
+              directory: dep.directory,
+              subdependency_metadata: dep.subdependency_metadata,
+              removed: dep.removed?
+            )],
             dependency_files: files,
             credentials: credentials
           ).updated_dependency_files

--- a/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
@@ -177,7 +177,6 @@ module Dependabot
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
         sig do
           params(updated_files: T::Array[Dependabot::DependencyFile]).returns(T::Array[Dependabot::DependencyFile])
         end
@@ -211,8 +210,6 @@ module Dependabot
             credentials: credentials
           ).updated_dependency_files
         end
-        # rubocop:enable Metrics/AbcSize
-
         sig do
           params(
             cmd: String,


### PR DESCRIPTION
### What are you trying to accomplish?

Most of our `T.unsafe` usage (101 of 163 calls) existed because `GithubWithRetries`, `GitlabWithRetries`, and `BitbucketWithRetries` delegate to their underlying clients via `method_missing`. Sorbet can't see those delegated methods, so every call site needed `T.unsafe`.

This PR adds RBI shim files that declare the delegated methods directly on the wrapper classes, then removes the `T.unsafe` wrappers at call sites. It also fixes a few other categories:

- Replaces 16 `T.let(x, T.untyped)` with their actual types (parsed TOML hashes, memoized strings, DependencySet, etc.)
- Replaces `Dependency.new(**T.unsafe(args))` kwarg splatting with explicit keyword arguments in 5 files
- Adds a `SentryContext` interface module so `error.sentry_context` calls can use `T.cast` instead of `T.unsafe`

### Anything you want to highlight for special attention from reviewers?

The shim files in shims are hand-written, not Tapioca-generated. They supplement the auto-generated gem RBIs by adding signatures for methods that Tapioca can't infer (because the gems use `method_missing`). `tapioca gem --verify` is unaffected.

The `Sawyer::Resource` attribute access pattern (`.type`, `.sha`, etc.) was converted to bracket notation (`[:type]`, `[:sha]`) where possible, since `Sawyer::Resource#[]` already has a typed signature.

### How will you know you've accomplished your goal?

Spoom coverage before and after:

| Metric | Before | After |
|---|---|---|
| Typed calls | 113,481 (92%) | 113,696 (93%) |
| Untyped calls | 9,392 | 9,110 (−282) |
| Strong sigil files | 314 | 319 (+5) |
| Method signatures | 14,783 | 14,849 (+66) |
