### PR TITLE
feat: add cooldown filter for github_actions using existing git_commit_checker and available_latest_version_tag

### DIFF
--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -8,6 +8,7 @@ require "sorbet-runtime"
 require "time"
 
 require "dependabot/errors"
+require "dependabot/git_tag_with_detail"
 require "dependabot/github_actions/helpers"
 require "dependabot/github_actions/requirement"
 require "dependabot/github_actions/update_checker"
@@ -16,6 +17,7 @@ require "dependabot/package/package_details"
 require "dependabot/package/package_release"
 require "dependabot/registry_client"
 require "dependabot/shared_helpers"
+require "dependabot/source"
 
 module Dependabot
   module GithubActions
@@ -125,6 +127,54 @@ module Dependabot
             end,
             T.nilable(T::Hash[Symbol, T.untyped])
           )
+        end
+
+        sig { returns(T::Array[Dependabot::GitTagWithDetail]) }
+        def fetch_tag_and_release_date
+          allowed_version_tags = git_commit_checker.allowed_version_tags
+          allowed_tag_names = Set.new(allowed_version_tags.map(&:name))
+
+          # Use the shared GitCommitChecker#refs_for_tag_with_detail to fetch all tags
+          # with release dates in a single clone (instead of one clone per tag)
+          all_refs_with_detail = git_commit_checker.refs_for_tag_with_detail
+
+          result = all_refs_with_detail.select do |ref|
+            allowed_tag_names.include?(ref.tag)
+          end
+
+          # Log an error if we couldn't fetch any release dates
+          if result.empty? && allowed_version_tags.any?
+            Dependabot.logger.error("Error fetching tag and release date: unable to fetch for allowed tags")
+          end
+
+          result
+        rescue StandardError => e
+          Dependabot.logger.error("Error fetching tag and release date: #{e.message}")
+          []
+        end
+
+        sig do
+          returns(T::Array[T::Hash[Symbol, T.untyped]])
+        end
+        def allowed_version_tags_with_release_dates
+          allowed_version_tags_hashes = git_commit_checker.local_tags_for_allowed_versions
+          tag_to_release_date = T.let({}, T::Hash[String, T.nilable(String)])
+
+          # Build a map of tag names to release dates for quick lookup
+          fetch_tag_and_release_date.each do |git_tag_with_detail|
+            tag_to_release_date[git_tag_with_detail.tag] = git_tag_with_detail.release_date
+          end
+
+          # Combine version info with release dates and sort by version descending
+          result = allowed_version_tags_hashes.map do |tag_hash|
+            tag_name = tag_hash.fetch(:tag)
+            tag_hash.merge(
+              release_date: tag_to_release_date[tag_name]
+            )
+          end
+
+          # Sort by version descending (newest first)
+          result.sort_by { |tag_hash| tag_hash.fetch(:version) }.reverse
         end
 
         private

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "excon"
 require "sorbet-runtime"
 
 require "dependabot/errors"
@@ -107,7 +106,7 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::GithubActions::Package::PackageDetailsFetcher)) }
         def package_details_fetcher
-          @package_details_fetcher = T.let(
+          @package_details_fetcher ||= T.let(
             Dependabot::GithubActions::Package::PackageDetailsFetcher
                         .new(
                           dependency: dependency,
@@ -158,19 +157,58 @@ module Dependabot
           return release unless cooldown_options
 
           Dependabot.logger.info("Initializing cooldown filter")
-          release_date = commit_metadata_details
 
-          unless release_date
-            Dependabot.logger.info("No release date found, skipping cooldown filtering")
-            return release
-          end
+          # If the proposed release is a commit SHA (String), check its date against cooldown
+          if release.is_a?(String)
+            Dependabot.logger.info("Checking cooldown for commit SHA: #{release}")
+            return release unless check_if_version_in_cooldown_period?(commit_metadata_details)
 
-          if release_in_cooldown_period?(Time.parse(release_date))
-            Dependabot.logger.info("Filtered out (cooldown) #{dependency.name}, #{release}")
+            # Proposed SHA is in cooldown; for a SHA-based proposal, return nil (don't fall back to tags)
+            Dependabot.logger.info("Proposed commit SHA is in cooldown, returning nil")
             return nil
           end
 
-          release
+          # For version tag proposals, fetch all allowed versions with release dates (single clone)
+          # This reuses a single GitCommitChecker instance within package_details_fetcher
+          allowed_versions_with_dates = T.must(package_details_fetcher).allowed_version_tags_with_release_dates
+          tags_in_cooldown = Set.new(select_version_tags_in_cooldown_period(allowed_versions_with_dates))
+          return release if tags_in_cooldown.empty?
+
+          # Walk through all allowed version tags in descending order (newest first)
+          # and return the first one NOT in cooldown
+          allowed_versions_with_dates.each do |tag_info|
+            tag_name = tag_info.fetch(:tag)
+            next if tags_in_cooldown.include?(tag_name)
+
+            # Found a version not in cooldown, return it
+            version = tag_info.fetch(:version)
+            Dependabot.logger.info("Found acceptable version outside cooldown: #{version}")
+            return version
+          end
+
+          # All versions are in cooldown, return nil to fallback to current version
+          Dependabot.logger.info("All versions are in cooldown period, returning current version")
+          nil
+        end
+
+        sig do
+          params(
+            tags_with_dates: T.nilable(
+              T.any(T::Array[Dependabot::GitTagWithDetail], T::Array[T::Hash[Symbol, T.untyped]])
+            )
+          ).returns(T::Array[String])
+        end
+        def select_version_tags_in_cooldown_period(tags_with_dates = nil)
+          tags_to_check = tags_with_dates || T.must(package_details_fetcher).fetch_tag_and_release_date
+          # Handle both GitTagWithDetail objects and hashes with release_date
+          in_cooldown = tags_to_check.select do |tag|
+            release_date = tag.is_a?(Hash) ? tag.fetch(:release_date, nil) : tag.release_date
+            check_if_version_in_cooldown_period?(release_date)
+          end
+          in_cooldown.map { |tag| tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag }
+        rescue StandardError => e
+          Dependabot.logger.error("Error checking if version is in cooldown (using empty filter): #{e.message}")
+          []
         end
 
         sig { returns(T.nilable(String)) }
@@ -194,8 +232,8 @@ module Dependabot
                 end
               end
             rescue StandardError => e
-              Dependabot.logger.error("Error (github actions) while checking release date for #{dependency.name}")
-              Dependabot.logger.error(e.message)
+              msg = "Error (github actions) while checking release date for #{dependency.name}: #{e.message}"
+              Dependabot.logger.warn(msg)
 
               nil
             end,
@@ -203,21 +241,30 @@ module Dependabot
           )
         end
 
-        sig { params(release_date: Time).returns(T::Boolean) }
-        def release_in_cooldown_period?(release_date)
-          cooldown = @cooldown_options
+        sig { params(release_date: T.nilable(String)).returns(T::Boolean) }
+        def check_if_version_in_cooldown_period?(release_date)
+          return false unless release_date&.length&.positive?
+          return false unless cooldown_options
+          return false unless T.must(cooldown_options).included?(dependency.name)
 
-          return false unless T.must(cooldown).included?(dependency.name)
+          release_time = Time.parse(T.must(release_date))
+          cooldown_days = T.must(cooldown_options).default_days
 
-          days = T.must(cooldown).default_days
-
-          Dependabot.logger.info(
-            "Days since release : #{(Time.now.to_i - release_date.to_i) / (24 * 60 * 60)} " \
-            "(cooldown days #{days})"
+          is_in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(
+            release_time,
+            cooldown_days
           )
 
-          Dependabot::UpdateCheckers::CooldownCalculation
-            .within_cooldown_window?(release_date, days)
+          passed_seconds = Time.now.to_i - release_time.to_i
+          days_since = passed_seconds / Dependabot::UpdateCheckers::CooldownCalculation::DAY_IN_SECONDS
+          Dependabot.logger.info(
+            "Days since release : #{days_since} (cooldown days #{cooldown_days})"
+          )
+
+          is_in_cooldown
+        rescue StandardError => e
+          Dependabot.logger.debug("Error parsing release date: #{e.message}")
+          false
         end
 
         sig { returns(String) }

--- a/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
@@ -252,4 +252,111 @@ RSpec.describe Dependabot::GithubActions::Package::PackageDetailsFetcher do
       end
     end
   end
+
+  describe "#fetch_tag_and_release_date" do
+    subject(:fetch_tag_and_release_date) { fetcher.fetch_tag_and_release_date }
+
+    let(:upload_pack_fixture) { "setup-node" }
+    let(:git_tag_with_details) do
+      [
+        Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "2024-01-01T00:00:00Z"),
+        Dependabot::GitTagWithDetail.new(tag: "v2.0.0", release_date: "2024-02-01T00:00:00Z"),
+        Dependabot::GitTagWithDetail.new(tag: "v3.0.0", release_date: "2024-03-01T00:00:00Z")
+      ]
+    end
+
+    before do
+      # Stub git_commit_checker to return mock tags with release dates
+      mock_checker = instance_double(Dependabot::GitCommitChecker)
+
+      # Also stub allowed_version_tags to include all our test tags
+      allow(mock_checker).to receive_messages(
+        refs_for_tag_with_detail: git_tag_with_details,
+        allowed_version_tags: git_tag_with_details.map { |tag|
+          double(name: tag.tag)
+        }
+      )
+      allow(fetcher).to receive(:git_commit_checker).and_return(mock_checker)
+    end
+
+    it "returns array of GitTagWithDetail objects" do
+      expect(fetch_tag_and_release_date).to be_an(Array)
+      expect(fetch_tag_and_release_date.first).to be_a(Dependabot::GitTagWithDetail)
+    end
+
+    it "includes tag and release_date attributes with correct values" do
+      results = fetch_tag_and_release_date
+      expect(results).to(
+        all(
+          have_attributes(
+            tag: an_instance_of(String),
+            release_date: an_instance_of(String)
+          )
+        )
+      )
+      # Assert specific tag values
+      tags = results.map(&:tag).sort
+      expect(tags).to include("v1.0.0", "v2.0.0", "v3.0.0")
+    end
+
+    it "filters to only allowed version tags" do
+      results = fetch_tag_and_release_date
+      expect(results.map(&:tag)).not_to be_empty
+      # All returned tags should be in the git_tag_with_details
+      expected_tags = git_tag_with_details.map(&:tag)
+      actual_tags = results.map(&:tag)
+      expect(actual_tags).to match_array(expected_tags)
+    end
+
+    it "preserves release dates for each tag" do
+      results = fetch_tag_and_release_date
+      tag_date_map = results.to_h { |item| [item.tag, item.release_date] }
+
+      git_tag_with_details.each do |git_tag|
+        expect(tag_date_map[git_tag.tag]).to eq(git_tag.release_date)
+      end
+    end
+
+    context "when git_commit_checker.refs_for_tag_with_detail fails" do
+      before do
+        mock_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(mock_checker).to receive(:allowed_version_tags).and_return([double(name: "v1.0.0")])
+        allow(mock_checker).to receive(:refs_for_tag_with_detail)
+          .and_raise(StandardError, "git error")
+        allow(fetcher).to receive(:git_commit_checker).and_return(mock_checker)
+      end
+
+      it "handles error gracefully and returns empty array" do
+        expect(fetch_tag_and_release_date).to eq([])
+      end
+
+      it "logs the error" do
+        expect(Dependabot.logger).to receive(:error).with(/Error fetching tag and release date/)
+        fetch_tag_and_release_date
+      end
+    end
+
+    context "when no tags match allowed versions" do
+      before do
+        mock_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(mock_checker).to receive_messages(
+          refs_for_tag_with_detail: [
+            Dependabot::GitTagWithDetail.new(tag: "v999.0.0", release_date: "2099-01-01T00:00:00Z")
+          ],
+          allowed_version_tags: [double(name: "v1.0.0")]
+        )
+        allow(fetcher).to receive(:git_commit_checker).and_return(mock_checker)
+      end
+
+      it "returns empty array when no tags match allowed versions" do
+        expect(fetch_tag_and_release_date).to eq([])
+      end
+
+      it "logs error when no release dates found for allowed tags" do
+        expect(Dependabot.logger).to receive(:error)
+          .with(/Error fetching tag and release date: unable to fetch for allowed tags/)
+        fetch_tag_and_release_date
+      end
+    end
+  end
 end

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe namespace::LatestVersionFinder do
       credentials: github_credentials,
       security_advisories: security_advisories,
       ignored_versions: ignored_versions,
-      raise_on_ignored: raise_on_ignored
+      raise_on_ignored: raise_on_ignored,
+      cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
     )
   end
 
@@ -280,6 +281,152 @@ RSpec.describe namespace::LatestVersionFinder do
           commit_sha: "b4cc9058ebd2336f73752f9d3c9b3835d52c66de",
           version: Dependabot::GithubActions::Version.new("0.0.24")
         )
+      end
+    end
+
+    describe "#select_version_tags_in_cooldown_period" do
+      subject(:selected_tags) { finder.send(:select_version_tags_in_cooldown_period) }
+
+      # Current time: 2024-04-03T16:00:00Z
+      let(:current_time) { Time.parse("2024-04-03T16:00:00Z") }
+
+      # Test fixtures: tags released at various dates
+      let(:git_tags_with_dates) do
+        [
+          # Within 90-day cooldown (released ~60 days ago)
+          Dependabot::GitTagWithDetail.new(tag: "v1.2.0", release_date: "2024-02-03T16:00:00Z"),
+          # Within 90-day cooldown (released ~30 days ago)
+          Dependabot::GitTagWithDetail.new(tag: "v1.1.5", release_date: "2024-03-04T16:00:00Z"),
+          # Outside 90-day cooldown (released ~100 days ago)
+          Dependabot::GitTagWithDetail.new(tag: "v1.1.0", release_date: "2023-12-25T16:00:00Z"),
+          # Within 90-day cooldown (released ~5 days ago)
+          Dependabot::GitTagWithDetail.new(tag: "v1.3.0", release_date: "2024-03-29T16:00:00Z")
+        ]
+      end
+
+      let(:finder) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: [],
+          credentials: github_credentials,
+          security_advisories: security_advisories,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
+          cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+        )
+      end
+
+      before do
+        allow(Time).to receive(:now).and_return(current_time)
+
+        # Stub the package_details_fetcher to return our test data
+        mock_fetcher = instance_double(Dependabot::GithubActions::Package::PackageDetailsFetcher)
+        allow(mock_fetcher).to receive(:fetch_tag_and_release_date).and_return(git_tags_with_dates)
+        allow(finder).to receive(:package_details_fetcher).and_return(mock_fetcher)
+      end
+
+      context "with 90-day cooldown enabled" do
+        it "returns array of tag names" do
+          expect(selected_tags).to be_an(Array)
+          expect(selected_tags).to all(be_a(String))
+        end
+
+        it "includes only tags released within cooldown period" do
+          # Tags released within 90 days: v1.2.0, v1.1.5, v1.3.0
+          # Tags outside cooldown: v1.1.0 (released 100 days ago)
+          expect(selected_tags).to include("v1.2.0", "v1.1.5", "v1.3.0")
+          expect(selected_tags).not_to include("v1.1.0")
+        end
+
+        it "excludes tags outside cooldown period" do
+          excluded_tags = selected_tags & ["v1.1.0"]
+          expect(excluded_tags).to be_empty
+        end
+
+        it "returns all filtered tags in correct format" do
+          expect(selected_tags.count).to eq(3)
+          expect(selected_tags.sort).to eq(["v1.1.5", "v1.2.0", "v1.3.0"].sort)
+        end
+      end
+
+      context "with 1-day cooldown" do
+        let(:finder) do
+          described_class.new(
+            dependency: dependency,
+            dependency_files: [],
+            credentials: github_credentials,
+            security_advisories: security_advisories,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
+            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 1)
+          )
+        end
+
+        it "returns only tags released within 1 day" do
+          # Only v1.3.0 (released ~5 days ago) should be excluded
+          # Only v1.1.5 and v1.3.0 and v1.2.0 and v1.1.0 should ALL be checked
+          # With 1-day cooldown: only v1.3.0 (5 days old) is outside
+          # Actually v1.2.0 (60 days), v1.1.5 (30 days), v1.1.0 (100 days) are all outside
+          # Only newly released tags within 1 day would be included
+          expect(selected_tags).to be_empty
+        end
+      end
+
+      context "when git fetch fails" do
+        let(:finder) do
+          described_class.new(
+            dependency: dependency,
+            dependency_files: [],
+            credentials: github_credentials,
+            security_advisories: security_advisories,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
+            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+          )
+        end
+
+        before do
+          mock_fetcher = instance_double(Dependabot::GithubActions::Package::PackageDetailsFetcher)
+          allow(mock_fetcher).to receive(:fetch_tag_and_release_date).and_raise(StandardError, "git error")
+          allow(finder).to receive(:package_details_fetcher).and_return(mock_fetcher)
+        end
+
+        it "handles error gracefully and returns empty array" do
+          expect(selected_tags).to eq([])
+        end
+
+        it "logs the error" do
+          expect(Dependabot.logger).to receive(:error).with(/Error checking if version is in cooldown/)
+          selected_tags
+        end
+      end
+
+      context "when all tags are in cooldown" do
+        let(:git_tags_with_dates) do
+          [
+            # All released recently
+            Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "2024-04-01T16:00:00Z"),
+            Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2024-04-02T16:00:00Z")
+          ]
+        end
+
+        it "returns all tags" do
+          expect(selected_tags).to eq(["v1.0.0", "v1.0.1"])
+        end
+      end
+
+      context "when no tags are in cooldown" do
+        let(:git_tags_with_dates) do
+          [
+            # All released long ago
+            Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "2023-01-01T16:00:00Z"),
+            Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2023-02-01T16:00:00Z")
+          ]
+        end
+
+        it "returns empty array" do
+          expect(selected_tags).to be_empty
+        end
       end
     end
   end

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -445,6 +445,23 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
         before do
           allow(Time).to receive(:now).and_return(Time.parse("2019-08-06 18:29:44 -0400"))
+
+          # Mock GitCommitChecker to return tag data for cooldown_filter
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_wrap_original do |method, **kwargs|
+            instance = method.call(**kwargs)
+
+            allow(instance).to receive_messages(
+              refs_for_tag_with_detail: [
+                Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2019-01-01T00:00:00+00:00"),
+                Dependabot::GitTagWithDetail.new(tag: "v1.1.0", release_date: "2019-07-20T00:00:00+00:00")
+              ],
+              local_tags_for_allowed_versions: [
+                { tag: "v1.0.1", version: Dependabot::GithubActions::Version.new("1.0.1") },
+                { tag: "v1.1.0", version: Dependabot::GithubActions::Version.new("1.1.0") }
+              ]
+            )
+            instance
+          end
         end
 
         it { is_expected.to eq(Gem::Version.new("1.0.1")) }
@@ -485,6 +502,12 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
+        before do
+          # Stub commit_metadata_details to return a date outside cooldown
+          finder = checker.send(:latest_version_finder)
+          allow(finder).to receive(:commit_metadata_details).and_return("2022-06-01T00:00:00+00:00")
+        end
+
         it "returns the expected value" do
           expect(latest_version).to eq(latest_commit_in_main)
         end
@@ -502,6 +525,12 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "f4b9c90516ad3bdcfdc6f4fcf8ba937d0bd40465" }
         let(:update_cooldown) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+        end
+
+        before do
+          # Stub commit_metadata_details to return a recent date (within cooldown)
+          finder = checker.send(:latest_version_finder)
+          allow(finder).to receive(:commit_metadata_details).and_return("2022-09-05T00:00:00+00:00")
         end
 
         it "returns the current version" do
@@ -523,19 +552,14 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
+        before do
+          # Stub commit_metadata_details to return a date outside cooldown
+          finder = checker.send(:latest_version_finder)
+          allow(finder).to receive(:commit_metadata_details).and_return("2022-06-01T00:00:00+00:00")
+        end
+
         it "returns the expected value" do
           expect(latest_version).to eq(latest_commit_in_devel)
-        end
-      end
-
-      context "when pinned to an out of date commit in a non default branch with cooldown enabled" do
-        let(:update_cooldown) do
-          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
-        end
-        let(:reference) { "96e7dec17bbeed08477b9edab6c3a573614b829d" }
-
-        it "returns the expected value" do
-          expect(latest_version).to eq("96e7dec17bbeed08477b9edab6c3a573614b829d")
         end
       end
 
@@ -551,6 +575,12 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "96e7dec17bbeed08477b9edab6c3a573614b829d" }
         let(:update_cooldown) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+        end
+
+        before do
+          # Stub commit_metadata_details to return a recent date (within cooldown)
+          finder = checker.send(:latest_version_finder)
+          allow(finder).to receive(:commit_metadata_details).and_return("2022-09-05T00:00:00+00:00")
         end
 
         it "returns the expected value" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14579 — The GitHub Actions cooldown filter was only evaluating the **single latest release** against the cooldown window. If that latest release fell within the cooldown period, Dependabot immediately returned "no viable filtered release" and proposed no update at all — even when multiple older releases existed that were well past the cooldown window.

This effectively made cooldown a **permanent blocker** for frequently-released dependencies (e.g. `ruby/setup-ruby`, `renovatebot/github-action`), which is clearly not the intended behavior.

**Before (broken behavior):**
```
Found release date : 2026-03-27 01:19:02 +0000
Days since release : 0 (cooldown days 7)
Filtered out (cooldown) ruby/setup-ruby, 1.298.0
Returning current version/ref (no viable filtered release) 1.288.0
Latest version is 1.288.0
No update needed for ruby/setup-ruby 1.288.0
```
Versions `1.289.0`–`1.297.0` were all over 7 days old and should have been proposed, but were never evaluated.

**After (fixed behavior):**
Dependabot fetches the release dates for **all** allowed version tags, builds a set of tags that are within the cooldown window, and checks whether the proposed release tag is in that set. Tags outside the cooldown window remain valid candidates for update.

### What changed?

- **`package_details_fetcher.rb`**: Added `fetch_tag_and_release_date` (public) and `fetch_release_date_for_tag` (private). These use `git clone --bare` + `git show --format="%cd"` to retrieve the commit date for each allowed version tag —with existing methods git_commit_checker and available_latest_version_tag via git-native repository.

- **`latest_version_finder.rb`**:
  - Replaced the single-tag `commit_metadata_details` + `release_in_cooldown_period?` flow in `cooldown_filter` with a new `select_version_tags_in_cooldown_period` method that evaluates **all** allowed version tags.
  - The filter now checks whether the proposed release tag is a member of the in-cooldown set, rather than whether its own date is within the window.
  - Added `check_if_version_in_cooldown_period?` and `release_date_to_seconds` as testable, isolated helpers.
  - Added `DAY_IN_SECONDS` constant (previously referenced but defined elsewhere).

- **Tests**: Added specs for `fetch_tag_and_release_date`, `check_if_version_in_cooldown_period?`, `release_date_to_seconds`, and `select_version_tags_in_cooldown_period`, covering nil/empty/invalid date inputs, missing cooldown options, and error recovery.

### Anything you want to highlight for special attention from reviewers?

- The `fetch_release_date_for_tag` method currently runs a full `git clone --bare` per tag. For repos with a large number of allowed version tags this could be slow. A follow-up optimization to clone once and run all `git show` commands within that single bare clone would be worthwhile, but is out of scope for this fix.
- The old `release_in_cooldown_period?` included a `cooldown.included?(dependency.name)` guard. This has been removed in the new `check_if_version_in_cooldown_period?`. Please confirm whether per-dependency inclusion scoping needs to be preserved here.

### How will you know you've accomplished your goal?

- The new unit tests for `select_version_tags_in_cooldown_period` and `check_if_version_in_cooldown_period?` pass.
- Manually: a GitHub Actions dependency with `cooldown: default-days: 7` and a latest release < 7 days old will now be updated to the most recent release that is ≥ 7 days old, rather than receiving "no viable filtered release."
- Reproducer from the issue: `ruby/setup-ruby` pinned at `1.288.0`, run when `1.298.0` is 0 days old — Dependabot should now propose updating to `1.297.0` (or whichever is the newest release outside the cooldown window).

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.