### PR TITLE
fix(github_actions): Use tagged release commit for SHA-pinned refs without local tag

### DIFF
--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -82,10 +82,7 @@ module Dependabot
           end
 
           if git_commit_checker.pinned_ref_looks_like_commit_sha? && latest_version_tag
-            latest_version = latest_version_tag&.fetch(:version)
-            return latest_commit_for_pinned_ref unless git_commit_checker.local_tag_for_pinned_sha
-
-            return latest_version
+            return latest_version_tag.fetch(:version)
           end
 
           # If the dependency is pinned to a tag that doesn't look like a
@@ -206,54 +203,6 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::Version)) }
         def current_version
           @current_version ||= T.let(dependency.numeric_version, T.nilable(Dependabot::Version))
-        end
-
-        sig { returns(T.nilable(String)) }
-        def latest_commit_for_pinned_ref
-          @latest_commit_for_pinned_ref ||= T.let(
-            begin
-              head_commit_for_ref_sha = git_commit_checker.head_commit_for_pinned_ref
-              if head_commit_for_ref_sha
-                head_commit_for_ref_sha
-              else
-                url = git_commit_checker.dependency_source_details&.fetch(:url)
-                source = T.must(Source.from_url(url))
-
-                SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-                  repo_contents_path = File.join(temp_dir, File.basename(source.repo))
-
-                  SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
-
-                  Dir.chdir(repo_contents_path) do
-                    ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
-                    git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
-                  end
-                end
-              end
-            end,
-            T.nilable(String)
-          )
-        end
-
-        sig { params(sha: String).returns(T.nilable(String)) }
-        def find_container_branch(sha)
-          branches_including_ref = SharedHelpers.run_shell_command(
-            "git branch --remotes --contains #{sha}",
-            fingerprint: "git branch --remotes --contains <sha>"
-          ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
-          return if branches_including_ref.empty?
-
-          current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }
-
-          if current_branch
-            current_branch.delete_prefix("HEAD -> ")
-          elsif branches_including_ref.size > 1
-            # If there are multiple non default branches including the pinned SHA,
-            # then it's unclear how we should proceed
-            raise "Multiple ambiguous branches (#{branches_including_ref.join(', ')}) include #{sha}!"
-          else
-            branches_including_ref.first
-          end
         end
 
         sig do

--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -65,7 +65,6 @@ module Dependabot
         sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
         attr_reader :security_advisories
 
-        # rubocop:disable Metrics/PerceivedComplexity
         sig { returns(T.nilable(T.any(Dependabot::Version, String))) }
         def release_list_for_git_dependency
           # TODO: Support Docker sources
@@ -82,14 +81,13 @@ module Dependabot
           end
 
           if git_commit_checker.pinned_ref_looks_like_commit_sha? && latest_version_tag
-            return latest_version_tag.fetch(:version)
+            return T.must(latest_version_tag).fetch(:version)
           end
 
           # If the dependency is pinned to a tag that doesn't look like a
           # version or a commit SHA then there's nothing we can do.
           nil
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
         def lowest_security_fix_version_tag

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -112,33 +112,6 @@ module Dependabot
         raise NotImplementedError
       end
 
-      sig { returns(T.nilable(String)) }
-      def latest_commit_for_pinned_ref
-        @latest_commit_for_pinned_ref ||= T.let(
-          begin
-            head_commit_for_ref_sha = git_commit_checker.head_commit_for_pinned_ref
-            if head_commit_for_ref_sha
-              head_commit_for_ref_sha
-            else
-              url = git_commit_checker.dependency_source_details&.fetch(:url)
-              source = T.must(Source.from_url(url))
-
-              SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-                repo_contents_path = File.join(temp_dir, File.basename(source.repo))
-
-                SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
-
-                Dir.chdir(repo_contents_path) do
-                  ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
-                  git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
-                end
-              end
-            end
-          end,
-          T.nilable(String)
-        )
-      end
-
       sig { params(source: T.nilable(T::Hash[Symbol, String])).returns(T.nilable(String)) }
       def updated_ref(source)
         # TODO: Support Docker sources
@@ -158,7 +131,7 @@ module Dependabot
 
         # Return the pinned git commit if one is available
         if source_git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           (new_commit_sha = latest_commit_sha(source_git_commit_checker))
+           (new_commit_sha = latest_commit_sha)
           return new_commit_sha
         end
 
@@ -166,16 +139,12 @@ module Dependabot
         nil
       end
 
-      sig { params(source_checker: Dependabot::GitCommitChecker).returns(T.nilable(String)) }
-      def latest_commit_sha(source_checker)
+      sig { returns(T.nilable(String)) }
+      def latest_commit_sha
         new_tag = T.must(latest_version_finder).latest_version_tag
         return unless new_tag
 
-        if source_checker.local_tag_for_pinned_sha
-          new_tag.fetch(:commit_sha)
-        else
-          latest_commit_for_pinned_ref
-        end
+        new_tag.fetch(:commit_sha)
       end
 
       sig { returns(Dependabot::GitCommitChecker) }
@@ -193,26 +162,6 @@ module Dependabot
           consider_version_branches_pinned: false,
           dependency_source_details: nil
         )
-      end
-
-      sig { params(sha: String).returns(T.nilable(String)) }
-      def find_container_branch(sha)
-        branches_including_ref = SharedHelpers.run_shell_command(
-          "git branch --remotes --contains #{sha}",
-          fingerprint: "git branch --remotes --contains <sha>"
-        ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
-        return if branches_including_ref.empty?
-
-        current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }
-
-        if current_branch
-          current_branch.delete_prefix("HEAD -> ")
-        elsif branches_including_ref.size > 1
-          # If there are multiple non default branches including the pinned SHA, then it's unclear how we should proceed
-          raise "Multiple ambiguous branches (#{branches_including_ref.join(', ')}) include #{sha}!"
-        else
-          branches_including_ref.first
-        end
       end
     end
   end

--- a/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe Dependabot::GithubActions::Package::PackageDetailsFetcher do
       let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
       let(:reference) { tip_of_master }
 
-      it "considers the commit itself as the latest version" do
-        expect(latest_version).to eq(tip_of_master)
+      it "returns the latest tagged version" do
+        expect(latest_version).to eq(Dependabot::GithubActions::Version.new("1.1"))
       end
     end
 
@@ -176,36 +176,37 @@ RSpec.describe Dependabot::GithubActions::Package::PackageDetailsFetcher do
 
       let(:latest_commit_in_main) { "9e487f29582587eeb4837c0552c886bb0644b6b9" }
       let(:latest_commit_in_devel) { "c7563454dd4fbe0ea69095188860a62a19658a04" }
+      let(:latest_tagged_version) { Dependabot::GithubActions::Version.new("1.5.1") }
 
       context "when pinned to an up to date commit in the default branch" do
         let(:reference) { latest_commit_in_main }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_main)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
       context "when pinned to an out of date commit in the default branch" do
         let(:reference) { "f4b9c90516ad3bdcfdc6f4fcf8ba937d0bd40465" }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_main)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
       context "when pinned to an up to date commit in a non default branch" do
         let(:reference) { latest_commit_in_devel }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_devel)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
       context "when pinned to an out of date commit in a non default branch" do
         let(:reference) { "96e7dec17bbeed08477b9edab6c3a573614b829d" }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_devel)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
     end

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe namespace::LatestVersionFinder do
       let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
       let(:reference) { tip_of_master }
 
-      it "considers the commit itself as the latest version" do
-        expect(latest_release_version).to eq(tip_of_master)
+      it "returns the latest tagged version" do
+        expect(latest_release_version).to eq(Gem::Version.new("1.1.0"))
       end
     end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
         let(:reference) { tip_of_master }
 
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
       end
 
       context "when a git commit SHA pointing to the tip of a branch named like a version" do
@@ -376,8 +376,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
       let(:reference) { tip_of_master }
 
-      it "considers the commit itself as the latest version" do
-        expect(latest_version).to eq(tip_of_master)
+      it "returns the latest tagged version" do
+        expect(latest_version).to eq(Gem::Version.new("1.1.0"))
       end
     end
 
@@ -483,6 +483,11 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
       let(:latest_commit_in_main) { "9e487f29582587eeb4837c0552c886bb0644b6b9" }
       let(:latest_commit_in_devel) { "c7563454dd4fbe0ea69095188860a62a19658a04" }
+      let(:latest_tagged_version) { Dependabot::GithubActions::Version.new("1.5.1") }
+      # With cooldown enabled (90 days from 2022-09-07), recent tags are filtered out.
+      # The cooldown filter walks tags in descending order and returns the first
+      # version whose release date falls outside the cooldown window.
+      let(:latest_tagged_version_outside_cooldown) { Dependabot::GithubActions::Version.new("1.4.2") }
 
       before do
         allow(Time).to receive(:now).and_return(Time.parse("2022-09-07 23:33:35 +0100"))
@@ -491,8 +496,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       context "when pinned to an up to date commit in the default branch" do
         let(:reference) { latest_commit_in_main }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_main)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
@@ -502,22 +507,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
-        before do
-          # Stub commit_metadata_details to return a date outside cooldown
-          finder = checker.send(:latest_version_finder)
-          allow(finder).to receive(:commit_metadata_details).and_return("2022-06-01T00:00:00+00:00")
-        end
-
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_main)
+        it "returns the latest tagged version outside cooldown" do
+          expect(latest_version).to eq(latest_tagged_version_outside_cooldown)
         end
       end
 
       context "when pinned to an out of date commit in the default branch" do
         let(:reference) { "f4b9c90516ad3bdcfdc6f4fcf8ba937d0bd40465" }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_main)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
@@ -527,22 +526,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
-        before do
-          # Stub commit_metadata_details to return a recent date (within cooldown)
-          finder = checker.send(:latest_version_finder)
-          allow(finder).to receive(:commit_metadata_details).and_return("2022-09-05T00:00:00+00:00")
-        end
-
-        it "returns the current version" do
-          expect(latest_version).to eq("f4b9c90516ad3bdcfdc6f4fcf8ba937d0bd40465")
+        it "returns the latest tagged version outside cooldown" do
+          expect(latest_version).to eq(latest_tagged_version_outside_cooldown)
         end
       end
 
       context "when pinned to an up to date commit in a non default branch" do
         let(:reference) { latest_commit_in_devel }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_devel)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
@@ -552,22 +545,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
-        before do
-          # Stub commit_metadata_details to return a date outside cooldown
-          finder = checker.send(:latest_version_finder)
-          allow(finder).to receive(:commit_metadata_details).and_return("2022-06-01T00:00:00+00:00")
-        end
-
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_devel)
+        it "returns the latest tagged version outside cooldown" do
+          expect(latest_version).to eq(latest_tagged_version_outside_cooldown)
         end
       end
 
       context "when pinned to an out of date commit in a non default branch" do
         let(:reference) { "96e7dec17bbeed08477b9edab6c3a573614b829d" }
 
-        it "returns the expected value" do
-          expect(latest_version).to eq(latest_commit_in_devel)
+        it "returns the latest tagged version" do
+          expect(latest_version).to eq(latest_tagged_version)
         end
       end
 
@@ -577,14 +564,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
         end
 
-        before do
-          # Stub commit_metadata_details to return a recent date (within cooldown)
-          finder = checker.send(:latest_version_finder)
-          allow(finder).to receive(:commit_metadata_details).and_return("2022-09-05T00:00:00+00:00")
-        end
-
-        it "returns the expected value" do
-          expect(latest_version).to eq("96e7dec17bbeed08477b9edab6c3a573614b829d")
+        it "returns the latest tagged version outside cooldown" do
+          expect(latest_version).to eq(latest_tagged_version_outside_cooldown)
         end
       end
     end
@@ -592,73 +573,27 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     context "when a git commit SHA not pointing to the tip of a branch" do
       let(:reference) { "1c24df3" }
 
-      before do
-        checker.instance_variable_set(:@git_commit_checker, git_commit_checker)
-        allow(git_commit_checker).to receive_messages(
-          branch_or_ref_in_release?: false,
-          head_commit_for_current_branch: reference
-        )
-
-        allow(Dir).to receive(:chdir).and_yield
-
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(%r{git clone --no-recurse-submodules https://github\.com/actions/setup-node},
-                any_args)
-          .and_return("")
-      end
-
       context "when it's in the current (default) branch" do
-        before do
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with("git branch --remotes --contains #{reference}",
-                  any_args)
-            .and_return("  origin/HEAD -> origin/master\n  origin/master")
-        end
-
         it "can update to the latest version" do
-          expect(latest_version).to eq(tip_of_master)
+          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
         end
       end
 
       context "when it's on a different branch" do
-        let(:tip_of_releases_v1) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
-
-        before do
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with("git branch --remotes --contains #{reference}",
-                  any_args)
-            .and_return("  origin/releases/v1\n")
-        end
-
         it "can update to the latest version" do
-          expect(latest_version).to eq(tip_of_releases_v1)
+          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
         end
       end
 
       context "when multiple branches include it and the current (default) branch among them" do
-        before do
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with("git branch --remotes --contains #{reference}",
-                  any_args)
-            .and_return("  origin/HEAD -> origin/master\n  origin/master\n  origin/v1.1\n")
-        end
-
         it "can update to the latest version" do
-          expect(latest_version).to eq(tip_of_master)
+          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
         end
       end
 
       context "when multiple branches include it and the current (default) branch NOT among them" do
-        before do
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with("git branch --remotes --contains #{reference}",
-                  any_args)
-            .and_return("  origin/3.3-stable\n  origin/production\n")
-        end
-
-        it "raises an error" do
-          expect { latest_version }
-            .to raise_error("Multiple ambiguous branches (3.3-stable, production) include #{reference}!")
+        it "can update to the latest version" do
+          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
         end
       end
     end
@@ -748,6 +683,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     context "when a git commit SHA pointing to the tip of a branch not named like a version" do
       let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
       let(:reference) { tip_of_master }
+      let(:v1_1_0_commit_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
 
       context "when the specified reference is not in the latest release" do
         let(:expected_requirements) do
@@ -758,7 +694,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             source: {
               type: "git",
               url: "https://github.com/actions/setup-node",
-              ref: tip_of_master,
+              ref: v1_1_0_commit_sha,
               branch: nil
             },
             metadata: { declaration_string: "actions/setup-node@master" }
@@ -838,6 +774,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
         context "when the previous version is a short SHA" do
           let(:reference) { "5273d0df" }
+          let(:tip_of_v10) { "34684effe7451ea95f60397e56ba34c06daced68" }
           let(:expected_requirements) do
             [{
               requirement: nil,
@@ -846,7 +783,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
               source: {
                 type: "git",
                 url: "https://github.com/actions/setup-node",
-                ref: "5273d0df",
+                ref: tip_of_v10,
                 branch: nil
               },
               metadata: { declaration_string: "actions/setup-node@master" }
@@ -1308,6 +1245,38 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
       it "updates tag ref to latest version and SHA refs to latest version SHA" do
         expect(updated_requirements).to eq(expected_requirements)
+      end
+    end
+
+    context "when SHA-pinned ref has no local tag but version tags exist" do
+      let(:dependency_name) { "actions/setup-node" }
+      let(:upload_pack_fixture) { "setup-node" }
+      let(:reference) { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "actions/setup-node",
+          version: nil,
+          package_manager: "github_actions",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow.yml",
+            metadata: { declaration_string: "actions/setup-node@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/setup-node",
+              ref: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              branch: nil
+            }
+          }]
+        )
+      end
+
+      let(:expected_tagged_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+
+      it "updates to the tagged release commit SHA, not the branch HEAD" do
+        reqs = checker.updated_requirements
+        expect(reqs.first[:source][:ref]).to eq(expected_tagged_sha)
       end
     end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -573,28 +573,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     context "when a git commit SHA not pointing to the tip of a branch" do
       let(:reference) { "1c24df3" }
 
-      context "when it's in the current (default) branch" do
-        it "can update to the latest version" do
-          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
-        end
-      end
-
-      context "when it's on a different branch" do
-        it "can update to the latest version" do
-          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
-        end
-      end
-
-      context "when multiple branches include it and the current (default) branch among them" do
-        it "can update to the latest version" do
-          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
-        end
-      end
-
-      context "when multiple branches include it and the current (default) branch NOT among them" do
-        it "can update to the latest version" do
-          expect(latest_version).to eq(Gem::Version.new("1.1.0"))
-        end
+      it "returns the latest tagged version regardless of which branch contains the SHA" do
+        expect(latest_version).to eq(Gem::Version.new("1.1.0"))
       end
     end
   end


### PR DESCRIPTION
## Summary

When a SHA-pinned GitHub Action ref has no matching version tag (`local_tag_for_pinned_sha` returns nil), `latest_commit_sha` previously fell through to `latest_commit_for_pinned_ref` which resolved to the HEAD of the containing branch — an untagged commit. This caused:
- Updates pointing at untagged commits (often on `main`) instead of tagged release commits (often on `releases/vN`)
- Version comments left stale and misleading (e.g., `# v4.31.9` when the SHA is actually an unrelated `main` branch HEAD)
- A self-perpetuating cycle: once an untagged SHA enters a workflow, every subsequent update takes the same wrong path

This is especially common with action repos using a release branch workflow like `github/codeql-action` (tags on `releases/v4`, development on `main`).

## Changes

- **`update_checker.rb`**: Simplified `latest_commit_sha` to always use `new_tag.fetch(:commit_sha)` when a latest version tag exists. Removed the now-unused `source_checker` parameter, the `local_tag_for_pinned_sha` gate, and the dead `latest_commit_for_pinned_ref` / `find_container_branch` methods.
- **`package_details_fetcher.rb`**: Same fix — always return `T.must(latest_version_tag).fetch(:version)` for SHA-pinned refs. Removed dead methods and the now-unnecessary `rubocop:disable Metrics/PerceivedComplexity` directive.
- **`update_checker_spec.rb`**: Added new test for the bug scenario. Consolidated the four identical "git commit SHA not pointing to tip of branch" sub-contexts (default branch, different branch, multiple branches with/without default) into a single test — since `find_container_branch` was removed, branch membership no longer affects behavior, and RuboCop flagged the repeated bodies (`RSpec/RepeatedExampleGroupBody`). Updated remaining tests to expect tagged versions instead of branch HEAD commits.
- **`package_details_fetcher_spec.rb`**: Updated "realworld repository" and "tip of master" tests to expect tagged versions instead of branch HEAD commits.
- **`latest_version_finder_spec.rb`**: Updated SHA-at-branch-tip test to expect tagged version instead of commit SHA.

## Root Cause

```ruby
# Before (buggy):
def latest_commit_sha(source_checker)
  new_tag = T.must(latest_version_finder).latest_version_tag
  return unless new_tag
  if source_checker.local_tag_for_pinned_sha
    new_tag.fetch(:commit_sha)       # Only when current SHA has a tag
  else
    latest_commit_for_pinned_ref     # BUG: returns untagged branch HEAD
  end
end

# After (fixed):
def latest_commit_sha
  new_tag = T.must(latest_version_finder).latest_version_tag
  return unless new_tag
  new_tag.fetch(:commit_sha)         # Always use the tagged release commit
end
```

The `else` branch was only reachable when `new_tag` already existed (we return nil before it), making it contradictory to ignore the resolved tag and return a branch HEAD instead.

## Test plan

- [x] New test: SHA-pinned ref without local tag resolves to tagged release commit SHA
- [x] Updated existing tests for new behavior (tagged version instead of branch HEAD)
- [x] Consolidated repeated RSpec context bodies to fix `RSpec/RepeatedExampleGroupBody` lint
- [x] Wrapped nilable `latest_version_tag` with `T.must()` for Sorbet compliance
- [x] Removed stale `rubocop:disable Metrics/PerceivedComplexity` directive
- [x] `update_checker_spec.rb`: 83 examples, 0 failures
- [x] `package_details_fetcher_spec.rb`: 21 examples, 0 failures
- [x] `latest_version_finder_spec.rb`: passing
- [ ] Manual verification with `dependabot/cli` against a repo using `github/codeql-action` SHA pins

Fixes https://github.com/dependabot/dependabot-core/issues/14716
Related: #7912, #8011, #13466, #14685

🤖 Generated with [Claude Code](https://claude.com/claude-code)