### PR TITLE
test: Verify Poetry v2 lock file groups/markers handling

### DIFF
--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -180,6 +180,45 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
         end
       end
 
+      describe "Poetry v2 lock file groups and markers" do
+        it "includes packages with groups field" do
+          # appdirs has groups = ["dev"] in the v2 lock file
+          appdirs = dependencies.find { |d| d.name == "appdirs" }
+          expect(appdirs).to be_a(Dependabot::Dependency)
+          expect(appdirs.version).to eq("1.4.3")
+        end
+
+        it "includes packages belonging to multiple groups" do
+          # certifi has groups = ["main", "dev"] in the v2 lock file
+          certifi = dependencies.find { |d| d.name == "certifi" }
+          expect(certifi).to be_a(Dependabot::Dependency)
+          expect(certifi.version).to eq("2018.4.16")
+        end
+
+        it "includes packages with markers field" do
+          # colorama has markers = 'sys_platform == "win32"' in the v2 lock file
+          colorama = dependencies.find { |d| d.name == "colorama" }
+          expect(colorama).to be_a(Dependabot::Dependency)
+          expect(colorama.version).to eq("0.3.9")
+        end
+
+        it "preserves groups and markers in parsed TOML" do
+          parsed = TomlRB.parse(poetry_lock_body)
+          packages = parsed.fetch("package", [])
+
+          colorama_pkg = packages.find { |p| p["name"] == "colorama" }
+          expect(colorama_pkg["groups"]).to eq(["dev"])
+          expect(colorama_pkg["markers"]).to eq("sys_platform == \"win32\"")
+
+          certifi_pkg = packages.find { |p| p["name"] == "certifi" }
+          expect(certifi_pkg["groups"]).to eq(%w(main dev))
+          expect(certifi_pkg).not_to have_key("markers")
+
+          appdirs_pkg = packages.find { |p| p["name"] == "appdirs" }
+          expect(appdirs_pkg["groups"]).to eq(["dev"])
+        end
+      end
+
       context "with a path dependency" do
         subject(:dependency_names) { dependencies.map(&:name) }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Verify that Poetry v2 lock file `groups` and `markers` fields are correctly handled during dependency parsing, as part of Poetry v2 support work.

Poetry v2 lock files include new metadata per package:
- `groups` (array, e.g. `["main", "dev"]`) — replaces the deprecated v1 `category` field
- `markers` (string, e.g. `sys_platform == "win32"`) — environment markers

**Investigation confirmed no production code changes are needed** — the existing architecture already handles these fields correctly:
- `TomlRB.parse()` is a generic TOML parser that passes through arbitrary keys
- Lock file updates shell out to `poetry update --lock`, so Poetry CLI regenerates the lock natively
- Production dependency detection uses `poetry show --only main`, not lock file fields

This PR adds explicit test coverage to formalize and document that verification.

### Anything you want to highlight for special attention from reviewers?

The existing `poetry.lock` test fixture (`python/spec/fixtures/poetry_locks/poetry.lock`) was already in Poetry v2 format (generated by Poetry 2.1.1) with `groups` and `markers` fields present. The new tests make the implicit coverage explicit by asserting:

1. Packages with `groups` field are parsed and included as dependencies
2. Packages belonging to multiple groups (e.g. `["main", "dev"]`) are handled correctly
3. Packages with `markers` field are parsed without errors
4. `TomlRB.parse()` preserves `groups` and `markers` in the parsed output hash

No production code touches lock file fields beyond `name`, `version`, `source.*`, and `dependencies` — so new fields are harmlessly ignored.

### How will you know you've accomplished your goal?

All 48 tests pass (44 existing + 4 new):

```
bin/test python spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
# 48 examples, 0 failures
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.