### PR TITLE
Fix python library detection for projects not published on PyPI

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -409,14 +409,18 @@ module Dependabot
       def check_pypi_for_library_match
         return false unless updating_pyproject? && library_details && !T.must(library_details)["name"].nil?
 
+        # If the project has a description in its pyproject.toml metadata, treat it as a
+        # library when PyPI is unavailable or the package isn't published there yet.
+        has_library_metadata = !T.must(library_details)["description"].nil?
+
         response = Dependabot::RegistryClient.get(
           url: "https://pypi.org/pypi/#{normalised_name(T.must(library_details)['name'])}/json/"
         )
-        return false unless response.status == 200
+        return has_library_metadata unless response.status == 200
 
         (JSON.parse(response.body)["info"] || {})["summary"] == T.must(library_details)["description"]
       rescue Excon::Error::Timeout, Excon::Error::Socket, URI::InvalidURIError
-        false
+        has_library_metadata
       end
 
       sig { returns(T::Boolean) }

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -1818,6 +1818,39 @@ RSpec.describe Dependabot::Python::UpdateChecker do
               .to have_been_made.once
           end
         end
+
+        context "when PyPI request raises Excon::Error::Timeout" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(Excon::Error::Timeout.new("connection timeout"))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
+        end
+
+        context "when PyPI request raises Excon::Error::Socket" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(Excon::Error::Socket.new(SocketError.new("getaddrinfo failed")))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
+        end
+
+        context "when PyPI request raises URI::InvalidURIError" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(URI::InvalidURIError.new("bad URI"))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
+        end
       end
 
       context "when updating a dependency in an additional requirements file" do

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -1775,10 +1775,22 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when dealing with a non-library" do
+        context "when the project is not on PyPI but has library metadata" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when dealing with a non-library" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
           end
 
           its([:requirement]) { is_expected.to eq("~2.19.1") }
@@ -1855,10 +1867,22 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when dealing with a non-library" do
+        context "when the project is not on PyPI but has library metadata" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when dealing with a non-library" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
           end
 
           its([:requirement]) { is_expected.to eq("~=2.19.1") }
@@ -1912,10 +1936,22 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when dealing with a non-library" do
+        context "when the project is not on PyPI but has library metadata" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when dealing with a non-library" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
           end
 
           its([:requirement]) { is_expected.to eq("~=2.19.1") }


### PR DESCRIPTION
### What are you trying to accomplish?
The `check_pypi_for_library_match` method returned false whenever PyPI returned a 404, causing projects with full library metadata in `pyproject.toml` (name + description) but not published on PyPI to be misclassified as applications. This meant the default `auto` versioning strategy fell back to `BumpVersions` instead of `WidenRanges`. 
Fixes https://github.com/dependabot/dependabot-core/issues/14702.

After https://github.com/dependabot/dependabot-core/pull/14666 was deployed, the `BumpVersions` strategy started bumping lower bounds of satisfied range requirements and the above misclassification became observable.

**Fix:**
When PyPI is unavailable (404, timeout, socket error), fall back to checking whether the project has a `description` field in its `pyproject.toml` metadata (`[project]`, `[tool.poetry]`, or `[build-system]`). If it does, treat it as a library (defaulting to `WidenRanges`). When PyPI returns 200, behavior is unchanged — summaries are compared to confirm identity.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**Tests:**
 - Added "not on PyPI but has library metadata" contexts confirming `WidenRanges` behavior
 - Updated "non-library" contexts to use a 200 response with mismatched description instead of 404
 - Applied across Poetry, standard Python, and build-system test groups
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
Projects which have full library metadata but are not published on PyPI are correctly classified as libraries and not as apps.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
