### PR TITLE
feat: Populate PoetryPackageManager version metadata

### DIFF
--- a/python/lib/dependabot/python/package_manager.rb
+++ b/python/lib/dependabot/python/package_manager.rb
@@ -57,9 +57,19 @@ module Dependabot
 
       LOCKFILE_NAME = "poetry.lock"
 
-      SUPPORTED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+      POETRY_V1 = "1"
+      POETRY_V2 = "2"
 
-      DEPRECATED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
+      # Keep versions in ascending order
+      SUPPORTED_VERSIONS = T.let(
+        [
+          Version.new(POETRY_V1),
+          Version.new(POETRY_V2)
+        ].freeze,
+        T::Array[Dependabot::Version]
+      )
+
+      DEPRECATED_VERSIONS = T.let([Version.new(POETRY_V1)].freeze, T::Array[Dependabot::Version])
 
       sig do
         params(
@@ -68,23 +78,15 @@ module Dependabot
         ).void
       end
       def initialize(raw_version, requirement = nil)
+        version = Version.new(raw_version)
         super(
           name: NAME,
-          version: Version.new(raw_version),
+          detected_version: Version.new(T.must(version.segments.first).to_s),
+          version: version,
           deprecated_versions: DEPRECATED_VERSIONS,
           supported_versions: SUPPORTED_VERSIONS,
           requirement: requirement,
        )
-      end
-
-      sig { override.returns(T::Boolean) }
-      def deprecated?
-        false
-      end
-
-      sig { override.returns(T::Boolean) }
-      def unsupported?
-        false
       end
 
       # Poetry supports requires-poetry constraints in pyproject.toml;

--- a/python/spec/dependabot/python/poetry_package_manager_spec.rb
+++ b/python/spec/dependabot/python/poetry_package_manager_spec.rb
@@ -8,10 +8,31 @@ require "spec_helper"
 RSpec.describe Dependabot::Python::PoetryPackageManager do
   let(:package_manager) { described_class.new("1.8.3") }
 
+  describe "version constants" do
+    it "supports Poetry v1 and v2" do
+      expect(described_class::SUPPORTED_VERSIONS).to eq(
+        [
+          Dependabot::Python::Version.new("1"),
+          Dependabot::Python::Version.new("2")
+        ]
+      )
+    end
+
+    it "deprecates Poetry v1" do
+      expect(described_class::DEPRECATED_VERSIONS).to eq(
+        [Dependabot::Python::Version.new("1")]
+      )
+    end
+  end
+
   describe "#initialize" do
     context "when version is a String" do
       it "sets the version correctly" do
         expect(package_manager.version).to eq("1.8.3")
+      end
+
+      it "sets the detected_version to the major version" do
+        expect(package_manager.detected_version).to eq(Dependabot::Python::Version.new("1"))
       end
 
       it "sets the name correctly" do
@@ -42,10 +63,64 @@ RSpec.describe Dependabot::Python::PoetryPackageManager do
     end
   end
 
+  describe "#deprecated?" do
+    context "when using Poetry 1.x" do
+      let(:package_manager) { described_class.new("1.8.3") }
+
+      it "returns true" do
+        expect(package_manager.deprecated?).to be true
+      end
+    end
+
+    context "when using Poetry 2.x" do
+      let(:package_manager) { described_class.new("2.2.1") }
+
+      it "returns false" do
+        expect(package_manager.deprecated?).to be false
+      end
+    end
+  end
+
+  describe "#unsupported?" do
+    context "when using Poetry 1.x" do
+      let(:package_manager) { described_class.new("1.8.3") }
+
+      it "returns false" do
+        expect(package_manager.unsupported?).to be false
+      end
+    end
+
+    context "when using Poetry 2.x" do
+      let(:package_manager) { described_class.new("2.2.1") }
+
+      it "returns false" do
+        expect(package_manager.unsupported?).to be false
+      end
+    end
+
+    context "when using a version older than all supported versions" do
+      let(:package_manager) { described_class.new("0.12.0") }
+
+      it "returns true" do
+        expect(package_manager.unsupported?).to be true
+      end
+    end
+  end
+
   describe "#raise_if_unsupported!" do
     context "when no requirement is set" do
+      let(:package_manager) { described_class.new("1.8.3") }
+
       it "does not raise an error" do
         expect { package_manager.raise_if_unsupported! }.not_to raise_error
+      end
+    end
+
+    context "when using a version older than all supported versions" do
+      let(:package_manager) { described_class.new("0.12.0") }
+
+      it "raises ToolVersionNotSupported" do
+        expect { package_manager.raise_if_unsupported! }.to raise_error(Dependabot::ToolVersionNotSupported)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

`PoetryPackageManager` had empty `SUPPORTED_VERSIONS` and `DEPRECATED_VERSIONS` arrays and hardcoded `deprecated?`/`unsupported?` to return `false`. This meant no version-gating, no deprecation warnings for Poetry 1.x users, and no version data for ecosystem dashboards.

This PR populates the version metadata so that:
- Poetry v1 is reported as **deprecated**, giving users a clear signal to upgrade to v2
- Poetry v2 is the supported version
- Versions older than v1 are correctly identified as **unsupported**
- Ecosystem dashboards can accurately reflect Poetry version adoption

### Anything you want to highlight for special attention from reviewers?

**`detected_version` pattern**: Following the same approach as Bundler, the constructor now extracts a major-only `detected_version` (e.g., `"1"` from `"1.8.3"`) and passes it separately from the full `version`. This is required because the base `VersionManager#deprecated?` uses `deprecated_versions.include?(detected_version)` — an exact-match comparison against major version entries.

**Poetry 1.x is deprecated, not unsupported**: `SUPPORTED_VERSIONS` includes both `["1", "2"]` so Poetry 1.x triggers a deprecation warning rather than blocking the job. This gives users time to upgrade before v1 is eventually moved to unsupported-only.

**Custom `raise_if_unsupported!` preserved**: The existing override that checks `requires-poetry` constraints from `pyproject.toml` is unchanged — it calls `super` first (which now does real version-gating work) and then additionally validates the project-level constraint.

### How will you know you've accomplished your goal?

- All 19 specs in `poetry_package_manager_spec.rb` pass, covering:
  - `SUPPORTED_VERSIONS` and `DEPRECATED_VERSIONS` contain the expected values
  - `detected_version` is extracted as major-only
  - `deprecated?` returns `true` for Poetry 1.x, `false` for 2.x
  - `unsupported?` returns `true` for pre-1.0, `false` for 1.x/2.x
  - `raise_if_unsupported!` raises for truly unsupported versions and for `requires-poetry` constraint violations
- RuboCop passes with no new offenses
- Sorbet type checking passes

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.