### PR TITLE
add a new PackageReference element next to existing PackageReference elements

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
@@ -24,7 +24,7 @@ public abstract class FileWriterTestsBase
         var requiredDependencies = requiredDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
         var addPackageReferenceElementForPinnedPackages = !useCentralPackageTransitivePinning;
         var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, addPackageReferenceElementForPinnedPackages);
-        Assert.True(success);
+        Assert.True(success, "Expected UpdatePackageVersionsAsync to succeed.");
 
         var expectedFileNames = expectedFiles.Select(f => f.path).ToHashSet();
         var actualFiles = (await tempDir.ReadFileContentsAsync(expectedFileNames)).ToDictionary(f => f.Path, f => f.Contents);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1997,4 +1997,38 @@ public class XmlFileWriterTests : FileWriterTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task NewReferenceIsAddedToItemGroupWithExistingPackageReferences()
+    {
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="A.Package.Not.Related" Version="1.2.3" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <AdditionalFiles Include="some-resource.json" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["This.Package.Gets.Pinned/4.5.5"],
+            requiredDependencyStrings: ["This.Package.Gets.Pinned/4.5.6"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <ItemGroup>
+                        <PackageReference Include="A.Package.Not.Related" Version="1.2.3" />
+                        <PackageReference Include="This.Package.Gets.Pinned" Version="4.5.6" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <AdditionalFiles Include="some-resource.json" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1999,7 +1999,7 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
-    public async Task NewReferenceIsAddedToItemGroupWithExistingPackageReferences()
+    public async Task NewReference_ItemGroupWithExistingPackageReferences_IsAdded()
     {
         await TestAsync(
             files: [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -150,29 +150,34 @@ public class XmlFileWriter : IFileWriter
                 // find last `<ItemGroup>` in the project...
                 Action addItemGroup = () => { }; // adding an ItemGroup to the project isn't always necessary, but it's much easier to prepare for it here
                 var projectDocument = filesAndContents[projectRelativePath];
-                var lastItemGroup = projectDocument.RootSyntax.Elements
-                    .LastOrDefault(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase));
-                if (lastItemGroup is null)
+                var itemGroups = projectDocument.RootSyntax.Elements
+                    .Where(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                var itemGroupsWithPackageReferences = itemGroups
+                    .Where(e => e.Elements.Any(c => c.Name.Equals(PackageReferenceElementName, StringComparison.OrdinalIgnoreCase)))
+                    .ToArray();
+                var itemGroupForInsertion = itemGroupsWithPackageReferences.LastOrDefault() ?? itemGroups.LastOrDefault();
+                if (itemGroupForInsertion is null)
                 {
                     _logger.Info($"No `<{ItemGroupElementName}>` element found in project; adding one.");
-                    lastItemGroup = XmlExtensions.CreateOpenCloseXmlElementSyntax(ItemGroupElementName,
+                    itemGroupForInsertion = XmlExtensions.CreateOpenCloseXmlElementSyntax(ItemGroupElementName,
                         new SyntaxList<SyntaxNode>([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia("  ")]),
                         insertIntermediateNewline: false);
                     addItemGroup = () =>
                     {
                         // add the new element
-                        var updatedRootSyntax = projectDocument.RootSyntax.AddChild(lastItemGroup);
+                        var updatedRootSyntax = projectDocument.RootSyntax.AddChild(itemGroupForInsertion);
                         var updatedProjectDocument = projectDocument.ReplaceNode(projectDocument.RootSyntax.AsNode, updatedRootSyntax.AsNode);
 
                         // reset well-known variables
                         projectDocument = updatedProjectDocument;
                         filesAndContents[projectRelativePath] = updatedProjectDocument;
-                        lastItemGroup = updatedProjectDocument.RootSyntax.Elements.Last(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase));
+                        itemGroupForInsertion = updatedProjectDocument.RootSyntax.Elements.Last(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase));
                     };
                 }
 
                 // ...find where the new item should go...
-                var elementsBeforeNew = GetOrderedElementsBeforeSpecified(lastItemGroup, PackageReferenceElementName, [IncludeAttributeName, UpdateAttributeName], requiredPackageVersion.Name);
+                var elementsBeforeNew = GetOrderedElementsBeforeSpecified(itemGroupForInsertion, PackageReferenceElementName, [IncludeAttributeName, UpdateAttributeName], requiredPackageVersion.Name);
 
                 // ...prepare a new `<PackageReference>` element...
                 var newElement = XmlExtensions.CreateSingleLineXmlElementSyntax(PackageReferenceElementName, leadingTrivia: new SyntaxList<SyntaxNode>())
@@ -221,7 +226,7 @@ public class XmlFileWriter : IFileWriter
                     else
                     {
                         // no prior package references; add to the front
-                        var itemGroupTrivia = lastItemGroup.AsNode.GetLeadingTrivia().ToList();
+                        var itemGroupTrivia = itemGroupForInsertion.AsNode.GetLeadingTrivia().ToList();
                         var priorEolIndex = itemGroupTrivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
                         var indentTrivia = itemGroupTrivia
                             .Skip(priorEolIndex + 1)
@@ -231,8 +236,8 @@ public class XmlFileWriter : IFileWriter
                         newElement = (IXmlElementSyntax)newElement.AsNode.WithLeadingTrivia(newTrivia);
                         var updatedItemGroup = (IXmlElementSyntax)ReplaceNode(
                             projectRelativePath,
-                            lastItemGroup.AsNode,
-                            lastItemGroup.InsertChild(newElement, 0).AsNode
+                            itemGroupForInsertion.AsNode,
+                            itemGroupForInsertion.InsertChild(newElement, 0).AsNode
                         );
                         newElement = (IXmlElementSyntax)updatedItemGroup.Content[0];
                     }


### PR DESCRIPTION
When adding a `<PackageReference>` element to an `<ItemGroup>` in an XML file, don't just pick the last one because it might be wrong.  Instead first try to pick the last item group *that already had `<PackageReference>` elements* and then fall back to the old behavior.