### PR TITLE
Nix: update pinned tag refs and versioned branch refs in flake.nix

### DIFF
--- a/nix/lib/dependabot/nix/file_parser.rb
+++ b/nix/lib/dependabot/nix/file_parser.rb
@@ -149,7 +149,7 @@ module Dependabot
           requirements: [{
             requirement: nil,
             file: "flake.lock",
-            source: { type: "git", url: url, branch: ref, ref: ref },
+            source: { type: "git", url: url, branch: nil, ref: ref },
             groups: []
           }]
         )

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -49,7 +49,13 @@ module Dependabot
         return unless old_ref
         return if old_ref == new_ref
 
-        FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+        updated_content =
+          FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+        return updated_content if updated_content
+
+        raise Dependabot::DependabotError,
+              "Unable to update flake.nix for #{dependency.name}: " \
+              "could not find input URL to rewrite from #{old_ref} to #{new_ref}"
       end
 
       sig { params(updated_nix_content: T.nilable(String)).returns(String) }

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -49,13 +49,7 @@ module Dependabot
         return unless old_ref
         return if old_ref == new_ref
 
-        updated_content =
-          FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
-        return updated_content if updated_content
-
-        raise Dependabot::DependabotError,
-              "Unable to update flake.nix for #{dependency.name}: " \
-              "could not find input URL to rewrite from #{old_ref} to #{new_ref}"
+        FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
       end
 
       sig { params(updated_nix_content: T.nilable(String)).returns(String) }

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -7,6 +7,7 @@ require "dependabot/errors"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/shared_helpers"
+require "dependabot/nix/flake_nix_parser"
 
 module Dependabot
   module Nix
@@ -15,14 +16,20 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
-        updated_lockfile_content = update_flake_lock
+        updated_files = []
+
+        updated_flake_nix_content = update_flake_nix
+        updated_files << updated_file(file: flake_nix, content: updated_flake_nix_content) if updated_flake_nix_content
+
+        updated_lockfile_content = update_flake_lock(updated_flake_nix_content)
 
         if updated_lockfile_content == flake_lock.content
           raise Dependabot::DependencyFileContentNotChanged,
                 "Expected flake.lock to change for #{dependency.name}, but it didn't"
         end
 
-        [updated_file(file: flake_lock, content: updated_lockfile_content)]
+        updated_files << updated_file(file: flake_lock, content: updated_lockfile_content)
+        updated_files
       end
 
       private
@@ -32,13 +39,26 @@ module Dependabot
         T.must(dependencies.first)
       end
 
-      sig { returns(String) }
-      def update_flake_lock
+      # Returns updated flake.nix content if the ref changed, nil otherwise.
+      sig { returns(T.nilable(String)) }
+      def update_flake_nix
+        new_ref = new_source_ref
+        return unless new_ref
+
+        old_ref = old_source_ref
+        return unless old_ref
+        return if old_ref == new_ref
+
+        FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+      end
+
+      sig { params(updated_nix_content: T.nilable(String)).returns(String) }
+      def update_flake_lock(updated_nix_content)
         SharedHelpers.in_a_temporary_repo_directory(
           flake_lock.directory,
           repo_contents_path
         ) do
-          File.write("flake.nix", T.must(flake_nix.content))
+          File.write("flake.nix", updated_nix_content || T.must(flake_nix.content))
           File.write("flake.lock", T.must(flake_lock.content))
 
           SharedHelpers.run_shell_command(
@@ -48,6 +68,16 @@ module Dependabot
 
           File.read("flake.lock")
         end
+      end
+
+      sig { returns(T.nilable(String)) }
+      def new_source_ref
+        dependency.requirements.first&.dig(:source, :ref)
+      end
+
+      sig { returns(T.nilable(String)) }
+      def old_source_ref
+        dependency.previous_requirements&.first&.dig(:source, :ref)
       end
 
       sig { override.void }

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -96,16 +96,19 @@ module Dependabot
       sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def find_url_match
         escaped_name = Regexp.escape(input_name)
+        # Nix identifiers can contain letters, digits, underscores, hyphens, and apostrophes.
+        # Anchor the name so we don't match inside longer identifiers (e.g. "my-nixpkgs").
+        bounded_name = "(?<![A-Za-z0-9_'\\-])#{escaped_name}(?![A-Za-z0-9_'\\-])"
 
         # Pattern 1: inputs.NAME.url = "URL";
         # Pattern 2: NAME.url = "URL";  (inside inputs block)
-        url_assignment = /(?:inputs\.)?#{escaped_name}\.url\s*=\s*"(?<url>[^"]+)"/
+        url_assignment = /(?:inputs\.)?#{bounded_name}\.url\s*=\s*"(?<url>[^"]+)"/
         match = url_assignment.match(content)
         return url_match_hash(match) if match
 
         # Pattern 3: NAME = { ... url = "URL"; ... }
         # Use a non-greedy match to find the url inside the attribute set
-        attr_set = /#{escaped_name}\s*=\s*\{[^}]*?\burl\s*=\s*"(?<url>[^"]+)"/m
+        attr_set = /#{bounded_name}\s*=\s*\{[^}]*?\burl\s*=\s*"(?<url>[^"]+)"/m
         match = attr_set.match(content)
         return url_match_hash(match) if match
 

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -103,16 +103,43 @@ module Dependabot
         # Pattern 1: inputs.NAME.url = "URL";
         # Pattern 2: NAME.url = "URL";  (inside inputs block)
         url_assignment = /(?:inputs\.)?#{bounded_name}\.url\s*=\s*"(?<url>[^"]+)"/
-        match = url_assignment.match(content)
+        match = find_uncommented_match(url_assignment)
         return url_match_hash(match) if match
 
         # Pattern 3: NAME = { ... url = "URL"; ... }
         # Use a non-greedy match to find the url inside the attribute set
         attr_set = /#{bounded_name}\s*=\s*\{[^}]*?\burl\s*=\s*"(?<url>[^"]+)"/m
-        match = attr_set.match(content)
+        match = find_uncommented_match(attr_set)
         return url_match_hash(match) if match
 
         nil
+      end
+
+      # Finds the first match that isn't inside a Nix comment (# or /* */).
+      sig { params(pattern: Regexp).returns(T.nilable(MatchData)) }
+      def find_uncommented_match(pattern)
+        content.to_enum(:scan, pattern).each do
+          match = T.must(Regexp.last_match)
+          next if inside_comment?(match.begin(0))
+
+          return match
+        end
+        nil
+      end
+
+      sig { params(pos: Integer).returns(T::Boolean) }
+      def inside_comment?(pos)
+        # Check for single-line comment: # at start of line before pos
+        line_start = content.rindex("\n", pos)&.+(1) || 0
+        line_before_pos = content[line_start...pos]
+        return true if line_before_pos&.match?(/(?:^|[^&])#/)
+
+        # Check for block comment: /* before pos without a closing */ between them
+        last_open = content.rindex("/*", pos)
+        return false unless last_open
+
+        last_close = content.rindex("*/", pos)
+        last_open > (last_close || -1)
       end
 
       sig { params(match: MatchData).returns(T::Hash[Symbol, T.untyped]) }

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -1,0 +1,147 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module Nix
+    # Parses flake.nix content to locate input URL declarations and extract
+    # their components (scheme, owner, repo, ref). Only handles the shorthand
+    # URL schemes (github:, gitlab:, sourcehut:) since those are the ones
+    # where the ref appears inline in the URL string.
+    class FlakeNixParser
+      extend T::Sig
+
+      # Matches shorthand flake URLs: github:owner/repo/ref or github:owner/repo
+      # Also handles gitlab: and sourcehut:~owner/repo/ref
+      FLAKE_URL_PATTERN = %r{
+        (?<scheme>github|gitlab|sourcehut):
+        (?<owner>~?[a-zA-Z0-9_\-\.]+)/
+        (?<repo>[a-zA-Z0-9_\-\.]+)
+        (?:/(?<ref>[a-zA-Z0-9_\-\./]+))?
+        (?:\?(?<query>[^"]*))?
+      }x
+      private_constant :FLAKE_URL_PATTERN
+
+      # Matches an input URL assignment tied to a specific input name.
+      # Covers the common syntactic forms:
+      #   inputs.NAME.url = "URL";
+      #   NAME.url = "URL";
+      #   NAME = { ... url = "URL"; ... };
+      #
+      # We build these dynamically per input name so that the name is anchored
+      # in the regex.
+      sig { params(content: String, input_name: String).returns(T.nilable(InputUrl)) }
+      def self.find_input_url(content, input_name)
+        new(content, input_name).find
+      end
+
+      sig { params(content: String, input_name: String, new_ref: String).returns(T.nilable(String)) }
+      def self.update_input_ref(content, input_name, new_ref)
+        new(content, input_name).update_ref(new_ref)
+      end
+
+      sig { params(content: String, input_name: String).void }
+      def initialize(content, input_name)
+        @content = content
+        @input_name = input_name
+      end
+
+      sig { returns(T.nilable(InputUrl)) }
+      def find
+        match = find_url_match
+        return unless match
+
+        url_str = match[:url]
+        url_match = FLAKE_URL_PATTERN.match(url_str)
+        return unless url_match
+
+        InputUrl.new(
+          full_url: url_str,
+          scheme: T.must(url_match[:scheme]),
+          owner: T.must(url_match[:owner]),
+          repo: T.must(url_match[:repo]),
+          ref: url_match[:ref],
+          query: url_match[:query],
+          match_start: match[:url_start],
+          match_end: match[:url_end]
+        )
+      end
+
+      sig { params(new_ref: String).returns(T.nilable(String)) }
+      def update_ref(new_ref)
+        input_url = find
+        return unless input_url
+        return unless input_url.ref # nothing to update if no ref
+
+        old_url = input_url.full_url
+        new_url = build_updated_url(input_url, new_ref)
+
+        updated = @content.dup
+        # Replace within the known match boundaries to avoid accidental matches elsewhere
+        updated[input_url.match_start...input_url.match_end] =
+          T.must(updated[input_url.match_start...input_url.match_end]).sub(old_url, new_url)
+        updated
+      end
+
+      private
+
+      sig { returns(String) }
+      attr_reader :content
+
+      sig { returns(String) }
+      attr_reader :input_name
+
+      # Returns a hash with :url, :url_start, :url_end if found, or nil.
+      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      def find_url_match
+        escaped_name = Regexp.escape(input_name)
+
+        # Pattern 1: inputs.NAME.url = "URL";
+        # Pattern 2: NAME.url = "URL";  (inside inputs block)
+        url_assignment = /(?:inputs\.)?#{escaped_name}\.url\s*=\s*"(?<url>[^"]+)"/
+        match = url_assignment.match(content)
+        return url_match_hash(match) if match
+
+        # Pattern 3: NAME = { ... url = "URL"; ... }
+        # Use a non-greedy match to find the url inside the attribute set
+        attr_set = /#{escaped_name}\s*=\s*\{[^}]*?\burl\s*=\s*"(?<url>[^"]+)"/m
+        match = attr_set.match(content)
+        return url_match_hash(match) if match
+
+        nil
+      end
+
+      sig { params(match: MatchData).returns(T::Hash[Symbol, T.untyped]) }
+      def url_match_hash(match)
+        url_capture_start = match.begin(:url)
+        url_capture_end = match.end(:url)
+        {
+          url: match[:url],
+          url_start: url_capture_start,
+          url_end: url_capture_end
+        }
+      end
+
+      sig { params(input_url: InputUrl, new_ref: String).returns(String) }
+      def build_updated_url(input_url, new_ref)
+        base = "#{input_url.scheme}:#{input_url.owner}/#{input_url.repo}/#{new_ref}"
+        input_url.query ? "#{base}?#{input_url.query}" : base
+      end
+
+      # Represents a parsed flake input URL from flake.nix
+      class InputUrl < T::Struct
+        const :full_url, String
+        const :scheme, String
+        const :owner, String
+        const :repo, String
+        const :ref, T.nilable(String)
+        const :query, T.nilable(String)
+        # Character positions of the URL string within the flake.nix content
+        # (inside the quotes, not including the quotes themselves)
+        const :match_start, Integer
+        const :match_end, Integer
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -23,6 +23,14 @@ module Dependabot
       }x
       private_constant :FLAKE_URL_PATTERN
 
+      # Matches indirect/registry shorthand URLs: nixpkgs/nixos-24.11
+      # These have no scheme prefix (no ":") and resolve via the nix flake registry.
+      INDIRECT_URL_PATTERN = %r{
+        \A(?<id>[a-zA-Z0-9_\-]+)
+        /(?<ref>[a-zA-Z0-9_\-\./]+)\z
+      }x
+      private_constant :INDIRECT_URL_PATTERN
+
       # Matches an input URL assignment tied to a specific input name.
       # Covers the common syntactic forms:
       #   inputs.NAME.url = "URL";
@@ -53,16 +61,33 @@ module Dependabot
         return unless match
 
         url_str = match[:url]
+
+        # Try shorthand scheme first (github:, gitlab:, sourcehut:)
         url_match = FLAKE_URL_PATTERN.match(url_str)
-        return unless url_match
+        if url_match
+          return InputUrl.new(
+            full_url: url_str,
+            scheme: T.must(url_match[:scheme]),
+            owner: T.must(url_match[:owner]),
+            repo: T.must(url_match[:repo]),
+            ref: url_match[:ref],
+            query: url_match[:query],
+            match_start: match[:url_start],
+            match_end: match[:url_end]
+          )
+        end
+
+        # Try indirect/registry shorthand (e.g. nixpkgs/nixos-24.11)
+        indirect_match = INDIRECT_URL_PATTERN.match(url_str)
+        return unless indirect_match
 
         InputUrl.new(
           full_url: url_str,
-          scheme: T.must(url_match[:scheme]),
-          owner: T.must(url_match[:owner]),
-          repo: T.must(url_match[:repo]),
-          ref: url_match[:ref],
-          query: url_match[:query],
+          scheme: "indirect",
+          owner: T.must(indirect_match[:id]),
+          repo: "",
+          ref: indirect_match[:ref],
+          query: nil,
           match_start: match[:url_start],
           match_end: match[:url_end]
         )
@@ -155,8 +180,12 @@ module Dependabot
 
       sig { params(input_url: InputUrl, new_ref: String).returns(String) }
       def build_updated_url(input_url, new_ref)
-        base = "#{input_url.scheme}:#{input_url.owner}/#{input_url.repo}/#{new_ref}"
-        input_url.query ? "#{base}?#{input_url.query}" : base
+        if input_url.scheme == "indirect"
+          "#{input_url.owner}/#{new_ref}"
+        else
+          base = "#{input_url.scheme}:#{input_url.owner}/#{input_url.repo}/#{new_ref}"
+          input_url.query ? "#{base}?#{input_url.query}" : base
+        end
       end
 
       # Represents a parsed flake input URL from flake.nix

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -151,9 +151,7 @@ module Dependabot
       sig { returns(T::Boolean) }
       def ref_pinned_to_version_tag?
         return false unless git_commit_checker.git_dependency?
-
-        ref = dependency_source_ref
-        return false unless ref
+        return false unless dependency_source_ref
 
         git_commit_checker.pinned_ref_looks_like_version?
       end

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -64,7 +64,7 @@ module Dependabot
         if ref_pinned_to_version_tag?
           fetch_latest_version_for_tag
         elsif ref_is_versioned_branch?
-          fetch_latest_version_for_versioned_branch
+          fetch_latest_version_for_versioned_branch || fetch_latest_version_for_commit
         else
           fetch_latest_version_for_commit
         end

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -178,7 +178,8 @@ module Dependabot
           VersionedBranchFinder.new(
             current_ref: ref,
             dependency: dependency,
-            credentials: credentials
+            credentials: credentials,
+            ignored_versions: ignored_versions
           ),
           T.nilable(VersionedBranchFinder)
         )

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -81,7 +81,7 @@ module Dependabot
           source = req[:source]
           next req unless source
 
-          req.merge(source: source.merge(ref: new_tag[:tag], branch: new_tag[:tag]))
+          req.merge(source: source.merge(ref: new_tag[:tag], branch: nil))
         end
       end
 
@@ -110,7 +110,7 @@ module Dependabot
           source = req[:source]
           next req unless source
 
-          req.merge(source: source.merge(ref: result[:branch], branch: result[:branch]))
+          req.merge(source: source.merge(ref: result[:branch], branch: nil))
         end
       end
 

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -15,6 +15,7 @@ module Dependabot
       extend T::Sig
 
       require_relative "update_checker/latest_version_finder"
+      require_relative "update_checker/versioned_branch_finder"
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_version
@@ -27,27 +28,29 @@ module Dependabot
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version
-        # Resolvability isn't an issue for flake inputs — they're independent.
         latest_version
       end
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock
-        # No concept of "unlocking" for flake inputs
         latest_version
       end
 
       sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
       def updated_requirements
-        # Flake input requirements are the URL and branch — we never update those.
-        dependency.requirements
+        if ref_pinned_to_version_tag?
+          updated_requirements_for_tag
+        elsif ref_is_versioned_branch?
+          updated_requirements_for_versioned_branch
+        else
+          dependency.requirements
+        end
       end
 
       private
 
       sig { override.returns(T::Boolean) }
       def latest_version_resolvable_with_full_unlock?
-        # Full unlock checks aren't relevant for flake inputs
         false
       end
 
@@ -58,6 +61,77 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def fetch_latest_version
+        if ref_pinned_to_version_tag?
+          fetch_latest_version_for_tag
+        elsif ref_is_versioned_branch?
+          fetch_latest_version_for_versioned_branch
+        else
+          fetch_latest_version_for_commit
+        end
+      end
+
+      # --- Tag-pinned ref support ---
+
+      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      def updated_requirements_for_tag
+        new_tag = latest_version_tag
+        return dependency.requirements unless new_tag
+
+        dependency.requirements.map do |req|
+          source = req[:source]
+          next req unless source
+
+          req.merge(source: source.merge(ref: new_tag[:tag], branch: new_tag[:tag]))
+        end
+      end
+
+      sig { returns(T.nilable(String)) }
+      def fetch_latest_version_for_tag
+        tag = latest_version_tag
+        tag&.fetch(:commit_sha)
+      end
+
+      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      def latest_version_tag
+        @latest_version_tag ||= T.let(
+          git_commit_checker.local_tag_for_latest_version,
+          T.nilable(T::Hash[Symbol, T.untyped])
+        )
+      end
+
+      # --- Versioned branch support ---
+
+      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      def updated_requirements_for_versioned_branch
+        result = latest_versioned_branch
+        return dependency.requirements unless result
+
+        dependency.requirements.map do |req|
+          source = req[:source]
+          next req unless source
+
+          req.merge(source: source.merge(ref: result[:branch], branch: result[:branch]))
+        end
+      end
+
+      sig { returns(T.nilable(String)) }
+      def fetch_latest_version_for_versioned_branch
+        result = latest_versioned_branch
+        result&.fetch(:commit_sha)
+      end
+
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      def latest_versioned_branch
+        @latest_versioned_branch ||= T.let(
+          versioned_branch_finder&.latest_versioned_branch,
+          T.nilable(T::Hash[Symbol, String])
+        )
+      end
+
+      # --- Commit-tracking (existing behavior) ---
+
+      sig { returns(T.nilable(String)) }
+      def fetch_latest_version_for_commit
         T.let(
           LatestVersionFinder.new(
             dependency: dependency,
@@ -69,6 +143,59 @@ module Dependabot
             raise_on_ignored: raise_on_ignored
           ).latest_tag,
           T.nilable(String)
+        )
+      end
+
+      # --- Ref classification ---
+
+      sig { returns(T::Boolean) }
+      def ref_pinned_to_version_tag?
+        return false unless git_commit_checker.git_dependency?
+
+        ref = dependency_source_ref
+        return false unless ref
+
+        git_commit_checker.pinned_ref_looks_like_version?
+      end
+
+      sig { returns(T::Boolean) }
+      def ref_is_versioned_branch?
+        finder = versioned_branch_finder
+        return false unless finder
+
+        finder.versioned_branch?
+      end
+
+      sig { returns(T.nilable(String)) }
+      def dependency_source_ref
+        dependency.source_details(allowed_types: ["git"])&.fetch(:ref, nil)
+      end
+
+      sig { returns(T.nilable(VersionedBranchFinder)) }
+      def versioned_branch_finder
+        ref = dependency_source_ref
+        return unless ref
+
+        @versioned_branch_finder ||= T.let(
+          VersionedBranchFinder.new(
+            current_ref: ref,
+            dependency: dependency,
+            credentials: credentials
+          ),
+          T.nilable(VersionedBranchFinder)
+        )
+      end
+
+      sig { returns(Dependabot::GitCommitChecker) }
+      def git_commit_checker
+        @git_commit_checker ||= T.let(
+          Dependabot::GitCommitChecker.new(
+            dependency: dependency,
+            credentials: credentials,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored
+          ),
+          T.nilable(Dependabot::GitCommitChecker)
         )
       end
     end

--- a/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 
 require "dependabot/nix/update_checker"
+require "dependabot/nix/requirement"
 require "dependabot/git_metadata_fetcher"
 require "dependabot/git_ref"
 
@@ -27,13 +28,15 @@ module Dependabot
           params(
             current_ref: String,
             dependency: Dependabot::Dependency,
-            credentials: T::Array[Dependabot::Credential]
+            credentials: T::Array[Dependabot::Credential],
+            ignored_versions: T::Array[String]
           ).void
         end
-        def initialize(current_ref:, dependency:, credentials:)
+        def initialize(current_ref:, dependency:, credentials:, ignored_versions: [])
           @current_ref = current_ref
           @dependency = dependency
           @credentials = credentials
+          @ignored_versions = ignored_versions
         end
 
         # Returns true if the current ref looks like a versioned branch.
@@ -68,6 +71,9 @@ module Dependabot
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
+        sig { returns(T::Array[String]) }
+        attr_reader :ignored_versions
+
         sig { returns(T.nilable(MatchData)) }
         def branch_version_match
           @branch_version_match ||= T.let(
@@ -85,22 +91,44 @@ module Dependabot
         end
         def find_latest_branch(prefix, current_version, suffix)
           candidates = remote_branches.filter_map do |ref|
-            branch_match = VERSIONED_BRANCH_PATTERN.match(ref.name)
-            next unless branch_match
-            next unless branch_match[1] == prefix
-            next unless branch_match[3] == suffix
-
-            version = parse_version(T.must(branch_match[2]))
-            next unless version
-            next unless (version <=> current_version) == 1
-
-            { branch: ref.name, commit_sha: ref.commit_sha, version: version }
+            build_candidate(ref, prefix, current_version, suffix)
           end
 
           latest = candidates.max_by { |c| c[:version] }
           return unless latest
 
           { branch: latest[:branch].to_s, commit_sha: latest[:commit_sha].to_s }
+        end
+
+        sig do
+          params(
+            ref: Dependabot::GitRef,
+            prefix: String,
+            current_version: T::Array[Integer],
+            suffix: T.nilable(String)
+          ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+        end
+        def build_candidate(ref, prefix, current_version, suffix)
+          branch_match = VERSIONED_BRANCH_PATTERN.match(ref.name)
+          return unless branch_match
+          return unless branch_match[1] == prefix
+          return unless branch_match[3] == suffix
+
+          version_str = T.must(branch_match[2])
+          version = parse_version(version_str)
+          return unless version
+          return unless (version <=> current_version) == 1
+          return if version_ignored?(version_str)
+
+          { branch: ref.name, commit_sha: ref.commit_sha, version: version }
+        end
+
+        sig { params(version_str: String).returns(T::Boolean) }
+        def version_ignored?(version_str)
+          return false if ignore_requirements.empty?
+
+          gem_version = Gem::Version.new(version_str)
+          ignore_requirements.any? { |req| req.satisfied_by?(gem_version) }
         end
 
         # Parses "YY.MM" into [year, month] for comparison.
@@ -116,6 +144,18 @@ module Dependabot
           [year, month]
         rescue ArgumentError
           nil
+        end
+
+        sig { returns(T::Array[Gem::Requirement]) }
+        def ignore_requirements
+          @ignore_requirements ||= T.let(
+            ignored_versions.flat_map do |req|
+              Dependabot::Nix::Requirement.requirements_array(req)
+            rescue Gem::Requirement::BadRequirementError
+              []
+            end,
+            T.nilable(T::Array[Gem::Requirement])
+          )
         end
 
         sig { returns(T::Array[Dependabot::GitRef]) }

--- a/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
@@ -1,0 +1,136 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/nix/update_checker"
+require "dependabot/git_metadata_fetcher"
+require "dependabot/git_ref"
+
+module Dependabot
+  module Nix
+    class UpdateChecker
+      # Detects versioned branch naming patterns (e.g. nixos-24.11, release-24.11)
+      # and finds the latest branch matching the same prefix.
+      class VersionedBranchFinder
+        extend T::Sig
+
+        # Matches branch names ending with a YY.MM version segment.
+        # Captures the prefix (including the separator) and the version.
+        # Examples: "nixos-24.11" => prefix="nixos-", version="24.11"
+        #           "release-24.11" => prefix="release-", version="24.11"
+        VERSIONED_BRANCH_PATTERN = /\A(.+[.\-_])(\d{2}\.\d{2})\z/
+        private_constant :VERSIONED_BRANCH_PATTERN
+
+        sig do
+          params(
+            current_ref: String,
+            dependency: Dependabot::Dependency,
+            credentials: T::Array[Dependabot::Credential]
+          ).void
+        end
+        def initialize(current_ref:, dependency:, credentials:)
+          @current_ref = current_ref
+          @dependency = dependency
+          @credentials = credentials
+        end
+
+        # Returns true if the current ref looks like a versioned branch.
+        sig { returns(T::Boolean) }
+        def versioned_branch?
+          !branch_version_match.nil?
+        end
+
+        # Returns the latest versioned branch info or nil if no newer branch exists.
+        # Returns { branch: "nixos-25.05", commit_sha: "abc123" } or nil.
+        sig { returns(T.nilable(T::Hash[Symbol, String])) }
+        def latest_versioned_branch
+          match = branch_version_match
+          return unless match
+
+          prefix = match[1]
+          current_version = parse_version(T.must(match[2]))
+          return unless current_version
+
+          best = find_latest_branch(T.must(prefix), current_version)
+          best
+        end
+
+        private
+
+        sig { returns(String) }
+        attr_reader :current_ref
+
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
+
+        sig { returns(T.nilable(MatchData)) }
+        def branch_version_match
+          @branch_version_match ||= T.let(
+            VERSIONED_BRANCH_PATTERN.match(current_ref),
+            T.nilable(MatchData)
+          )
+        end
+
+        sig { params(prefix: String, current_version: T::Array[Integer]).returns(T.nilable(T::Hash[Symbol, String])) }
+        def find_latest_branch(prefix, current_version)
+          candidates = remote_branches.filter_map do |ref|
+            branch_match = VERSIONED_BRANCH_PATTERN.match(ref.name)
+            next unless branch_match
+            next unless branch_match[1] == prefix
+
+            version = parse_version(T.must(branch_match[2]))
+            next unless version
+            next unless (version <=> current_version) == 1
+
+            { branch: ref.name, commit_sha: ref.commit_sha, version: version }
+          end
+
+          latest = candidates.max_by { |c| c[:version] }
+          return unless latest
+
+          { branch: latest[:branch].to_s, commit_sha: latest[:commit_sha].to_s }
+        end
+
+        # Parses "YY.MM" into [year, month] for comparison.
+        sig { params(version_str: String).returns(T.nilable(T::Array[Integer])) }
+        def parse_version(version_str)
+          parts = version_str.split(".")
+          return unless parts.length == 2
+
+          year = Integer(T.must(parts[0]), 10)
+          month = Integer(T.must(parts[1]), 10)
+          return unless month.between?(1, 12)
+
+          [year, month]
+        rescue ArgumentError
+          nil
+        end
+
+        sig { returns(T::Array[Dependabot::GitRef]) }
+        def remote_branches
+          @remote_branches ||= T.let(
+            git_metadata_fetcher.refs_for_upload_pack.select do |ref|
+              ref.ref_type == Dependabot::RefType::Head
+            end,
+            T.nilable(T::Array[Dependabot::GitRef])
+          )
+        end
+
+        sig { returns(Dependabot::GitMetadataFetcher) }
+        def git_metadata_fetcher
+          @git_metadata_fetcher ||= T.let(
+            Dependabot::GitMetadataFetcher.new(
+              url: dependency.source_details&.fetch(:url, nil),
+              credentials: credentials
+            ),
+            T.nilable(Dependabot::GitMetadataFetcher)
+          )
+        end
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
@@ -15,11 +15,12 @@ module Dependabot
       class VersionedBranchFinder
         extend T::Sig
 
-        # Matches branch names ending with a YY.MM version segment.
-        # Captures the prefix (including the separator) and the version.
-        # Examples: "nixos-24.11" => prefix="nixos-", version="24.11"
-        #           "release-24.11" => prefix="release-", version="24.11"
-        VERSIONED_BRANCH_PATTERN = /\A(.+[.\-_])(\d{2}\.\d{2})\z/
+        # Matches branch names with a YY.MM version segment and optional suffix.
+        # Captures: prefix (including separator), version, and optional suffix.
+        # Examples: "nixos-24.11" => prefix="nixos-", version="24.11", suffix=nil
+        #           "nixos-24.11-small" => prefix="nixos-", version="24.11", suffix="-small"
+        #           "release-24.11-aarch64" => prefix="release-", version="24.11", suffix="-aarch64"
+        VERSIONED_BRANCH_PATTERN = /\A(.+[.\-_])(\d{2}\.\d{2})(-[a-zA-Z0-9]+)?\z/
         private_constant :VERSIONED_BRANCH_PATTERN
 
         sig do
@@ -52,8 +53,8 @@ module Dependabot
           current_version = parse_version(T.must(match[2]))
           return unless current_version
 
-          best = find_latest_branch(T.must(prefix), current_version)
-          best
+          suffix = match[3] # nil if no suffix, e.g. "-small" if present
+          find_latest_branch(T.must(prefix), current_version, suffix)
         end
 
         private
@@ -75,12 +76,19 @@ module Dependabot
           )
         end
 
-        sig { params(prefix: String, current_version: T::Array[Integer]).returns(T.nilable(T::Hash[Symbol, String])) }
-        def find_latest_branch(prefix, current_version)
+        sig do
+          params(
+            prefix: String,
+            current_version: T::Array[Integer],
+            suffix: T.nilable(String)
+          ).returns(T.nilable(T::Hash[Symbol, String]))
+        end
+        def find_latest_branch(prefix, current_version, suffix)
           candidates = remote_branches.filter_map do |ref|
             branch_match = VERSIONED_BRANCH_PATTERN.match(ref.name)
             next unless branch_match
             next unless branch_match[1] == prefix
+            next unless branch_match[3] == suffix
 
             version = parse_version(T.must(branch_match[2]))
             next unless version

--- a/nix/spec/dependabot/nix/file_parser_spec.rb
+++ b/nix/spec/dependabot/nix/file_parser_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Nix::FileParser do
             source: {
               type: "git",
               url: "https://github.com/NixOS/nixpkgs",
-              branch: "nixos-unstable",
+              branch: nil,
               ref: "nixos-unstable"
             },
             groups: []

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Dependabot::Nix::FileUpdater do
             source: {
               type: "git",
               url: "https://github.com/cachix/devenv",
-              branch: "v0.6.2",
+              branch: nil,
               ref: "v0.6.2"
             },
             groups: []

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -175,5 +175,53 @@ RSpec.describe Dependabot::Nix::FileUpdater do
           .with("flake.nix", a_string_including("github:cachix/devenv/v0.6.2"))
       end
     end
+
+    context "with a versioned branch input (ref changed)" do
+      let(:flake_nix_content) { fixture("flake_with_versioned_branch.nix") }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "new_sha_def456",
+          previous_version: "old_sha_abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/NixOS/nixpkgs",
+              branch: nil,
+              ref: "nixos-25.05"
+            },
+            groups: []
+          }],
+          previous_requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/NixOS/nixpkgs",
+              branch: nil,
+              ref: "nixos-24.11"
+            },
+            groups: []
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      let(:updated_lock_content) { '{"updated": true}' }
+
+      it "returns both flake.nix and flake.lock" do
+        expect(updated_files.length).to eq(2)
+        expect(updated_files.map(&:name)).to contain_exactly("flake.nix", "flake.lock")
+      end
+
+      it "rewrites the branch in flake.nix" do
+        nix_file = updated_files.find { |f| f.name == "flake.nix" }
+        expect(nix_file.content).to include('"github:NixOS/nixpkgs/nixos-25.05"')
+        expect(nix_file.content).not_to include("nixos-24.11")
+      end
+    end
   end
 end

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         source: {
           type: "git",
           url: "https://github.com/NixOS/nixpkgs",
-          branch: "nixos-unstable",
+          branch: nil,
           ref: "nixos-unstable"
         },
         groups: []
@@ -30,7 +30,7 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         source: {
           type: "git",
           url: "https://github.com/NixOS/nixpkgs",
-          branch: "nixos-unstable",
+          branch: nil,
           ref: "nixos-unstable"
         },
         groups: []
@@ -102,19 +102,78 @@ RSpec.describe Dependabot::Nix::FileUpdater do
       allow(File).to receive(:read).with("flake.lock").and_return(updated_lock_content)
     end
 
-    it "returns one updated file" do
-      expect(updated_files.length).to eq(1)
+    context "with a branch-tracking input (ref unchanged)" do
+      it "returns only the updated flake.lock" do
+        expect(updated_files.length).to eq(1)
+        expect(updated_files.first.name).to eq("flake.lock")
+      end
+
+      it "calls nix flake update with the input name" do
+        updated_files
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+      end
     end
 
-    it "returns the updated flake.lock" do
-      expect(updated_files.first.name).to eq("flake.lock")
-    end
+    context "with a tag-pinned input (ref changed)" do
+      let(:flake_nix_content) { fixture("flake_with_tag.nix") }
 
-    it "calls nix flake update with the input name" do
-      updated_files
-      expect(Dependabot::SharedHelpers)
-        .to have_received(:run_shell_command)
-        .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "devenv",
+          version: "new_sha_def456",
+          previous_version: "old_sha_abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/cachix/devenv",
+              branch: "v0.6.2",
+              ref: "v0.6.2"
+            },
+            groups: []
+          }],
+          previous_requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/cachix/devenv",
+              branch: nil,
+              ref: "v0.5"
+            },
+            groups: []
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      let(:updated_lock_content) { '{"updated": true}' }
+
+      it "returns both flake.nix and flake.lock" do
+        expect(updated_files.length).to eq(2)
+        expect(updated_files.map(&:name)).to contain_exactly("flake.nix", "flake.lock")
+      end
+
+      it "rewrites the tag in flake.nix" do
+        nix_file = updated_files.find { |f| f.name == "flake.nix" }
+        expect(nix_file.content).to include('"github:cachix/devenv/v0.6.2"')
+        expect(nix_file.content).not_to include('"github:cachix/devenv/v0.5"')
+      end
+
+      it "preserves other inputs in flake.nix" do
+        nix_file = updated_files.find { |f| f.name == "flake.nix" }
+        expect(nix_file.content).to include('"github:NixOS/nixpkgs/nixos-unstable"')
+        expect(nix_file.content).to include('"github:numtide/flake-utils"')
+      end
+
+      it "writes the updated flake.nix before running nix" do
+        updated_files
+        expect(File).to have_received(:write)
+          .with("flake.nix", a_string_including("github:cachix/devenv/v0.6.2"))
+      end
     end
   end
 end

--- a/nix/spec/dependabot/nix/fixtures/flake_with_tag.nix
+++ b/nix/spec/dependabot/nix/fixtures/flake_with_tag.nix
@@ -1,0 +1,17 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    devenv.url = "github:cachix/devenv/v0.5";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      devenv,
+      flake-utils,
+    }:
+    {
+    };
+}

--- a/nix/spec/dependabot/nix/fixtures/flake_with_versioned_branch.nix
+++ b/nix/spec/dependabot/nix/fixtures/flake_with_versioned_branch.nix
@@ -1,0 +1,18 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    home-manager = {
+      url = "github:nix-community/home-manager/release-24.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+    }:
+    {
+    };
+}

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -173,6 +173,44 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
         expect(result.repo).to eq("nixpkgs")
       end
     end
+
+    context "with commented-out input" do
+      let(:content) do
+        <<~NIX
+          {
+            # inputs.nixpkgs.url = "github:NixOS/nixpkgs/old-ref";
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+            outputs = { ... }: { };
+          }
+        NIX
+      end
+
+      it "skips the commented line and finds the real input" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.ref).to eq("nixos-unstable")
+      end
+    end
+
+    context "with block-commented input" do
+      let(:content) do
+        <<~NIX
+          {
+            /* inputs.nixpkgs.url = "github:NixOS/nixpkgs/old-ref"; */
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+            outputs = { ... }: { };
+          }
+        NIX
+      end
+
+      it "skips the block comment and finds the real input" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.ref).to eq("nixos-unstable")
+      end
+    end
   end
 
   describe ".update_input_ref" do

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -211,6 +211,26 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
         expect(result.ref).to eq("nixos-unstable")
       end
     end
+
+    context "with indirect/shorthand URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "nixpkgs/nixos-24.11";
+            outputs = { ... }: { };
+          }
+        NIX
+      end
+
+      it "parses the indirect URL" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("indirect")
+        expect(result.owner).to eq("nixpkgs")
+        expect(result.ref).to eq("nixos-24.11")
+      end
+    end
   end
 
   describe ".update_input_ref" do
@@ -281,6 +301,24 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
       it "returns nil" do
         updated = described_class.update_input_ref(content, "nonexistent", "v1.0")
         expect(updated).to be_nil
+      end
+    end
+
+    context "with indirect/shorthand URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "nixpkgs/nixos-24.11";
+            outputs = { ... }: { };
+          }
+        NIX
+      end
+
+      it "rewrites the ref in the indirect URL" do
+        updated = described_class.update_input_ref(content, "nixpkgs", "nixos-25.05")
+
+        expect(updated).to include('"nixpkgs/nixos-25.05"')
+        expect(updated).not_to include("nixos-24.11")
       end
     end
   end

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -1,0 +1,229 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/flake_nix_parser"
+
+RSpec.describe Dependabot::Nix::FlakeNixParser do
+  def fixture(name)
+    File.read(
+      File.join(__dir__, "fixtures", name)
+    )
+  end
+
+  describe ".find_input_url" do
+    context "with dot-notation inputs" do
+      let(:content) { fixture("flake.nix") }
+
+      it "finds a URL with a ref" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("github")
+        expect(result.owner).to eq("NixOS")
+        expect(result.repo).to eq("nixpkgs")
+        expect(result.ref).to eq("nixos-unstable")
+        expect(result.full_url).to eq("github:NixOS/nixpkgs/nixos-unstable")
+      end
+
+      it "finds a URL without a ref" do
+        result = described_class.find_input_url(content, "flake-utils")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("github")
+        expect(result.owner).to eq("numtide")
+        expect(result.repo).to eq("flake-utils")
+        expect(result.ref).to be_nil
+      end
+
+      it "returns nil for unknown input names" do
+        result = described_class.find_input_url(content, "nonexistent")
+        expect(result).to be_nil
+      end
+    end
+
+    context "with tag-pinned inputs" do
+      let(:content) { fixture("flake_with_tag.nix") }
+
+      it "finds the tag ref" do
+        result = described_class.find_input_url(content, "devenv")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("github")
+        expect(result.owner).to eq("cachix")
+        expect(result.repo).to eq("devenv")
+        expect(result.ref).to eq("v0.5")
+      end
+    end
+
+    context "with attribute set syntax" do
+      let(:content) { fixture("flake_with_versioned_branch.nix") }
+
+      it "finds URL inside attribute set block" do
+        result = described_class.find_input_url(content, "home-manager")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("github")
+        expect(result.owner).to eq("nix-community")
+        expect(result.repo).to eq("home-manager")
+        expect(result.ref).to eq("release-24.11")
+      end
+
+      it "still finds dot-notation inputs" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.ref).to eq("nixos-24.11")
+      end
+    end
+
+    context "with gitlab URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.mylib.url = "gitlab:myorg/myrepo/main";
+            outputs = { self, mylib }: { };
+          }
+        NIX
+      end
+
+      it "parses gitlab scheme" do
+        result = described_class.find_input_url(content, "mylib")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("gitlab")
+        expect(result.owner).to eq("myorg")
+        expect(result.repo).to eq("myrepo")
+        expect(result.ref).to eq("main")
+      end
+    end
+
+    context "with sourcehut URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.mylib.url = "sourcehut:~user/myrepo/v1.0";
+            outputs = { self, mylib }: { };
+          }
+        NIX
+      end
+
+      it "parses sourcehut scheme with tilde prefix" do
+        result = described_class.find_input_url(content, "mylib")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("sourcehut")
+        expect(result.owner).to eq("~user")
+        expect(result.repo).to eq("myrepo")
+        expect(result.ref).to eq("v1.0")
+      end
+    end
+
+    context "with query parameters" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable?host=github.corp.example.com";
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      it "captures query params separately" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.ref).to eq("nixos-unstable")
+        expect(result.query).to eq("host=github.corp.example.com")
+      end
+    end
+
+    context "with non-shorthand URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.mylib.url = "git+https://example.com/repo.git?ref=main";
+            outputs = { self, mylib }: { };
+          }
+        NIX
+      end
+
+      it "returns nil for non-shorthand URLs" do
+        result = described_class.find_input_url(content, "mylib")
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe ".update_input_ref" do
+    context "with dot-notation input" do
+      let(:content) { fixture("flake_with_tag.nix") }
+
+      it "rewrites the ref in the URL" do
+        updated = described_class.update_input_ref(content, "devenv", "v0.6.2")
+
+        expect(updated).to include('"github:cachix/devenv/v0.6.2"')
+        expect(updated).not_to include('"github:cachix/devenv/v0.5"')
+      end
+
+      it "does not modify other inputs" do
+        updated = described_class.update_input_ref(content, "devenv", "v0.6.2")
+
+        expect(updated).to include('"github:NixOS/nixpkgs/nixos-unstable"')
+        expect(updated).to include('"github:numtide/flake-utils"')
+      end
+    end
+
+    context "with attribute set syntax" do
+      let(:content) { fixture("flake_with_versioned_branch.nix") }
+
+      it "rewrites the ref inside the attribute set" do
+        updated = described_class.update_input_ref(content, "home-manager", "release-25.05")
+
+        expect(updated).to include('"github:nix-community/home-manager/release-25.05"')
+        expect(updated).not_to include("release-24.11")
+      end
+
+      it "does not modify other inputs" do
+        updated = described_class.update_input_ref(content, "home-manager", "release-25.05")
+
+        expect(updated).to include('"github:NixOS/nixpkgs/nixos-24.11"')
+      end
+    end
+
+    context "with query parameters" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11?host=github.corp.example.com";
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      it "preserves query parameters" do
+        updated = described_class.update_input_ref(content, "nixpkgs", "nixos-25.05")
+
+        expect(updated).to include('"github:NixOS/nixpkgs/nixos-25.05?host=github.corp.example.com"')
+      end
+    end
+
+    context "when input has no ref" do
+      let(:content) { fixture("flake.nix") }
+
+      it "returns nil when there is no ref to update" do
+        updated = described_class.update_input_ref(content, "flake-utils", "v2.0")
+        expect(updated).to be_nil
+      end
+    end
+
+    context "when input is not found" do
+      let(:content) { fixture("flake.nix") }
+
+      it "returns nil" do
+        updated = described_class.update_input_ref(content, "nonexistent", "v1.0")
+        expect(updated).to be_nil
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -153,6 +153,26 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
         expect(result).to be_nil
       end
     end
+
+    context "with similar input names" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+            inputs.my-nixpkgs.url = "github:myorg/my-nixpkgs/main";
+            outputs = { ... }: { };
+          }
+        NIX
+      end
+
+      it "does not match a longer name containing the input name" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.owner).to eq("NixOS")
+        expect(result.repo).to eq("nixpkgs")
+      end
+    end
   end
 
   describe ".update_input_ref" do

--- a/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
@@ -82,6 +82,24 @@ RSpec.describe Dependabot::Nix::UpdateChecker::VersionedBranchFinder do
 
       it { expect(finder.versioned_branch?).to be true }
     end
+
+    context "with nixos-24.11-small" do
+      let(:current_ref) { "nixos-24.11-small" }
+
+      it { expect(finder.versioned_branch?).to be true }
+    end
+
+    context "with nixpkgs-24.11-darwin" do
+      let(:current_ref) { "nixpkgs-24.11-darwin" }
+
+      it { expect(finder.versioned_branch?).to be true }
+    end
+
+    context "with nixos-unstable-small" do
+      let(:current_ref) { "nixos-unstable-small" }
+
+      it { expect(finder.versioned_branch?).to be false }
+    end
   end
 
   describe "#latest_versioned_branch" do
@@ -173,6 +191,25 @@ RSpec.describe Dependabot::Nix::UpdateChecker::VersionedBranchFinder do
 
       it "returns nil" do
         expect(finder.latest_versioned_branch).to be_nil
+      end
+    end
+
+    context "with a suffixed branch (nixos-24.11-small)" do
+      let(:current_ref) { "nixos-24.11-small" }
+
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-24.11-small", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "ccc333", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05-small", commit_sha: "ddd444", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05-aarch64", commit_sha: "eee555", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      it "only matches branches with the same suffix" do
+        result = finder.latest_versioned_branch
+        expect(result).to eq({ branch: "nixos-25.05-small", commit_sha: "ddd444" })
       end
     end
   end

--- a/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
@@ -1,0 +1,179 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/git_ref"
+require "dependabot/nix/update_checker/versioned_branch_finder"
+
+RSpec.describe Dependabot::Nix::UpdateChecker::VersionedBranchFinder do
+  subject(:finder) do
+    described_class.new(
+      current_ref: current_ref,
+      dependency: dependency,
+      credentials: credentials
+    )
+  end
+
+  let(:credentials) do
+    [Dependabot::Credential.new(
+      {
+        "type" => "git_source",
+        "host" => "github.com",
+        "username" => "x-access-token",
+        "password" => "token"
+      }
+    )]
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "nixpkgs",
+      version: "abc123",
+      requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        groups: [],
+        source: { type: "git", url: "https://github.com/NixOS/nixpkgs", branch: nil, ref: current_ref }
+      }],
+      package_manager: "nix"
+    )
+  end
+
+  let(:git_metadata_fetcher) { instance_double(Dependabot::GitMetadataFetcher) }
+
+  before do
+    allow(Dependabot::GitMetadataFetcher).to receive(:new).and_return(git_metadata_fetcher)
+  end
+
+  describe "#versioned_branch?" do
+    context "with a versioned branch like nixos-24.11" do
+      let(:current_ref) { "nixos-24.11" }
+
+      it { expect(finder.versioned_branch?).to be true }
+    end
+
+    context "with a versioned branch like release-24.11" do
+      let(:current_ref) { "release-24.11" }
+
+      it { expect(finder.versioned_branch?).to be true }
+    end
+
+    context "with a rolling branch like nixos-unstable" do
+      let(:current_ref) { "nixos-unstable" }
+
+      it { expect(finder.versioned_branch?).to be false }
+    end
+
+    context "with a plain branch like main" do
+      let(:current_ref) { "main" }
+
+      it { expect(finder.versioned_branch?).to be false }
+    end
+
+    context "with a semver tag like v0.5" do
+      let(:current_ref) { "v0.5" }
+
+      it { expect(finder.versioned_branch?).to be false }
+    end
+
+    context "with nixpkgs-24.11" do
+      let(:current_ref) { "nixpkgs-24.11" }
+
+      it { expect(finder.versioned_branch?).to be true }
+    end
+  end
+
+  describe "#latest_versioned_branch" do
+    let(:current_ref) { "nixos-24.11" }
+
+    let(:remote_branches) do
+      [
+        Dependabot::GitRef.new(name: "nixos-24.05", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+        Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head),
+        Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "ccc333", ref_type: Dependabot::RefType::Head),
+        Dependabot::GitRef.new(name: "nixos-unstable", commit_sha: "ddd444", ref_type: Dependabot::RefType::Head),
+        Dependabot::GitRef.new(name: "v1.0", commit_sha: "eee555", ref_type: Dependabot::RefType::Tag)
+      ]
+    end
+
+    before do
+      allow(git_metadata_fetcher).to receive(:refs_for_upload_pack).and_return(remote_branches)
+    end
+
+    it "returns the latest versioned branch" do
+      result = finder.latest_versioned_branch
+      expect(result).to eq({ branch: "nixos-25.05", commit_sha: "ccc333" })
+    end
+
+    context "when there is no newer branch" do
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-24.05", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      it "returns nil" do
+        expect(finder.latest_versioned_branch).to be_nil
+      end
+    end
+
+    context "with release-prefixed branches" do
+      let(:current_ref) { "release-24.11" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "home-manager",
+          version: "abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "git", url: "https://github.com/nix-community/home-manager",
+              branch: nil, ref: current_ref
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "release-24.05", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "release-24.11", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "release-25.05", commit_sha: "ccc333", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "main", commit_sha: "ddd444", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      it "returns the latest branch with matching prefix" do
+        result = finder.latest_versioned_branch
+        expect(result).to eq({ branch: "release-25.05", commit_sha: "ccc333" })
+      end
+    end
+
+    context "when multiple newer versions exist" do
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "ccc333", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.11", commit_sha: "fff666", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      it "returns the highest version" do
+        result = finder.latest_versioned_branch
+        expect(result).to eq({ branch: "nixos-25.11", commit_sha: "fff666" })
+      end
+    end
+
+    context "with a non-versioned branch" do
+      let(:current_ref) { "nixos-unstable" }
+
+      it "returns nil" do
+        expect(finder.latest_versioned_branch).to be_nil
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/versioned_branch_finder_spec.rb
@@ -212,5 +212,82 @@ RSpec.describe Dependabot::Nix::UpdateChecker::VersionedBranchFinder do
         expect(result).to eq({ branch: "nixos-25.05-small", commit_sha: "ddd444" })
       end
     end
+
+    context "with ignored_versions filtering branches" do
+      let(:current_ref) { "nixos-23.05" }
+
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-23.05", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-23.11", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-24.05", commit_sha: "ccc333", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "ddd444", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "eee555", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      let(:finder_with_ignored) do
+        described_class.new(
+          current_ref: current_ref,
+          dependency: dependency,
+          credentials: credentials,
+          ignored_versions: [">= 24"]
+        )
+      end
+
+      it "filters out branches matching the ignore requirement" do
+        result = finder_with_ignored.latest_versioned_branch
+        expect(result).to eq({ branch: "nixos-23.11", commit_sha: "bbb222" })
+      end
+    end
+
+    context "with ignored_versions filtering all newer branches" do
+      let(:current_ref) { "nixos-24.11" }
+
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      let(:finder_with_ignored) do
+        described_class.new(
+          current_ref: current_ref,
+          dependency: dependency,
+          credentials: credentials,
+          ignored_versions: [">= 25"]
+        )
+      end
+
+      it "returns nil when all newer branches are ignored" do
+        expect(finder_with_ignored.latest_versioned_branch).to be_nil
+      end
+    end
+
+    context "with malformed ignored_versions" do
+      let(:current_ref) { "nixos-24.11" }
+
+      let(:remote_branches) do
+        [
+          Dependabot::GitRef.new(name: "nixos-24.11", commit_sha: "aaa111", ref_type: Dependabot::RefType::Head),
+          Dependabot::GitRef.new(name: "nixos-25.05", commit_sha: "bbb222", ref_type: Dependabot::RefType::Head)
+        ]
+      end
+
+      let(:finder_with_ignored) do
+        described_class.new(
+          current_ref: current_ref,
+          dependency: dependency,
+          credentials: credentials,
+          ignored_versions: ["> abc123invalid"]
+        )
+      end
+
+      it "gracefully ignores malformed requirements and still finds branches" do
+        result = finder_with_ignored.latest_versioned_branch
+        expect(result).to eq({ branch: "nixos-25.05", commit_sha: "bbb222" })
+      end
+    end
   end
 end

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -208,8 +208,9 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
           .to receive(:new).and_return(branch_finder)
       end
 
-      it "returns nil when no newer branch exists" do
-        expect(checker.latest_version).to be_nil
+      it "falls back to commit tracking" do
+        allow(checker).to receive(:fetch_latest_version_for_commit).and_return("ddd444")
+        expect(checker.latest_version).to eq("ddd444")
       end
     end
   end

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
       it "returns updated requirements with the new tag" do
         updated = checker.updated_requirements
         expect(updated.first[:source][:ref]).to eq("v0.6.2")
-        expect(updated.first[:source][:branch]).to eq("v0.6.2")
+        expect(updated.first[:source][:branch]).to be_nil
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
       it "returns updated requirements with the new branch" do
         updated = checker.updated_requirements
         expect(updated.first[:source][:ref]).to eq("nixos-25.05")
-        expect(updated.first[:source][:branch]).to eq("nixos-25.05")
+        expect(updated.first[:source][:branch]).to be_nil
       end
     end
   end

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -62,6 +62,158 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
     end
   end
 
+  describe "#latest_version" do
+    context "with a tag-pinned input" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "devenv",
+          version: "abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/cachix/devenv", branch: nil, ref: "v0.5" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: true,
+          local_tag_for_latest_version: {
+            tag: "v0.6.2", commit_sha: "def456", tag_sha: "def456"
+          }
+        )
+      end
+
+      it "returns the commit SHA of the latest tag" do
+        expect(checker.latest_version).to eq("def456")
+      end
+
+      it "reports as updatable" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be true
+      end
+    end
+
+    context "with a tag-pinned input already at latest" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "devenv",
+          version: "def456",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/cachix/devenv", branch: nil, ref: "v0.6.2" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: true,
+          local_tag_for_latest_version: {
+            tag: "v0.6.2", commit_sha: "def456", tag_sha: "def456"
+          }
+        )
+      end
+
+      it "returns the current version" do
+        expect(checker.latest_version).to eq("def456")
+      end
+
+      it "reports as not updatable" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be false
+      end
+    end
+
+    context "with a versioned branch input" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/NixOS/nixpkgs", branch: nil, ref: "nixos-24.11" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: false
+        )
+
+        branch_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::VersionedBranchFinder,
+          versioned_branch?: true,
+          latest_versioned_branch: { branch: "nixos-25.05", commit_sha: "ccc333" }
+        )
+        allow(Dependabot::Nix::UpdateChecker::VersionedBranchFinder)
+          .to receive(:new).and_return(branch_finder)
+      end
+
+      it "returns the commit SHA of the latest branch" do
+        expect(checker.latest_version).to eq("ccc333")
+      end
+
+      it "reports as updatable" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be true
+      end
+    end
+
+    context "with a versioned branch already at latest" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "ccc333",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/NixOS/nixpkgs", branch: nil, ref: "nixos-25.05" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: false
+        )
+
+        branch_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::VersionedBranchFinder,
+          versioned_branch?: true,
+          latest_versioned_branch: nil
+        )
+        allow(Dependabot::Nix::UpdateChecker::VersionedBranchFinder)
+          .to receive(:new).and_return(branch_finder)
+      end
+
+      it "returns nil when no newer branch exists" do
+        expect(checker.latest_version).to be_nil
+      end
+    end
+  end
+
   describe "#updated_requirements" do
     context "with a branch-tracking input" do
       before do

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -7,7 +7,6 @@ require "dependabot/nix/update_checker"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::Nix::UpdateChecker do
-  let(:branch) { "nixos-unstable" }
   let(:url) { "https://github.com/NixOS/nixpkgs" }
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -17,7 +16,7 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         file: "flake.lock",
         requirement: nil,
         groups: [],
-        source: { type: "git", url: url, branch: branch, ref: branch }
+        source: { type: "git", url: url, branch: nil, ref: "nixos-unstable" }
       }],
       package_manager: "nix"
     )
@@ -40,6 +39,12 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }
 
+    before do
+      git_checker = instance_double(Dependabot::GitCommitChecker)
+      allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+      allow(git_checker).to receive_messages(git_dependency?: true, pinned_ref_looks_like_version?: false)
+    end
+
     context "when the dependency is outdated" do
       before { allow(checker).to receive(:latest_version).and_return("new_sha") }
 
@@ -58,8 +63,90 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
   end
 
   describe "#updated_requirements" do
-    it "returns the existing requirements unchanged" do
-      expect(checker.updated_requirements).to eq(dependency.requirements)
+    context "with a branch-tracking input" do
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(git_dependency?: true, pinned_ref_looks_like_version?: false)
+      end
+
+      it "returns the existing requirements unchanged" do
+        allow(checker).to receive(:latest_version).and_return("new_sha")
+        expect(checker.updated_requirements).to eq(dependency.requirements)
+      end
+    end
+
+    context "with a tag-pinned input" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "devenv",
+          version: "abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/cachix/devenv", branch: nil, ref: "v0.5" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: true,
+          local_tag_for_latest_version: {
+            tag: "v0.6.2", commit_sha: "def456", tag_sha: "def456"
+          }
+        )
+      end
+
+      it "returns updated requirements with the new tag" do
+        updated = checker.updated_requirements
+        expect(updated.first[:source][:ref]).to eq("v0.6.2")
+        expect(updated.first[:source][:branch]).to eq("v0.6.2")
+      end
+    end
+
+    context "with a versioned branch input" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/NixOS/nixpkgs", branch: nil, ref: "nixos-24.11" }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: false
+        )
+
+        branch_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::VersionedBranchFinder,
+          versioned_branch?: true,
+          latest_versioned_branch: { branch: "nixos-25.05", commit_sha: "ccc333" }
+        )
+        allow(Dependabot::Nix::UpdateChecker::VersionedBranchFinder)
+          .to receive(:new).and_return(branch_finder)
+      end
+
+      it "returns updated requirements with the new branch" do
+        updated = checker.updated_requirements
+        expect(updated.first[:source][:ref]).to eq("nixos-25.05")
+        expect(updated.first[:source][:branch]).to eq("nixos-25.05")
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Add support for updating pinned refs inside `flake.nix`, addressing #14670 and #14671. The initial nix implementation (#14498) only updated `flake.lock`; this extends it to rewrite URLs in `flake.nix` when the ref itself needs to change.

Two new update modes:
- Tag refs (e.g. `github:cachix/devenv/v0.5` → `v0.6.2`): enumerate tags via `GitCommitChecker`, pick the latest by semver.
- Versioned branches (e.g. `nixos-24.11` → `nixos-25.05`): scan remote branches matching the same `prefix-YY.MM` pattern, pick the highest.

Rolling branches like `nixos-unstable` are unaffected and stay on the existing commit-tracking path.

### Anything you want to highlight for special attention from reviewers?

- `FlakeNixParser` uses regex to find input URLs in `flake.nix`, tied to the input name (not a blind content search). It handles `github:`, `gitlab:`, `sourcehut:` shorthand schemes. Generic `git+https://` URLs are not rewritten since they use a different ref format.
- `FileParser` now sets `branch: nil` instead of `branch: ref`. This is needed so `GitCommitChecker.pinned?` can tell tags from branches. Previously `branch == ref` always returned false from `pinned?`.
- `VersionedBranchFinder` only matches `YY.MM` suffixes with a separator before them. It won't match `nixos-unstable` or bare semver like `v1.0`.
- Non-semver tags are skipped for now. We can relax this later based on user feedback.
- Smoke tests: dependabot/smoke-tests#452

### How will you know you've accomplished your goal?

- All 87 unit tests pass (12 new).
- Rubocop and Sorbet pass clean.
- Smoke tests pass for all three scenarios: commit tracking, tag update, versioned branch update.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.