### PR TITLE
Poetry Dynamic dependency handling

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -95,6 +95,10 @@ module Dependabot
             # Poetry manages its own build system dependencies
             next if using_poetry? && dep["requirement_type"] == "build-system.requires"
 
+            # When dependencies or optional-dependencies are listed in project.dynamic,
+            # they are managed by the build backend (e.g. Poetry) — skip the PEP 621 path
+            next if dynamic_pep621_dep?(dep["requirement_type"])
+
             dependencies <<
               Dependency.new(
                 name: normalise(dep["name"]),
@@ -229,6 +233,28 @@ module Dependabot
         sig { returns(T.untyped) }
         def using_pdm?
           using_pep621? && pdm_lock
+        end
+
+        sig { returns(T::Array[String]) }
+        def dynamic_fields
+          @dynamic_fields ||= T.let(
+            parsed_pyproject.dig("project", "dynamic") || [],
+            T.nilable(T::Array[String])
+          )
+        end
+
+        sig { params(requirement_type: T.nilable(String)).returns(T::Boolean) }
+        def dynamic_pep621_dep?(requirement_type)
+          return false unless using_poetry?
+          return false unless requirement_type
+
+          if requirement_type == "dependencies"
+            dynamic_fields.include?("dependencies")
+          elsif parsed_pyproject.dig("project", "optional-dependencies")&.key?(requirement_type)
+            dynamic_fields.include?("optional-dependencies")
+          else
+            false
+          end
         end
 
         # Create a DependencySet where each element has no requirement. Any

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -226,7 +226,7 @@ module Dependabot
         def dynamic_fields
           @dynamic_fields ||= T.let(
             parsed_pyproject.dig("project", "dynamic") || [],
-            T.nilable(T::Array[String])
+            T::Array[String]
           )
         end
 

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -84,20 +84,7 @@ module Dependabot
           return dependencies if using_pdm?
 
           parse_pep621_pep735_dependencies.each do |dep|
-            # If a requirement has a `<` or `<=` marker then updating it is
-            # probably blocked. Ignore it.
-            next if dep["markers"]&.include?("<")
-
-            # If no requirement, don't add it
-            next if dep["requirement"].empty?
-
-            # Skip build-system.requires dependencies when using Poetry
-            # Poetry manages its own build system dependencies
-            next if using_poetry? && dep["requirement_type"] == "build-system.requires"
-
-            # When dependencies or optional-dependencies are listed in project.dynamic,
-            # they are managed by the build backend (e.g. Poetry) — skip the PEP 621 path
-            next if dynamic_pep621_dep?(dep["requirement_type"])
+            next if skip_pep621_dep?(dep)
 
             dependencies <<
               Dependency.new(
@@ -241,6 +228,24 @@ module Dependabot
             parsed_pyproject.dig("project", "dynamic") || [],
             T.nilable(T::Array[String])
           )
+        end
+
+        sig { params(dep: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        def skip_pep621_dep?(dep)
+          # If a requirement has a `<` or `<=` marker then updating it is
+          # probably blocked. Ignore it.
+          return true if dep["markers"]&.include?("<")
+
+          # If no requirement, don't add it
+          return true if dep["requirement"].empty?
+
+          # Skip build-system.requires dependencies when using Poetry
+          # Poetry manages its own build system dependencies
+          return true if using_poetry? && dep["requirement_type"] == "build-system.requires"
+
+          # When dependencies or optional-dependencies are listed in project.dynamic,
+          # they are managed by the build backend (e.g. Poetry) — skip the PEP 621 path
+          dynamic_pep621_dep?(dep["requirement_type"])
         end
 
         sig { params(requirement_type: T.nilable(String)).returns(T::Boolean) }

--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -25,6 +25,7 @@ module Dependabot
         sig { params(dependency_files: T::Array[Dependabot::DependencyFile]).void }
         def initialize(dependency_files:)
           @dependency_files = dependency_files
+          @dynamic_fields = T.let(nil, T.nilable(T::Array[String]))
         end
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
@@ -224,10 +225,7 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def dynamic_fields
-          @dynamic_fields ||= T.let(
-            parsed_pyproject.dig("project", "dynamic") || [],
-            T::Array[String]
-          )
+          @dynamic_fields ||= parsed_pyproject.dig("project", "dynamic") || []
         end
 
         sig { params(dep: T::Hash[String, T.untyped]).returns(T::Boolean) }

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
@@ -38,13 +38,16 @@ module Dependabot
             old_specifiers = parse_specifiers(old_req)
             new_specifiers = parse_specifiers(new_req)
 
-            version_map = {}
-            old_specifiers.each_with_index do |old_spec, i|
-              new_spec = new_specifiers[i]
-              next unless new_spec && old_spec[:operator] == new_spec[:operator]
-              next if old_spec[:version] == new_spec[:version]
+            old_by_op = {}
+            old_specifiers.each { |s| old_by_op[s[:operator]] = s[:version] }
 
-              version_map[[old_spec[:operator], old_spec[:version]]] = new_spec[:version]
+            version_map = {}
+            new_specifiers.each do |new_spec|
+              old_version = old_by_op[new_spec[:operator]]
+              next unless old_version
+              next if old_version == new_spec[:version]
+
+              version_map[[new_spec[:operator], old_version]] = new_spec[:version]
             end
 
             result = source_req.dup

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
@@ -38,24 +38,45 @@ module Dependabot
             old_specifiers = parse_specifiers(old_req)
             new_specifiers = parse_specifiers(new_req)
 
-            old_by_op = {}
-            old_specifiers.each { |s| old_by_op[s[:operator]] = s[:version] }
+            old_versions_by_op = group_versions_by_operator(old_specifiers)
+            new_versions_by_op = group_versions_by_operator(new_specifiers)
 
-            version_map = {}
-            new_specifiers.each do |new_spec|
-              old_version = old_by_op[new_spec[:operator]]
-              next unless old_version
-              next if old_version == new_spec[:version]
+            replacements = T.let([], T::Array[T::Hash[Symbol, String]])
+            new_versions_by_op.each do |operator, new_versions|
+              old_versions = old_versions_by_op[operator]
+              next unless old_versions
+              next unless old_versions.length == new_versions.length
 
-              version_map[[new_spec[:operator], old_version]] = new_spec[:version]
+              old_versions.zip(new_versions).each do |old_version, new_version|
+                next if old_version == new_version
+
+                replacements << {
+                  operator: operator,
+                  old_version: T.must(old_version),
+                  new_version: T.must(new_version)
+                }
+              end
             end
 
             result = source_req.dup
-            version_map.each do |(operator, old_version), new_version|
-              pattern = /(#{Regexp.escape(operator)}\s*)#{Regexp.escape(old_version)}/
-              result = result.sub(pattern, "\\1#{new_version}")
+            replacements.each do |replacement|
+              pattern = /(#{Regexp.escape(T.must(replacement[:operator]))}\s*)#{Regexp.escape(T.must(replacement[:old_version]))}/
+              result = result.sub(pattern, "\\1#{replacement[:new_version]}")
             end
             result
+          end
+
+          sig { params(specifiers: T::Array[T::Hash[Symbol, String]]).returns(T::Hash[String, T::Array[String]]) }
+          def group_versions_by_operator(specifiers)
+            specifiers.each_with_object(
+              T.let({}, T::Hash[String, T::Array[String]])
+            ) do |specifier, grouped_versions|
+              operator = specifier[:operator]
+              version = specifier[:version]
+
+              grouped_versions[operator] ||= []
+              T.must(grouped_versions[operator]) << version
+            end
           end
 
           sig { params(req: String).returns(T::Array[T::Hash[Symbol, String]]) }

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
@@ -52,7 +52,7 @@ module Dependabot
 
                 replacements << {
                   operator: operator,
-                  old_version: T.must(old_version),
+                  old_version: old_version,
                   new_version: T.must(new_version)
                 }
               end
@@ -60,8 +60,9 @@ module Dependabot
 
             result = source_req.dup
             replacements.each do |replacement|
-              pattern = /(#{Regexp.escape(T.must(replacement[:operator]))}\s*)#{Regexp.escape(T.must(replacement[:old_version]))}/
-              result = result.sub(pattern, "\\1#{replacement[:new_version]}")
+              op = Regexp.escape(T.must(replacement[:operator]))
+              ver = Regexp.escape(T.must(replacement[:old_version]))
+              result = result.sub(/(#{op}\s*)#{ver}/, "\\1#{replacement[:new_version]}")
             end
             result
           end
@@ -71,8 +72,8 @@ module Dependabot
             specifiers.each_with_object(
               T.let({}, T::Hash[String, T::Array[String]])
             ) do |specifier, grouped_versions|
-              operator = specifier[:operator]
-              version = specifier[:version]
+              operator = T.must(specifier[:operator])
+              version = T.must(specifier[:version])
 
               grouped_versions[operator] ||= []
               T.must(grouped_versions[operator]) << version

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -27,10 +27,10 @@ module Dependabot
         # preserving extras and environment markers.
         sig { params(entry: String, version: String).returns(String) }
         def self.pin_pep508_entry(entry, version)
-          m = entry.match(PEP508_PREFIX)
-          return entry unless m
+          prefix_match = entry.match(PEP508_PREFIX)
+          return entry unless prefix_match
 
-          prefix = T.must(m[:prefix])
+          prefix = T.must(prefix_match[:prefix])
           rest = T.must(entry[prefix.length..])
 
           # Extract the environment marker ("; ..." suffix) if present

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -16,38 +16,28 @@ module Dependabot
       class PyprojectPreparer
         extend T::Sig
 
-        # Builds a regex pattern that matches a PEP 508 package name,
-        # treating hyphens, underscores, and dots as interchangeable per PEP 508.
-        sig { params(name: String).returns(String) }
-        def self.pep508_name_pattern(name)
-          Regexp.escape(name).gsub("\\-", "[-_.]").gsub("_", "[-_.]").gsub("\\.", "[-_.]")
-        end
-        private_class_method :pep508_name_pattern
+        # Fixed regex for extracting the name+extras prefix from a PEP 508 entry.
+        # Does not interpolate library input, avoiding polynomial backtracking.
+        PEP508_PREFIX = T.let(
+          /\A(?<prefix>(?<name>[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)(?:\[[^\]]*\])?)/i,
+          Regexp
+        )
 
         # Pins a single PEP 508 dependency entry string to a specific version,
         # preserving extras and environment markers.
-        #
-        # Handles three PEP 508 forms:
-        #   "name[extras] (>=1.0,<2.0) ; marker"   — parenthesized specifiers
-        #   "name[extras]>=1.0,<2.0 ; marker"       — bare specifiers
-        #   "name[extras] ; marker"                  — no specifiers
-        sig { params(entry: String, name_pattern: String, version: String).returns(String) }
-        def self.pin_pep508_entry(entry, name_pattern, version)
-          prefix   = "(?<pre>#{name_pattern}(?:\\[[^\\]]*\\])?)"
-          extras   = "(?:\\[[^\\]]*\\])?"
-          marker   = "(?<rest>\\s*(?:;.*)?)"
-          operator = "[><=!~]"
+        sig { params(entry: String, version: String).returns(String) }
+        def self.pin_pep508_entry(entry, version)
+          m = entry.match(PEP508_PREFIX)
+          return entry unless m
 
-          if entry.match?(/\A#{name_pattern}#{extras}\s*\(#{operator}/i)
-            # Parenthesized specifiers: strip the (...) block entirely
-            entry.sub(/#{prefix}\s*\(#{operator}[^)]*\)#{marker}/i, "\\k<pre>==#{version}\\k<rest>")
-          elsif entry.match?(/\A#{name_pattern}#{extras}\s*#{operator}/i)
-            # Bare specifiers: strip everything up to the marker
-            entry.sub(/#{prefix}\s*#{operator}[^;]*?(?=\s*;|\s*\z)/i, "\\k<pre>==#{version}")
-          else
-            # No specifiers: just pin after the name
-            entry.sub(/#{prefix}#{marker}/i, "\\k<pre>==#{version}\\k<rest>")
-          end
+          prefix = T.must(m[:prefix])
+          rest = T.must(entry[prefix.length..])
+
+          # Extract the environment marker ("; ..." suffix) if present
+          marker_match = rest.match(/(\s*;.*)/)
+          marker = marker_match ? marker_match[1] : ""
+
+          "#{prefix}==#{version}#{marker}"
         end
         private_class_method :pin_pep508_entry
 
@@ -88,12 +78,14 @@ module Dependabot
 
         sig { params(dep_arrays: T::Array[T::Array[String]], dep: Dependabot::Dependency).void }
         def self.pin_pep621_dep_in_arrays!(dep_arrays, dep)
-          name_pattern = pep508_name_pattern(dep.name)
+          normalised_name = NameNormaliser.normalise(dep.name)
           dep_arrays.each do |arr|
             arr.each_with_index do |entry, i|
-              next unless entry.match?(/\A#{name_pattern}(\[[^\]]*\])?\s*(\z|[(><=!~;,])/i)
+              match = entry.match(PEP508_PREFIX)
+              next unless match
+              next unless NameNormaliser.normalise(T.must(match[:name])) == normalised_name
 
-              arr[i] = pin_pep508_entry(entry, name_pattern, T.must(dep.version))
+              arr[i] = pin_pep508_entry(entry, T.must(dep.version))
             end
           end
         end
@@ -238,8 +230,7 @@ module Dependabot
             locked_details = locked_details(dep_name)
             next unless (locked_version = locked_details&.fetch("version"))
 
-            name_pattern = self.class.send(:pep508_name_pattern, T.must(match[1]))
-            dep_array[index] = self.class.send(:pin_pep508_entry, entry, name_pattern, locked_version)
+            dep_array[index] = self.class.send(:pin_pep508_entry, entry, locked_version)
           end
         end
 

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -26,18 +26,27 @@ module Dependabot
 
         # Pins a single PEP 508 dependency entry string to a specific version,
         # preserving extras and environment markers.
+        #
+        # Handles three PEP 508 forms:
+        #   "name[extras] (>=1.0,<2.0) ; marker"   — parenthesized specifiers
+        #   "name[extras]>=1.0,<2.0 ; marker"       — bare specifiers
+        #   "name[extras] ; marker"                  — no specifiers
         sig { params(entry: String, name_pattern: String, version: String).returns(String) }
         def self.pin_pep508_entry(entry, name_pattern, version)
-          if entry.match?(/\A#{name_pattern}(\[.*?\])?\s*[><=!~]/i)
-            entry.sub(
-              /(?<pre>#{name_pattern}(?:\[.*?\])?)\s*[><=!~][^;]*?(?=\s*;|\s*\z)/i,
-              "\\k<pre>==#{version}"
-            )
+          prefix   = "(?<pre>#{name_pattern}(?:\\[.*?\\])?)"
+          extras   = "(?:\\[.*?\\])?"
+          marker   = "(?<rest>\\s*(?:;.*)?)"
+          operator = "[><=!~]"
+
+          if entry.match?(/\A#{name_pattern}#{extras}\s*\(#{operator}/i)
+            # Parenthesized specifiers: strip the (...) block entirely
+            entry.sub(/#{prefix}\s*\(#{operator}[^)]*\)#{marker}/i, "\\k<pre>==#{version}\\k<rest>")
+          elsif entry.match?(/\A#{name_pattern}#{extras}\s*#{operator}/i)
+            # Bare specifiers: strip everything up to the marker
+            entry.sub(/#{prefix}\s*#{operator}[^;]*?(?=\s*;|\s*\z)/i, "\\k<pre>==#{version}")
           else
-            entry.sub(
-              /(?<pre>#{name_pattern}(?:\[.*?\])?)(?<rest>\s*(?:;.*)?)/i,
-              "\\k<pre>==#{version}\\k<rest>"
-            )
+            # No specifiers: just pin after the name
+            entry.sub(/#{prefix}#{marker}/i, "\\k<pre>==#{version}\\k<rest>")
           end
         end
         private_class_method :pin_pep508_entry
@@ -82,7 +91,7 @@ module Dependabot
           name_pattern = pep508_name_pattern(dep.name)
           dep_arrays.each do |arr|
             arr.each_with_index do |entry, i|
-              next unless entry.match?(/\A#{name_pattern}(\[.*?\])?\s*(\z|[><=!~;,])/i)
+              next unless entry.match?(/\A#{name_pattern}(\[.*?\])?\s*(\z|[(><=!~;,])/i)
 
               arr[i] = pin_pep508_entry(entry, name_pattern, T.must(dep.version))
             end
@@ -138,8 +147,8 @@ module Dependabot
             .gsub('#{', "{")
         end
 
-        # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/AbcSize
+        UNSUPPORTED_SOURCE_TYPES = T.let(%w(directory file url).freeze, T::Array[String])
+
         sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(String) }
         def freeze_top_level_dependencies_except(dependencies)
           return pyproject_content unless lockfile
@@ -154,32 +163,10 @@ module Dependabot
           Dependabot::Python::FileParser::PyprojectFilesParser::POETRY_DEPENDENCY_TYPES.each do |key|
             next unless poetry_object[key]
 
-            source_types = %w(directory file url)
             poetry_object.fetch(key).each do |dep_name, _|
               next if excluded_names.include?(normalise(dep_name))
 
-              locked_details = locked_details(dep_name)
-
-              next unless (locked_version = locked_details&.fetch("version"))
-
-              next if source_types.include?(locked_details.dig("source", "type"))
-
-              if locked_details.dig("source", "type") == "git"
-                poetry_object[key][dep_name] = {
-                  "git" => locked_details.dig("source", "url"),
-                  "rev" => locked_details.dig("source", "reference")
-                }
-                subdirectory = locked_details.dig("source", "subdirectory")
-                poetry_object[key][dep_name]["subdirectory"] = subdirectory if subdirectory
-              elsif poetry_object[key][dep_name].is_a?(Hash)
-                poetry_object[key][dep_name]["version"] = locked_version
-              elsif poetry_object[key][dep_name].is_a?(Array)
-                # if it has multiple-constraints, locking to a single version is
-                # going to result in a bad lockfile, ignore
-                next
-              else
-                poetry_object[key][dep_name] = locked_version
-              end
+              freeze_poetry_dep!(poetry_object[key], dep_name)
             end
           end
 
@@ -188,8 +175,6 @@ module Dependabot
 
           TomlRB.dump(pyproject_object)
         end
-        # rubocop:enable Metrics/AbcSize
-        # rubocop:enable Metrics/PerceivedComplexity
 
         private
 
@@ -198,6 +183,33 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :lockfile
+
+        sig { params(deps_hash: T::Hash[String, T.untyped], dep_name: String).void }
+        def freeze_poetry_dep!(deps_hash, dep_name)
+          details = locked_details(dep_name)
+          return unless (locked_version = details&.fetch("version"))
+
+          source_type = details.dig("source", "type")
+          return if UNSUPPORTED_SOURCE_TYPES.include?(source_type)
+
+          if source_type == "git"
+            freeze_git_dep!(deps_hash, dep_name, details)
+          elsif deps_hash[dep_name].is_a?(Hash)
+            deps_hash[dep_name]["version"] = locked_version
+          elsif !deps_hash[dep_name].is_a?(Array)
+            deps_hash[dep_name] = locked_version
+          end
+        end
+
+        sig { params(deps_hash: T::Hash[String, T.untyped], dep_name: String, details: T::Hash[String, T.untyped]).void }
+        def freeze_git_dep!(deps_hash, dep_name, details)
+          deps_hash[dep_name] = {
+            "git" => details.dig("source", "url"),
+            "rev" => details.dig("source", "reference")
+          }
+          subdirectory = details.dig("source", "subdirectory")
+          deps_hash[dep_name]["subdirectory"] = subdirectory if subdirectory
+        end
 
         sig { params(pyproject_object: T::Hash[String, T.untyped], excluded_names: T::Array[String]).void }
         def freeze_pep621_top_level_deps!(pyproject_object, excluded_names)

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -33,8 +33,8 @@ module Dependabot
         #   "name[extras] ; marker"                  — no specifiers
         sig { params(entry: String, name_pattern: String, version: String).returns(String) }
         def self.pin_pep508_entry(entry, name_pattern, version)
-          prefix   = "(?<pre>#{name_pattern}(?:\\[.*?\\])?)"
-          extras   = "(?:\\[.*?\\])?"
+          prefix   = "(?<pre>#{name_pattern}(?:\\[[^\\]]*\\])?)"
+          extras   = "(?:\\[[^\\]]*\\])?"
           marker   = "(?<rest>\\s*(?:;.*)?)"
           operator = "[><=!~]"
 
@@ -91,7 +91,7 @@ module Dependabot
           name_pattern = pep508_name_pattern(dep.name)
           dep_arrays.each do |arr|
             arr.each_with_index do |entry, i|
-              next unless entry.match?(/\A#{name_pattern}(\[.*?\])?\s*(\z|[(><=!~;,])/i)
+              next unless entry.match?(/\A#{name_pattern}(\[[^\]]*\])?\s*(\z|[(><=!~;,])/i)
 
               arr[i] = pin_pep508_entry(entry, name_pattern, T.must(dep.version))
             end

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -464,6 +464,42 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
           expect(pydantic.requirements.first[:groups]).to eq(["dependencies"])
         end
       end
+
+      context "with dynamic dependencies in Poetry project" do
+        subject(:dependencies) { parser.dependency_set.dependencies }
+
+        let(:pyproject_fixture_name) { "pep621_dynamic_dependencies.toml" }
+
+        it "skips PEP 621 dependencies when dependencies is dynamic" do
+          dep_names = dependencies.map(&:name)
+          # Poetry deps are parsed but PEP 621 [project] dependencies are not
+          # since they are marked as dynamic and managed by Poetry
+          expect(dep_names).to include("requests", "django")
+          dependencies.each do |dep|
+            expect(dep.requirements.first[:groups]).to eq(["dependencies"])
+          end
+        end
+      end
+
+      context "with dynamic optional-dependencies in Poetry project" do
+        subject(:dependencies) { parser.dependency_set.dependencies }
+
+        let(:pyproject_fixture_name) { "pep621_dynamic_optional_dependencies.toml" }
+
+        it "skips PEP 621 optional deps but keeps non-dynamic deps" do
+          dep_names = dependencies.map(&:name)
+          # requests comes from [project] dependencies (not dynamic)
+          expect(dep_names).to include("requests")
+          req = dependencies.find { |d| d.name == "requests" }
+          expect(req.requirements.first[:groups]).to eq(["dependencies"])
+        end
+
+        it "does not duplicate optional deps from PEP 621 when dynamic" do
+          pysocks_deps = dependencies.select { |d| d.name == "pysocks" }
+          # Should only appear once (from Poetry), not duplicated from PEP 621
+          expect(pysocks_deps.length).to eq(1)
+        end
+      end
     end
 
     describe "with pep 735" do

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -479,6 +479,14 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
             expect(dep.requirements.first[:groups]).to eq(["dependencies"])
           end
         end
+
+        it "does not duplicate deps from PEP 621 when dynamic" do
+          # Each dep should appear only once (from Poetry), not duplicated from [project].dependencies
+          requests_deps = dependencies.select { |d| d.name == "requests" }
+          django_deps = dependencies.select { |d| d.name == "django" }
+          expect(requests_deps.length).to eq(1)
+          expect(django_deps.length).to eq(1)
+        end
       end
 
       context "with dynamic optional-dependencies in Poetry project" do

--- a/python/spec/fixtures/pyproject_files/pep621_dynamic_dependencies.toml
+++ b/python/spec/fixtures/pyproject_files/pep621_dynamic_dependencies.toml
@@ -4,6 +4,11 @@ version = "1.0.0"
 requires-python = ">=3.10"
 dynamic = ["dependencies"]
 
+dependencies = [
+    "requests>=2.13.0",
+    "django>=5.0.0",
+]
+
 [tool.poetry]
 package-mode = false
 

--- a/python/spec/fixtures/pyproject_files/pep621_dynamic_dependencies.toml
+++ b/python/spec/fixtures/pyproject_files/pep621_dynamic_dependencies.toml
@@ -1,0 +1,16 @@
+[project]
+name = "my-package"
+version = "1.0.0"
+requires-python = ">=3.10"
+dynamic = ["dependencies"]
+
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+requests = { version = ">=2.13.0", source = "private-source" }
+django = "^5.0.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/python/spec/fixtures/pyproject_files/pep621_dynamic_optional_dependencies.toml
+++ b/python/spec/fixtures/pyproject_files/pep621_dynamic_optional_dependencies.toml
@@ -1,0 +1,24 @@
+[project]
+name = "my-package"
+version = "1.0.0"
+requires-python = ">=3.10"
+dynamic = ["optional-dependencies"]
+
+dependencies = [
+    "requests>=2.13.0",
+]
+
+[project.optional-dependencies]
+socks = [
+    "PySocks>=1.5.6",
+]
+
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.group.socks.dependencies]
+PySocks = { version = ">=1.5.6" }
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### What are you trying to accomplish?

When a Poetry `pyproject.toml` lists `dependencies` or `optional-dependencies` in `[project].dynamic`, those are managed by Poetry, not statically declared. Dependabot was parsing them from `[project]` anyway, creating duplicates and updating the wrong location. This PR skips dynamic PEP 621 dependencies when Poetry is the build backend.

Additionally fixes two CodeQL polynomial-regex alerts in `PyprojectPreparer` by replacing interpolated name patterns with a fixed `PEP508_PREFIX` constant and `NameNormaliser`-based matching. Also refactors `freeze_top_level_dependencies_except` into smaller helpers, extracts a `Pep621Updater` from `PoetryFileUpdater`, and fixes `BumpVersions` strategy for range requirements.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

The regex refactoring in `pyproject_preparer.rb` addresses CodeQL polynomial backtracking alerts. `pin_pep508_entry` signature changed from `(entry, name_pattern, version)` to `(entry, version)` — it uses a fixed regex instead of interpolating dependency names. Name matching now uses `NameNormaliser.normalise()` comparison instead of dynamic regex patterns.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Poetry projects with `dynamic = ["dependencies"]` or `dynamic = ["optional-dependencies"]` in `[project]` will no longer produce duplicate dependencies or attempt PEP 621 updates for Poetry-managed deps. Range requirements like `>=1.0,<2.0` are correctly bumped under the `BumpVersions` strategy.

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
