### PR TITLE
treat all warnings as errors

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/DotNetPackageCorrelation/DotNetPackageCorrelation.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/DotNetPackageCorrelation/DotNetPackageCorrelation.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
+    <NoWarn>NU1510</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/DotNetPackageCorrelation/DotNetPackageCorrelation.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/DotNetPackageCorrelation/DotNetPackageCorrelation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
-    <NoWarn>NU1510</NoWarn>
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
@@ -10,6 +10,8 @@
     <NoWarn>$(NoWarn);SYSLIB0014</NoWarn><!-- obsolete -->
     <NuGetSourceLocation>$(MSBuildThisFileDirectory)..\..\NuGet.Client</NuGetSourceLocation>
     <SharedDirectory>$(NuGetSourceLocation)\build\Shared</SharedDirectory>
+    <NoWarn>$(NoWarn);CA1416</NoWarn><!-- platform compatibility in vendored NuGet.Client code -->
+    <NoWarn>$(NoWarn);CS0436</NoWarn><!-- type conflicts with imported types in vendored NuGet.Client code -->
     <Version>6.8.0</Version>
   </PropertyGroup>
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU1510</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.PackageManagement/NuGet.PackageManagement.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.PackageManagement/NuGet.PackageManagement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(CommonTargetFramework)</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591;CS1580;CS1574;CS1573;RS0041</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1580;CS1574;CS1573;RS0041;NU1510</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -145,7 +145,7 @@ public class CloneWorkerTests
         var cloneWorker = new CloneWorker("JOB-ID", testApiHandler, testGitCommandHandler, new TestLogger());
         using var testDirectory = new TemporaryDirectory();
         var jobFilePath = Path.Combine(testDirectory.DirectoryPath, "job.json");
-        await File.WriteAllTextAsync(jobFilePath, "not json");
+        await File.WriteAllTextAsync(jobFilePath, "not json", TestContext.Current.CancellationToken);
 
         // act
         var result = await cloneWorker.RunAsync(new FileInfo(jobFilePath), new DirectoryInfo(testDirectory.DirectoryPath));
@@ -183,7 +183,7 @@ public class CloneWorkerTests
                     ]
                 }
             }
-            """);
+            """, TestContext.Current.CancellationToken);
 
         // act
         var result = await cloneWorker.RunAsync(new FileInfo(jobFilePath), new DirectoryInfo(testDirectory.DirectoryPath));

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -12,8 +12,8 @@ using Xunit;
 
 namespace NuGetUpdater.Core.Test.Run;
 
-using TestFile = (string Path, string Content);
 using RawTestFile = (string Path, byte[] Content);
+using TestFile = (string Path, string Content);
 
 public class EndToEndTests
 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
@@ -1,6 +1,7 @@
+using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Run.UpdateHandlers;
-using NuGetUpdater.Core.Run;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlersTestsBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlersTestsBase.cs
@@ -1,6 +1,7 @@
+using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Run.UpdateHandlers;
-using NuGetUpdater.Core.Run;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -186,7 +186,7 @@ public class UpdatedDependencyListTests
         {
             var fullFilePath = Path.Join(tempDir.DirectoryPath, testFile);
             Directory.CreateDirectory(Path.GetDirectoryName(fullFilePath)!);
-            await File.WriteAllTextAsync(fullFilePath, "");
+            await File.WriteAllTextAsync(fullFilePath, "", TestContext.Current.CancellationToken);
         }
         var discovery = new WorkspaceDiscoveryResult()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestBase.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 
-using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
 
 using Xunit;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
@@ -2,8 +2,9 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
-using NuGet.Versioning;
 using NuGet;
+using NuGet.Versioning;
+
 using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Test

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -43,14 +43,14 @@ public class SpecialFilePatcherTests
         // act
         using (var patcher = new SpecialImportsConditionPatcher(projectPath))
         {
-            var actualPatchedContent = await File.ReadAllTextAsync(projectPath);
+            var actualPatchedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
 
             // assert
             Assert.Equal(expectedPatchedContent.Replace("\r", ""), actualPatchedContent.Replace("\r", ""));
         }
 
         // assert again
-        var restoredContent = await File.ReadAllTextAsync(projectPath);
+        var restoredContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
         Assert.Equal(restoredContent.Replace("\r", ""), fileContent.Replace("\r", ""));
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LinuxOnlyAttribute.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LinuxOnlyAttribute.cs
@@ -1,8 +1,13 @@
+using System.Runtime.CompilerServices;
+
 using Xunit;
 
 public class LinuxOnlyFactAttribute : FactAttribute
 {
-    public LinuxOnlyFactAttribute()
+    public LinuxOnlyFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
     {
         if (!OperatingSystem.IsLinux())
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/CommitOptions_IncludeScopeConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/CommitOptions_IncludeScopeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run;


### PR DESCRIPTION
Promote all warnings to errors.  Fix where possible, but otherwise suppress at the project level when necessary.