### PR TITLE
Python/UV: Failed ephemeral lockfiles tag snapshots as degraded

### DIFF
--- a/common/lib/dependabot/dependency_graphers/base.rb
+++ b/common/lib/dependabot/dependency_graphers/base.rb
@@ -100,16 +100,35 @@ module Dependabot
 
       sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::Dependency]) }
       def safe_fetch_subdependencies(dependency)
-        return [] if @errored_fetching_subdependencies
+        return [] if errored_fetching_subdependencies
 
         fetch_subdependencies(dependency).filter_map do |dependency_name|
           dependencies_by_name[dependency_name]
         end
       rescue StandardError => e
-        @errored_fetching_subdependencies = true
+        errored_fetching_subdependencies!
         @subdependency_error = T.let(e, T.nilable(StandardError))
         Dependabot.logger.error("Error fetching subdependencies: #{e.message}")
         []
+      end
+
+      # TODO(brrygrdn): Replace this with a `degraded` flag and a `reason` string/enum
+      #
+      # Nearly all failure modes we have so far amount to 'we couldn't get the full tree for some reason' which is
+      # semantically the same as failing to fetch subdependences, but it is elides some specific information we
+      # could use to improve user-facing errors in future, e.g.
+      # - Auth failure doing a necessary operation; fix your auth please
+      # - Auth failure generating an ephemeral lockfile; fix your auth -or- check in your lockfile
+      #
+      # The reason this isn't precise enough is that in some ecosystems, the degradation from an ephemeral lockfile
+      # goes further and we cannot actually tell versions of top-level dependencies either.
+      #
+      # To reflect this properly as we expand our ecosystems, setting a generic degraded flag along with user
+      # guidance from the ecosystem-specific implementation will allow us to be clearer on remediation in UIs
+      # in addition to the job logs.
+      sig { void }
+      def errored_fetching_subdependencies!
+        @errored_fetching_subdependencies = true
       end
 
       # Each grapher is expected to implement a method to look up the parents of a given dependency.

--- a/common/lib/dependabot/dependency_graphers/base.rb
+++ b/common/lib/dependabot/dependency_graphers/base.rb
@@ -115,7 +115,7 @@ module Dependabot
       # TODO(brrygrdn): Replace this with a `degraded` flag and a `reason` string/enum
       #
       # Nearly all failure modes we have so far amount to 'we couldn't get the full tree for some reason' which is
-      # semantically the same as failing to fetch subdependences, but it is elides some specific information we
+      # semantically the same as failing to fetch subdependencies, but it is elides some specific information we
       # could use to improve user-facing errors in future, e.g.
       # - Auth failure doing a necessary operation; fix your auth please
       # - Auth failure generating an ephemeral lockfile; fix your auth -or- check in your lockfile

--- a/go_modules/lib/dependabot/go_modules/dependency_grapher.rb
+++ b/go_modules/lib/dependabot/go_modules/dependency_grapher.rb
@@ -31,10 +31,6 @@ module Dependabot
 
       private
 
-      # TODO: Build subdependency in this class and assign here -or- assign metadata in the parser
-      #
-      # We can do whichever makes most sense on a case-by-case basis, for Go the trade off on
-      # doing this in the parser shouldn't add a huge overhead.
       sig { override.params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
       def fetch_subdependencies(dependency)
         # go mod graph returns all dependencies it finds, even if it has been pruned. So filter those out.

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -88,7 +88,11 @@ module Dependabot
         )
 
         ephemeral_lockfile = generator.generate
-        return unless ephemeral_lockfile
+        unless ephemeral_lockfile
+          # Set the degraded flag since we won't have all dependencies.
+          errored_fetching_subdependencies!
+          return
+        end
 
         inject_ephemeral_lockfile(ephemeral_lockfile)
         @ephemeral_lockfile_generated = T.let(true, T.nilable(T::Boolean))
@@ -96,7 +100,9 @@ module Dependabot
         Dependabot.logger.info(
           "Successfully generated ephemeral #{ephemeral_lockfile.name} for dependency graphing"
         )
-      rescue StandardError => e
+      rescue SharedHelpers::HelperSubprocessFailed => e
+        errored_fetching_subdependencies!
+        @subdependency_error = e
         Dependabot.logger.warn(
           "Failed to generate ephemeral lockfile: #{e.message}. " \
           "Dependency versions may not be resolved."

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -94,7 +94,7 @@ module Dependabot
         Dependabot.logger.info(
           "Successfully generated ephemeral #{ephemeral_lockfile.name} for dependency graphing"
         )
-      rescue SharedHelpers::HelperSubprocessFailed => e
+      rescue StandardError => e
         errored_fetching_subdependencies!
         @subdependency_error = e
         Dependabot.logger.warn(

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -88,12 +88,6 @@ module Dependabot
         )
 
         ephemeral_lockfile = generator.generate
-        unless ephemeral_lockfile
-          # Set the degraded flag since we won't have all dependencies.
-          errored_fetching_subdependencies!
-          return
-        end
-
         inject_ephemeral_lockfile(ephemeral_lockfile)
         @ephemeral_lockfile_generated = T.let(true, T.nilable(T::Boolean))
 

--- a/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
+++ b/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
@@ -81,7 +81,7 @@ module Dependabot
         def read_generated_lockfile
           unless File.exist?(LOCKFILE_NAME)
             Dependabot.logger.error("#{LOCKFILE_NAME} was not generated")
-            raise Dependabot::DependencyFileNotEvaluatable.new("#{LOCKFILE_NAME} was not generated")
+            raise Dependabot::DependencyFileNotEvaluatable, "#{LOCKFILE_NAME} was not generated"
           end
 
           content = File.read(LOCKFILE_NAME)

--- a/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
+++ b/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
@@ -44,7 +44,7 @@ module Dependabot
           end
         rescue SharedHelpers::HelperSubprocessFailed => e
           handle_generation_error(e)
-          nil
+          raise
         end
 
         private
@@ -80,8 +80,8 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         def read_generated_lockfile
           unless File.exist?(LOCKFILE_NAME)
-            Dependabot.logger.warn("#{LOCKFILE_NAME} was not generated")
-            return nil
+            Dependabot.logger.error("#{LOCKFILE_NAME} was not generated")
+            raise Dependabot::DependencyFileNotEvaluatable.new("#{LOCKFILE_NAME} was not generated")
           end
 
           content = File.read(LOCKFILE_NAME)

--- a/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
+++ b/python/lib/dependabot/python/dependency_grapher/lockfile_generator.rb
@@ -28,7 +28,7 @@ module Dependabot
           @credentials = credentials
         end
 
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
+        sig { returns(Dependabot::DependencyFile) }
         def generate
           SharedHelpers.in_a_temporary_directory do
             SharedHelpers.with_git_configured(credentials: credentials) do
@@ -77,7 +77,7 @@ module Dependabot
           run_poetry_command("pyenv exec poetry lock --no-interaction")
         end
 
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
+        sig { returns(Dependabot::DependencyFile) }
         def read_generated_lockfile
           unless File.exist?(LOCKFILE_NAME)
             Dependabot.logger.error("#{LOCKFILE_NAME} was not generated")

--- a/python/spec/dependabot/python/dependency_grapher/lockfile_generator_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher/lockfile_generator_spec.rb
@@ -132,13 +132,18 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
                      ))
       end
 
-      it "returns nil" do
-        expect(generator.generate).to be_nil
+      it "propagates the error" do
+        expect{ generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
 
       it "logs the error" do
         allow(Dependabot.logger).to receive(:error)
-        generator.generate
+
+        begin
+          generator.generate
+        rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+        end
+
         expect(Dependabot.logger).to have_received(:error).with(/Failed to generate poetry\.lock/)
       end
     end
@@ -163,14 +168,19 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
         allow(File).to receive(:exist?).with("poetry.lock").and_return(false)
       end
 
-      it "returns nil" do
-        expect(generator.generate).to be_nil
+      it "raises Dependabot::DependencyFileNotEvaluatable" do
+        expect{ generator.generate }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
       end
 
-      it "logs a warning" do
-        allow(Dependabot.logger).to receive(:warn)
-        generator.generate
-        expect(Dependabot.logger).to have_received(:warn).with("poetry.lock was not generated")
+      it "logs an error" do
+        allow(Dependabot.logger).to receive(:error)
+
+        begin
+          generator.generate
+        rescue Dependabot::DependencyFileNotEvaluatable
+        end
+
+        expect(Dependabot.logger).to have_received(:error).with("poetry.lock was not generated")
       end
     end
   end

--- a/python/spec/dependabot/python/dependency_grapher/lockfile_generator_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher/lockfile_generator_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
       end
 
       it "propagates the error" do
-        expect{ generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
 
       it "logs the error" do
@@ -141,7 +141,8 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
 
         begin
           generator.generate
-        rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+        rescue StandardError
+          nil
         end
 
         expect(Dependabot.logger).to have_received(:error).with(/Failed to generate poetry\.lock/)
@@ -169,7 +170,7 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
       end
 
       it "raises Dependabot::DependencyFileNotEvaluatable" do
-        expect{ generator.generate }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+        expect { generator.generate }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
       end
 
       it "logs an error" do
@@ -178,6 +179,7 @@ RSpec.describe Dependabot::Python::DependencyGrapher::LockfileGenerator do
         begin
           generator.generate
         rescue Dependabot::DependencyFileNotEvaluatable
+          nil
         end
 
         expect(Dependabot.logger).to have_received(:error).with("poetry.lock was not generated")

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -253,10 +253,18 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
     end
 
     context "when poetry.lock is not present" do
+      let(:ephemeral_lockfile) do
+        Dependabot::DependencyFile.new(
+          name: "poetry.lock",
+          content: fixture("dependency_grapher", "poetry_lock_with_relationships.lock"),
+          directory: "/"
+        )
+      end
+
       let(:lockfile_generator) do
         instance_double(
           Dependabot::Python::DependencyGrapher::LockfileGenerator,
-          generate: nil
+          generate: ephemeral_lockfile
         )
       end
 
@@ -273,32 +281,6 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
             credentials: []
           )
         expect(lockfile_generator).to have_received(:generate)
-      end
-
-      context "when lockfile generation fails" do
-        it "sets the errored_fetching_subdependencies flag" do
-          grapher.resolved_dependencies
-
-          expect(grapher.errored_fetching_subdependencies).to be(true)
-        end
-
-        it "returns dependencies without relationship data" do
-          resolved_dependencies = grapher.resolved_dependencies
-
-          resolved_dependencies.each_value do |dep|
-            expect(dep.dependencies).to eq([])
-          end
-        end
-
-        it "returns PURLs without resolved versions" do
-          resolved_dependencies = grapher.resolved_dependencies
-
-          expect(resolved_dependencies.keys).to include(
-            "pkg:pypi/flask",
-            "pkg:pypi/requests",
-            "pkg:pypi/ruff"
-          )
-        end
       end
 
       context "when lockfile generation raises an error" do
@@ -326,6 +308,16 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
 
           expect(grapher.subdependency_error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
           expect(grapher.subdependency_error.message).to include("poetry lock failed")
+        end
+
+        it "returns PURLs without resolved versions" do
+          resolved_dependencies = grapher.resolved_dependencies
+
+          expect(resolved_dependencies.keys).to include(
+            "pkg:pypi/flask",
+            "pkg:pypi/requests",
+            "pkg:pypi/ruff"
+          )
         end
 
         it "returns dependencies without relationship data" do

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -276,6 +276,12 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
       end
 
       context "when lockfile generation fails" do
+        it "sets the errored_fetching_subdependencies flag" do
+          grapher.resolved_dependencies
+
+          expect(grapher.errored_fetching_subdependencies).to be(true)
+        end
+
         it "returns dependencies without relationship data" do
           resolved_dependencies = grapher.resolved_dependencies
 
@@ -292,6 +298,42 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
             "pkg:pypi/requests",
             "pkg:pypi/ruff"
           )
+        end
+      end
+
+      context "when lockfile generation raises an error" do
+        let(:lockfile_generator) do
+          instance_double(
+            Dependabot::Python::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "poetry lock failed: authentication required",
+                error_context: {}
+              )
+            )
+          end
+        end
+
+        it "sets the error flag for degraded status" do
+          grapher.resolved_dependencies
+
+          expect(grapher.errored_fetching_subdependencies).to be(true)
+        end
+
+        it "preserves the original error as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          expect(grapher.subdependency_error.message).to include("poetry lock failed")
+        end
+
+        it "returns dependencies without relationship data" do
+          resolved_dependencies = grapher.resolved_dependencies
+
+          resolved_dependencies.each_value do |dep|
+            expect(dep.dependencies).to eq([])
+          end
         end
       end
 

--- a/uv/lib/dependabot/uv/dependency_grapher.rb
+++ b/uv/lib/dependabot/uv/dependency_grapher.rb
@@ -84,7 +84,9 @@ module Dependabot
           rels[parent].concat(lockfile_child_names(package_data))
         end
       rescue StandardError => e
-        Dependabot.logger.warn("Failed to parse uv.lock relationships: #{e.message}")
+        errored_fetching_subdependencies!
+        @subdependency_error = e
+        Dependabot.logger.error("Failed to parse uv.lock relationships: #{e.message}")
         {}
       end
 

--- a/uv/spec/dependabot/uv/dependency_grapher_spec.rb
+++ b/uv/spec/dependabot/uv/dependency_grapher_spec.rb
@@ -126,6 +126,25 @@ RSpec.describe Dependabot::Uv::DependencyGrapher do
       end
     end
 
+    context "when lockfile parsing raises an error" do
+      let(:uv_lock_file) do
+        Dependabot::DependencyFile.new(
+          name: "uv.lock",
+          content: "not valid toml {{{",
+          directory: "/"
+        )
+      end
+
+      let(:dependency_files) { [pyproject_toml, uv_lock_file] }
+
+      it "sets errored_fetching_subdependencies and subdependency_error" do
+        grapher.resolved_dependencies
+
+        expect(grapher.errored_fetching_subdependencies).to be(true)
+        expect(grapher.subdependency_error).to be_a(StandardError)
+      end
+    end
+
     context "when serializing lockfile-backed dependencies" do
       let(:uv_lock_file) do
         Dependabot::DependencyFile.new(


### PR DESCRIPTION
### What are you trying to accomplish?

Python is the first ecosystem with an 'ephemeral' lockfile strategy for dependency graphs that we are wiring up end-to-end with Dependency Graph and Dependabot Alerts.

As part of this, we need to make sure we handle failure to generate this file as a 'degraded' state where we've only obtained information about direct dependencies.

### Anything you want to highlight for special attention from reviewers?

We have an existing mechanism for this that, until now, has strictly had a contract of:
> We have a full picture of your direct dependencies, but not your transitive dependencies

This is _almost_ in the case of ephemeral lockfiles, for Poetry at least it also means we don't know the exact, resolved versions of your dependencies either.

Rather than implement a contract change to make degraded go from one concrete reason to two reasons, mindful there may be more ecosystem specific nuances in future, I've decided to use the existing degraded state as 'good enough' for now - it will inform the user of the problem and refer them to the logs.

I will fast-follow to do the heavily lifting around "degraded" signals as I start into our final round of preparation on npm parsers that also use this mechanisim.

### How will you know you've accomplished your goal?

I will be able to verify that a job where we are generating a snapshot without the degraded tag due to missing creds is now correctly marked as such.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
