### PR TITLE
Nix: forward credentials to nix flake update for private repos

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -541,8 +541,10 @@ module Dependabot
       return nil if env.nil?
 
       env.transform_keys(&:to_s).each_with_object({}) do |(key, value), result|
-        # Only redact if the key contains "TOKEN" (case-insensitive)
-        result[key] = if key.match?(/TOKEN/i)
+        # Redact keys that contain "TOKEN" (case-insensitive) or carry
+        # configuration that may embed credentials (e.g. NIX_CONFIG's
+        # access-tokens setting).
+        result[key] = if key.match?(/TOKEN/i) || key == "NIX_CONFIG"
                         "<redacted>"
                       else
                         value

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -769,5 +769,17 @@ RSpec.describe Dependabot::SharedHelpers do
       sanitized = described_class.sanitize_env_for_logging(env)
       expect(sanitized).to eq({})
     end
+
+    it "redacts NIX_CONFIG which may embed access tokens" do
+      env = {
+        "NIX_CONFIG" => "access-tokens = github.com=ghp_secrettoken",
+        "PATH" => "/usr/bin"
+      }
+
+      sanitized = described_class.sanitize_env_for_logging(env)
+
+      expect(sanitized["NIX_CONFIG"]).to eq("<redacted>")
+      expect(sanitized["PATH"]).to eq("/usr/bin")
+    end
   end
 end

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -63,11 +63,27 @@ module Dependabot
 
           SharedHelpers.run_shell_command(
             "nix flake update #{dependency.name}",
+            env: nix_access_tokens_env,
             fingerprint: "nix flake update <input_name>"
           )
 
           File.read("flake.lock")
         end
+      end
+
+      # Builds NIX_CONFIG with access-tokens from git_source credentials so
+      # nix flake update can authenticate against private repositories.
+      # Uses NIX_CONFIG rather than --extra-access-tokens to keep tokens
+      # out of the process command line.
+      sig { returns(T::Hash[String, String]) }
+      def nix_access_tokens_env
+        tokens = credentials
+                 .select { |c| c["type"] == "git_source" && c["password"] }
+                 .map { |c| "#{c['host']}=#{c['password']}" }
+
+        return {} if tokens.empty?
+
+        { "NIX_CONFIG" => "access-tokens = #{tokens.join(' ')}" }
       end
 
       sig { returns(T.nilable(String)) }

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -77,9 +77,17 @@ module Dependabot
       # out of the process command line.
       sig { returns(T::Hash[String, String]) }
       def nix_access_tokens_env
-        tokens = credentials
-                 .select { |c| c["type"] == "git_source" && c["password"] }
-                 .map { |c| "#{c['host']}=#{c['password']}" }
+        host_token_pairs = credentials.filter_map do |credential|
+          next unless credential["type"] == "git_source"
+
+          host = credential["host"]
+          password = credential["password"]
+          next if host.to_s.empty? || password.to_s.empty?
+
+          [host, password]
+        end
+
+        tokens = host_token_pairs.uniq(&:first).map { |host, password| "#{host}=#{password}" }
 
         return {} if tokens.empty?
 

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -108,11 +108,15 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         expect(updated_files.first.name).to eq("flake.lock")
       end
 
-      it "calls nix flake update with the input name" do
+      it "calls nix flake update with the input name and credentials" do
         updated_files
         expect(Dependabot::SharedHelpers)
           .to have_received(:run_shell_command)
-          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+          .with(
+            "nix flake update nixpkgs",
+            env: { "NIX_CONFIG" => "access-tokens = github.com=token" },
+            fingerprint: "nix flake update <input_name>"
+          )
       end
     end
 
@@ -221,6 +225,80 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         nix_file = updated_files.find { |f| f.name == "flake.nix" }
         expect(nix_file.content).to include('"github:NixOS/nixpkgs/nixos-25.05"')
         expect(nix_file.content).not_to include("nixos-24.11")
+      end
+    end
+  end
+
+  describe "#nix_access_tokens_env" do
+    context "with a single git_source credential" do
+      it "returns NIX_CONFIG with the access token" do
+        env = updater.send(:nix_access_tokens_env)
+        expect(env).to eq({ "NIX_CONFIG" => "access-tokens = github.com=token" })
+      end
+    end
+
+    context "with multiple git_source credentials" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: [flake_nix, flake_lock],
+          dependencies: [dependency],
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "gh-token"
+            },
+            {
+              "type" => "git_source",
+              "host" => "gitlab.example.com",
+              "username" => "oauth2",
+              "password" => "gl-token"
+            }
+          ]
+        )
+      end
+
+      it "includes all credentials" do
+        env = updater.send(:nix_access_tokens_env)
+        expect(env["NIX_CONFIG"]).to include("github.com=gh-token")
+        expect(env["NIX_CONFIG"]).to include("gitlab.example.com=gl-token")
+      end
+    end
+
+    context "with no git_source credentials" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: [flake_nix, flake_lock],
+          dependencies: [dependency],
+          credentials: []
+        )
+      end
+
+      it "returns an empty hash" do
+        env = updater.send(:nix_access_tokens_env)
+        expect(env).to eq({})
+      end
+    end
+
+    context "with credentials missing a password" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: [flake_nix, flake_lock],
+          dependencies: [dependency],
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token"
+            }
+          ]
+        )
+      end
+
+      it "skips credentials without a password" do
+        env = updater.send(:nix_access_tokens_env)
+        expect(env).to eq({})
       end
     end
   end

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -229,12 +229,27 @@ RSpec.describe Dependabot::Nix::FileUpdater do
     end
   end
 
-  describe "#nix_access_tokens_env" do
-    context "with a single git_source credential" do
-      it "returns NIX_CONFIG with the access token" do
-        env = updater.send(:nix_access_tokens_env)
-        expect(env).to eq({ "NIX_CONFIG" => "access-tokens = github.com=token" })
-      end
+  describe "#updated_dependency_files credential forwarding" do
+    subject(:updated_files) { updater.updated_dependency_files }
+
+    let(:updated_lock_content) do
+      flake_lock_content.gsub(
+        "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "new_sha_abc123"
+      )
+    end
+
+    before do
+      allow(Dependabot::SharedHelpers)
+        .to receive(:in_a_temporary_repo_directory)
+        .and_yield
+      allow(Dependabot::SharedHelpers)
+        .to receive(:run_shell_command)
+      allow(File).to receive(:write).and_call_original
+      allow(File).to receive(:write).with("flake.nix", anything)
+      allow(File).to receive(:write).with("flake.lock", anything)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with("flake.lock").and_return(updated_lock_content)
     end
 
     context "with multiple git_source credentials" do
@@ -259,10 +274,44 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      it "includes all credentials" do
-        env = updater.send(:nix_access_tokens_env)
-        expect(env["NIX_CONFIG"]).to include("github.com=gh-token")
-        expect(env["NIX_CONFIG"]).to include("gitlab.example.com=gl-token")
+      it "forwards NIX_CONFIG with all access tokens to nix flake update" do
+        updated_files
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command) do |_cmd, **kwargs|
+          expect(kwargs[:env]["NIX_CONFIG"]).to include("github.com=gh-token")
+          expect(kwargs[:env]["NIX_CONFIG"]).to include("gitlab.example.com=gl-token")
+        end
+      end
+    end
+
+    context "with duplicate credentials for the same host" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: [flake_nix, flake_lock],
+          dependencies: [dependency],
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "first-token"
+            },
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "second-token"
+            }
+          ]
+        )
+      end
+
+      it "dedupes by host, keeping the first credential" do
+        updated_files
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          "nix flake update nixpkgs",
+          env: { "NIX_CONFIG" => "access-tokens = github.com=first-token" },
+          fingerprint: "nix flake update <input_name>"
+        )
       end
     end
 
@@ -275,9 +324,13 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      it "returns an empty hash" do
-        env = updater.send(:nix_access_tokens_env)
-        expect(env).to eq({})
+      it "passes an empty env hash" do
+        updated_files
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          "nix flake update nixpkgs",
+          env: {},
+          fingerprint: "nix flake update <input_name>"
+        )
       end
     end
 
@@ -297,8 +350,37 @@ RSpec.describe Dependabot::Nix::FileUpdater do
       end
 
       it "skips credentials without a password" do
-        env = updater.send(:nix_access_tokens_env)
-        expect(env).to eq({})
+        updated_files
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          "nix flake update nixpkgs",
+          env: {},
+          fingerprint: "nix flake update <input_name>"
+        )
+      end
+    end
+
+    context "with credentials missing a host" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: [flake_nix, flake_lock],
+          dependencies: [dependency],
+          credentials: [
+            {
+              "type" => "git_source",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          ]
+        )
+      end
+
+      it "skips credentials without a host" do
+        updated_files
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          "nix flake update nixpkgs",
+          env: {},
+          fingerprint: "nix flake update <input_name>"
+        )
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

`nix flake update` runs without authentication, so it fails on private flake inputs. This passes git_source credentials to nix via the `NIX_CONFIG` environment variable so private GitHub, GitLab, and self-hosted repos work. Fixes #14682.

### Anything you want to highlight for special attention from reviewers?

- Uses `NIX_CONFIG="access-tokens = github.com=TOKEN ..."` rather than the `--extra-access-tokens` CLI flag. The CLI flag shows tokens in `ps` output and error messages. `NIX_CONFIG` doesn't.
- The Dependabot proxy already intercepts HTTPS and injects auth for known hosts, so `github:` inputs that fetch tarballs are likely covered. The `access-tokens` setting is a second layer that covers nix's own API calls and any fetches that bypass the proxy (e.g. `git` type inputs).
- Credentials without a `password` field are skipped.

### How will you know you've accomplished your goal?

- Unit tests pass, including new tests for single/multiple/empty/missing-password credential cases.
- Rubocop and Sorbet pass clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.