### PR TITLE
fix(github_actions): apply cooldown to ref rewrites

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -152,7 +152,7 @@ module Dependabot
 
         # Return the git tag if updating a pinned version
         if source_git_commit_checker.pinned_ref_looks_like_version? &&
-           (new_tag = T.must(latest_version_finder).latest_version_tag)
+           (new_tag = T.must(latest_version_finder).latest_version_tag_respecting_cooldown)
           return new_tag.fetch(:tag)
         end
 
@@ -168,11 +168,12 @@ module Dependabot
 
       sig { params(source_checker: Dependabot::GitCommitChecker).returns(T.nilable(String)) }
       def latest_commit_sha(source_checker)
-        new_tag = T.must(latest_version_finder).latest_version_tag
-        return unless new_tag
+        latest_tag = T.must(latest_version_finder).latest_version_tag
+        return unless latest_tag
 
         if source_checker.local_tag_for_pinned_sha
-          new_tag.fetch(:commit_sha)
+          new_tag = T.must(latest_version_finder).latest_version_tag_respecting_cooldown
+          new_tag&.fetch(:commit_sha)
         else
           latest_commit_for_pinned_ref
         end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -102,6 +102,30 @@ module Dependabot
           available_latest_version_tag
         end
 
+        sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        def latest_version_tag_respecting_cooldown
+          return @latest_version_tag_respecting_cooldown if defined?(@latest_version_tag_respecting_cooldown)
+
+          @latest_version_tag_respecting_cooldown = T.let(
+            begin
+              selected_release = latest_release_version
+              if selected_release.nil? || selected_release.is_a?(String)
+                nil
+              else
+                latest_tag = available_latest_version_tag
+                if latest_tag&.fetch(:version) == selected_release
+                  latest_tag
+                else
+                  T.must(package_details_fetcher)
+                   .allowed_version_tags_with_release_dates
+                   .find { |tag_hash| tag_hash.fetch(:version) == selected_release }
+                end
+              end
+            end,
+            T.nilable(T::Hash[Symbol, T.untyped])
+          )
+        end
+
         private
 
         sig { returns(T.nilable(Dependabot::GithubActions::Package::PackageDetailsFetcher)) }

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -284,6 +284,97 @@ RSpec.describe namespace::LatestVersionFinder do
       end
     end
 
+    describe "#latest_version_tag_respecting_cooldown" do
+      subject(:latest_version_tag_respecting_cooldown) { finder.latest_version_tag_respecting_cooldown }
+
+      context "when cooldown filters out the latest major tag" do
+        let(:dependency_name) { "actions/checkout" }
+        let(:upload_pack_fixture) { "checkout" }
+        let(:reference) { "v2" }
+        let(:dependency_version) { "2" }
+        let(:dependency_source) do
+          {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v2",
+            branch: nil
+          }
+        end
+        let(:finder) do
+          described_class.new(
+            dependency: dependency,
+            dependency_files: [],
+            credentials: github_credentials,
+            security_advisories: security_advisories,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
+            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+          )
+        end
+
+        before do
+          allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
+            tags_with_dates.filter_map do |tag|
+              tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
+              tag_name if tag_name.start_with?("v3")
+            end
+          end
+        end
+
+        it "returns the tag hash for the selected cooled-down release" do
+          expect(latest_version_tag_respecting_cooldown).to include(
+            tag: "v2.7.0",
+            commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
+            version: Dependabot::GithubActions::Version.new("2.7.0")
+          )
+        end
+      end
+
+      context "when latest version tag is outside cooldown" do
+        let(:dependency_name) { "actions/checkout" }
+        let(:upload_pack_fixture) { "checkout" }
+        let(:reference) { "v2" }
+        let(:dependency_version) { "2" }
+        let(:dependency_source) do
+          {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v2",
+            branch: nil
+          }
+        end
+        let(:finder) do
+          described_class.new(
+            dependency: dependency,
+            dependency_files: [],
+            credentials: github_credentials,
+            security_advisories: security_advisories,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
+            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+          )
+        end
+
+        before do
+          allow(finder).to receive(:select_version_tags_in_cooldown_period).and_return([])
+        end
+
+        it "returns the same tag as latest_version_tag" do
+          expect(latest_version_tag_respecting_cooldown).to eq(finder.latest_version_tag)
+        end
+      end
+
+      context "when the selected release is a SHA" do
+        before do
+          allow(finder).to receive(:latest_release_version).and_return("deadbeef")
+        end
+
+        it "returns nil" do
+          expect(latest_version_tag_respecting_cooldown).to be_nil
+        end
+      end
+    end
+
     describe "#select_version_tags_in_cooldown_period" do
       subject(:selected_tags) { finder.send(:select_version_tags_in_cooldown_period) }
 

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -223,6 +223,97 @@ RSpec.describe namespace::LatestVersionFinder do
     it { is_expected.to eq(Dependabot::GithubActions::Version.new("2.0.0")) }
   end
 
+  describe "#latest_version_tag_respecting_cooldown" do
+    subject(:latest_version_tag_respecting_cooldown) { finder.latest_version_tag_respecting_cooldown }
+
+    context "when cooldown filters out the latest major tag" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+      let(:reference) { "v2" }
+      let(:dependency_version) { "2" }
+      let(:dependency_source) do
+        {
+          type: "git",
+          url: "https://github.com/actions/checkout",
+          ref: "v2",
+          branch: nil
+        }
+      end
+      let(:finder) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: [],
+          credentials: github_credentials,
+          security_advisories: security_advisories,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
+          cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+        )
+      end
+
+      before do
+        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
+          tags_with_dates.filter_map do |tag|
+            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
+            tag_name if tag_name.start_with?("v3")
+          end
+        end
+      end
+
+      it "returns the tag hash for the selected cooled-down release" do
+        expect(latest_version_tag_respecting_cooldown).to include(
+          tag: "v2.7.0",
+          commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
+          version: Dependabot::GithubActions::Version.new("2.7.0")
+        )
+      end
+    end
+
+    context "when latest version tag is outside cooldown" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+      let(:reference) { "v2" }
+      let(:dependency_version) { "2" }
+      let(:dependency_source) do
+        {
+          type: "git",
+          url: "https://github.com/actions/checkout",
+          ref: "v2",
+          branch: nil
+        }
+      end
+      let(:finder) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: [],
+          credentials: github_credentials,
+          security_advisories: security_advisories,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
+          cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+        )
+      end
+
+      before do
+        allow(finder).to receive(:select_version_tags_in_cooldown_period).and_return([])
+      end
+
+      it "returns the same tag as latest_version_tag" do
+        expect(latest_version_tag_respecting_cooldown).to eq(finder.latest_version_tag)
+      end
+    end
+
+    context "when the selected release is a SHA" do
+      before do
+        allow(finder).to receive(:latest_release_version).and_return("deadbeef")
+      end
+
+      it "returns nil" do
+        expect(latest_version_tag_respecting_cooldown).to be_nil
+      end
+    end
+  end
+
   # Regression test for version tag prefix handling
   # Bug: Dependabot returns main branch commit instead of latest tag when
   # dependency refs like "0.0.13" don't match prefixed tags like "v0.0.13"
@@ -281,97 +372,6 @@ RSpec.describe namespace::LatestVersionFinder do
           commit_sha: "b4cc9058ebd2336f73752f9d3c9b3835d52c66de",
           version: Dependabot::GithubActions::Version.new("0.0.24")
         )
-      end
-    end
-
-    describe "#latest_version_tag_respecting_cooldown" do
-      subject(:latest_version_tag_respecting_cooldown) { finder.latest_version_tag_respecting_cooldown }
-
-      context "when cooldown filters out the latest major tag" do
-        let(:dependency_name) { "actions/checkout" }
-        let(:upload_pack_fixture) { "checkout" }
-        let(:reference) { "v2" }
-        let(:dependency_version) { "2" }
-        let(:dependency_source) do
-          {
-            type: "git",
-            url: "https://github.com/actions/checkout",
-            ref: "v2",
-            branch: nil
-          }
-        end
-        let(:finder) do
-          described_class.new(
-            dependency: dependency,
-            dependency_files: [],
-            credentials: github_credentials,
-            security_advisories: security_advisories,
-            ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored,
-            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
-          )
-        end
-
-        before do
-          allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
-            tags_with_dates.filter_map do |tag|
-              tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
-              tag_name if tag_name.start_with?("v3")
-            end
-          end
-        end
-
-        it "returns the tag hash for the selected cooled-down release" do
-          expect(latest_version_tag_respecting_cooldown).to include(
-            tag: "v2.7.0",
-            commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5",
-            version: Dependabot::GithubActions::Version.new("2.7.0")
-          )
-        end
-      end
-
-      context "when latest version tag is outside cooldown" do
-        let(:dependency_name) { "actions/checkout" }
-        let(:upload_pack_fixture) { "checkout" }
-        let(:reference) { "v2" }
-        let(:dependency_version) { "2" }
-        let(:dependency_source) do
-          {
-            type: "git",
-            url: "https://github.com/actions/checkout",
-            ref: "v2",
-            branch: nil
-          }
-        end
-        let(:finder) do
-          described_class.new(
-            dependency: dependency,
-            dependency_files: [],
-            credentials: github_credentials,
-            security_advisories: security_advisories,
-            ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored,
-            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
-          )
-        end
-
-        before do
-          allow(finder).to receive(:select_version_tags_in_cooldown_period).and_return([])
-        end
-
-        it "returns the same tag as latest_version_tag" do
-          expect(latest_version_tag_respecting_cooldown).to eq(finder.latest_version_tag)
-        end
-      end
-
-      context "when the selected release is a SHA" do
-        before do
-          allow(finder).to receive(:latest_release_version).and_return("deadbeef")
-        end
-
-        it "returns nil" do
-          expect(latest_version_tag_respecting_cooldown).to be_nil
-        end
       end
     end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -736,6 +736,40 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     it { is_expected.to eq(Dependabot::GithubActions::Version.new("2.0.0")) }
   end
 
+  describe "#latest_commit_sha" do
+    let(:source_checker) do
+      instance_double(Dependabot::GitCommitChecker, local_tag_for_pinned_sha: local_tag_for_pinned_sha)
+    end
+    let(:local_tag_for_pinned_sha) { false }
+    let(:latest_version_tag) { nil }
+
+    before do
+      allow(checker).to receive_messages(
+        latest_version_finder: instance_double(
+          Dependabot::GithubActions::UpdateChecker::LatestVersionFinder,
+          latest_version_tag: latest_version_tag
+        ),
+        latest_commit_for_pinned_ref: "branch-head-sha"
+      )
+    end
+
+    context "when no latest version tag is available" do
+      it "returns nil instead of falling back to branch head" do
+        expect(checker.send(:latest_commit_sha, source_checker)).to be_nil
+      end
+    end
+
+    context "when latest version tag exists and current SHA is not tag-resolvable" do
+      let(:latest_version_tag) do
+        { tag: "v2.7.0", commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5" }
+      end
+
+      it "falls back to branch head commit behavior" do
+        expect(checker.send(:latest_commit_sha, source_checker)).to eq("branch-head-sha")
+      end
+    end
+  end
+
   describe "#updated_requirements" do
     subject(:updated_requirements) { checker.updated_requirements }
 
@@ -1054,6 +1088,54 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         end
 
         it { is_expected.to eq(expected_requirements) }
+      end
+    end
+
+    context "when cooldown filters out the latest major for a version tag reference" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+      let(:reference) { "v2" }
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      end
+
+      before do
+        finder = checker.send(:latest_version_finder)
+        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
+          tags_with_dates.filter_map do |tag|
+            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
+            tag_name if tag_name.start_with?("v3")
+          end
+        end
+      end
+
+      it "keeps metadata and rewritten version tag aligned to cooled-down target" do
+        expect(checker.latest_version).to eq(Dependabot::GithubActions::Version.new("2.7.0"))
+        expect(updated_requirements.first.dig(:source, :ref)).to eq("v2.7.0")
+      end
+    end
+
+    context "when cooldown filters out the latest major for a tag-resolvable SHA reference" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+      let(:reference) { "8f4b7f84864484a7bf31766abe9204da3cbe65b3" }
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      end
+
+      before do
+        finder = checker.send(:latest_version_finder)
+        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
+          tags_with_dates.filter_map do |tag|
+            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
+            tag_name if tag_name.start_with?("v3")
+          end
+        end
+      end
+
+      it "rewrites SHA to the cooled-down tag commit, not the uncooldowned latest tag commit" do
+        expect(checker.latest_version).to eq(Dependabot::GithubActions::Version.new("2.7.0"))
+        expect(updated_requirements.first.dig(:source, :ref)).to eq("ee0669bd1cc54295c223e0bb666b733df41de1c5")
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14685.

GitHub Actions PRs with cooldown configured ship incorrect workflow diffs that don't match the PR metadata (e.g., title says bump X from v1.2.3 to v1.2.4, diff bumps to v2.0). In particular, the PR metadata appears to describe the correct, cooldown-respecting change, whereas the diff does not respect the cooldown.

This was a regression introduced by #14621 and released in v0.369.0.

`LatestVersionFinder` has two methods that look interchangeable:
- `latest_version`, which is used for the PR title and body, applies `cooldown_filter`
- `latest_version_tag`, which is used to pick the ref written into the workflow file, does not use `cooldown_filter`

Before #14621, `cooldown_filter` either returned the latest version or suppressed the update entirely, so both methods agreed whenever a PR was proposed. #14621 made `cooldown_filter` walk back to older tags when the
 latest is in cooldown, which is the correct fix for #14579. However, the ref-rewrite path was not updated accordingly, so the two methods diverged.

This PR adds `latest_version_tag_respecting_cooldown` and calls it from both ref-rewrite branches i.rb: the version-pin path and the SHA-pin tag-resolvable path.

> Disclaimer: this PR was generated with AI-assistance. All code was reviewed by me (a human!).

### Anything you want to highlight for special attention from reviewers?

### How will you know you've accomplished your goal?

Tested end-to-end on MRE from [shaanmajid/dependabot-mre](https://github.com/shaanmajid/dependabot-mre/). The MRE pins `softprops/action-gh-release@v2` with a 7-day cooldown.

Relevant release timeline for [softprops/action-gh-release](https://github.com/softprops/action-gh-release):

| Tag | Published (UTC) | Inside 7-day window? |
| --- | --- | --- |
| [v2.6.1](https://github.com/softprops/action-gh-release/releases/tag/v2.6.1) | 2026-03-16T00:57:39Z | no |
| [v2.6.2](https://github.com/softprops/action-gh-release/releases/tag/v2.6.2) | 2026-04-12T03:32:29Z | yes |
| [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) | 2026-04-12T04:46:49Z | yes |

The correct, cooldown-compliant target at the time of writing would be `v2.6.1`.

Run (from inside `bin/docker-dev-shell github_actions`):

```sh
bin/dry-run.rb \
  --cooldown '{"default-days": 7}' \
  --pull-request \
  github_actions shaanmajid/dependabot-mre
```

Before (`main` @ [`d617cbdf`](https://github.com/dependabot/dependabot-core/commit/d617cbdf51c42ba07856de3f416683e347760bfc)):

<details>
<summary> Output </summary>

```
=== softprops/action-gh-release (2)
 => checking for updates 2/2
 => latest available version is 2.6.1
 => latest allowed version is 2.6.1
 => chore(ci): bump softprops/action-gh-release from 2 to 2.6.1

    ± .github/workflows/release.yml
    @@ -12,6 +12,6 @@
           - uses: actions/checkout@v4

           - name: Create GitHub Release
    -        uses: softprops/action-gh-release@v2
    +        uses: softprops/action-gh-release@v3
             with:
               generate_release_notes: true

Pull Request Title: chore(ci): bump softprops/action-gh-release from 2 to 2.6.1
```
</details>

Note that PR title and commit message name `2.6.1`, but the workflow diff rewrites to `@v3` (same behavior as the dry-run PR shaanmajid/dependabot-mre#1).

After ( this branch @ [`8fdb2fae`](https://github.com/dependabot/dependabot-core/pull/14734/commits/8fdb2fae5b6d14f501b677a936e37988e0a5bc61)):

<details>
<summary> Output </summary>

```
=== softprops/action-gh-release (2)
 => checking for updates 2/2
 => latest available version is 2.6.1
 => latest allowed version is 2.6.1
 => chore(ci): bump softprops/action-gh-release from 2 to 2.6.1

    ± .github/workflows/release.yml
    @@ -12,6 +12,6 @@
           - uses: actions/checkout@v4

           - name: Create GitHub Release
    -        uses: softprops/action-gh-release@v2
    +        uses: softprops/action-gh-release@v2.6.1
             with:
               generate_release_notes: true

Pull Request Title: chore(ci): bump softprops/action-gh-release from 2 to 2.6.1
```
</details>

Title, commit message, workflow diff, and the `compare/v2...v2.6.1` link in the PR body all agree on the cooldown-respecting target.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
