### PR TITLE
Fix crash when devcontainer ecosystem group is specified

### DIFF
--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -31,7 +31,7 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::Dependency]) }
         def parse
-          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+          SharedHelpers.in_a_temporary_repo_directory("/", repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials) do
               parse_cli_json(evaluate_with_cli)
             end
@@ -41,26 +41,16 @@ module Dependabot
         private
 
         sig { returns(String) }
-        def base_dir
-          File.dirname(config_dependency_file.path)
-        end
-
-        sig { returns(String) }
-        def config_name
-          File.basename(config_dependency_file.path)
-        end
-
-        sig { returns(T.nilable(String)) }
-        def config_contents
-          config_dependency_file.content
+        def config_file_path
+          config_dependency_file.name
         end
 
         # https://github.com/devcontainers/cli/blob/9444540283b236298c28f397dea879e7ec222ca1/src/spec-node/devContainersSpecCLI.ts#L1072
         sig { returns(T::Hash[String, T.untyped]) }
         def evaluate_with_cli
-          raise "config_name must be a string" unless config_name.is_a?(String) && !config_name.empty?
+          raise "config_file_path must be a string" unless config_file_path.is_a?(String) && !config_file_path.empty?
 
-          cmd = "devcontainer outdated --workspace-folder . --config #{config_name} --output-format json"
+          cmd = "devcontainer outdated --workspace-folder . --config #{config_file_path} --output-format json"
           Dependabot.logger.info("Running command: #{cmd}")
 
           json = SharedHelpers.run_shell_command(

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -31,7 +31,7 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::Dependency]) }
         def parse
-          SharedHelpers.in_a_temporary_repo_directory("/", repo_contents_path) do
+          SharedHelpers.in_a_temporary_repo_directory(config_dependency_file.directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials) do
               parse_cli_json(evaluate_with_cli)
             end

--- a/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
@@ -37,7 +37,7 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def update
-          SharedHelpers.in_a_temporary_repo_directory("/", repo_contents_path) do
+          SharedHelpers.in_a_temporary_repo_directory(manifest.directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials) do
               update_manifests(
                 target_requirement: requirement,

--- a/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater/config_updater.rb
@@ -37,14 +37,14 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def update
-          SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+          SharedHelpers.in_a_temporary_repo_directory("/", repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials) do
               update_manifests(
                 target_requirement: requirement,
                 target_version: version
               )
 
-              [File.read(manifest_name), File.read(lockfile_name)].compact
+              [File.read(manifest_file_path), File.read(lockfile_path)].compact
             end
           end
         end
@@ -52,18 +52,15 @@ module Dependabot
         private
 
         sig { returns(String) }
-        def base_dir
-          File.dirname(manifest.path)
+        def manifest_file_path
+          manifest.name
         end
 
         sig { returns(String) }
-        def manifest_name
-          File.basename(manifest.path)
-        end
-
-        sig { returns(String) }
-        def lockfile_name
-          Utils.expected_lockfile_name(manifest_name)
+        def lockfile_path
+          dir = File.dirname(manifest.name)
+          lockfile_basename = Utils.expected_lockfile_name(File.basename(manifest.name))
+          Pathname.new(File.join(dir, lockfile_basename)).cleanpath.to_path
         end
 
         sig do
@@ -78,8 +75,8 @@ module Dependabot
           run_devcontainer_upgrade(target_version)
 
           # Now replace specific version back with target requirement
-          force_target_requirement(manifest_name, from: target_version, to: target_requirement)
-          force_target_requirement(lockfile_name, from: target_version, to: target_requirement)
+          force_target_requirement(manifest_file_path, from: target_version, to: target_requirement)
+          force_target_requirement(lockfile_path, from: target_version, to: target_requirement)
         end
 
         sig { params(file_name: String, from: String, to: T.any(String, Dependabot::Devcontainers::Version)).void }
@@ -92,7 +89,7 @@ module Dependabot
           cmd = "devcontainer upgrade " \
                 "--workspace-folder . " \
                 "--feature #{feature} " \
-                "--config #{manifest_name} " \
+                "--config #{manifest_file_path} " \
                 "--target-version #{target_version}"
 
           Dependabot.logger.info("Running command: `#{cmd}`")

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -6,6 +6,8 @@ require "dependabot/dependency_file"
 require "dependabot/source"
 require "dependabot/devcontainers/file_parser"
 require "dependabot/devcontainers/requirement"
+require "dependabot/workspace"
+require "dependabot/workspace/git"
 require_common_spec "file_parsers/shared_examples_for_file_parsers"
 
 RSpec.describe Dependabot::Devcontainers::FileParser do
@@ -74,6 +76,68 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
             {
               requirement: "1",
               file: ".devcontainer.json",
+              groups: ["feature"],
+              source: nil
+            }
+          ],
+          metadata: {}
+        }
+      ].freeze
+    end
+
+    it_behaves_like "parse"
+  end
+
+  context "with a devcontainer.json in a .devcontainer folder and an active workspace" do
+    let(:project_name) { "config_in_dot_devcontainer_folder" }
+    let(:directory) { "/" }
+
+    let(:workspace_path) { Pathname.new(repo_contents_path).expand_path }
+    let(:workspace) { Dependabot::Workspace::Git.new(workspace_path) }
+
+    before do
+      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
+    end
+
+    after do
+      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
+    end
+
+    let(:expectations) do
+      [
+        {
+          name: "ghcr.io/codspace/versioning/foo",
+          version: "1.1.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/bar",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1",
+              file: ".devcontainer/devcontainer.json",
+              groups: ["feature"],
+              source: nil
+            }
+          ],
+          metadata: {}
+        },
+        {
+          name: "ghcr.io/codspace/versioning/baz",
+          version: "1.0.0",
+          requirements: [
+            {
+              requirement: "1.0",
+              file: ".devcontainer/devcontainer.json",
               groups: ["feature"],
               source: nil
             }

--- a/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_parser_spec.rb
@@ -95,14 +95,6 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
     let(:workspace_path) { Pathname.new(repo_contents_path).expand_path }
     let(:workspace) { Dependabot::Workspace::Git.new(workspace_path) }
 
-    before do
-      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
-    end
-
-    after do
-      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
-    end
-
     let(:expectations) do
       [
         {
@@ -145,6 +137,14 @@ RSpec.describe Dependabot::Devcontainers::FileParser do
           metadata: {}
         }
       ].freeze
+    end
+
+    before do
+      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
+    end
+
+    after do
+      allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
     end
 
     it_behaves_like "parse"

--- a/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
@@ -6,6 +6,8 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/devcontainers/file_updater"
 require "dependabot/devcontainers/requirement"
+require "dependabot/workspace"
+require "dependabot/workspace/git"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::Devcontainers::FileUpdater do
@@ -106,6 +108,52 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
       end
 
       it "updates the version in both manifests" do
+        expect(updated_dependency_files.size).to eq(1)
+
+        config = updated_dependency_files.first
+        expect(config.name).to eq(".devcontainer/devcontainer.json")
+        expect(config.content).to include("ghcr.io/codspace/versioning/baz:2.0\"")
+      end
+    end
+
+    context "when there are multiple manifests with an active workspace" do
+      let(:project_name) { "multiple_configs" }
+
+      let(:workspace_path) { Pathname.new(repo_contents_path).expand_path }
+      let(:workspace) { Dependabot::Workspace::Git.new(workspace_path) }
+
+      before do
+        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
+      end
+
+      after do
+        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
+      end
+
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "ghcr.io/codspace/versioning/baz",
+            version: "2.0.0",
+            previous_version: "1.1.0",
+            requirements: [{
+              requirement: "2.0",
+              groups: ["feature"],
+              file: ".devcontainer/devcontainer.json",
+              source: nil
+            }],
+            previous_requirements: [{
+              requirement: "1.0",
+              groups: ["feature"],
+              file: ".devcontainer/devcontainer.json",
+              source: nil
+            }],
+            package_manager: "devcontainers"
+          )
+        ]
+      end
+
+      it "updates the version in the subdirectory manifest" do
         expect(updated_dependency_files.size).to eq(1)
 
         config = updated_dependency_files.first

--- a/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/file_updater_spec.rb
@@ -122,14 +122,6 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
       let(:workspace_path) { Pathname.new(repo_contents_path).expand_path }
       let(:workspace) { Dependabot::Workspace::Git.new(workspace_path) }
 
-      before do
-        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
-      end
-
-      after do
-        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
-      end
-
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -151,6 +143,14 @@ RSpec.describe Dependabot::Devcontainers::FileUpdater do
             package_manager: "devcontainers"
           )
         ]
+      end
+
+      before do
+        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)
+      end
+
+      after do
+        allow(Dependabot::Workspace).to receive(:active_workspace).and_return(nil)
       end
 
       it "updates the version in the subdirectory manifest" do

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -55,11 +55,18 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     instance_double(
       Dependabot::Job,
       dependencies: job_dependencies,
+      clone?: clone_job,
+      repo_contents_path: repo_contents_path,
       security_advisories_for: security_advisories,
       updating_a_pull_request?: false,
-      source: instance_double(Dependabot::Source, directory: "/")
+      source: source
     )
   end
+
+  let(:clone_job) { false }
+  let(:repo_contents_path) { nil }
+  let(:source_directory) { "/" }
+  let(:source) { instance_double(Dependabot::Source, directory: source_directory) }
 
   let(:group) do
     instance_double(
@@ -440,6 +447,49 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           test_instance.compile_all_dependency_changes_for(group)
         end
       end
+    end
+  end
+
+  describe "workspace handling in compile_all_dependency_changes_for" do
+    let(:clone_job) { true }
+    let(:repo_contents_path) { "/tmp/dependabot/repo" }
+    let(:source_directory) { "/services/api/../api" }
+
+    before do
+      allow(test_instance).to receive(:prepare_workspace).and_call_original
+      allow(test_instance).to receive(:cleanup_workspace).and_call_original
+      allow(test_instance).to receive_messages(
+        compile_updates_for: [],
+        skip_dependency?: false,
+        deduce_updated_dependency: nil,
+        store_changes: nil,
+        record_warning_notices: nil
+      )
+      allow(Dependabot::Updater::DependencyGroupChangeBatch).to receive(:new).and_return(
+        instance_double(
+          Dependabot::Updater::DependencyGroupChangeBatch,
+          current_dependency_files: dependency_files,
+          updated_dependencies: [],
+          updated_dependency_files: dependency_files,
+          add_updated_dependency: nil,
+          merge: nil
+        )
+      )
+      allow(Dependabot::DependencyChange).to receive(:new).and_return(
+        instance_double(Dependabot::DependencyChange, all_have_previous_version?: true)
+      )
+      allow(Dependabot::Workspace).to receive(:setup)
+      allow(Dependabot::Workspace).to receive(:cleanup!)
+    end
+
+    it "sets up and cleans up the workspace for clone jobs" do
+      test_instance.compile_all_dependency_changes_for(group)
+
+      expect(Dependabot::Workspace).to have_received(:setup).with(
+        repo_contents_path: repo_contents_path,
+        directory: Pathname.new(source_directory).cleanpath
+      )
+      expect(Dependabot::Workspace).to have_received(:cleanup!).once
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes [#11790](https://github.com/dependabot/dependabot-core/issues/11790) — the devcontainers updater crashes whenever `groups` is configured.

Group updates call `Dependabot::Workspace.setup`, which makes a workspace active. While active, `SharedHelpers.in_a_temporary_repo_directory` delegates to `Workspace#change` and **ignores** the `directory` argument, leaving cwd at the repo root. The devcontainers parser/updater were relying on that argument to `chdir` into .devcontainer before invoking the CLI with `--config <basename>`, so the CLI couldn't find the manifest.

Fix: in both feature_dependency_parser.rb and config_updater.rb, pass `DependencyFile#directory` as the temp-repo dir and `DependencyFile#name` (path relative to source root) as `--config`. Works in both code paths.

### Anything you want to highlight for special attention from reviewers?

No

### How will you know you've accomplished your goal?

- New parser spec (active workspace + manifest in subfolder) reproduces the failing path from the issue and now passes.
- New updater spec verifies subdirectory manifests are written correctly with a workspace active.
- New `prepare_workspace`/`cleanup_workspace` regression test in group_update_creation_spec.rb.
- The minimal repro in #11790 no longer raises during parse. (Direct link to repro: https://github.com/brooke-hamilton/dependabot-devcontainer-repro)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand. 