### PR TITLE
fix(python): filter non-requirements .txt files using filename regex patterns

### DIFF
--- a/python/lib/dependabot/python/shared_file_fetcher.rb
+++ b/python/lib/dependabot/python/shared_file_fetcher.rb
@@ -26,6 +26,19 @@ module Dependabot
       DEPENDENCY_TYPES = T.let(%w(packages dev-packages).freeze, T::Array[String])
       MAX_FILE_SIZE = T.let(500_000, Integer)
 
+      # Regex patterns for detecting Python requirements.txt manifest variants.
+      # Ported from github/dependency-snapshots-api.
+      #
+      # Matches "requirements" preceded by a hyphen, period, underscore, start-of-string, or slash,
+      # followed by non-whitespace chars and ".txt".
+      # Examples: requirements.txt, requirements.prod.txt, requirements/production.txt
+      REQUIREMENTS_TXT_REGEX = T.let(%r{(?:[-._]|^|/)requirements[^\s]*\.txt$}i, Regexp)
+
+      # More lenient: matches "require" with optional prefix (no dots/whitespace)
+      # and optional hyphen/underscore/slash suffix. Does not match "require" as a substring.
+      # Examples: require.txt, require-test.txt, py3-require.txt, pyenv_require_e2e.txt
+      REQUIRE_TXT_REGEX = T.let(%r{[^\s|.]*require(?:[-_/][^\s|.]*)?\.txt$}i, Regexp)
+
       sig { abstract.returns(T::Array[String]) }
       def self.ecosystem_specific_required_files; end
 
@@ -169,7 +182,7 @@ module Dependabot
 
             repo_contents
               .select { |f| f.type == "file" }
-              .select { |f| f.name.end_with?(".txt", ".in") }
+              .select { |f| potential_requirements_file?(f.name) }
               .reject { |f| f.size > MAX_FILE_SIZE }
               .map { |f| fetch_file_from_host(f.name) }
               .select { |f| requirements_file?(f) }
@@ -193,7 +206,7 @@ module Dependabot
 
         repo_contents(dir: relative_reqs_dir)
           .select { |f| f.type == "file" }
-          .select { |f| f.name.end_with?(".txt", ".in") }
+          .select { |f| potential_requirements_file?(File.join(relative_reqs_dir, f.name)) }
           .reject { |f| f.size > MAX_FILE_SIZE }
           .map { |f| fetch_file_from_host("#{relative_reqs_dir}/#{f.name}") }
           .select { |f| requirements_file?(f) }
@@ -377,6 +390,24 @@ module Dependabot
           end
 
         uneditable_reqs + editable_reqs
+      end
+
+      # Checks if a filename matches known Python requirements.txt naming patterns.
+      sig { params(path: String).returns(T::Boolean) }
+      def requirements_txt_filename?(path)
+        path.match?(REQUIREMENTS_TXT_REGEX) || path.match?(REQUIRE_TXT_REGEX)
+      end
+
+      # When the feature flag is enabled, only considers .txt files whose names match
+      # requirements patterns (plus all .in files). When disabled, falls back to the
+      # original behavior of accepting any .txt or .in file.
+      sig { params(path: String).returns(T::Boolean) }
+      def potential_requirements_file?(path)
+        unless Dependabot::Experiments.enabled?(:python_requirements_file_name_filtering)
+          return path.end_with?(".txt", ".in")
+        end
+
+        path.end_with?(".in") || requirements_txt_filename?(path)
       end
 
       sig { params(path: String).returns(String) }

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -234,6 +234,18 @@ RSpec.describe Dependabot::Python::FileFetcher do
               .to match_array(%w(todo.txt requirements.txt))
           end
         end
+
+        context "when python_requirements_file_name_filtering is enabled" do
+          before do
+            Dependabot::Experiments.register(:python_requirements_file_name_filtering, true)
+          end
+
+          it "skips the non-requirements txt file" do
+            expect(file_fetcher_instance.files.count).to eq(1)
+            expect(file_fetcher_instance.files.map(&:name))
+              .to eq(["requirements.txt"])
+          end
+        end
       end
 
       context "when dealing with a todo.txt can't be encoded to UTF-8" do
@@ -653,6 +665,30 @@ RSpec.describe Dependabot::Python::FileFetcher do
               requirements/typing.in
             )
           )
+      end
+
+      context "when python_requirements_file_name_filtering is enabled" do
+        before do
+          Dependabot::Experiments.register(:python_requirements_file_name_filtering, true)
+        end
+
+        it "still fetches requirements files from subdirectories using the full path for filtering" do
+          expect(file_fetcher_instance.files.map(&:name))
+            .to match_array(
+              %w(
+                requirements.txt
+                setup.py
+                requirements/coverage.txt
+                requirements/test.txt
+                requirements/tools.txt
+                requirements/typing.txt
+                requirements/coverage.in
+                requirements/test.in
+                requirements/tools.in
+                requirements/typing.in
+              )
+            )
+        end
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a bug where non-requirements `.txt` files (e.g., `todo.txt`) are incorrectly parsed as Python dependency manifests, causing package names to be substituted with integers in the dependency graph.

The root cause is that the file fetcher picks up ALL `.txt` files and the content validation (`requirements_file?`) is too lenient, allowing bystander text files through. Additionally, the grapher's `pip_requirements_file` falls back to any `.txt` file.

The fix ports regex patterns that have been battle tested on dependency graph and the monolith to validate filenames before considering them as requirements files:
- `REQUIREMENTS_TXT_REGEX`: matches `requirements.txt`, `requirements.prod.txt`, `requirements/production.txt`, etc.
- `REQUIRE_TXT_REGEX`: matches `require.txt`, `require-test.txt`, `py3-require.txt`, etc.

### Anything you want to highlight for special attention from reviewers?

The file fetcher change is gated behind `:python_requirements_file_name_filtering` so it can be rolled out via the monolith.

### How will you know you have accomplished your goal?

Tests pass

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.