### PR TITLE
Add JSON Kubernetes manifest support for container image updates

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -18,13 +18,13 @@ module Dependabot
 
       sig { override.returns(String) }
       def self.required_files_message
-        "Repo must contain a Dockerfile, Containerfile, or Kubernetes YAML files."
+        "Repo must contain a Dockerfile, Containerfile, or Kubernetes manifest files (YAML/JSON)."
       end
 
       sig { override.params(filenames: T::Array[String]).returns(T::Boolean) }
       def self.required_files_in?(filenames)
         filenames.any? { |f| f.match?(DOCKER_REGEXP) } or
-          filenames.any? { |f| f.match?(YAML_REGEXP) }
+          filenames.any? { |f| f.match?(MANIFEST_REGEXP) }
       end
 
       sig { override.returns(T::Array[DependencyFile]) }

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "json"
 require "dependabot/shared/shared_file_parser"
 require "dependabot/docker/package_manager"
 
@@ -10,6 +11,8 @@ module Dependabot
       extend T::Sig
 
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
+      JSON_REGEXP = /^[^\.].*\.json$/i
+      MANIFEST_REGEXP = /^[^\.].*\.(ya?ml|json)$/i
       FROM = /FROM/i
       PLATFORM = /--platform\=(?<platform>\S+)/
       TAG_NO_PREFIX = /(?<tag>[\w][\w.-]{0,127})/
@@ -73,22 +76,26 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def dockerfiles
-        # The Docker file fetcher fetches Dockerfiles and yaml files. Reject yaml files.
-        dependency_files.reject { |f| f.type == "file" && f.name.match?(YAML_REGEXP) }
+        # The Docker file fetcher fetches Dockerfiles, YAML, and JSON files. Reject manifest files.
+        dependency_files.reject { |f| f.type == "file" && f.name.match?(MANIFEST_REGEXP) }
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def manifest_files
-        dependency_files.select { |f| f.type == "file" && f.name.match?(YAML_REGEXP) }
+        dependency_files.select { |f| f.type == "file" && f.name.match?(MANIFEST_REGEXP) }
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(DependencySet) }
       def workfile_file_dependencies(file)
         dependency_set = DependencySet.new
 
-        resources = T.must(file.content).split(/^---$/).map(&:strip).reject(&:empty?)
-        resources.flat_map do |resource|
-          json = YAML.safe_load(resource, aliases: true)
+        parsed_resources = if file.name.match?(JSON_REGEXP)
+                             parse_json_resources(file)
+                           else
+                             parse_yaml_resources(file)
+                           end
+
+        parsed_resources.flat_map do |json|
           images = deep_fetch_images(json).uniq
 
           images.each do |string|
@@ -107,8 +114,29 @@ module Dependabot
 
         dependency_set
       rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias => e
-        Dependabot.logger.error("Failed to parse file #{file.path}: #{e.message}")
+        Dependabot.logger.error("Failed to parse YAML file #{file.path}: #{e.message}")
         raise Dependabot::DependencyFileNotParseable.new(file.path, e.message)
+      rescue JSON::ParserError => e
+        Dependabot.logger.error("Failed to parse JSON file #{file.path}: #{e.message}")
+        raise Dependabot::DependencyFileNotParseable.new(file.path, e.message)
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[T.untyped]) }
+      def parse_yaml_resources(file)
+        T.must(file.content).split(/^---$/).map(&:strip).reject(&:empty?).map do |resource|
+          YAML.safe_load(resource, aliases: true)
+        end
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[T.untyped]) }
+      def parse_json_resources(file)
+        json = JSON.parse(T.must(file.content))
+        # A JSON Kubernetes manifest may contain a List with items, or be a single resource
+        if json.is_a?(Hash) && json["kind"]&.end_with?("List") && json["items"].is_a?(Array)
+          json["items"]
+        else
+          [json]
+        end
       end
 
       sig { params(json_obj: T.anything).returns(T::Array[String]) }

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -12,6 +12,7 @@ module Dependabot
       extend T::Sig
 
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
+      MANIFEST_REGEXP = /^[^\.].*\.(ya?ml|json)$/i
       FROM_REGEX = /FROM(\s+--platform\=\S+)?/i
 
       sig { override.returns(String) }
@@ -21,7 +22,7 @@ module Dependabot
 
       sig { override.returns(Regexp) }
       def yaml_file_pattern
-        YAML_REGEXP
+        MANIFEST_REGEXP
       end
 
       sig { override.returns(Regexp) }

--- a/docker/lib/dependabot/shared/shared_file_fetcher.rb
+++ b/docker/lib/dependabot/shared/shared_file_fetcher.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "json"
 require "sorbet-runtime"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
@@ -15,6 +16,8 @@ module Dependabot
       abstract!
 
       YAML_REGEXP = /^[^\.].*\.ya?ml$/i
+      JSON_REGEXP = /^[^\.].*\.json$/i
+      MANIFEST_REGEXP = /^[^\.].*\.(ya?ml|json)$/i
 
       sig { abstract.returns(Regexp) }
       def self.filename_regex; end
@@ -42,8 +45,24 @@ module Dependabot
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
+      def correctly_encoded_jsonfiles
+        candidate_files = jsonfiles.select { |f| f.content&.valid_encoding? }
+        candidate_files.select do |f|
+          content = JSON.parse(T.must(f.content))
+          likely_kubernetes_resource?(content)
+        rescue JSON::ParserError
+          false
+        end
+      end
+
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
       def incorrectly_encoded_yamlfiles
         yamlfiles.reject { |f| f.content&.valid_encoding? }
+      end
+
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      def incorrectly_encoded_jsonfiles
+        jsonfiles.reject { |f| f.content&.valid_encoding? }
       end
 
       sig do
@@ -54,14 +73,20 @@ module Dependabot
       def raise_appropriate_error(
         incorrectly_encoded_files = []
       )
-        if incorrectly_encoded_files.none? && incorrectly_encoded_yamlfiles.none?
+        if incorrectly_encoded_files.none? && incorrectly_encoded_yamlfiles.none? && incorrectly_encoded_jsonfiles.none?
           raise Dependabot::DependencyFileNotFound.new(
             File.join(directory, "Dockerfile"),
-            "No Dockerfiles nor Kubernetes YAML found in #{directory}"
+            "No Dockerfiles nor Kubernetes manifests (YAML/JSON) found in #{directory}"
           )
         end
 
-        invalid_files = incorrectly_encoded_files.any? ? incorrectly_encoded_files : incorrectly_encoded_yamlfiles
+        invalid_files = if incorrectly_encoded_files.any?
+                          incorrectly_encoded_files
+                        elsif incorrectly_encoded_yamlfiles.any?
+                          incorrectly_encoded_yamlfiles
+                        else
+                          incorrectly_encoded_jsonfiles
+                        end
         raise Dependabot::DependencyFileNotParseable, T.must(invalid_files.first).path
       end
 
@@ -81,10 +106,24 @@ module Dependabot
         )
       end
 
+      sig { returns(T::Array[DependencyFile]) }
+      def jsonfiles
+        @jsonfiles ||= T.let(
+          repo_contents(raise_errors: false)
+            .select { |f| f.type == "file" && f.name.match?(JSON_REGEXP) }
+            .map do |f|
+              fetched = fetch_file_from_host(f.name)
+              fetched.content = T.must(fetched.content)[1..-1] if fetched.content&.start_with?("\uFEFF")
+              fetched
+            end,
+          T.nilable(T::Array[DependencyFile])
+        )
+      end
+
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files
         fetched_files = []
-        fetched_files + correctly_encoded_yamlfiles
+        fetched_files + correctly_encoded_yamlfiles + correctly_encoded_jsonfiles
       end
 
       private

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -168,10 +168,15 @@ module Dependabot
         modified_content = content
 
         old_images.each do |old_image|
-          old_image_regex = /^\s*(?:-\s)?image:\s+#{old_image}(?=\s|$)/
-          modified_content = modified_content&.gsub(old_image_regex) do |old_img|
+          escaped_image = Regexp.escape(old_image)
+          # Match YAML format: image: value
+          yaml_image_regex = /^\s*(?:-\s)?image:\s+#{escaped_image}(?=\s|$)/
+          # Match JSON format: "image": "value"
+          json_image_regex = /(?<="image":\s")#{escaped_image}(?=")/
+          modified_content = modified_content&.gsub(yaml_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, new_yaml_image(file).to_s)
           end
+          modified_content = modified_content&.gsub(json_image_regex, new_yaml_image(file).to_s)
         end
         modified_content
       end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -1152,6 +1152,188 @@ RSpec.describe Dependabot::Docker::FileParser do
     end
   end
 
+  describe "JSON parse" do
+    let(:json_parser) { described_class.new(dependency_files: jsonfiles, source: source) }
+    let(:jsonfile_fixture_name) { "pod.json" }
+    let(:jsonfile_body) do
+      fixture("kubernetes", "json", jsonfile_fixture_name)
+    end
+    let(:jsonfile) do
+      Dependabot::DependencyFile.new(name: jsonfile_fixture_name, content: jsonfile_body)
+    end
+    let(:jsonfiles) { [jsonfile] }
+
+    subject(:dependencies) { json_parser.parse }
+
+    its(:length) { is_expected.to eq(1) }
+
+    describe "the first dependency" do
+      subject(:dependency) { dependencies.first }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "pod.json",
+          source: { tag: "1.14.2" }
+        }]
+      end
+
+      it "has the right details" do
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.name).to eq("nginx")
+        expect(dependency.version).to eq("1.14.2")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
+    context "with a namespace" do
+      let(:jsonfile_fixture_name) { "namespace.json" }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "namespace.json",
+            source: { tag: "1.14.2" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("my-repo/nginx")
+          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
+    context "with a digest and tag" do
+      subject(:dependency) { dependencies.first }
+
+      let(:jsonfile_fixture_name) { "digest_and_tag.json" }
+
+      it "determines the correct version" do
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.name).to eq("ubuntu")
+        expect(dependency.version).to eq("12.04.5")
+        expect(dependency.requirements).to eq(
+          [{
+            requirement: nil,
+            groups: [],
+            file: "digest_and_tag.json",
+            source: {
+              tag: "12.04.5",
+              digest: "18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005"
+            }
+          }]
+        )
+      end
+    end
+
+    context "with multiple images" do
+      let(:jsonfile_fixture_name) { "multiple.json" }
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "multiple.json",
+            source: { tag: "17.04" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies.last }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "multiple.json",
+            source: { tag: "1.14.2" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("nginx")
+          expect(dependency.version).to eq("1.14.2")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
+    context "with a Kubernetes List" do
+      let(:jsonfile_fixture_name) { "list.json" }
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("nginx")
+          expect(dependency.version).to eq("1.2.34")
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies.last }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("20.04.2")
+        end
+      end
+    end
+
+    context "with a private registry" do
+      let(:jsonfile_fixture_name) { "private_tag.json" }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "private_tag.json",
+            source: {
+              registry: "registry-host.io:5000",
+              tag: "17.04"
+            }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("myreg/ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+  end
+
   describe "YAML parse" do
     subject(:dependencies) { helm_parser.parse }
 

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1409,6 +1409,106 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         its(:content) { is_expected.to include "kind: Pod" }
       end
     end
+
+    context "with a JSON Kubernetes manifest" do
+      let(:json_dependency) do
+        Dependabot::Dependency.new(
+          name: "ubuntu",
+          version: "17.10",
+          previous_version: "17.04",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "multiple.json",
+            source: { tag: "17.10" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "multiple.json",
+            source: { tag: "17.04" }
+          }],
+          package_manager: "docker"
+        )
+      end
+      let(:jsonfile_body) { fixture("kubernetes", "json", "multiple.json") }
+      let(:jsonfile) do
+        Dependabot::DependencyFile.new(
+          content: jsonfile_body,
+          name: "multiple.json"
+        )
+      end
+      let(:json_files) { [jsonfile] }
+      let(:json_updater) do
+        described_class.new(
+          dependency_files: json_files,
+          dependencies: [json_dependency],
+          credentials: credentials
+        )
+      end
+
+      subject(:updated_files) { json_updater.updated_dependency_files }
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the updated JSON file" do
+        subject(:updated_jsonfile) do
+          updated_files.find { |f| f.name == "multiple.json" }
+        end
+
+        its(:content) { is_expected.to include '"image": "ubuntu:17.10"' }
+        its(:content) { is_expected.to include '"image": "nginx:1.14.2"' }
+        its(:content) { is_expected.to include '"kind": "Pod"' }
+      end
+
+      context "with a digest update" do
+        let(:jsonfile_body) { fixture("kubernetes", "json", "digest_and_tag.json") }
+        let(:jsonfile) do
+          Dependabot::DependencyFile.new(
+            content: jsonfile_body,
+            name: "digest_and_tag.json"
+          )
+        end
+        let(:json_dependency) do
+          Dependabot::Dependency.new(
+            name: "ubuntu",
+            version: "17.10",
+            previous_version: "12.04.5",
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "digest_and_tag.json",
+              source: {
+                tag: "17.10",
+                digest: "3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
+                        "ca97eba880ebf600d68608"
+              }
+            }],
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "digest_and_tag.json",
+              source: {
+                tag: "12.04.5",
+                digest: "18305429afa14ea462f810146ba44d4363ae76e4c8" \
+                        "dfc38288cf73aa07485005"
+              }
+            }],
+            package_manager: "docker"
+          )
+        end
+
+        describe "the updated JSON file" do
+          subject(:updated_jsonfile) do
+            updated_files.find { |f| f.name == "digest_and_tag.json" }
+          end
+
+          its(:content) do
+            is_expected.to include '"image": "ubuntu:17.10@sha256:3ea1ca1aa'
+          end
+        end
+      end
+    end
   end
 
   describe "#updated_dependency_files" do

--- a/docker/spec/fixtures/kubernetes/json/digest.json
+++ b/docker/spec/fixtures/kubernetes/json/digest.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "ubuntu"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "ubuntu",
+        "image": "ubuntu@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docker/spec/fixtures/kubernetes/json/digest_and_tag.json
+++ b/docker/spec/fixtures/kubernetes/json/digest_and_tag.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "ubuntu"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "ubuntu",
+        "image": "ubuntu:12.04.5@sha256:18305429afa14ea462f810146ba44d4363ae76e4c8dfc38288cf73aa07485005",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docker/spec/fixtures/kubernetes/json/list.json
+++ b/docker/spec/fixtures/kubernetes/json/list.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "name": "nginx"
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx:1.2.34",
+            "ports": [
+              {
+                "containerPort": 80
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "name": "ubuntu"
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu:20.04.2"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docker/spec/fixtures/kubernetes/json/multiple.json
+++ b/docker/spec/fixtures/kubernetes/json/multiple.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "ubuntu"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "ubuntu",
+        "image": "ubuntu:17.04",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      },
+      {
+        "name": "nginx",
+        "image": "nginx:1.14.2",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docker/spec/fixtures/kubernetes/json/namespace.json
+++ b/docker/spec/fixtures/kubernetes/json/namespace.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "nginx"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nginx",
+        "image": "my-repo/nginx:1.14.2",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docker/spec/fixtures/kubernetes/json/pod.json
+++ b/docker/spec/fixtures/kubernetes/json/pod.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "nginx"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nginx",
+        "image": "nginx:1.14.2",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docker/spec/fixtures/kubernetes/json/private_tag.json
+++ b/docker/spec/fixtures/kubernetes/json/private_tag.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "ubuntu"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "ubuntu",
+        "image": "registry-host.io:5000/myreg/ubuntu:17.04",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Dependabot currently only detects container image references in Kubernetes manifests with `.yml`/`.yaml` extensions ([documented in the FAQ](https://eng.ms/docs/products/dependabot/automatic-container-updates): `apiVersion AND kind (ext:yml OR ext:yaml)`). This PR adds support for `.json` Kubernetes manifests, which are used in various deployment systems (e.g., Azure Service Fabric Cosmic deploy, custom orchestration tooling).

**Problem:** Many teams define Kubernetes-style container resources in `.json` files (e.g., `app-resources.json`) that contain `apiVersion`, `kind`, and `image` fields in the same structure as YAML manifests. These files are completely invisible to Dependabot today, meaning container image digest updates must be done manually — a compliance and security concern.

**Solution:** Extend the existing manifest detection pipeline to also discover, parse, and update `.json` files:

### Changes

| File | Change |
|------|--------|
| `shared_file_fetcher.rb` | Add `JSON_REGEXP`, `MANIFEST_REGEXP`, `jsonfiles` discovery, `correctly_encoded_jsonfiles` validation with `apiVersion`/`kind` heuristic |
| `file_fetcher.rb` | Use `MANIFEST_REGEXP` in `required_files_in?` to accept `.json` files |
| `file_parser.rb` | Add `JSON_REGEXP`/`MANIFEST_REGEXP`, route `.json` files to `parse_json_resources` (using `JSON.parse` with Kubernetes List support) instead of YAML `---` splitting |
| `file_updater.rb` | Use `MANIFEST_REGEXP` for `yaml_file_pattern` so `.json` files route through manifest update path |
| `shared_file_updater.rb` | Add JSON-aware regex (`"image": "value"`) alongside existing YAML regex (`image: value`) in `update_image` |

### Test coverage

- 7 JSON fixture files mirroring existing YAML fixtures (`pod`, `multiple`, `digest`, `digest_and_tag`, `list`, `namespace`, `private_tag`)
- Parser specs: single image, namespace, digest+tag, multiple images, Kubernetes List, private registry
- Updater specs: tag update, digest+tag update

### Design decisions

- **Kubernetes List support:** JSON manifests commonly use `kind: List` with an `items` array (equivalent to YAML `---` document separators). `parse_json_resources` unwraps these automatically.
- **Backward compatible:** Existing YAML behavior is completely unchanged. The `YAML_REGEXP` constant is preserved alongside the new `MANIFEST_REGEXP`.
- **`Regexp.escape` in updater:** The existing YAML image regex interpolated unescaped image strings (containing `.`, `/`, `@`). The JSON regex uses `Regexp.escape` for safety; the YAML path continues using the existing pattern to avoid behavioral changes.

### Example affected files

```json
{
  "apiVersion": "v1",
  "kind": "List",
  "items": [{
    "spec": {
      "containers": [{
        "image": "mcr.microsoft.com/geneva/distroless/mdsd:recommended@sha256:0b01b93c..."
      }]
    }
  }]
}
```

## Test plan

- [ ] Existing YAML Kubernetes manifest tests continue to pass
- [ ] New JSON parser tests pass for all fixture types
- [ ] New JSON updater tests verify tag and digest replacement in JSON format
- [ ] Existing Dockerfile and Helm chart tests are unaffected