### PR TITLE
detect file indentation characters

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -2031,4 +2031,34 @@ public class XmlFileWriterTests : FileWriterTestsBase
             ]
         );
     }
+
+    [Fact]
+    public async Task NewReference_AtStartOfItemGroup_HonorsIndentation()
+    {
+        // this test requires tabs and rather than deal with various editor states, a tab character is explicitly included
+        var tb = '\t';
+        await TestAsync(
+            files: [
+                ("project.csproj", $"""
+                    <Project Sdk="Microsoft.NET.Sdk">
+                    {tb}<ItemGroup>
+                    {tb}{tb}<AdditionalFiles Include="some-resource.json" />
+                    {tb}</ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["This.Package.Gets.Pinned/4.5.5"],
+            requiredDependencyStrings: ["This.Package.Gets.Pinned/4.5.6"],
+            expectedFiles: [
+                ("project.csproj", $"""
+                    <Project Sdk="Microsoft.NET.Sdk">
+                    {tb}<ItemGroup>
+                    {tb}{tb}<PackageReference Include="This.Package.Gets.Pinned" Version="4.5.6" />
+                    {tb}{tb}<AdditionalFiles Include="some-resource.json" />
+                    {tb}</ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests_GetDocumentIndentationCharactersTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests_GetDocumentIndentationCharactersTests.cs
@@ -1,0 +1,120 @@
+using NuGetUpdater.Core.Updater.FileWriters;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Update.FileWriters;
+
+public class XmlFileWriterTests_GetDocumentIndentationCharactersTests
+{
+    [Theory]
+    [MemberData(nameof(GetDocumentationIndentationCharactersTestData))]
+    public async Task GetDocumentIndentationCharacters(string documentContents, string expectedIndentation)
+    {
+        var fileName = "project.csproj";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((fileName, documentContents));
+        var documentSyntax = await XmlFileWriter.ReadFileContentsAsync(new DirectoryInfo(tempDir.DirectoryPath), fileName);
+        var actualIndentation = XmlFileWriter.GetDocumentIndentationCharacters(documentSyntax);
+        Assert.Equal(expectedIndentation, actualIndentation);
+    }
+
+    public static IEnumerable<object[]> GetDocumentationIndentationCharactersTestData()
+    {
+        var tb = '\t';
+
+        //
+        // common scenarios
+        //
+
+        // two spaces
+        yield return [
+            // documentContents
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net5.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            "  "
+        ];
+
+        // four spaces
+        yield return [
+            // documentContents
+            """
+            <Project>
+                <PropertyGroup>
+                    <TargetFramework>net5.0</TargetFramework>
+                </PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            "    "
+        ];
+
+        //
+        // less common
+        //
+
+        // one tab
+        yield return [
+            // documentContents
+            $"""
+            <Project>
+            {tb}<PropertyGroup>
+            {tb}{tb}<TargetFramework>net5.0</TargetFramework>
+            {tb}</PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            "\t"
+        ];
+
+        //
+        // uncommon but still valid
+        //
+
+        // one space
+        yield return [
+            // documentContents
+            """
+            <Project>
+             <PropertyGroup>
+              <TargetFramework>net5.0</TargetFramework>
+             </PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            " "
+        ];
+
+        // three spaces
+        yield return [
+            // documentContents
+            """
+            <Project>
+               <PropertyGroup>
+                  <TargetFramework>net5.0</TargetFramework>
+               </PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            "   "
+        ];
+
+        // two tabs
+        yield return [
+            // documentContents
+            $"""
+            <Project>
+            {tb}{tb}<PropertyGroup>
+            {tb}{tb}{tb}{tb}<TargetFramework>net5.0</TargetFramework>
+            {tb}{tb}</PropertyGroup>
+            </Project>
+            """,
+            // expectedIndentation
+            "\t\t"
+        ];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -150,6 +150,7 @@ public class XmlFileWriter : IFileWriter
                 // find last `<ItemGroup>` in the project...
                 Action addItemGroup = () => { }; // adding an ItemGroup to the project isn't always necessary, but it's much easier to prepare for it here
                 var projectDocument = filesAndContents[projectRelativePath];
+                var indentation = GetDocumentIndentationCharacters(projectDocument);
                 var itemGroups = projectDocument.RootSyntax.Elements
                     .Where(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
@@ -161,7 +162,7 @@ public class XmlFileWriter : IFileWriter
                 {
                     _logger.Info($"No `<{ItemGroupElementName}>` element found in project; adding one.");
                     itemGroupForInsertion = XmlExtensions.CreateOpenCloseXmlElementSyntax(ItemGroupElementName,
-                        new SyntaxList<SyntaxNode>([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia("  ")]),
+                        new SyntaxList<SyntaxNode>([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(indentation)]),
                         insertIntermediateNewline: false);
                     addItemGroup = () =>
                     {
@@ -232,7 +233,7 @@ public class XmlFileWriter : IFileWriter
                             .Skip(priorEolIndex + 1)
                             .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
                             .ToArray();
-                        var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia("  "), .. indentTrivia]);
+                        var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(indentation), .. indentTrivia]);
                         newElement = (IXmlElementSyntax)newElement.AsNode.WithLeadingTrivia(newTrivia);
                         var updatedItemGroup = (IXmlElementSyntax)ReplaceNode(
                             projectRelativePath,
@@ -358,7 +359,9 @@ public class XmlFileWriter : IFileWriter
                                 .Skip(priorEolIndex + 1)
                                 .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
                                 .ToArray();
-                            var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia("  "), .. indentTrivia]);
+                            var packageVersionDocument = filesAndContents[filePath];
+                            var packageVersionIndentation = GetDocumentIndentationCharacters(packageVersionDocument);
+                            var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(packageVersionIndentation), .. indentTrivia]);
                             newVersionElement = (IXmlElementSyntax)newVersionElement.AsNode.WithLeadingTrivia(newTrivia).WithoutTrailingTrivia();
                             var insertionIndex = 0;
                             var replacementPackageVersionGroup = packageVersionGroup
@@ -586,7 +589,7 @@ public class XmlFileWriter : IFileWriter
         return elementsBeforeNew;
     }
 
-    private static async Task<XmlDocumentSyntax> ReadFileContentsAsync(DirectoryInfo repoContentsPath, string path)
+    internal static async Task<XmlDocumentSyntax> ReadFileContentsAsync(DirectoryInfo repoContentsPath, string path)
     {
         var fullPath = Path.Join(repoContentsPath.FullName, path);
         var contents = await File.ReadAllTextAsync(fullPath);
@@ -700,5 +703,24 @@ public class XmlFileWriter : IFileWriter
         }
 
         return newRange.ToString();
+    }
+
+    public static string GetDocumentIndentationCharacters(XmlDocumentSyntax document)
+    {
+        // find the first element with leading whitespace and assume that's the document indentation
+        var nodeLeadingLineTrivias = document.DescendantNodes()
+            .Select(n => n.GetLeadingTrivia().ToList())
+            .Select(l =>
+            {
+                var priorEolIndex = l.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
+                var leadingTriviaParts = l.Skip(priorEolIndex + 1)
+                    .Select(t => t.ToFullString());
+                var leadingTrivia = string.Concat(leadingTriviaParts);
+                return leadingTrivia;
+            })
+            .ToArray();
+        var nodeLeadingLineTrivia = nodeLeadingLineTrivias
+            .FirstOrDefault(t => !string.IsNullOrEmpty(t));
+        return nodeLeadingLineTrivia ?? "  ";
     }
 }


### PR DESCRIPTION
When adding new `<PackageReference>` or `<PackageVersion>` elements to an `<ItemGroup>`, we previously copied the line indentation for the `<ItemGroup>` and appended two spaces.  This wasn't correct and could lead to some weird files.

The fix taken is to check the existing file for the first non-blank line indentation and use that as the single indentation sequence to use.  If nothing was found only then do we revert the default of two spaces.  If a file has inconsistent indentation, like spaces for the first `<PropertyGroup>` and tabs everwhere else, this will do the wrong thing but at that point we're in weird states anyway.