### PR TITLE
 Replace Job's untyped hashes with T::ImmutableStruct

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -95,7 +95,14 @@ module Dependabot
         dependency_group: dependency_group,
         pr_message_max_length: pr_message_max_length,
         pr_message_encoding: pr_message_encoding,
-        ignore_conditions: job.ignore_conditions,
+        ignore_conditions: job.ignore_conditions.map do |ic|
+          {
+            "dependency-name" => ic.dependency_name,
+            "version-requirement" => ic.version_requirement,
+            "source" => ic.source,
+            "updated-at" => ic.updated_at
+          }.compact
+        end,
         notices: notices
       ).message
 

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -15,6 +15,10 @@ require "dependabot/pull_request"
 require "dependabot/package/release_cooldown_options"
 require "dependabot/updater/update_type_helper"
 
+require "dependabot/job/allowed_update"
+require "dependabot/job/ignore_condition"
+require "dependabot/job/security_advisory_entry"
+
 # Describes a single Dependabot workload within the GitHub-integrated Service
 #
 # This primarily acts as a value class to hold inputs for various Core objects
@@ -62,7 +66,7 @@ module Dependabot
       T::Array[Symbol]
     )
 
-    sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::Job::AllowedUpdate]) }
     attr_reader :allowed_updates
 
     sig { returns(T::Array[Dependabot::Credential]) }
@@ -86,7 +90,7 @@ module Dependabot
     sig { returns(String) }
     attr_reader :command
 
-    sig { returns(T::Array[T.untyped]) }
+    sig { returns(T::Array[Dependabot::Job::IgnoreCondition]) }
     attr_reader :ignore_conditions
 
     sig { returns(String) }
@@ -95,7 +99,7 @@ module Dependabot
     sig { returns(T.nilable(Dependabot::RequirementsUpdateStrategy)) }
     attr_reader :requirements_update_strategy
 
-    sig { returns(T::Array[T.untyped]) }
+    sig { returns(T::Array[Dependabot::Job::SecurityAdvisoryEntry]) }
     attr_reader :security_advisories
 
     sig { returns(T::Boolean) }
@@ -168,8 +172,11 @@ module Dependabot
     def initialize(attributes) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       @id                             = T.let(attributes.fetch(:id), String)
       @command                        = T.let(attributes.fetch(:command, ""), String)
-      @allowed_updates                = T.let(attributes.fetch(:allowed_updates), T::Array[T.untyped])
-      @commit_message_options         = T.let(
+      @allowed_updates                = T.let(
+        attributes.fetch(:allowed_updates).map { |h| AllowedUpdate.from_hash(h) },
+        T::Array[AllowedUpdate]
+      )
+      @commit_message_options = T.let(
         attributes.fetch(:commit_message_options, {}),
         T.nilable(T::Hash[T.untyped, T.untyped])
       )
@@ -195,7 +202,10 @@ module Dependabot
         attributes.fetch(:experiments, {}),
         T.nilable(T::Hash[T.untyped, T.untyped])
       )
-      @ignore_conditions              =  T.let(attributes.fetch(:ignore_conditions), T::Array[T.untyped])
+      @ignore_conditions = T.let(
+        attributes.fetch(:ignore_conditions).map { |h| Job::IgnoreCondition.from_hash(h) },
+        T::Array[Job::IgnoreCondition]
+      )
       @package_manager                =  T.let(attributes.fetch(:package_manager), String)
       @reject_external_code           =  T.let(attributes.fetch(:reject_external_code, false), T::Boolean)
       @repo_contents_path             =  T.let(attributes.fetch(:repo_contents_path, nil), T.nilable(String))
@@ -207,7 +217,10 @@ module Dependabot
         T.nilable(Dependabot::RequirementsUpdateStrategy)
       )
 
-      @security_advisories            = T.let(attributes.fetch(:security_advisories), T::Array[T.untyped])
+      @security_advisories = T.let(
+        attributes.fetch(:security_advisories).map { |h| SecurityAdvisoryEntry.from_hash(h) },
+        T::Array[SecurityAdvisoryEntry]
+      )
       @security_updates_only          = T.let(attributes.fetch(:security_updates_only), T::Boolean)
       @source                         = T.let(build_source(attributes.fetch(:source)), Dependabot::Source)
       @token                          = T.let(attributes.fetch(:token, nil), T.nilable(String))
@@ -327,18 +340,17 @@ module Dependabot
 
       allowed_updates.any? do |update|
         # Check the update-type (defaulting to all)
-        update_type = update.fetch("update-type", "all")
         # NOTE: Preview supports specifying a "security" update type whereas
         # native will say "security-updates-only"
-        security_update = update_type == "security" || security_updates_only?
+        security_update = update.update_type == "security" || security_updates_only?
         next false if security_update && !vulnerable?(dependency, check_previous_version)
 
         # Check the dependency-name (defaulting to matching)
-        condition_name = update.fetch("dependency-name", dependency.name)
+        condition_name = update.dependency_name || dependency.name
         next false unless name_match?(condition_name, dependency.name)
 
         # Check the dependency-type (defaulting to all)
-        dep_type = update.fetch("dependency-type", "all")
+        dep_type = update.dependency_type
         next false if dep_type == "indirect" &&
                       dependency.requirements.any?
         # In dependabot-api, dependency-type is defaulting to "direct" not "all". Ignoring
@@ -428,18 +440,16 @@ module Dependabot
     def security_advisories_for(dependency)
       relevant_advisories =
         security_advisories
-        .select { |adv| adv.fetch("dependency-name").casecmp(dependency.name).zero? }
+        .select { |adv| T.must(adv.dependency_name.casecmp(dependency.name)).zero? }
+
+      requirement_class = Dependabot::Utils.requirement_class_for_package_manager(package_manager)
 
       relevant_advisories.map do |adv|
-        vulnerable_versions = adv["affected-versions"] || []
-        safe_versions = (adv["patched-versions"] || []) +
-                        (adv["unaffected-versions"] || [])
-
         Dependabot::SecurityAdvisory.new(
           dependency_name: dependency.name,
           package_manager: package_manager,
-          vulnerable_versions: vulnerable_versions,
-          safe_versions: safe_versions
+          vulnerable_versions: adv.affected_versions.flat_map { |v| requirement_class.requirements_array(v) },
+          safe_versions: adv.patched_versions + adv.unaffected_versions
         )
       end
     end
@@ -470,16 +480,14 @@ module Dependabot
     # were created via "@dependabot ignore version" commands
     sig { params(dependency: Dependabot::Dependency).void }
     def log_ignore_conditions_for(dependency)
-      conditions = ignore_conditions.select { |ic| name_match?(ic["dependency-name"], dependency.name) }
+      conditions = ignore_conditions.select { |ic| name_match?(ic.dependency_name, dependency.name) }
       if conditions.any?
         Dependabot.logger.info("Ignored versions:")
         conditions.each do |ic|
-          unless ic["version-requirement"].nil?
-            Dependabot.logger.info("  #{ic['version-requirement']} - from #{ic['source']}")
-          end
+          Dependabot.logger.info("  #{ic.version_requirement} - from #{ic.source}") unless ic.version_requirement.nil?
 
-          ic["update-types"]&.each do |update_type|
-            msg = "  #{update_type} - from #{ic['source']}"
+          ic.update_types&.each do |update_type|
+            msg = "  #{update_type} - from #{ic.source}"
             msg += " (doesn't apply to security update)" if security_updates_only?
             Dependabot.logger.info(msg)
           end
@@ -577,26 +585,26 @@ module Dependabot
       return [] if matching_rules.any? { |r| allow_rule_permits_all_types?(r) }
 
       matching_rules
-        .flat_map { |r| r.fetch("update-types", []) }
+        .flat_map(&:update_types)
         .filter_map { |t| t.is_a?(String) ? t.downcase.strip : nil }
         .select { |t| Dependabot::Updater::UpdateTypeHelper::ALL_SEMVER_UPDATE_TYPES.include?(t) }
         .uniq
     end
 
-    sig { params(dependency: Dependabot::Dependency).returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { params(dependency: Dependabot::Dependency).returns(T::Array[AllowedUpdate]) }
     def matching_allow_rules(dependency)
       allowed_updates.select do |update|
         allow_rule_matches_dependency?(update, dependency)
       end
     end
 
-    sig { params(update: T::Hash[String, T.untyped], dependency: Dependabot::Dependency).returns(T::Boolean) }
+    sig { params(update: AllowedUpdate, dependency: Dependabot::Dependency).returns(T::Boolean) }
     def allow_rule_matches_dependency?(update, dependency)
-      condition_name = update.fetch("dependency-name", nil)
+      condition_name = update.dependency_name
       return false if condition_name && !name_match?(condition_name, dependency.name)
 
-      dep_type = update.fetch("dependency-type", nil)
-      return true if dep_type.nil? || dep_type == "all"
+      dep_type = update.dependency_type
+      return true if dep_type == "all"
 
       # Indirect deps don't match top-level type rules (matching allowed_update? behavior)
       return false if dependency.requirements.none? && TOP_LEVEL_DEPENDENCY_TYPES.include?(dep_type)
@@ -610,9 +618,9 @@ module Dependabot
       end
     end
 
-    sig { params(rule: T::Hash[String, T.untyped]).returns(T::Boolean) }
+    sig { params(rule: AllowedUpdate).returns(T::Boolean) }
     def allow_rule_permits_all_types?(rule)
-      !rule.key?("update-types") || !rule["update-types"].is_a?(Array) || rule["update-types"].empty?
+      rule.update_types.empty?
     end
 
     sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::Version)) }
@@ -731,17 +739,16 @@ module Dependabot
     def calculate_update_config
       update_config_ignore_conditions = ignore_conditions.map do |ic|
         Dependabot::Config::IgnoreCondition.new(
-          dependency_name: T.let(ic["dependency-name"], String),
-          versions: T.let([ic["version-requirement"]].compact, T::Array[String]),
-          update_types: T.let(ic["update-types"], T.nilable(T::Array[String]))
+          dependency_name: ic.dependency_name,
+          versions: [ic.version_requirement].compact,
+          update_types: ic.update_types
         )
       end
 
-      update_config = Dependabot::Config::UpdateConfig.new(
-        ignore_conditions: T.let(update_config_ignore_conditions, T::Array[Dependabot::Config::IgnoreCondition]),
-        exclude_paths: T.let(exclude_paths, T.nilable(T::Array[String]))
+      Dependabot::Config::UpdateConfig.new(
+        ignore_conditions: update_config_ignore_conditions,
+        exclude_paths: exclude_paths
       )
-      T.let(update_config, Dependabot::Config::UpdateConfig)
     end
   end
 end

--- a/updater/lib/dependabot/job/allowed_update.rb
+++ b/updater/lib/dependabot/job/allowed_update.rb
@@ -1,0 +1,44 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of an allowed update rule from the job definition.
+    #
+    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # downstream code gets compile-time checked field access instead of
+    # hash key lookups that return T.untyped.
+    class AllowedUpdate < T::ImmutableStruct
+      extend T::Sig
+
+      const :dependency_name, T.nilable(String)
+      const :dependency_type, String, default: "all"
+      const :update_type, String, default: "all"
+      const :update_types, T::Array[String], default: []
+
+      sig { params(hash: T::Hash[String, T.untyped]).returns(AllowedUpdate) }
+      def self.from_hash(hash)
+        new(
+          dependency_name: hash["dependency-name"],
+          dependency_type: hash.fetch("dependency-type", "all"),
+          update_type: hash.fetch("update-type", "all"),
+          update_types: hash.fetch("update-types", []) || []
+        )
+      end
+
+      # Temporary bridge: returns the original hash format for code that
+      # still expects hash access. Remove once all callers are migrated.
+      sig { returns(T::Hash[String, T.untyped]) }
+      def to_hash
+        h = T.let({}, T::Hash[String, T.untyped])
+        h["dependency-name"] = dependency_name if dependency_name
+        h["dependency-type"] = dependency_type
+        h["update-type"] = update_type
+        h["update-types"] = update_types unless update_types.empty?
+        h
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/job/allowed_update.rb
+++ b/updater/lib/dependabot/job/allowed_update.rb
@@ -22,8 +22,8 @@ module Dependabot
       def self.from_hash(hash)
         new(
           dependency_name: hash["dependency-name"],
-          dependency_type: hash.fetch("dependency-type", "all"),
-          update_type: hash.fetch("update-type", "all"),
+          dependency_type: hash.fetch("dependency-type", "all") || "all",
+          update_type: hash.fetch("update-type", "all") || "all",
           update_types: hash.fetch("update-types", []) || []
         )
       end

--- a/updater/lib/dependabot/job/ignore_condition.rb
+++ b/updater/lib/dependabot/job/ignore_condition.rb
@@ -1,0 +1,34 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of an ignore condition from the job definition.
+    #
+    # The raw JSON uses string keys like "dependency-name" and "version-requirement".
+    # This struct parses those into typed fields at the boundary so the rest of
+    # the codebase gets compile-time field access.
+    class IgnoreCondition < T::ImmutableStruct
+      extend T::Sig
+
+      const :dependency_name, String
+      const :version_requirement, T.nilable(String)
+      const :update_types, T.nilable(T::Array[String])
+      const :source, T.nilable(String)
+      const :updated_at, T.nilable(String)
+
+      sig { params(hash: T::Hash[String, T.untyped]).returns(IgnoreCondition) }
+      def self.from_hash(hash)
+        new(
+          dependency_name: hash.fetch("dependency-name"),
+          version_requirement: hash["version-requirement"],
+          update_types: hash["update-types"],
+          source: hash["source"],
+          updated_at: hash["updated-at"]
+        )
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/job/security_advisory_entry.rb
+++ b/updater/lib/dependabot/job/security_advisory_entry.rb
@@ -1,0 +1,28 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of a security advisory from the job definition.
+    class SecurityAdvisoryEntry < T::ImmutableStruct
+      extend T::Sig
+
+      const :dependency_name, String
+      const :affected_versions, T::Array[String], default: []
+      const :patched_versions, T::Array[String], default: []
+      const :unaffected_versions, T::Array[String], default: []
+
+      sig { params(hash: T::Hash[String, T.untyped]).returns(SecurityAdvisoryEntry) }
+      def self.from_hash(hash)
+        new(
+          dependency_name: hash.fetch("dependency-name"),
+          affected_versions: hash.fetch("affected-versions", []) || [],
+          patched_versions: hash.fetch("patched-versions", []) || [],
+          unaffected_versions: hash.fetch("unaffected-versions", []) || []
+        )
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -326,7 +326,7 @@ module Dependabot
 
         sig { returns(String) }
         def security_advisory_dependency
-          T.cast(job.security_advisories.first, T::Hash[String, String])["dependency-name"].to_s
+          job.security_advisories.first&.dependency_name.to_s
         end
       end
     end

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -227,7 +227,9 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         allow(job).to receive_messages(
           allowed_update?: true,
           dependencies: ["dummy-pkg-a"],
-          security_advisories: [{ "dependency-name" => "dummy-pkg-a" }]
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "dummy-pkg-a" })
+          ]
         )
       end
 
@@ -302,7 +304,9 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         )
         allow(job).to receive_messages(
           allowed_update?: true,
-          security_advisories: [{ "dependency-name" => "dummy-pkg-a" }]
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "dummy-pkg-a" })
+          ]
         )
       end
 
@@ -332,7 +336,9 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         )
         allow(job).to receive_messages(
           allowed_update?: true,
-          security_advisories: [{ "dependency-name" => "dummy-pkg-a" }]
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "dummy-pkg-a" })
+          ]
         )
       end
 
@@ -362,7 +368,9 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         )
         allow(job).to receive_messages(
           allowed_update?: true,
-          security_advisories: [{ "dependency-name" => "Dummy-Pkg-A" }]
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "Dummy-Pkg-A" })
+          ]
         )
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

`allowed_updates`, `ignore_conditions`, and `security_advisories` in the `Job` class were `T::Hash[String, T.untyped]` bags. Every access like `update.fetch("dependency-name")` returned `T.untyped`, which propagated through every method that touched them.

This replaces the three hashes with `T::ImmutableStruct` models (`AllowedUpdate`, `Job::IgnoreCondition`, `SecurityAdvisoryEntry`). Each has a `from_hash` class method that parses the raw JSON in the `Job` constructor. After that, all downstream code uses typed field access (`update.dependency_name`) instead of string key lookups.

Follows the ["parse, don't validate"](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/) approach from [#13139](https://github.com/dependabot/dependabot-core/pull/13139), applied to updater.

### Anything you want to highlight for special attention from reviewers?

The `Job::IgnoreCondition` struct is separate from `Dependabot::Config::IgnoreCondition` (which lives in common). The Job version includes the `source` field used for logging, which the Config version doesn't have. `calculate_update_config` maps between them.

dependency_change.rb converts back to hashes when passing ignore conditions to `MessageBuilder`, since that class lives in common and shouldn't depend on updater types.

### How will you know you've accomplished your goal?

`bundle exec srb tc` passes with no errors. `bundle exec rubocop` is clean. The struct fields are now type checked at compile time, so any typo in a field name (e.g. `update.dependecy_name`) would fail the type checker instead of silently returning nil at runtime.