### PR TITLE
uv: Use env vars for index auth when URL matches pyproject.toml

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -433,7 +433,7 @@ module Dependabot
                                 end
 
           matched_credentials.each do |cred, index_name|
-            env_name = T.must(index_name).upcase.gsub(/[^A-Z0-9]/, "_")
+            env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
 
             env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
 

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -357,7 +357,7 @@ module Dependabot
         def lock_index_options
           credentials
             .select { |cred| cred["type"] == "python_index" }
-            .reject { |cred| defined_in_pyproject?(cred) }
+            .reject { |cred| cred.replaces_base? ? defined_in_pyproject?(cred) : explicit_index?(cred) }
             .map do |cred|
             authed_url = AuthedUrlBuilder.authed_url(credential: cred)
 

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -357,7 +357,7 @@ module Dependabot
         def lock_index_options
           credentials
             .select { |cred| cred["type"] == "python_index" }
-            .reject { |cred| explicit_index?(cred) }
+            .reject { |cred| defined_in_pyproject?(cred) }
             .map do |cred|
             authed_url = AuthedUrlBuilder.authed_url(credential: cred)
 
@@ -377,6 +377,14 @@ module Dependabot
           uv_indices.any? do |_name, config|
             config["explicit"] == true && normalize_index_url(config["url"].to_s) == cred_url
           end
+        end
+
+        # Checks if a credential's index URL matches any index defined in pyproject.toml.
+        # When true, authentication is provided via env vars so uv uses the pyproject.toml URL,
+        # preserving URL format alignment between pyproject.toml and uv.lock.
+        sig { params(credential: Dependabot::Credential).returns(T::Boolean) }
+        def defined_in_pyproject?(credential)
+          !find_index_name_for_credential(credential).nil?
         end
 
         sig { params(url: String).returns(String) }
@@ -419,7 +427,7 @@ module Dependabot
 
           credentials
             .select { |cred| cred["type"] == "python_index" }
-            .select { |cred| explicit_index?(cred) }
+            .select { |cred| defined_in_pyproject?(cred) }
             .each do |cred|
             index_name = find_index_name_for_credential(cred)
             next unless index_name

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -285,7 +285,7 @@ module Dependabot
           command = "pyenv exec uv lock --upgrade-package #{package_spec} #{options}"
           fingerprint = "pyenv exec uv lock --upgrade-package <dependency_name> #{options_fingerprint}"
 
-          env_vars = explicit_index_env_vars.merge(setuptools_scm_pretend_version_env_vars)
+          env_vars = pyproject_index_env_vars.merge(setuptools_scm_pretend_version_env_vars)
 
           run_command(command, fingerprint: fingerprint, env: env_vars)
         end
@@ -422,17 +422,15 @@ module Dependabot
         # (the proxy handles authentication). This is for those running Dependabot
         # themselves and for dry-run.
         sig { returns(T::Hash[String, String]) }
-        def explicit_index_env_vars
+        def pyproject_index_env_vars
           env_vars = {}
 
           credentials
             .select { |cred| cred["type"] == "python_index" }
-            .select { |cred| defined_in_pyproject?(cred) }
-            .each do |cred|
-            index_name = find_index_name_for_credential(cred)
-            next unless index_name
-
-            env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
+            .filter_map { |cred| [cred, find_index_name_for_credential(cred)] }
+            .reject { |_cred, index_name| index_name.nil? }
+            .each do |cred, index_name|
+            env_name = T.must(index_name).upcase.gsub(/[^A-Z0-9]/, "_")
 
             env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
 

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -425,11 +425,14 @@ module Dependabot
         def pyproject_index_env_vars
           env_vars = {}
 
-          credentials
-            .select { |cred| cred["type"] == "python_index" }
-            .filter_map { |cred| [cred, find_index_name_for_credential(cred)] }
-            .reject { |_cred, index_name| index_name.nil? }
-            .each do |cred, index_name|
+          matched_credentials = credentials
+                                .select { |cred| cred["type"] == "python_index" }
+                                .filter_map do |cred|
+                                  index_name = find_index_name_for_credential(cred)
+                                  [cred, index_name] if index_name
+                                end
+
+          matched_credentials.each do |cred, index_name|
             env_name = T.must(index_name).upcase.gsub(/[^A-Z0-9]/, "_")
 
             env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -606,9 +606,9 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "does not include CLI flags for indices defined in pyproject.toml" do
+      it "includes --index flag for non-explicit indices defined in pyproject.toml" do
         options = lock_index_options.join(" ")
-        expect(options).not_to include("--index")
+        expect(options).to include("--index https://token@private-pypi.example.com/simple")
         expect(options).not_to include("--default-index")
       end
     end

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -703,8 +703,8 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
     end
   end
 
-  describe "#explicit_index_env_vars" do
-    subject(:explicit_index_env_vars) { updater.send(:explicit_index_env_vars) }
+  describe "#pyproject_index_env_vars" do
+    subject(:pyproject_index_env_vars) { updater.send(:pyproject_index_env_vars) }
 
     context "with an explicit index requiring authentication" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_explicit_index.toml") }
@@ -724,7 +724,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns environment variables for explicit index authentication" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_USERNAME" => "my_user",
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_password"
         )
@@ -748,7 +748,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns environment variables with token as password" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "secret_token"
         )
       end
@@ -771,7 +771,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns environment variables for matching pyproject.toml index" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "token"
         )
       end
@@ -794,7 +794,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns empty hash" do
-        expect(explicit_index_env_vars).to eq({})
+        expect(pyproject_index_env_vars).to eq({})
       end
     end
 
@@ -823,10 +823,10 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns environment variables for all indices defined in pyproject.toml" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "explicit_token"
         )
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_FALLBACK_PYPI_PASSWORD" => "fallback_token"
         )
       end
@@ -850,7 +850,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "returns environment variables for replaces-base credentials matching pyproject.toml indices" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_USERNAME" => "my_user",
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_password"
         )
@@ -875,7 +875,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "matches URLs ignoring trailing slashes for env var generation" do
-        expect(explicit_index_env_vars).to include(
+        expect(pyproject_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_USERNAME" => "my_user",
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_password"
         )

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -606,12 +606,14 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "includes --index flag for non-explicit indices" do
-        expect(lock_index_options).to include("--index https://token@private-pypi.example.com/simple")
+      it "does not include CLI flags for indices defined in pyproject.toml" do
+        options = lock_index_options.join(" ")
+        expect(options).not_to include("--index")
+        expect(options).not_to include("--default-index")
       end
     end
 
-    context "with replaces-base credential matching an explicit index" do
+    context "with replaces-base credential matching a pyproject.toml index" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_explicit_index.toml") }
 
       let(:credentials) do
@@ -627,8 +629,33 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "still uses --default-index when replaces-base is true, ignoring explicit flag" do
-        expect(lock_index_options).to include("--default-index https://secret_token@private-pypi.example.com/simple")
+      it "does not include CLI flags when credential matches a pyproject.toml index" do
+        options = lock_index_options.join(" ")
+        expect(options).not_to include("--default-index")
+        expect(options).not_to include("--index")
+      end
+    end
+
+    context "with replaces-base credential with trailing slash matching pyproject.toml index" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_explicit_index.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple/",
+              "token" => "secret_token",
+              "replaces-base" => true
+            }
+          )
+        ]
+      end
+
+      it "matches URLs ignoring trailing slashes for replaces-base credentials" do
+        options = lock_index_options.join(" ")
+        expect(options).not_to include("--default-index")
+        expect(options).not_to include("--index")
       end
     end
 
@@ -727,7 +754,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
     end
 
-    context "with no explicit indices" do
+    context "with no explicit indices but matching pyproject.toml index" do
       let(:pyproject_content) { fixture("pyproject_files", "uv_non_explicit_index.toml") }
 
       let(:credentials) do
@@ -736,6 +763,29 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
             {
               "type" => "python_index",
               "index-url" => "https://private-pypi.example.com/simple",
+              "token" => "token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "returns environment variables for matching pyproject.toml index" do
+        expect(explicit_index_env_vars).to include(
+          "UV_INDEX_COMPANY_PYPI_PASSWORD" => "token"
+        )
+      end
+    end
+
+    context "with no matching pyproject.toml index" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_non_explicit_index.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://unrelated-pypi.example.com/simple",
               "token" => "token",
               "replaces-base" => false
             }
@@ -772,11 +822,63 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         ]
       end
 
-      it "returns environment variables only for explicit indices" do
+      it "returns environment variables for all indices defined in pyproject.toml" do
         expect(explicit_index_env_vars).to include(
           "UV_INDEX_COMPANY_PYPI_PASSWORD" => "explicit_token"
         )
-        expect(explicit_index_env_vars).not_to have_key("UV_INDEX_FALLBACK_PYPI_PASSWORD")
+        expect(explicit_index_env_vars).to include(
+          "UV_INDEX_FALLBACK_PYPI_PASSWORD" => "fallback_token"
+        )
+      end
+    end
+
+    context "with replaces-base credential matching a pyproject.toml index" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_explicit_index.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple",
+              "username" => "my_user",
+              "password" => "my_password",
+              "replaces-base" => true
+            }
+          )
+        ]
+      end
+
+      it "returns environment variables for replaces-base credentials matching pyproject.toml indices" do
+        expect(explicit_index_env_vars).to include(
+          "UV_INDEX_COMPANY_PYPI_USERNAME" => "my_user",
+          "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_password"
+        )
+      end
+    end
+
+    context "with replaces-base credential with trailing slash matching pyproject.toml index" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_explicit_index.toml") }
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple/",
+              "username" => "my_user",
+              "password" => "my_password",
+              "replaces-base" => true
+            }
+          )
+        ]
+      end
+
+      it "matches URLs ignoring trailing slashes for env var generation" do
+        expect(explicit_index_env_vars).to include(
+          "UV_INDEX_COMPANY_PYPI_USERNAME" => "my_user",
+          "UV_INDEX_COMPANY_PYPI_PASSWORD" => "my_password"
+        )
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

When a private registry's index URL in the Dependabot config differs from the one in `pyproject.toml` only by a trailing slash (e.g., https://example.com/simple vs https://example.com/simple/), dependabot was passing the credential URL via `--default-index` / `--index` CLI flags to uv lock. This caused `uv` to write the credential's URL into uv.lock instead of preserving the URL from `pyproject.toml`, creating a mismatch between the two files.

Customers expect `pyproject.toml` and `uv.lock` to stay aligned — dependabot should not alter the index URL format in the lockfile.

This PR changes the authentication strategy: when a credential's index URL matches a `[[tool.uv.index]]`entry in `pyproject.toml` (after normalizing trailing slashes), we now provide authentication via `UV_INDEX_*_USERNAME/UV_INDEX_*_PASSWORD` environment variables instead of CLI flags. This lets `uv` resolve the index from `pyproject.toml` natively, keeping URLs consistent across both files.

This applies to all credential types, including `replaces-base` credentials, as long as the URL matches a configured index in `pyproject.toml`.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Validated by running the dependabot CLI against [a reproduction of the reported issue](https://github.com/thavaahariharangit/uv-url-update-in-lock-fr-13024-1/actions/runs/24510875536/job/71641395397). Compared the output before and after the fix — the `lockfile` now preserves the index URL from `pyproject.toml` instead of replacing it with the credential URL.

<img width="1881" height="262" alt="image" src="https://github.com/user-attachments/assets/0012723f-c7b1-4a89-8a08-d00606dafbf6" />



### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
