### PR TITLE
don't do a build on legacy projects

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -111,6 +111,102 @@ public partial class DiscoveryWorkerTests
         }
 
         [Fact]
+        public async Task AttemptedSDKDiscoveryDoesNotInvokeBuild()
+        {
+            // Ensure the `Build` target (which eventually calls `CoreCompile`) isn't invoked when detecting SDK-style packages
+            // in a legacy project.  Doing that full invocation is usually harmless, but slow and it fills the log with red herrings.
+
+            // To test this a legacy project is given a target with `BeforeTargets="CoreCompile"` which writes a sentinel file to disk
+            // so we have to ensure that file doesn't get created.
+            using var tempDir = new TemporaryDirectory();
+            var sentinelFile = Path.Combine(tempDir.DirectoryPath, "sentinel.txt");
+
+            await TestDiscoveryAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("PackageReferencedThroughLegacyMechanism", "1.0.0", "net48"),
+                    MockNuGetPackage.CreateSimplePackage("PackageReferencedThroughCPMMechanism", "2.0.0", "net48"),
+                ],
+                workspacePath: "src",
+                files: [
+                    ("Directory.Build.props", """
+                        <Project>
+                          <ItemGroup>
+                            <PackageReference Include="PackageReferencedThroughCPMMechanism" />
+                          </ItemGroup>
+                        </Project>
+                    """),
+                    ("Directory.Build.targets", "<Project />"),
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagedPackageVersionsCentrally>true</ManagedPackageVersionsCentrally>
+                            <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageVersion Include="PackageReferencedThroughCPMMechanism" Version="2.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("src/myproj.csproj", $$"""
+                        <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                          <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                          <PropertyGroup>
+                            <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <None Include="packages.config" />
+                          </ItemGroup>
+                          <ItemGroup>
+                            <Reference Include="PackageReferencedThroughLegacyMechanism">
+                              <HintPath>packages\PackageReferencedThroughLegacyMechanism.1.0.0\lib\net48\PackageReferencedThroughLegacyMechanism.dll</HintPath>
+                              <Private>True</Private>
+                            </Reference>
+                          </ItemGroup>
+                          <Target Name="PreCoreCompileSentinel" BeforeTargets="CoreCompile">
+                            <WriteLinesToFile File="{{sentinelFile}}" Lines="CoreCompile target was called" Overwrite="true" />
+                          </Target>
+                          <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                        </Project>
+                        """),
+                    ("src/packages.config", """
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <packages>
+                          <package id="PackageReferencedThroughLegacyMechanism" version="1.0.0" targetFramework="net48" />
+                        </packages>
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "myproj.csproj",
+                            TargetFrameworks = ["net48"],
+                            Dependencies = [
+                                new("PackageReferencedThroughLegacyMechanism", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net48"]),
+                                new("PackageReferencedThroughCPMMechanism", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net48"], IsDirect: true),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "../Directory.Build.props",
+                                "../Directory.Build.targets",
+                                "../Directory.Packages.props"
+                            ],
+                            AdditionalFiles = [
+                                "packages.config"
+                            ],
+                        }
+                    ],
+                }
+            );
+
+            // Verify that the CoreCompile target was not called by checking that the sentinel file was not created
+            Assert.False(File.Exists(sentinelFile), "CoreCompile target should not have been called during discovery");
+        }
+
+        [Fact]
         public async Task DiscoveryWorksEvenWithTargetsImportsOnlyProvidedByVisualStudio()
         {
             await TestDiscoveryAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -711,6 +711,8 @@ public partial class DiscoveryWorkerTests
                             <TargetFramework>net8.0</TargetFramework>
                             <!-- the SDK turns `<TargetFramework>net8.0</TargetFramework>` into the following -->
                             <TargetFrameworkMoniker>.NETCoreApp,Version=8.0</TargetFrameworkMoniker>
+                            <!-- the SDK sets this property but we need to fake it so it appears to be an SDK-style project -->
+                            <NETCoreSdkVersion>10.0.100</NETCoreSdkVersion>
                           </PropertyGroup>
 
                           <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -320,8 +320,14 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         var normalizedProjectPaths = projectPaths.SelectMany(p => PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(p, repoRootPath) ?? []).Distinct().ToImmutableArray();
 
         // Find all MSBuild files that may contain special imports
-        var msbuildExtensions = new[] { ".props", ".targets", ".csproj", ".vbproj", ".fsproj" };
-        var filesToPatch = Directory.GetFiles(repoRootPath, "*.*", SearchOption.AllDirectories)
+        var enumerationOptions = new EnumerationOptions()
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+        };
+        var msbuildExtensions = new[] { ".props", ".targets", ".proj", ".csproj", ".vbproj", ".fsproj" };
+        var filesToPatch = Directory.GetFiles(repoRootPath, "*.*", enumerationOptions)
             .Where(f => msbuildExtensions.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase))
             .ToImmutableArray();
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -318,7 +318,14 @@ public partial class DiscoveryWorker : IDiscoveryWorker
     private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForProjectPathsAsync(string repoRootPath, string workspacePath, IEnumerable<string> projectPaths)
     {
         var normalizedProjectPaths = projectPaths.SelectMany(p => PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(p, repoRootPath) ?? []).Distinct().ToImmutableArray();
-        var disposables = normalizedProjectPaths.Select(p => new SpecialImportsConditionPatcher(p)).ToImmutableArray();
+
+        // Find all MSBuild files that may contain special imports
+        var msbuildExtensions = new[] { ".props", ".targets", ".csproj", ".vbproj", ".fsproj" };
+        var filesToPatch = Directory.GetFiles(repoRootPath, "*.*", SearchOption.AllDirectories)
+            .Where(f => msbuildExtensions.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase))
+            .ToImmutableArray();
+
+        var disposables = filesToPatch.Select(p => new SpecialImportsConditionPatcher(p)).ToImmutableArray();
         var results = new Dictionary<string, ProjectDiscoveryResult>(StringComparer.Ordinal);
 
         try

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -62,6 +62,12 @@ internal static class SdkProjectDiscovery
         "GenerateBuildDependencyFile"
     ];
 
+    // these targets are required to evaluate a legacy project with a single operation
+    private static readonly ImmutableArray<string> LegacyProjectSingleRestoreTargetNames = ["ResolveProjectReferences"];
+
+    // this property evaluates to a version number in an SDK-style project and is unset or empty otherwise
+    private const string NETCoreSdkVersionPropertyName = "NETCoreSdkVersion";
+
     // this seems to be the maximum number of TFMs that can be restored in parallel without running into race conditions
     private const int MaximumParallelTargetFrameworkRestores = 2;
 
@@ -137,20 +143,39 @@ internal static class SdkProjectDiscovery
             var binLogPath = Path.Combine(Path.GetTempPath(), $"msbuild_{Guid.NewGuid():d}.binlog");
             try
             {
-                // when using single restore, we can directly invoke the relevant targets
+                // when using single restore, we can directly invoke the relevant targets...
                 var args = new List<string>() { "msbuild", startingProjectPath };
-                var targets = await MSBuildHelper.GetProjectTargetsAsync(startingProjectPath, logger);
-                var useDirectRestore = SingleRestoreTargetNames.All(targets.Contains);
+
+                // ...but determining what the the relevant targets are can be complicated
+
+                // For SDK-style projects  the targets `Restore`, `ResolveProjectReferences`, and `GenerateBuildDependencyFile`
+                // are necessary.  If the project has a single target framework, those magic targets will all be present and can
+                // be directly invoked, but if the project has multiple target frameworks, those targets will _NOT_ be directly
+                // present and we instead have to invoke the `Build` target and specify the three magic values as `InnerTargets`.
+
+                // If the project is legacy then those three magic targets will not be present, but we shouldn't use the `Build`
+                // and `InnerTargets` trick because that's an SDK-only mechanism, so we instead only need to invoke
+                // `ResolveProjectReferences` to gather all `PackageReference` items and further down we re-build the transitive
+                // dependency set.  Without the legacy project check, we could incorrectly invoke `Build` which eventually tries
+                // to call `csc.exe` which is unnecessary and can be slow.
+                var netCoreSdkVersionValue = await MSBuildHelper.GetProjectPropertyAsync(startingProjectPath, NETCoreSdkVersionPropertyName, logger);
+                var isLegacyProject = string.IsNullOrEmpty(netCoreSdkVersionValue);
+                var requiredTargets = isLegacyProject
+                    ? LegacyProjectSingleRestoreTargetNames
+                    : SingleRestoreTargetNames;
+
+                var actualTargets = await MSBuildHelper.GetProjectTargetsAsync(startingProjectPath, logger);
+                var useDirectRestore = requiredTargets.All(actualTargets.Contains);
                 if (useDirectRestore || isIndividualTfmRestore)
                 {
                     // directly call the required targets
-                    args.Add($"/t:{string.Join(",", SingleRestoreTargetNames)}");
+                    args.Add($"/t:{string.Join(",", requiredTargets)}");
                 }
                 else
                 {
                     // delegate to the inner build and call those targets
                     args.Add("/t:Build");
-                    args.Add($"/p:InnerTargets=\"{string.Join(";", SingleRestoreTargetNames)}\"");
+                    args.Add($"/p:InnerTargets=\"{string.Join(";", requiredTargets)}\"");
                 }
 
                 // inject various props and targets to help with discovery
@@ -384,7 +409,7 @@ internal static class SdkProjectDiscovery
         foreach (var projectPath in resolvedProperties.Keys)
         {
             var projectProperties = resolvedProperties[projectPath];
-            var isProjectLegacy = !projectProperties.ContainsKey("NETCoreSdkVersion"); // legacy projects don't contain this property
+            var isProjectLegacy = !projectProperties.ContainsKey(NETCoreSdkVersionPropertyName); // legacy projects don't contain this property
             if (isProjectLegacy)
             {
                 logger.Info($"Project {projectPath} is legacy");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -146,7 +146,7 @@ internal static class SdkProjectDiscovery
                 // when using single restore, we can directly invoke the relevant targets...
                 var args = new List<string>() { "msbuild", startingProjectPath };
 
-                // ...but determining what the the relevant targets are can be complicated
+                // ...but determining what the relevant targets are can be complicated
 
                 // For SDK-style projects  the targets `Restore`, `ResolveProjectReferences`, and `GenerateBuildDependencyFile`
                 // are necessary.  If the project has a single target framework, those magic targets will all be present and can

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/GetProperty.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/GetProperty.targets
@@ -1,0 +1,9 @@
+<Project>
+  <Target Name="_Dependabot_GetProperty">
+    <PropertyGroup>
+      <!-- the following value will get copied and replaced at runtime -->
+      <_DependabotPropertyValue>%RequestedPropertyName%</_DependabotPropertyValue>
+    </PropertyGroup>
+    <Message Importance="High" Text="__PROPERTY_VALUE:$(_DependabotPropertyValue)" />
+  </Target>
+</Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -11,6 +11,7 @@
     <None Include="DependencyDiscovery.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DependencyDiscoveryTargetingPacks.props" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DependencyDiscovery.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="GetProperty.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="TargetFrameworkReporter.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -566,6 +566,44 @@ internal static partial class MSBuildHelper
         var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
         if (exitCode != 0)
         {
+            if (stdOut.Contains("error MSB1001: Unknown switch."))
+            {
+                // older versions of MSBuild don't allow `-getProperty` so we go a different route
+                // we can't force an indirect property evaluation, but we can force import a custom targets file that effectively renames the property
+                var tempDir = Directory.CreateTempSubdirectory("__get_msbuild_property_");
+                try
+                {
+                    // prepare magic contents
+                    var targetsTemplateContents = await File.ReadAllTextAsync(GetFileFromRuntimeDirectory("GetProperty.targets"));
+                    var targetContents = targetsTemplateContents.Replace("%RequestedPropertyName%", $"$({propertyName})");
+
+                    // write magic contents
+                    var tempTargetsPath = Path.Combine(tempDir.FullName, $"GetProperty_{propertyName}.targets");
+                    await File.WriteAllTextAsync(tempTargetsPath, targetContents);
+
+                    // do it
+                    args = [
+                        "msbuild",
+                        projectPath,
+                        $"/p:CustomAfterMicrosoftCommonTargets={tempTargetsPath}",
+                        "/t:_Dependabot_GetProperty",
+                    ];
+                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
+                    if (exitCode == 0)
+                    {
+                        var match = Regex.Match(stdOut, "__PROPERTY_VALUE:(?<PropertyValue>[^$]*)$", RegexOptions.Multiline);
+                        if (match.Success)
+                        {
+                            return match.Groups["PropertyValue"].Value.Trim();
+                        }
+                    }
+                }
+                finally
+                {
+                    tempDir.Delete(recursive: true);
+                }
+            }
+
             logger.Warn($"Unable to determine property '{propertyName}' for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
             return null;
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -546,13 +546,13 @@ internal static partial class MSBuildHelper
         return targets;
     }
 
-    internal static async Task<ImmutableArray<string>> GetProjectTargetFrameworksAsync(string projectPath, ILogger logger)
+    internal static async Task<string?> GetProjectPropertyAsync(string projectPath, string propertyName, ILogger logger)
     {
         var extension = Path.GetExtension(projectPath)?.ToLowerInvariant();
         if (extension == ".sln" || extension == ".slnx")
         {
-            // solution files don't specify target frameworks, so we can skip the process invocation
-            return [];
+            // solution files don't specify properties, so we can skip the process invocation
+            return null;
         }
 
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
@@ -560,17 +560,28 @@ internal static partial class MSBuildHelper
         {
             "msbuild",
             projectPath,
-            "-getProperty:TargetFrameworks"
+            $"-getProperty:{propertyName}"
         };
 
         var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
         if (exitCode != 0)
         {
-            logger.Warn($"Unable to determine target frameworks for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
+            logger.Warn($"Unable to determine property '{propertyName}' for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
+            return null;
+        }
+
+        return stdOut.Trim();
+    }
+
+    internal static async Task<ImmutableArray<string>> GetProjectTargetFrameworksAsync(string projectPath, ILogger logger)
+    {
+        var rawValue = await GetProjectPropertyAsync(projectPath, "TargetFrameworks", logger);
+        if (rawValue is null)
+        {
             return [];
         }
 
-        var tfms = Regex.Replace(stdOut, "@[\r\n\t ]", "")
+        var tfms = Regex.Replace(rawValue, "@[\r\n\t ]", "")
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .OrderBy(t => t)
             .ToImmutableArray();


### PR DESCRIPTION
Legacy projects can specify SDK-style packages with `<PackageReference Include="..." />` and we use direct MSBuild invocations to resolve those, but due to complexities with how the SDK is organized this could lead to incorrectly trying to run `csc.exe` on a legacy project.  It had no ill effect and packages were properly detected but it slowed down dependency discovery and could fill the log with red herrings.

To correct this we do smarter project type detection and do slightly different things when invoking MSBuild.  Full details in the source comments in `SdkProjectDiscovery.cs`.

Since we're doing the correct thing for legacy projects now, we had to update the handling of special targets files that only exist in a Visual Studio installation.  Before we'd only add special handling to remove those imports on the target project, but now we need to traverse the whole repo to do it.  It's not too expensive, though, we just scan for all MSBuild files and process those.

Another weird side effect I discovered is that one of the tricks to get a property value from MSBuild doesn't work on .NET 7 and earlier (and we use this trick to detect SDK vs legacy projects), so I detect when that error occurs and emit some custom MSBuild so we can accomplish the same task.