### PR TITLE
fix: Guard against nil dependencies in Poetry group sections

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_files_parser.rb
@@ -69,7 +69,10 @@ module Dependabot
 
           groups = T.must(poetry_root)["group"] || {}
           groups.each do |group, group_spec|
-            dependencies += parse_poetry_dependency_group(group, group_spec["dependencies"])
+            deps = group_spec["dependencies"]
+            next unless deps
+
+            dependencies += parse_poetry_dependency_group(group, deps)
           end
           dependencies
         end

--- a/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_files_parser_spec.rb
@@ -329,6 +329,17 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectFilesParser do
       end
     end
 
+    context "with a group that has no dependencies key" do
+      subject(:dependency_names) { dependencies.map(&:name) }
+
+      let(:pyproject_fixture_name) { "poetry_group_without_dependencies.toml" }
+
+      it "does not raise and parses the other dependencies" do
+        expect(dependency_names).to include("requests")
+        expect(dependency_names).to include("pytest")
+      end
+    end
+
     context "with package specify source" do
       subject(:dependency) { dependencies.find { |f| f.name == "black" } }
 

--- a/python/spec/fixtures/pyproject_files/poetry_group_without_dependencies.toml
+++ b/python/spec/fixtures/pyproject_files/poetry_group_without_dependencies.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "PoetryGroups"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = ">=3.10"
+requests = "^2.31.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
+# Group with optional = true but no dependencies key
+[tool.poetry.group.docs]
+optional = true


### PR DESCRIPTION
## Summary

Fix `NoMethodError: undefined method 'each' for nil` in `PyprojectFilesParser#parse_poetry_dependency_group` when a Poetry group section exists without a `dependencies` key.

## Problem

Poetry `pyproject.toml` files can have group sections with only metadata (e.g. `optional = true`) and no `dependencies` key:

```toml
[tool.poetry.group.docs]
optional = true
```

When parsing these, `group_spec["dependencies"]` returns `nil`, which is passed to `parse_poetry_dependency_group` where `.each` is called on it, causing a `NoMethodError`.

## Fix

Skip groups that have no `dependencies` key instead of passing `nil` to the parser method.

## Changes

- **`pyproject_files_parser.rb`** — Add nil guard before calling `parse_poetry_dependency_group`
- **`pyproject_files_parser_spec.rb`** — Add regression test with a fixture that has a group section without dependencies
- **`poetry_group_without_dependencies.toml`** — New test fixture