### PR TITLE
Remove unused Properties from ProjectDiscoveryResult and delete Property type

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Test.Update;
@@ -96,8 +95,6 @@ public class DiscoveryWorkerTestBase : TestBase
             Assert.True(actualProject is not null, $"Unable to find project with path `{expectedProject.FilePath.NormalizePathToUnix()}` in collection [{string.Join(", ", actualProjects.Select(p => p.FilePath))}]");
             Assert.Equal(expectedProject.FilePath.NormalizePathToUnix(), actualProject.FilePath.NormalizePathToUnix());
 
-            var actualProperties = actualProject.Properties;
-            AssertEx.Equal(expectedProject.Properties, actualProperties, PropertyComparer.Instance);
             AssertEx.Equal(expectedProject.TargetFrameworks, actualProject.TargetFrameworks);
             AssertEx.Equal(expectedProject.ReferencedProjectPaths, actualProject.ReferencedProjectPaths);
             AssertEx.Equal(expectedProject.ImportedFiles, actualProject.ImportedFiles);
@@ -151,22 +148,5 @@ public class DiscoveryWorkerTestBase : TestBase
         // run discovery
         var result = await action(temporaryDirectory.DirectoryPath);
         return result;
-    }
-
-    internal class PropertyComparer : IEqualityComparer<Property>
-    {
-        public static PropertyComparer Instance { get; } = new();
-
-        public bool Equals(Property? x, Property? y)
-        {
-            return x?.Name == y?.Name &&
-                   x?.Value == y?.Value &&
-                   x?.SourceFilePath.NormalizePathToUnix() == y?.SourceFilePath.NormalizePathToUnix();
-        }
-
-        public int GetHashCode([DisallowNull] Property obj)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.PackagesConfig.cs
@@ -42,9 +42,6 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
-                            Properties = [
-                                new("TargetFramework", "net46", "myproj.csproj")
-                            ],
                             TargetFrameworks = ["net46"],
                             Dependencies = [
                                 new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
@@ -97,7 +94,6 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "myproj.csproj",
-                            Properties = [new("TargetFramework", "net46", "src/myproj.csproj")],
                             TargetFrameworks = ["net46"],
                             Dependencies = [
                                 new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net46"]),
@@ -165,7 +161,6 @@ public partial class DiscoveryWorkerTests
                         new()
                         {
                             FilePath = "project1.csproj",
-                            Properties = [],
                             TargetFrameworks = ["net48"],
                             Dependencies = [
                                 new("Some.Package", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net48"]),

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Proj.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Proj.cs
@@ -68,10 +68,6 @@ public partial class DiscoveryWorkerTests
                             [
                                 new("Package.A", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                             ],
-                            Properties =
-                            [
-                                new("TargetFramework", "net8.0", "src/project1/project1.csproj")
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
@@ -83,10 +79,6 @@ public partial class DiscoveryWorkerTests
                             Dependencies =
                             [
                                 new("Package.B", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                            ],
-                            Properties =
-                            [
-                                new("TargetFramework", "net8.0", "src/project2/project2.csproj")
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -52,9 +52,6 @@ public partial class DiscoveryWorkerTests
                                 new("Package.A", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: true),
                                 new("Package.B", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: true),
                             ],
-                            Properties = [
-                                new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
-                            ],
                             TargetFrameworks = ["net7.0", "net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [
@@ -118,12 +115,6 @@ public partial class DiscoveryWorkerTests
                                 new("Package.A", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                                 new("Package.B", "4.5.6", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                             ],
-                            Properties = [
-                                new("ImplicitUsings", "enable", "project.csproj"),
-                                new("Nullable", "enable", "project.csproj"),
-                                new("OutputType", "Exe", "project.csproj"),
-                                new("TargetFramework", "net8.0", "project.csproj"),
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [
@@ -173,10 +164,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "project.csproj",
                             Dependencies = [
                                 new("Global.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                            ],
-                            Properties = [
-                                new("ManagePackageVersionsCentrally", "true", "project.csproj"),
-                                new("TargetFramework", "net8.0", "project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
@@ -242,9 +229,6 @@ public partial class DiscoveryWorkerTests
                                 new("Package.B", "4.5.6", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: true),
                                 new("Global.Package", "7.8.9", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: true),
                             ],
-                            Properties = [
-                                new("TargetFramework", "net7.0", "myproj.csproj"),
-                            ],
                             TargetFrameworks = ["net7.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [
@@ -295,9 +279,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "myproj.csproj",
                             Dependencies = [
                                 new("Package.A", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                            ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
@@ -368,9 +349,6 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                             ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", "myproj.csproj"),
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
@@ -414,9 +392,6 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Some.Package", "1.2.3.4", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                                 new("Transitive.Dependency", "5.6.7.8", DependencyType.Unknown, TargetFrameworks: ["net7.0", "net8.0"], IsTransitive: true),
-                            ],
-                            Properties = [
-                                new("TargetFrameworks", "net7.0;net8.0", "myproj.csproj"),
                             ],
                             TargetFrameworks = ["net7.0", "net8.0"],
                             ReferencedProjectPaths = [],
@@ -478,9 +453,6 @@ public partial class DiscoveryWorkerTests
                             ReferencedProjectPaths = [
                                 "../src/helpers.csproj",
                             ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", @"test/unit-tests.csproj"),
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ImportedFiles = [],
                             AdditionalFiles = [],
@@ -490,9 +462,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "../src/helpers.csproj",
                             Dependencies = [
                                 new("Package.B", "4.5.6", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                            ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", @"src/helpers.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
@@ -556,9 +525,6 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                             ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", @"projects/library.csproj"),
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
@@ -598,9 +564,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "project.csproj",
                             Dependencies = [
                                 new("Some.Os.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net9.0-windows"], IsDirect: true)
-                            ],
-                            Properties = [
-                                new("TargetFramework", "net9.0-windows", "project.csproj")
                             ],
                             TargetFrameworks = ["net9.0-windows"],
                             ReferencedProjectPaths = [],
@@ -643,9 +606,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "project.csproj",
                             Dependencies = [
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos", "net8.0-windows"], IsDirect: true),
-                            ],
-                            Properties = [
-                                new("TargetFrameworks", "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos;net8.0-windows", @"src/project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0-android", "net8.0-ios", "net8.0-maccatalyst", "net8.0-macos", "net8.0-windows"],
                             ReferencedProjectPaths = [],
@@ -691,9 +651,6 @@ public partial class DiscoveryWorkerTests
                             FilePath = "project.csproj",
                             Dependencies = [
                                 new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                            ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", "src/project.csproj"),
                             ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
@@ -815,10 +772,6 @@ public partial class DiscoveryWorkerTests
                             Dependencies = [
                                 new("Test.Only.Package", "1.0.99", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true)
                             ],
-                            Properties = [
-                                new("TargetFramework", "net8.0", "project.csproj"),
-                                new("TargetFrameworkMoniker", ".NETCoreApp,Version=8.0", "project.csproj"),
-                            ],
                             TargetFrameworks = ["net8.0"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
@@ -867,7 +820,6 @@ public partial class DiscoveryWorkerTests
                                 new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net48"], IsDirect: true),
                                 new("Some.Transitive.Dependency", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net48"], IsTransitive: true),
                             ],
-                            Properties = [],
                             TargetFrameworks = ["net48"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [],
@@ -927,7 +879,6 @@ public partial class DiscoveryWorkerTests
                                 new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net48"], IsDirect: true),
                                 new("Some.Transitive.Dependency", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net48"], IsTransitive: true),
                             ],
-                            Properties = [],
                             TargetFrameworks = ["net48"],
                             ReferencedProjectPaths = [],
                             ImportedFiles = [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -60,10 +60,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         FilePath = Path.GetFileName(projectPath),
                         TargetFrameworks = ["net8.0"],
                         Dependencies = expectedDependencies.ToImmutableArray(),
-                        Properties = [
-                            new("SomePackageVersion", "9.0.1", projectPath),
-                            new("TargetFramework", "net8.0", projectPath),
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -105,9 +101,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net472"],
                         Dependencies = [
                             new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net472"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net472", "src/project.csproj"),
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
@@ -152,10 +145,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("SomePackageVersion", "9.0.1", "src/project.csproj"),
-                            new("TargetFramework", "net8.0", "src/project.csproj"),
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
@@ -203,10 +192,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                             new("Some.Package2", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                        ],
-                        Properties = [
-                            new("SomePackageVersion", "9.0.1", "src/project.csproj"),
-                            new("TargetFramework", "net8.0", "src/project.csproj"),
                         ],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -293,9 +278,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                         ],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "src/test/project1/project1.csproj"),
-                        ],
                         ImportedFiles = [],
                         AdditionalFiles = [],
                     },
@@ -306,9 +288,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         ReferencedProjectPaths = [],
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "src/TEST/project2/project2.csproj"),
                         ],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -355,10 +334,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                             new("Some.Package2", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
-                        ],
-                        Properties = [
-                            new("SomePackageVersion", "9.0.1", "src/project.csproj"),
-                            new("TargetFramework", "net8.0", "src/project.csproj"),
                         ],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -414,7 +389,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "7.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
                         ],
-                        Properties = [],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [
@@ -472,9 +446,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "src/project.csproj")
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [
@@ -587,9 +558,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true),
                         ],
-                        Properties = [
-                            new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj")
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [
                             "../Directory.Build.props",
@@ -678,9 +646,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Transitive.Package", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net9.0"], IsDirect: false, IsTransitive: true),
                         ],
-                        Properties = [
-                            new("TargetFramework", "net9.0", "src/project.csproj")
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [
                             "../Directory.Build.props",
@@ -767,9 +732,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net9.0"],
                         Dependencies = [
                             new("Transitive.Package", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true),
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net9.0", "src/project.csproj")
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [
@@ -860,9 +822,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         FilePath = "client/client.csproj",
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [new("Package.A", "1.2.3", DependencyType.PackageReference, IsDirect: true, TargetFrameworks: ["net8.0"])],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "src/client/client.csproj"),
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -872,9 +831,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         FilePath = "server/server.csproj",
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [new("Package.B", "4.5.6", DependencyType.PackageReference, IsDirect: true, TargetFrameworks: ["net8.0"])],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "src/server/server.csproj"),
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -925,9 +881,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net7.0"],
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("TargetFrameworks", "net7.0", "src/project.csproj")
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
@@ -1008,9 +961,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net7.0", "net8.0"],
                         Dependencies = [
                             new("Some.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net7.0", "net8.0"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("TargetFrameworks", "net7.0;net8.0", "src/project.csproj"),
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [
@@ -1094,9 +1044,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [
                             new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net8.0", @"src/supported.csproj"),
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
@@ -1436,9 +1383,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                         ],
-                        Properties = [
-                            new("TargetFramework", "net8.0", "project.csproj"),
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -1571,10 +1515,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Some.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                         ],
-                        Properties = [
-                            new("RestoreUseStaticGraphEvaluation", "true", "project.csproj"),
-                            new("TargetFramework", "net8.0", "project.csproj"),
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -1645,11 +1585,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                             new("Package1", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true),
                             new("Package2", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true),
                         ],
-                        Properties = [
-                            new("MSBuildTreatWarningsAsErrors", "false", "src/project.csproj"), // this was specifically overridden by discovery
-                            new("TargetFramework", "net9.0", "src/project.csproj"),
-                            new("TreatWarningsAsErrors", "false", "src/project.csproj"), // this was specifically overridden by discovery
-                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = ["Directory.Packages.props"],
                         AdditionalFiles = [],
@@ -1695,9 +1630,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         Dependencies = [
                             new("Package.A", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"], IsDirect: true),
                             new("Package.B", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net9.0"], IsDirect: false, IsTransitive: true),
-                        ],
-                        Properties = [
-                            new("TargetFramework", "net9.0", "src/project.csproj"),
                         ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
@@ -1758,7 +1690,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             Dependencies = [new("Package.A", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net9.0"], IsDirect: true)],
             IsSuccess = true,
             Error = null,
-            Properties = [new("PropertyA", "Uno", "src/project.csproj")],
             TargetFrameworks = ["net8.0"],
             ReferencedProjectPaths = ["referenced/a.csproj"],
             ImportedFiles = ["imported/a.props"],
@@ -1774,7 +1705,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ],
             IsSuccess = true,
             Error = null,
-            Properties = [new("PropertyB", "Dos", "src/project.csproj")],
             TargetFrameworks = ["net9.0"],
             ReferencedProjectPaths = ["referenced/b.csproj"],
             ImportedFiles = ["imported/b.props"],
@@ -1803,13 +1733,6 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
 
         Assert.True(merged.IsSuccess);
         Assert.Null(merged.Error);
-
-        AssertEx.Equal(
-            [
-                new("PropertyA", "Uno", "src/project.csproj"),
-                new("PropertyB", "Dos", "src/project.csproj"),
-            ],
-            merged.Properties);
 
         AssertEx.Equal(["net8.0", "net9.0"], merged.TargetFrameworks);
         AssertEx.Equal(["referenced/a.csproj", "referenced/b.csproj"], merged.ReferencedProjectPaths);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -17,7 +17,6 @@ public record ExpectedWorkspaceDiscoveryResult : NativeResult
 
 public record ExpectedSdkProjectDiscoveryResult : ExpectedDependencyDiscoveryResult
 {
-    public required ImmutableArray<Property> Properties { get; init; }
     public required ImmutableArray<string> TargetFrameworks { get; init; }
     public required ImmutableArray<string> ReferencedProjectPaths { get; init; }
     public required ImmutableArray<string> ImportedFiles { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
@@ -47,10 +47,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Transitive.Dependency", "4.5.6", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true)
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -97,10 +93,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         // dependencies come from `Directory.Build.targets`, but it's through the evaluation of `src/library.csproj` that it's found
                         new("Top.Level.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true),
                         new("Transitive.Dependency", "4.5.6", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true)
-                    ],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
@@ -164,10 +156,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     ReferencedProjectPaths = [
                         "../library2/library2.csproj"
                     ],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library1/library1.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     AdditionalFiles = [],
                 },
@@ -177,10 +165,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     Dependencies =
                     [
                         new("Dependency.From.Other.Project", "4.5.6", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
-                    ],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library2/library2.csproj"),
                     ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
@@ -240,10 +224,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     ReferencedProjectPaths = [
                         "../library2/library2.csproj",
                     ],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library1/library1.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     AdditionalFiles = [],
                 },
@@ -256,10 +236,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Transitive.Dependency", "4.5.6", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTransitive: true)
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/library2/library2.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -307,10 +283,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Some.Dependency", "1.2.3", DependencyType.PackageReference, TargetFrameworks: [.. sortedTargetFrameworks], IsDirect: true),
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFrameworks", string.Join(";", targetFrameworks), "src/library.csproj"),
-                    ],
                     TargetFrameworks = [.. sortedTargetFrameworks],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -352,10 +324,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Some.Dependency", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["netstandard2.0"], IsDirect: true),
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFramework", "netstandard2.0", "src/library.csproj"),
-                    ],
                     TargetFrameworks = ["netstandard2.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -404,11 +372,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                     ImportedFiles =
                     [
                         "Directory.Build.props",
-                    ],
-                    Properties =
-                    [
-                        new("ManagePackageVersionsCentrally", "true", "src/library.csproj"),
-                        new("TargetFramework", "net8.0", "src/library.csproj"),
                     ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
@@ -472,11 +435,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         "../NonStandardPackages.props",
                         "Directory.Build.props",
                     ],
-                    Properties =
-                    [
-                        new("ManagePackageVersionsCentrally", "true", "src/library.csproj"),
-                        new("TargetFramework", "net8.0", "src/library.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -518,10 +476,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Some.Dependency", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net9.0-windows"], IsDirect: true),
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFramework", "net9.0-windows", "src/library.csproj"),
-                    ],
                     TargetFrameworks = ["net9.0-windows"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -574,10 +528,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Super.Transitive.Dependency", "7.8.9", DependencyType.Unknown, TargetFrameworks: ["net9.0"], IsTransitive: true),
                     ],
                     ImportedFiles = [],
-                    Properties =
-                    [
-                        new("TargetFramework", "net9.0", "src/library.csproj"),
-                    ],
                     TargetFrameworks = ["net9.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -627,10 +577,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"], IsDirect: true)
                     ],
                     ImportedFiles = ["Directory.Build.props", "Directory.Build.targets", "Directory.Packages.props"],
-                    Properties =
-                    [
-                        new("TargetFramework", "net8.0", "src/project.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],
@@ -681,10 +627,6 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
                         new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0", "net9.0"], IsDirect: true)
                     ],
                     ImportedFiles = ["Directory.Build.props", "Directory.Build.targets", "Directory.Packages.props"],
-                    Properties =
-                    [
-                        new("TargetFrameworks", "net8.0;net9.0", "src/project.csproj"),
-                    ],
                     TargetFrameworks = ["net8.0", "net9.0"],
                     ReferencedProjectPaths = [],
                     AdditionalFiles = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -379,7 +379,6 @@ public class EndToEndTests
                         FilePath = p.FilePath,
                         ImportedFiles = p.ImportedFiles,
                         IsSuccess = p.IsSuccess,
-                        Properties = p.Properties,
                         ReferencedProjectPaths = p.ReferencedProjectPaths,
                         TargetFrameworks = p.TargetFrameworks,
                     }).ToImmutableArray()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -41,7 +41,6 @@ public class UpdatedDependencyListTests
                         new("Microsoft.Extensions.DependencyModel", "6.0.0", DependencyType.PackageReference, TargetFrameworks: ["net6.0"]),
                     ],
                     IsSuccess = true,
-                    Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],
@@ -53,7 +52,6 @@ public class UpdatedDependencyListTests
                     Dependencies = [
                     ],
                     IsSuccess = true,
-                    Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],
@@ -67,7 +65,6 @@ public class UpdatedDependencyListTests
                         new("Newtonsoft.Json", "13.0.1", DependencyType.PackagesConfig, TargetFrameworks: ["net6.0"]),
                     ],
                     IsSuccess = true,
-                    Properties = [],
                     TargetFrameworks = ["net8.0"],
                     ReferencedProjectPaths = [],
                     ImportedFiles = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -411,10 +411,6 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         var mergedDependencies = mergedDependenciesSet.Values
             .OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
             .ToImmutableArray();
-        var mergedProperties = result1.Properties.Concat(result2.Properties)
-            .DistinctBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(p => p.Name)
-            .ToImmutableArray();
         var mergedTargetFrameworks = result1.TargetFrameworks.Concat(result2.TargetFrameworks)
             .Select(t =>
             {
@@ -450,7 +446,6 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             Dependencies = mergedDependencies,
             IsSuccess = result1.IsSuccess && result2.IsSuccess,
             Error = result1.Error ?? result2.Error,
-            Properties = mergedProperties,
             TargetFrameworks = mergedTargetFrameworks,
             ReferencedProjectPaths = mergedReferencedProjects,
             ImportedFiles = mergedImportedFiles,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -10,7 +10,6 @@ public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
     public required ImmutableArray<Dependency> Dependencies { get; init; }
     public bool IsSuccess { get; init; } = true;
     public JobErrorBase? Error { get; init; } = null;
-    public ImmutableArray<Property> Properties { get; init; } = [];
     public ImmutableArray<string> TargetFrameworks { get; init; } = [];
     public ImmutableArray<string> ReferencedProjectPaths { get; init; } = [];
     public required ImmutableArray<string> ImportedFiles { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
 using System.Xml.Linq;
-using System.Xml.XPath;
 
 using Microsoft.Build.Logging.StructuredLogger;
 
@@ -482,9 +481,6 @@ internal static class SdkProjectDiscovery
             }
 
             var projectFullDirectory = Path.GetDirectoryName(projectPath)!;
-            var doc = XDocument.Load(projectPath);
-            var localPropertyDefinitionElements = doc.Root!.XPathSelectElements("/Project/PropertyGroup/*");
-            var projectPropertyNames = localPropertyDefinitionElements.Select(e => e.Name.LocalName).ToHashSet(StringComparer.OrdinalIgnoreCase);
             var projectRelativePath = Path.GetRelativePath(workspacePath, projectPath);
 
             var propertiesForProject = resolvedProperties.GetOrAdd(projectPath, () => new(StringComparer.OrdinalIgnoreCase));
@@ -611,11 +607,6 @@ internal static class SdkProjectDiscovery
 
             // others
             var projectProperties = resolvedProperties[projectPath];
-            var properties = projectProperties
-                .Where(pkvp => projectPropertyNames.Contains(pkvp.Key))
-                .Select(pkvp => new Property(pkvp.Key, pkvp.Value, Path.GetRelativePath(repoRootPath, projectPath).NormalizePathToUnix()))
-                .OrderBy(p => p.Name)
-                .ToImmutableArray();
             var referenced = referencedProjects.GetOrAdd(projectPath, () => new(PathComparer.Instance))
                 .Select(p => Path.GetRelativePath(projectFullDirectory, p).NormalizePathToUnix())
                 .OrderBy(p => p)
@@ -640,7 +631,6 @@ internal static class SdkProjectDiscovery
                 FilePath = projectRelativePath,
                 Dependencies = dependencies,
                 TargetFrameworks = tfms,
-                Properties = properties,
                 ReferencedProjectPaths = referenced,
                 ImportedFiles = imported,
                 AdditionalFiles = additional,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Property.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Property.cs
@@ -1,6 +1,0 @@
-namespace NuGetUpdater.Core;
-
-public sealed record Property(
-    string Name,
-    string Value,
-    string SourceFilePath);


### PR DESCRIPTION
The Properties field on ProjectDiscoveryResult was not consumed by any downstream code. This removes the property, the Property record type, and all associated dead code including:
- Property computation in SdkProjectDiscovery
- Property merging in DiscoveryWorker.MergeProjectDiscovery
- PropertyComparer test helper
- All Properties assignments in test files
