### PR TITLE
fix(uv): derive `--index URL`s from uv.lock registry sources instead of credential `index-url`

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -3,7 +3,6 @@
 
 require "toml-rb"
 require "open3"
-require "uri"
 require "dependabot/dependency"
 require "dependabot/shared_helpers"
 require "dependabot/uv/language_version_manager"
@@ -25,6 +24,7 @@ module Dependabot
         require_relative "pyproject_preparer"
         require_relative "version_config_parser"
         require_relative "lock_file_error_handler"
+        require_relative "lock_index_credential_matcher"
 
         REQUIRED_FILES = %w(pyproject.toml uv.lock).freeze # At least one of these files should be present
 
@@ -364,9 +364,10 @@ module Dependabot
 
           options = T.let([], T::Array[String])
           used_credential_urls = T.let([], T::Array[String])
+          credential_matcher = LockIndexCredentialMatcher.new(credentials: filtered_credentials)
 
           uv_lock_registry_urls.each do |registry_url|
-            credential = best_credential_for_registry_url(filtered_credentials, registry_url)
+            credential = credential_matcher.best_credential_for_registry_url(registry_url)
             next unless credential
 
             used_credential_urls << credential["index-url"].to_s
@@ -397,56 +398,6 @@ module Dependabot
         def authed_registry_url(credential, registry_url)
           lock_credential = Dependabot::Credential.new(credential.to_h.merge("index-url" => registry_url))
           AuthedUrlBuilder.authed_url(credential: lock_credential)
-        end
-
-        sig do
-          params(credentials: T::Array[Dependabot::Credential], registry_url: String)
-            .returns(T.nilable(Dependabot::Credential))
-        end
-        def best_credential_for_registry_url(credentials, registry_url)
-          credential_scores = credentials.map do |credential|
-            [credential, credential_match_score(credential["index-url"].to_s, registry_url)]
-          end
-          best_match = credential_scores.max_by { |_, score| score }
-
-          return nil unless best_match
-          return nil if best_match[1].negative?
-
-          best_match[0]
-        end
-
-        sig { params(credential_url: String, registry_url: String).returns(Integer) }
-        def credential_match_score(credential_url, registry_url)
-          normalized_credential_url = normalize_index_url(credential_url)
-          normalized_registry_url = normalize_index_url(registry_url)
-
-          return 100_000 if normalized_credential_url == normalized_registry_url
-
-          credential_uri = URI.parse(normalized_credential_url)
-          registry_uri = URI.parse(normalized_registry_url)
-
-          return -1 unless credential_uri.scheme == registry_uri.scheme
-          return -1 unless credential_uri.host == registry_uri.host
-          return -1 unless credential_uri.port == registry_uri.port
-
-          credential_path = normalized_uri_path(credential_uri)
-          registry_path = normalized_uri_path(registry_uri)
-
-          return 1 if credential_path == "/"
-
-          if registry_path.start_with?(credential_path.chomp("/") + "/")
-            credential_path.length
-          else
-            -1
-          end
-        rescue URI::InvalidURIError
-          -1
-        end
-
-        sig { params(uri: URI::Generic).returns(String) }
-        def normalized_uri_path(uri)
-          path = uri.path.to_s
-          path.empty? ? "/" : path
         end
 
         sig { returns(T::Array[String]) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -3,6 +3,7 @@
 
 require "toml-rb"
 require "open3"
+require "uri"
 require "dependabot/dependency"
 require "dependabot/shared_helpers"
 require "dependabot/uv/language_version_manager"
@@ -355,18 +356,110 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def lock_index_options
-          credentials
-            .select { |cred| cred["type"] == "python_index" }
-            .reject { |cred| cred.replaces_base? ? defined_in_pyproject?(cred) : explicit_index?(cred) }
-            .map do |cred|
-            authed_url = AuthedUrlBuilder.authed_url(credential: cred)
+          filtered_credentials = credentials
+                                 .select { |cred| cred["type"] == "python_index" }
+                                 .reject do |cred|
+                                   cred.replaces_base? ? defined_in_pyproject?(cred) : explicit_index?(cred)
+                                 end
 
-            if cred.replaces_base?
-              "--default-index #{authed_url}"
-            else
-              "--index #{authed_url}"
-            end
+          options = T.let([], T::Array[String])
+          used_credential_urls = T.let([], T::Array[String])
+
+          uv_lock_registry_urls.each do |registry_url|
+            credential = best_credential_for_registry_url(filtered_credentials, registry_url)
+            next unless credential
+
+            used_credential_urls << credential["index-url"].to_s
+            options << option_for_credential_url(credential, authed_registry_url(credential, registry_url))
           end
+
+          # Fall back to credential URLs for indices not represented in uv.lock.
+          filtered_credentials.each do |credential|
+            next if used_credential_urls.include?(credential["index-url"].to_s)
+
+            authed_url = AuthedUrlBuilder.authed_url(credential: credential)
+            options << option_for_credential_url(credential, authed_url)
+          end
+
+          options.uniq
+        end
+
+        sig { params(credential: Dependabot::Credential, url: String).returns(String) }
+        def option_for_credential_url(credential, url)
+          if credential.replaces_base?
+            "--default-index #{url}"
+          else
+            "--index #{url}"
+          end
+        end
+
+        sig { params(credential: Dependabot::Credential, registry_url: String).returns(String) }
+        def authed_registry_url(credential, registry_url)
+          lock_credential = Dependabot::Credential.new(credential.to_h.merge("index-url" => registry_url))
+          AuthedUrlBuilder.authed_url(credential: lock_credential)
+        end
+
+        sig do
+          params(credentials: T::Array[Dependabot::Credential], registry_url: String)
+            .returns(T.nilable(Dependabot::Credential))
+        end
+        def best_credential_for_registry_url(credentials, registry_url)
+          credential_scores = credentials.map do |credential|
+            [credential, credential_match_score(credential["index-url"].to_s, registry_url)]
+          end
+          best_match = credential_scores.max_by { |_, score| score }
+
+          return nil unless best_match
+          return nil if best_match[1].negative?
+
+          best_match[0]
+        end
+
+        sig { params(credential_url: String, registry_url: String).returns(Integer) }
+        def credential_match_score(credential_url, registry_url)
+          normalized_credential_url = normalize_index_url(credential_url)
+          normalized_registry_url = normalize_index_url(registry_url)
+
+          return 100_000 if normalized_credential_url == normalized_registry_url
+
+          credential_uri = URI.parse(normalized_credential_url)
+          registry_uri = URI.parse(normalized_registry_url)
+
+          return -1 unless credential_uri.scheme == registry_uri.scheme
+          return -1 unless credential_uri.host == registry_uri.host
+          return -1 unless credential_uri.port == registry_uri.port
+
+          credential_path = credential_uri.path.to_s
+          registry_path = registry_uri.path.to_s
+
+          if registry_path.start_with?(credential_path.chomp("/") + "/")
+            credential_path.length
+          elsif credential_path == "/"
+            1
+          else
+            0
+          end
+        rescue URI::InvalidURIError
+          -1
+        end
+
+        sig { returns(T::Array[String]) }
+        def uv_lock_registry_urls
+          return [] unless lockfile&.content
+
+          parsed = TomlRB.parse(T.must(lockfile).content)
+          packages = parsed["package"]
+          return [] unless packages.is_a?(Array)
+
+          packages.filter_map do |package|
+            source = package["source"]
+            next unless source.is_a?(Hash)
+
+            registry = source["registry"]
+            registry if registry.is_a?(String)
+          end.uniq
+        rescue TomlRB::ParseError
+          []
         end
 
         sig { params(credential: Dependabot::Credential).returns(T::Boolean) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -429,18 +429,24 @@ module Dependabot
           return -1 unless credential_uri.host == registry_uri.host
           return -1 unless credential_uri.port == registry_uri.port
 
-          credential_path = credential_uri.path.to_s
-          registry_path = registry_uri.path.to_s
+          credential_path = normalized_uri_path(credential_uri)
+          registry_path = normalized_uri_path(registry_uri)
+
+          return 1 if credential_path == "/"
 
           if registry_path.start_with?(credential_path.chomp("/") + "/")
             credential_path.length
-          elsif credential_path == "/"
-            1
           else
-            0
+            -1
           end
         rescue URI::InvalidURIError
           -1
+        end
+
+        sig { params(uri: URI::Generic).returns(String) }
+        def normalized_uri_path(uri)
+          path = uri.path.to_s
+          path.empty? ? "/" : path
         end
 
         sig { returns(T::Array[String]) }
@@ -553,9 +559,9 @@ module Dependabot
 
         sig { params(options: String).returns(String) }
         def lock_options_fingerprint(options)
-          options.sub(
+          options.gsub(
             /--default-index\s+\S+/, "--default-index <default_index>"
-          ).sub(
+          ).gsub(
             /--index\s+\S+/, "--index <index>"
           )
         end

--- a/uv/lib/dependabot/uv/file_updater/lock_index_credential_matcher.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_index_credential_matcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "uri"

--- a/uv/lib/dependabot/uv/file_updater/lock_index_credential_matcher.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_index_credential_matcher.rb
@@ -1,0 +1,74 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "uri"
+require "dependabot/uv/file_updater"
+
+module Dependabot
+  module Uv
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class LockIndexCredentialMatcher
+        extend T::Sig
+
+        sig { params(credentials: T::Array[Dependabot::Credential]).void }
+        def initialize(credentials:)
+          @credentials = credentials
+        end
+
+        sig { params(registry_url: String).returns(T.nilable(Dependabot::Credential)) }
+        def best_credential_for_registry_url(registry_url)
+          credential_scores = @credentials.map do |credential|
+            [credential, credential_match_score(credential["index-url"].to_s, registry_url)]
+          end
+          best_match = credential_scores.max_by { |_, score| score }
+
+          return nil unless best_match
+          return nil if best_match[1].negative?
+
+          best_match[0]
+        end
+
+        private
+
+        sig { params(credential_url: String, registry_url: String).returns(Integer) }
+        def credential_match_score(credential_url, registry_url)
+          normalized_credential_url = normalize_index_url(credential_url)
+          normalized_registry_url = normalize_index_url(registry_url)
+
+          return 100_000 if normalized_credential_url == normalized_registry_url
+
+          credential_uri = URI.parse(normalized_credential_url)
+          registry_uri = URI.parse(normalized_registry_url)
+
+          return -1 unless credential_uri.scheme == registry_uri.scheme
+          return -1 unless credential_uri.host == registry_uri.host
+          return -1 unless credential_uri.port == registry_uri.port
+
+          credential_path = normalized_uri_path(credential_uri)
+          registry_path = normalized_uri_path(registry_uri)
+
+          return 1 if credential_path == "/"
+
+          if registry_path.start_with?(credential_path.chomp("/") + "/")
+            credential_path.length
+          else
+            -1
+          end
+        rescue URI::InvalidURIError
+          -1
+        end
+
+        sig { params(url: String).returns(String) }
+        def normalize_index_url(url)
+          url.chomp("/")
+        end
+
+        sig { params(uri: URI::Generic).returns(String) }
+        def normalized_uri_path(uri)
+          path = uri.path.to_s
+          path.empty? ? "/" : path
+        end
+      end
+    end
+  end
+end

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -701,6 +701,70 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         expect(options).not_to include("--index")
       end
     end
+
+    context "when uv.lock registry URLs differ from credential index-url paths" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
+      let(:lockfile_content) do
+        <<~LOCK
+          version = 1
+          revision = 1
+
+          [[package]]
+          name = "requests"
+          version = "2.32.3"
+          source = { registry = "https://pypi.example.com/pypi" }
+        LOCK
+      end
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://pypi.example.com/",
+              "token" => "token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "uses uv.lock registry URLs for --index and applies credential auth" do
+        expect(lock_index_options).to eq(["--index https://token@pypi.example.com/pypi"])
+      end
+    end
+
+    context "when uv.lock has no matching registry for a credential" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
+      let(:lockfile_content) do
+        <<~LOCK
+          version = 1
+          revision = 1
+
+          [[package]]
+          name = "requests"
+          version = "2.32.3"
+          source = { registry = "https://pypi.org/simple" }
+        LOCK
+      end
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private-pypi.example.com/simple",
+              "token" => "token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "falls back to the credential URL" do
+        expect(lock_index_options).to eq(["--index https://token@private-pypi.example.com/simple"])
+      end
+    end
   end
 
   describe "#pyproject_index_env_vars" do

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -765,6 +765,90 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         expect(lock_index_options).to eq(["--index https://token@private-pypi.example.com/simple"])
       end
     end
+
+    context "when credentials share host but paths do not match the registry" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
+      let(:lockfile_content) do
+        <<~LOCK
+          version = 1
+          revision = 1
+
+          [[package]]
+          name = "requests"
+          version = "2.32.3"
+          source = { registry = "https://pypi.example.com/pypi" }
+        LOCK
+      end
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://pypi.example.com/repo-a",
+              "token" => "token_a",
+              "replaces-base" => false
+            }
+          ),
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://pypi.example.com/repo-b",
+              "token" => "token_b",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "does not apply an unrelated credential token to the lockfile registry URL" do
+        options = lock_index_options.join(" ")
+
+        expect(options).not_to include("@pypi.example.com/pypi")
+        expect(options).to include("--index https://token_a@pypi.example.com/repo-a")
+        expect(options).to include("--index https://token_b@pypi.example.com/repo-b")
+      end
+    end
+
+    context "when a root-scoped credential and a non-matching scoped credential share a host" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
+      let(:lockfile_content) do
+        <<~LOCK
+          version = 1
+          revision = 1
+
+          [[package]]
+          name = "requests"
+          version = "2.32.3"
+          source = { registry = "https://pypi.example.com/pypi" }
+        LOCK
+      end
+
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://pypi.example.com/repo-a",
+              "token" => "token_a",
+              "replaces-base" => false
+            }
+          ),
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://pypi.example.com/",
+              "token" => "root_token",
+              "replaces-base" => false
+            }
+          )
+        ]
+      end
+
+      it "prefers the root-scoped credential for registry paths not under other scopes" do
+        expect(lock_index_options).to include("--index https://root_token@pypi.example.com/pypi")
+      end
+    end
   end
 
   describe "#pyproject_index_env_vars" do
@@ -995,6 +1079,18 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
 
     it "replaces sensitive information in the fingerprint with placeholders" do
       expect(lock_options_fingerprint).to eq("--default-index <default_index> --index <index>")
+    end
+
+    context "when multiple index options are present" do
+      let(:options) do
+        "--index https://token1@example.com/simple --index https://token2@example.com/simple " \
+          "--default-index https://token3@default.example.com/simple"
+      end
+
+      it "redacts all index URLs" do
+        expect(lock_options_fingerprint)
+          .to eq("--index <index> --index <index> --default-index <default_index>")
+      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

When a private PyPI server serves its Simple API and package downloads at different path prefixes, there is no single `index-url` value that satisfies both the proxy's auth scoping and uv's index lookup path.

uv.lock already records the correct Simple API registry URL for every package in its `source.registry` field. Use those URLs to build `--index` flags instead of the credential `index-url`, matching credentials by host and longest-prefix path score. Fall back to the credential URL when no lockfile registry entry matches.

This decouples the two concerns:
- `--index` comes from uv.lock source entries → uv hits the correct path
- `index-url` in dependabot.yml is only used by the proxy for auth scoping

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Tests added (in `lock_file_updater_spec.rb`):

1. `when uv.lock registry URLs differ from credential index-url paths` — asserts that when a credential's `index-url` is `https://pypi.example.com/` (root) but uv.lock records `source.registry = "https://pypi.example.com/pypi"`, the generated `--index` flag uses the lockfile registry path with the credential token applied: `--index https://token@pypi.example.com/pypi`.

2. `when uv.lock has no matching registry for a credential` — asserts that when no lockfile registry entry matches a credential's host, the code falls back to the credential `index-url` unchanged (preserving existing behaviour).

All 71 existing `lock_file_updater` specs continue to pass, confirming no regressions to the explicit-index, defined-in-pyproject, trailing-slash normalisation, and replaces-base flows.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
