### PR TITLE
Add support for SDK-style SQL Server database projects

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -87,17 +87,9 @@ RUN chmod +x $DEPENDABOT_HOME/dependabot-updater/bin/run
 # .NET install targeting packs
 RUN pwsh $DEPENDABOT_HOME/dependabot-updater/bin/install-targeting-packs.ps1
 
-# Install Microsoft.Build.Sql package to enable MSBuild operations with SQL projects
-# TODO(liesen): dotnet package download: https://github.com/NuGet/Home/pull/14495
+# Download Microsoft.Build.Sql for SQL project (.sqlproj) support
 RUN mkdir /tmp/msbuild-sdks \
- && curl -L https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/1.0.0 -o /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg
-
-# # Set up the .NET SDK resolver path for Microsoft.Build.Sql
-# RUN cp /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg.zip \
-#  && unzip /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg "sdk/*" "tools/*" -d ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql \
-#  # Rename the 'sdk' as .NET expects it to be named 'Sdk'
-#  && mv ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/sdk ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/Sdk \
-#  && rm /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg.zip
+  && curl -L https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/2.1.0 -o /tmp/msbuild-sdks/Microsoft.Build.Sql.2.1.0.nupkg
 
 # Enable MSBuild operations with a shallow clone for repos that use the Nerdbank.GitVersioning package
 ENV NBGV_GitEngine=Disabled

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -89,7 +89,7 @@ RUN pwsh $DEPENDABOT_HOME/dependabot-updater/bin/install-targeting-packs.ps1
 
 # Download Microsoft.Build.Sql for SQL project (.sqlproj) support
 RUN mkdir /tmp/msbuild-sdks \
-  && curl -L https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/2.1.0 -o /tmp/msbuild-sdks/Microsoft.Build.Sql.2.1.0.nupkg
+  && curl -fsSL https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/2.1.0 -o /tmp/msbuild-sdks/Microsoft.Build.Sql.2.1.0.nupkg
 
 # Enable MSBuild operations with a shallow clone for repos that use the Nerdbank.GitVersioning package
 ENV NBGV_GitEngine=Disabled

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -87,5 +87,17 @@ RUN chmod +x $DEPENDABOT_HOME/dependabot-updater/bin/run
 # .NET install targeting packs
 RUN pwsh $DEPENDABOT_HOME/dependabot-updater/bin/install-targeting-packs.ps1
 
+# Install Microsoft.Build.Sql package to enable MSBuild operations with SQL projects
+# TODO(liesen): dotnet package download: https://github.com/NuGet/Home/pull/14495
+RUN mkdir /tmp/msbuild-sdks \
+ && curl -L https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/1.0.0 -o /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg
+
+# # Set up the .NET SDK resolver path for Microsoft.Build.Sql
+# RUN cp /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg.zip \
+#  && unzip /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg "sdk/*" "tools/*" -d ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql \
+#  # Rename the 'sdk' as .NET expects it to be named 'Sdk'
+#  && mv ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/sdk ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/Sdk \
+#  && rm /tmp/msbuild-sdks/Microsoft.Build.Sql.1.0.0.nupkg.zip
+
 # Enable MSBuild operations with a shallow clone for repos that use the Nerdbank.GitVersioning package
 ENV NBGV_GitEngine=Disabled

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -96,7 +96,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 (projectPath, """
                     <?xml version="1.0" encoding="utf-8"?>
                     <Project DefaultTargets="Build">
-                    <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+                    <Sdk Name="Microsoft.Build.Sql" Version="2.1.0" />
                       <PropertyGroup>
                         <Name>sample</Name>
                         <DSP>Microsoft.Data.Tools.Schema.Sql.Sql160DatabaseSchemaProvider</DSP>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -74,6 +74,61 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task TestSqlprojFile()
+    {
+        var projectPath = "src/sample.sqlproj";
+        var dependencyId = "Microsoft.SqlServer.Dacpacs.Master";
+        var resolvedDependencyVersion = "160.2.5";
+        var targetFramework = "netstandard2.1";
+        var expectedDependencies = new List<Dependency>()
+        {
+            new Dependency(dependencyId, resolvedDependencyVersion, DependencyType.PackageReference, TargetFrameworks: [targetFramework], IsDirect: true)
+        };
+
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage(dependencyId, resolvedDependencyVersion, targetFramework),
+            ],
+            workspacePath: "src",
+            files: new[]
+            {
+                (projectPath, """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <Project DefaultTargets="Build">
+                    <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+                      <PropertyGroup>
+                        <Name>sample</Name>
+                        <DSP>Microsoft.Data.Tools.Schema.Sql.Sql160DatabaseSchemaProvider</DSP>
+                        <ModelCollation>1033, CI</ModelCollation>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageReference Include="Microsoft.SqlServer.Dacpacs.Master" Version="160.*" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            },
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "sample.sqlproj",
+                        TargetFrameworks = [targetFramework],
+                        Dependencies = expectedDependencies.ToImmutableArray(),
+                        Properties = [new("DSP", "Microsoft.Data.Tools.Schema.Sql.Sql160DatabaseSchemaProvider", projectPath), new("ModelCollation", "1033, CI", projectPath), new("Name", "sample", projectPath)],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
     public async Task FindDependenciesFromSDKProjectsWithDesktopTFM()
     {
         await TestDiscoveryAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -323,12 +323,15 @@ public abstract class UpdateWorkerTestBase : TestBase
 
             // ensure only the test feed is used
             string relativeLocalFeedPath = Path.GetRelativePath(temporaryDirectory, localFeedPath);
+            // TODO(liesen): For the Microsoft.Build.Sql SDK: either use the NuGet-based SDK resolver like here,
+            // or install the SDK into the MSBuild-SDKs folder. See Dockerfile.
             await File.WriteAllTextAsync(Path.Join(temporaryDirectory, "NuGet.Config"), $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>
                   <packageSources>
                     <clear />
                     <add key="local-feed" value="{relativeLocalFeedPath}" />
+                    <add key="msbuild-sdks" value="/tmp/msbuild-sdks" />
                   </packageSources>
                 </configuration>
                 """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/UpdateWorkerTestBase.cs
@@ -323,8 +323,7 @@ public abstract class UpdateWorkerTestBase : TestBase
 
             // ensure only the test feed is used
             string relativeLocalFeedPath = Path.GetRelativePath(temporaryDirectory, localFeedPath);
-            // TODO(liesen): For the Microsoft.Build.Sql SDK: either use the NuGet-based SDK resolver like here,
-            // or install the SDK into the MSBuild-SDKs folder. See Dockerfile.
+            // The Microsoft.Build.Sql SDK is resolved via the msbuild-sdks NuGet source (see Dockerfile).
             await File.WriteAllTextAsync(Path.Join(temporaryDirectory, "NuGet.Config"), $"""
                 <?xml version="1.0" encoding="utf-8"?>
                 <configuration>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -214,6 +214,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                     case ".csproj":
                     case ".fsproj":
                     case ".vbproj":
+                    case ".sqlproj":
                         return true;
                     default:
                         return false;
@@ -267,6 +268,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                     case ".csproj":
                     case ".vbproj":
                     case ".fsproj":
+                    case ".sqlproj":
                         expandedProjects.Add(candidateEntryPoint);
                         break;
                     default:


### PR DESCRIPTION
### What are you trying to accomplish?

Add support for [SDK-style SQL Server database projects](https://learn.microsoft.com/en-us/sql/ssdt/sql-server-data-tools-sdk-style) (`.sqlproj` files) in the NuGet ecosystem.

SDK-style `.sqlproj` files share the same MSBuild format as `.csproj`/`.fsproj`/`.vbproj` and declare NuGet dependencies identically. They differ only in file extension and the `Sdk="Microsoft.Build.Sql"` attribute on the root `Project` element. Without this change, the discovery worker silently ignores `.sqlproj` files and Dependabot never updates their NuGet dependencies.

Fixes #13188. Previously discussed in #4424 (closed before `.sqlproj` became SDK-style).

A workaround exists: rename `.sqlproj` to `.csproj`, as shown in [this workflow run](https://github.com/liesen/dependabot-sqlproj/actions/runs/17649156718). This PR removes that workaround.

### Anything you want to highlight for special attention from reviewers?

The core change is a one-liner: add `.sqlproj` to the extension allowlist in `DiscoveryWorker.cs`. The non-obvious part is making the test work.

`Microsoft.Build.Sql` must be pre-installed in the container for testing: the container has no network access at runtime, so NuGet cannot fetch the SDK on demand. The `nuget/Dockerfile` downloads the `.nupkg` to `/tmp/msbuild-sdks/`. `UpdateWorkerTestBase` registers that directory as a `packageSources` entry.

An alternative is to extract the `.nupkg` directly into the MSBuild SDKs folder for a specific SDK version:

```dockerfile
RUN curl -L https://www.nuget.org/api/v2/package/Microsoft.Build.Sql/2.1.0 -o /tmp/Microsoft.Build.Sql.2.1.0.nupkg.zip \
 && unzip /tmp/Microsoft.Build.Sql.2.1.0.nupkg.zip "sdk/*" "tools/*" -d ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql \
 # Rename 'sdk' to 'Sdk' as .NET requires
 && mv ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/sdk ${DOTNET_INSTALL_DIR}/sdk/${DOTNET_STS_SDK_VERSION}/Sdks/Microsoft.Build.Sql/Sdk \
 && rm /tmp/Microsoft.Build.Sql.2.1.0.nupkg.zip
```

This approach requires a specific SDK version at build time (`DOTNET_STS_SDK_VERSION`) and silently fails for projects targeting other installed SDKs. The NuGet source approach works across all installed SDK versions.

### How will you know you've accomplished your goal?

`TestSqlprojFile` in `DiscoveryWorkerTests` covers `.sqlproj` discovery. It uses the existing `MockNuGetPackage` infrastructure and runs without network access or a real SQL Server toolchain.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
