### PR TITLE
percent-encode npm releaser names in Maintainer changes section

### DIFF
--- a/bun/lib/dependabot/bun/metadata_finder.rb
+++ b/bun/lib/dependabot/bun/metadata_finder.rb
@@ -16,6 +16,10 @@ module Dependabot
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
 
+      # RFC 3986 unreserved; others need encoding (explicit ASCII class avoids UTF-8 \w issues)
+      CHARS_REQUIRING_ENCODING = T.let(/[^A-Za-z0-9._~-]/, Regexp)
+      private_constant :CHARS_REQUIRING_ENCODING
+
       sig { override.returns(T.nilable(String)) }
       def homepage_url
         # Attempt to use version_listing first, as fetching the entire listing
@@ -28,16 +32,28 @@ module Dependabot
 
       sig { override.returns(T.nilable(String)) }
       def maintainer_changes
-        return unless npm_releaser
+        releaser = npm_releaser
+        return unless releaser
         return unless npm_listing.dig("time", dependency.version)
-        return if previous_releasers&.include?(npm_releaser)
+        return if previous_releasers&.include?(releaser)
 
+        encoded_releaser = encode_npm_releaser(releaser)
         "This version was pushed to npm by " \
-          "[#{npm_releaser}](https://www.npmjs.com/~#{npm_releaser}), a new " \
+          "[#{releaser}](https://www.npmjs.com/~#{encoded_releaser}), a new " \
           "releaser for #{dependency.name} since your current version."
       end
 
       private
+
+      # Percent-encodes npm releaser names for safe inclusion in npmjs.com profile URLs.
+      sig { params(releaser: String).returns(String) }
+      def encode_npm_releaser(releaser)
+        return releaser unless releaser.match?(CHARS_REQUIRING_ENCODING)
+
+        releaser.gsub(CHARS_REQUIRING_ENCODING) do |char|
+          char.bytes.map { |byte| "%#{format('%02X', byte)}" }.join
+        end
+      end
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source

--- a/bun/spec/dependabot/bun/metadata_finder_spec.rb
+++ b/bun/spec/dependabot/bun/metadata_finder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
       requirements: [
         { file: "package.json", requirement: "^1.0", groups: [], source: nil }
       ],
-      package_manager: "npm_and_yarn"
+      package_manager: "bun"
     )
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
               ref: "master"
             }
           }],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 
@@ -298,7 +298,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
                 url: "https://npm.fury.io/dependabot"
               }
             }],
-            package_manager: "npm_and_yarn"
+            package_manager: "bun"
           )
         end
 
@@ -395,7 +395,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
               }
             }
           ],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 
@@ -437,7 +437,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
               }
             }
           ],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 
@@ -513,7 +513,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
             groups: [],
             source: nil
           }],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 
@@ -522,6 +522,36 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
           "This version was pushed to npm by " \
           "[dougwilson](https://www.npmjs.com/~dougwilson), a new releaser " \
           "for etag since your current version."
+        )
+      end
+    end
+
+    context "when the maintainer name contains spaces" do
+      let(:dependency_name) { "npm-package-json-lint" }
+      let(:npm_url) { "https://registry.npmjs.org/npm-package-json-lint" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "10.0.0",
+          previous_version: "9.0.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^10.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "bun"
+        )
+      end
+      let(:npm_all_versions_response) do
+        fixture("npm_responses", "npm-package-json-lint.json")
+      end
+
+      it "properly URL-encodes the maintainer name in the link" do
+        expect(maintainer_changes).to eq(
+          "This version was pushed to npm by " \
+          "[GitHub Actions](https://www.npmjs.com/~GitHub%20Actions), a new releaser " \
+          "for npm-package-json-lint since your current version."
         )
       end
     end
@@ -538,7 +568,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
           requirements: [
             { file: "package.json", requirement: "^1.0", groups: [], source: nil }
           ],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 
@@ -646,7 +676,7 @@ RSpec.describe Dependabot::Bun::MetadataFinder do
               source: { type: "registry", url: "https://npm.fury.io/dependabot" }
             }
           ],
-          package_manager: "npm_and_yarn"
+          package_manager: "bun"
         )
       end
 

--- a/bun/spec/fixtures/npm_responses/npm-package-json-lint.json
+++ b/bun/spec/fixtures/npm_responses/npm-package-json-lint.json
@@ -1,0 +1,116 @@
+{
+  "_attachments": {},
+  "_id": "npm-package-json-lint",
+  "_rev": "142-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+  "bugs": {
+    "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+  },
+  "contributors": [
+    {
+      "email": "eric@example.com",
+      "name": "Eric Cornelissen"
+    }
+  ],
+  "description": "Configurable npm package.json linter",
+  "dist-tags": {
+    "latest": "10.0.0"
+  },
+  "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+  "keywords": [
+    "lint",
+    "npm",
+    "package.json"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "github-actions@github.com",
+      "name": "GitHub Actions"
+    }
+  ],
+  "name": "npm-package-json-lint",
+  "readme": "# npm-package-json-lint\n\nA utility for linting npm package.json files.\n",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+  },
+  "time": {
+    "created": "2020-01-01T00:00:00.000Z",
+    "modified": "2024-01-02T00:00:00.000Z",
+    "9.0.0": "2024-01-01T00:00:00.000Z",
+    "10.0.0": "2024-01-02T00:00:00.000Z"
+  },
+  "versions": {
+    "9.0.0": {
+      "_from": ".",
+      "_id": "npm-package-json-lint@9.0.0",
+      "_npmUser": {
+        "email": "eric@example.com",
+        "name": "oldmaintainer"
+      },
+      "_npmVersion": "11.10.0",
+      "_shasum": "8f14e45fceea167a5a36dedd4bea2543fba3442a",
+      "bugs": {
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+      },
+      "description": "Configurable npm package.json linter",
+      "dist": {
+        "shasum": "8f14e45fceea167a5a36dedd4bea2543fba3442a",
+        "tarball": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-9.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+      "keywords": [
+        "lint",
+        "npm",
+        "package.json"
+      ],
+      "license": "MIT",
+      "main": "dist/index.js",
+      "name": "npm-package-json-lint",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+      },
+      "version": "9.0.0"
+    },
+    "10.0.0": {
+      "_from": ".",
+      "_id": "npm-package-json-lint@10.0.0",
+      "_npmUser": {
+        "email": "github-actions@github.com",
+        "name": "GitHub Actions"
+      },
+      "_npmVersion": "11.11.0",
+      "_shasum": "df3c6c4ce8db6c0f5f5b92b0c1c1c0c0c0c0c0c0",
+      "bugs": {
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+      },
+      "description": "Configurable npm package.json linter",
+      "dist": {
+        "shasum": "df3c6c4ce8db6c0f5f5b92b0c1c1c0c0c0c0c0c0",
+        "tarball": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-10.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+      "keywords": [
+        "lint",
+        "npm",
+        "package.json"
+      ],
+      "license": "MIT",
+      "main": "dist/index.js",
+      "name": "npm-package-json-lint",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+      },
+      "version": "10.0.0"
+    }
+  }
+}

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -24,6 +24,10 @@ module Dependabot
         T::Array[String]
       )
 
+      # RFC 3986 unreserved ASCII characters; everything else needs percent-encoding.
+      CHARS_REQUIRING_ENCODING = T.let(/[^A-Za-z0-9._~-]/, Regexp)
+      private_constant :CHARS_REQUIRING_ENCODING
+
       sig { override.returns(T.nilable(String)) }
       def homepage_url
         # Attempt to use version_listing first, as fetching the entire listing
@@ -36,12 +40,14 @@ module Dependabot
 
       sig { override.returns(T.nilable(String)) }
       def maintainer_changes
-        return unless npm_releaser
+        releaser = npm_releaser
+        return unless releaser
         return unless npm_listing.dig("time", dependency.version)
-        return if previous_releasers&.include?(npm_releaser)
+        return if previous_releasers&.include?(releaser)
 
+        encoded_releaser = encode_npm_releaser(releaser)
         "This version was pushed to npm by " \
-          "[#{npm_releaser}](https://www.npmjs.com/~#{npm_releaser}), a new " \
+          "[#{releaser}](https://www.npmjs.com/~#{encoded_releaser}), a new " \
           "releaser for #{dependency.name} since your current version."
       end
 
@@ -95,6 +101,16 @@ module Dependabot
         script_names = scripts.map { |s| "`#{s}`" }.join(", ")
         noun = scripts.size == 1 ? "script" : "scripts"
         "#{action} #{script_names} #{noun}"
+      end
+
+      # Percent-encodes npm releaser names for safe inclusion in npmjs.com profile URLs.
+      sig { params(releaser: String).returns(String) }
+      def encode_npm_releaser(releaser)
+        return releaser unless releaser.match?(CHARS_REQUIRING_ENCODING)
+
+        releaser.gsub(CHARS_REQUIRING_ENCODING) do |char|
+          char.bytes.map { |byte| "%#{format('%02X', byte)}" }.join
+        end
       end
 
       sig { params(version: T.nilable(String)).returns(T::Hash[String, String]) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -526,6 +526,36 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
         )
       end
     end
+
+    context "when the maintainer name contains spaces" do
+      let(:dependency_name) { "npm-package-json-lint" }
+      let(:npm_url) { "https://registry.npmjs.org/npm-package-json-lint" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "10.0.0",
+          previous_version: "9.0.0",
+          requirements: [{
+            file: "package.json",
+            requirement: "^10.0",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+      let(:npm_all_versions_response) do
+        fixture("npm_responses", "npm-package-json-lint.json")
+      end
+
+      it "properly URL-encodes the maintainer name in the link" do
+        expect(maintainer_changes).to eq(
+          "This version was pushed to npm by " \
+          "[GitHub Actions](https://www.npmjs.com/~GitHub%20Actions), a new releaser " \
+          "for npm-package-json-lint since your current version."
+        )
+      end
+    end
   end
 
   describe "#install_script_changes" do

--- a/npm_and_yarn/spec/fixtures/npm_responses/npm-package-json-lint.json
+++ b/npm_and_yarn/spec/fixtures/npm_responses/npm-package-json-lint.json
@@ -1,0 +1,116 @@
+{
+  "_attachments": {},
+  "_id": "npm-package-json-lint",
+  "_rev": "142-abc1234567890",
+  "bugs": {
+    "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+  },
+  "contributors": [
+    {
+      "email": "eric@example.com",
+      "name": "Eric Cornelissen"
+    }
+  ],
+  "description": "Configurable npm package.json linter",
+  "dist-tags": {
+    "latest": "10.0.0"
+  },
+  "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+  "keywords": [
+    "lint",
+    "npm",
+    "package.json"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "github-actions@github.com",
+      "name": "GitHub Actions"
+    }
+  ],
+  "name": "npm-package-json-lint",
+  "readme": "# npm-package-json-lint\n\nA utility for linting npm package.json files.\n",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+  },
+  "time": {
+    "created": "2020-01-01T00:00:00.000Z",
+    "modified": "2024-01-02T00:00:00.000Z",
+    "9.0.0": "2024-01-01T00:00:00.000Z",
+    "10.0.0": "2024-01-02T00:00:00.000Z"
+  },
+  "versions": {
+    "9.0.0": {
+      "_from": ".",
+      "_id": "npm-package-json-lint@9.0.0",
+      "_npmUser": {
+        "email": "eric@example.com",
+        "name": "oldmaintainer"
+      },
+      "_npmVersion": "11.10.0",
+      "_shasum": "8f14e45fceea167a5a36dedd4bea2543fba3442a",
+      "bugs": {
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+      },
+      "description": "Configurable npm package.json linter",
+      "dist": {
+        "shasum": "8f14e45fceea167a5a36dedd4bea2543fba3442a",
+        "tarball": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-9.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+      "keywords": [
+        "lint",
+        "npm",
+        "package.json"
+      ],
+      "license": "MIT",
+      "main": "dist/index.js",
+      "name": "npm-package-json-lint",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+      },
+      "version": "9.0.0"
+    },
+    "10.0.0": {
+      "_from": ".",
+      "_id": "npm-package-json-lint@10.0.0",
+      "_npmUser": {
+        "email": "github-actions@github.com",
+        "name": "GitHub Actions"
+      },
+      "_npmVersion": "11.11.0",
+      "_shasum": "df3c6c4ce8db6c0f5f5b92b0c1c1c0c0c0c0c0c0",
+      "bugs": {
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint/issues"
+      },
+      "description": "Configurable npm package.json linter",
+      "dist": {
+        "shasum": "df3c6c4ce8db6c0f5f5b92b0c1c1c0c0c0c0c0c0",
+        "tarball": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-10.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "homepage": "https://github.com/ericcornelissen/npm-package-json-lint",
+      "keywords": [
+        "lint",
+        "npm",
+        "package.json"
+      ],
+      "license": "MIT",
+      "main": "dist/index.js",
+      "name": "npm-package-json-lint",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/ericcornelissen/npm-package-json-lint"
+      },
+      "version": "10.0.0"
+    }
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14595 — The Maintainer changes section in Dependabot PR bodies for npm/Bun dependencies can generate a broken Markdown link if the npm releaser name contains spaces or other URL-unsafe characters (e.g., `"GitHub Actions"`).

Previously, the link was constructed like:
```
This version was pushed to npm by [GitHub Actions](https://www.npmjs.com/~GitHub Actions), ...
```
The unencoded space makes the URL invalid in both Markdown and web standards.

This PR fixes the issue for **both `npm_and_yarn` and `bun`** ecosystems. The Bun `MetadataFinder` is a near-mirror of the npm one and had the same bug; both are fixed here together.

### Anything you want to highlight for special attention from reviewers?

- A new private helper `encode_npm_releaser` is introduced in both `npm_and_yarn/metadata_finder.rb` and `bun/metadata_finder.rb`. It percent-encodes the npm releaser name per RFC 3986 before interpolating it into the npmjs.com profile URL — e.g., `"GitHub Actions"` → `"GitHub%20Actions"`.
- The helper uses an explicit ASCII character class (`/[^A-Za-z0-9._~-]/`) rather than `\w` to avoid incorrectly bypassing encoding for Unicode characters under UTF-8.
- Display text (the visible link label) is intentionally left unencoded for readability.
- `normalize_registry_url` in both finders strips leading/trailing whitespace and encodes all whitespace as `%20` for consistency. `dependency_url` uses the same `gsub(/\s+/, "%20")` normalization.
- The npmjs.com profile URL for bot releasers like `"GitHub Actions"` may still 404 — this is an upstream npm limitation outside Dependabot's control. This fix only ensures the Markdown and URI are syntactically valid.
- The `bun` spec fixtures are also updated so that `package_manager` is correctly set to `"bun"` (was incorrectly `"npm_and_yarn"`), fixing spec isolation.

### How will you know you've accomplished your goal?

- All new and existing specs pass, explicitly verifying `%20` encoding for spaces in npm releaser profile links for both `npm_and_yarn` and `bun`.
- A new fixture (`npm-package-json-lint.json`) is added to both `npm_and_yarn` and `bun` spec fixtures, covering the space-in-releaser-name scenario end-to-end.
- Registry URL normalization behavior is validated through the public `#source_url` API via `WebMock` request assertions (not via private method calls).
- Smoke test coverage tracked in dependabot/smoke-tests#455.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.