### PR TITLE
Support latest Python patch versions in the python and uv ecosystems, use uv 0.11.6

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,14 +3,14 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.2
-ARG PY_3_13=3.13.11
-ARG PY_3_12=3.12.12
-ARG PY_3_11=3.11.14
-ARG PY_3_10=3.10.19
-ARG PY_3_9=3.9.24
+ARG PY_3_14=3.14.4
+ARG PY_3_13=3.13.13
+ARG PY_3_12=3.12.13
+ARG PY_3_11=3.11.15
+ARG PY_3_10=3.10.20
+ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.16
+ARG PYENV_VERSION=v2.6.27
 
 FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
 ARG PY_3_14

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -16,12 +16,12 @@ module Dependabot
       # ARG PY_3_13=3.13.2
       # Note: uv ecosystem aliases this class, so updates here apply to both ecosystems.
       PRE_INSTALLED_PYTHON_VERSIONS_RAW = %w(
-        3.14.2
-        3.13.11
-        3.12.12
-        3.11.14
-        3.10.19
-        3.9.24
+        3.14.4
+        3.13.13
+        3.12.13
+        3.11.15
+        3.10.20
+        3.9.25
       ).freeze
 
       PRE_INSTALLED_PYTHON_VERSIONS = T.let(

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -12,7 +12,7 @@ ARG PY_3_9=3.9.24
 ARG PYENV_VERSION=v2.6.16
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
-FROM ghcr.io/astral-sh/uv:0.10.9 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.6 AS uv
 
 FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
 ARG PY_3_14

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -2,14 +2,14 @@
 # This list must match the versions specified in
 # uv/lib/dependabot/uv/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.2
-ARG PY_3_13=3.13.11
-ARG PY_3_12=3.12.12
-ARG PY_3_11=3.11.14
-ARG PY_3_10=3.10.19
-ARG PY_3_9=3.9.24
+ARG PY_3_14=3.14.4
+ARG PY_3_13=3.13.13
+ARG PY_3_12=3.12.13
+ARG PY_3_11=3.11.15
+ARG PY_3_10=3.10.20
+ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.16
+ARG PYENV_VERSION=v2.6.27
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
 FROM ghcr.io/astral-sh/uv:0.11.6 AS uv

--- a/uv/helpers/requirements.txt
+++ b/uv/helpers/requirements.txt
@@ -7,7 +7,7 @@ plette==2.1.0
 poetry==1.8.5
 # TODO: Replace 3p package `tomli` with 3.11's new stdlib `tomllib` once we drop support for Python 3.10.
 tomli==2.0.1
-uv==0.10.9
+uv==0.11.6
 
 # Some dependencies will only install if Cython is present
 Cython==3.0.10


### PR DESCRIPTION
### What are you trying to accomplish?

The ability to target the latest patch versions of Python. This includes:

- Upgrade uv from 0.10.9 to 0.11.6
- Upgrade to pyenv from 2.6.16 to 2.6.27

I originally thought that I just needed the uv upgrade, but I need both since pyenv is how Dependabot internally manages the available Python version (it seems).

### Anything you want to highlight for special attention from reviewers?

Similar to #14381 but also includes a pyenv upgrade.

### How will you know you've accomplished your goal?

If newer patch versions of Python are supported

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
