### PR TITLE
Fix python update_not_possible error with `bump_versions` strategy

### DIFF
--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -267,22 +267,34 @@ module Dependabot
 
         sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
         def update_requirement(req)
-          requirement_strings = req[:requirement].split(",").map(&:strip)
-
-          new_requirement =
-            if requirement_strings.any? { |r| r.match?(/^[=\d]/) }
-              find_and_update_equality_match(requirement_strings)
-            elsif requirement_strings.any? { |r| r.start_with?("~=") }
-              tw_req = requirement_strings.find { |r| r.start_with?("~=") }
-              bump_version(tw_req, latest_resolvable_version.to_s)
-            elsif new_version_satisfies?(req)
-              req.fetch(:requirement)
-            else
-              update_requirements_range(requirement_strings)
-            end
+          new_requirement = updated_requirement_string(req)
           req.merge(requirement: new_requirement)
         rescue UnfixableRequirement
           req.merge(requirement: :unfixable)
+        end
+
+        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T.any(String, Symbol)) }
+        def updated_requirement_string(req)
+          requirement_strings = req[:requirement].split(",").map(&:strip)
+
+          if requirement_strings.any? { |r| r.match?(/^[=\d]/) }
+            find_and_update_equality_match(requirement_strings)
+          elsif requirement_strings.any? { |r| r.start_with?("~=") }
+            tw_req = requirement_strings.find { |r| r.start_with?("~=") }
+            bump_version(tw_req, latest_resolvable_version.to_s)
+          elsif bump_lower_bound?(requirement_strings)
+            bump_requirements_range(requirement_strings)
+          elsif new_version_satisfies?(req)
+            req.fetch(:requirement)
+          else
+            update_requirements_range(requirement_strings)
+          end
+        end
+
+        sig { params(requirement_strings: T::Array[String]).returns(T::Boolean) }
+        def bump_lower_bound?(requirement_strings)
+          update_strategy == RequirementsUpdateStrategy::BumpVersions &&
+            requirement_strings.any? { |r| r.strip.start_with?(">") }
         end
 
         sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
         context "when a range requirement was specified" do
           let(:requirement_txt_req_string) { ">=1.3.0" }
 
-          it { is_expected.to eq(requirement_txt_req) }
+          its([:requirement]) { is_expected.to eq(">=1.5.0") }
 
           context "when requirement version is too high" do
             let(:requirement_txt_req_string) { ">=2.0.0" }
@@ -135,26 +135,33 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "when requirement had a local version" do
             let(:requirement_txt_req_string) { ">=1.3.0+gc.1" }
 
-            it { is_expected.to eq(requirement_txt_req) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0") }
           end
 
           context "with an upper bound" do
             let(:requirement_txt_req_string) { ">=1.3.0, <=1.5.0" }
 
-            it { is_expected.to eq(requirement_txt_req) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0,<=1.5.0") }
 
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq(">=1.9,<=1.10") }
+                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
               end
             end
+          end
+
+          context "with an upper bound and bump_versions strategy" do
+            let(:requirement_txt_req_string) { ">=1.9.2, <2" }
+            let(:latest_resolvable_version) { "1.10.1" }
+
+            its([:requirement]) { is_expected.to eq(">=1.10.1,<2") }
           end
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?
When a pip dependency in a `requirements.txt` file uses a range constraint like `>=1.9.2,<2` and the `bump_versions` (aka `increase`) strategy is configured, Dependabot reports "No update possible" even when a newer version exists within the range.

This happens because `update_requirement` short-circuits when `new_version_satisfies?` returns true, leaving the requirement unchanged. Without a lockfile, the unchanged requirement means `changed_requirements` is empty, so `requirements_can_update?` returns false and the update is classified as `:update_not_possible`.

The pyproject.toml handler (`update_pyproject_version_core`) already handles this correctly by calling `bump_requirements_range` to bump the lower bound regardless of whether the new version satisfies the existing range.

Fixes https://github.com/dependabot/dependabot-core/issues/14762.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**Fix:**
In `update_requirement` (used for .txt and .in files), when the strategy is `BumpVersions` and the requirement contains a lower bound (`>` or `>=`), call `bump_requirements_range` to bump the lower bound to the latest version.

 For example:
`>=1.9.2,<2` with latest `1.10.1` → `>=1.10.1,<2`

This produces a changed requirement, which correctly triggers a PR.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
If the the job with `BumpVersions` strategy runs fine and creates a bump PR for the dependency.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
