### PR TITLE
Keep pinned git references

### DIFF
--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -33,6 +33,9 @@ module Dependabot
           prefix = T.must(prefix_match[:prefix])
           rest = T.must(entry[prefix.length..])
 
+          # Skip direct references (e.g. "pkg @ git+https://...") — already pinned to a URL
+          return entry if rest.match?(/\A\s*@\s/)
+
           # Extract the environment marker ("; ..." suffix) if present
           marker_match = rest.match(/(\s*;.*)/)
           marker = marker_match ? marker_match[1] : ""

--- a/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
@@ -263,6 +263,28 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
       end
     end
 
+    context "with PEP 621 dependencies containing direct references" do
+      let(:dependencies) { [] }
+      let(:pyproject_fixture_name) { "pep621_hybrid_direct_ref.toml" }
+      let(:poetry_lock_fixture_name) { "caret_version.lock" }
+
+      it "preserves direct references unchanged" do
+        result = freeze_top_level_dependencies_except
+        parsed = TomlRB.parse(result)
+        project_deps = parsed.dig("project", "dependencies")
+        git_dep = project_deps.find { |d| d.include?("ffmpeg-python") }
+        expect(git_dep).to eq("ffmpeg-python @ git+https://github.com/example/ffmpeg-python")
+      end
+
+      it "still freezes normal version-specifier dependencies" do
+        result = freeze_top_level_dependencies_except
+        parsed = TomlRB.parse(result)
+        project_deps = parsed.dig("project", "dependencies")
+        requests_dep = project_deps.find { |d| d.start_with?("requests") }
+        expect(requests_dep).to eq("requests==1.2.3")
+      end
+    end
+
     context "with PEP 621 dependencies containing environment markers" do
       let(:dependencies) { [] }
       let(:pyproject_fixture_name) { "pep621_hybrid_with_markers.toml" }

--- a/python/spec/fixtures/pyproject_files/pep621_hybrid_direct_ref.toml
+++ b/python/spec/fixtures/pyproject_files/pep621_hybrid_direct_ref.toml
@@ -1,0 +1,21 @@
+[project]
+name = "test"
+version = "0.1.0"
+description = ""
+requires-python = ">=3.9"
+
+dependencies = [
+    "requests>=2.13.0",
+    "ffmpeg-python @ git+https://github.com/example/ffmpeg-python",
+]
+
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+requests = { version = "^2.13", source = "private-source" }
+
+[[tool.poetry.source]]
+name = "private-source"
+url = "https://private.example.com/simple"
+priority = "supplemental"


### PR DESCRIPTION
### What are you trying to accomplish?

pin_pep508_entry in pyproject_preparer.rb does not handle PEP 508 direct references,  it silently drops the @ git+ URL and replaces the dep with ==versio.

fixes: https://github.com/dependabot/dependabot-core/issues/14728

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

No longer drop `@ git+https://...`

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.