### PR TITLE
Support TOML 1.1 multiline inline table syntax in Cargo manifests

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -9,6 +9,7 @@ require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/file_filtering"
 require "dependabot/cargo/file_parser"
+require "dependabot/cargo/toml_parser"
 
 # Docs on Cargo workspaces:
 # https://doc.rust-lang.org/cargo/reference/manifest.html#the-workspace-section
@@ -31,7 +32,7 @@ module Dependabot
       sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def ecosystem_versions
         channel = if rust_toolchain
-                    TomlRB.parse(T.must(rust_toolchain).content).dig("toolchain", "channel")
+                    TomlParser.parse(T.must(T.must(rust_toolchain).content)).dig("toolchain", "channel")
                   else
                     "default"
                   end
@@ -413,7 +414,7 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(T::Hash[T.untyped, T.untyped]) }
       def parsed_file(file)
-        TomlRB.parse(file.content)
+        TomlParser.parse(T.must(file.content))
       rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
         raise Dependabot::DependencyFileNotParseable, file.path
       end

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -13,6 +13,7 @@ require "dependabot/errors"
 require "dependabot/cargo/registry_fetcher"
 require "dependabot/cargo/language"
 require "dependabot/cargo/package_manager"
+require "dependabot/cargo/toml_parser"
 
 # Relevant Cargo docs can be found at:
 # - https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -402,7 +403,7 @@ module Dependabot
       sig { params(file: DependencyFile).returns(T.untyped) }
       def parsed_file(file)
         @parsed_file ||= T.let({}, T.untyped)
-        @parsed_file[file.name] ||= TomlRB.parse(file.content)
+        @parsed_file[file.name] ||= TomlParser.parse(T.must(file.content))
       rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
         raise Dependabot::DependencyFileNotParseable, file.path
       end

--- a/cargo/lib/dependabot/cargo/file_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater.rb
@@ -99,7 +99,7 @@ module Dependabot
       def workspace_root_manifest?(file)
         return false unless file.name == "Cargo.toml"
 
-        parsed_file = TomlParser.parse(file.content)
+        parsed_file = TomlParser.parse(T.must(file.content))
         parsed_file.key?("workspace") && parsed_file["workspace"].key?("dependencies")
       rescue TomlRB::ParseError
         false

--- a/cargo/lib/dependabot/cargo/file_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater.rb
@@ -8,6 +8,7 @@ require "dependabot/git_commit_checker"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/shared_helpers"
+require "dependabot/cargo/toml_parser"
 
 module Dependabot
   module Cargo
@@ -98,7 +99,7 @@ module Dependabot
       def workspace_root_manifest?(file)
         return false unless file.name == "Cargo.toml"
 
-        parsed_file = TomlRB.parse(file.content)
+        parsed_file = TomlParser.parse(file.content)
         parsed_file.key?("workspace") && parsed_file["workspace"].key?("dependencies")
       rescue TomlRB::ParseError
         false

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -193,7 +193,7 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def git_previous_version
-          TomlParser.parse(lockfile.content)
+          TomlParser.parse(T.must(lockfile.content))
                     .fetch("package", [])
                     .select { |p| p["name"] == dependency.name }
                     .find { |p| p["source"].end_with?(dependency.previous_version) }
@@ -449,7 +449,7 @@ module Dependabot
           @git_ssh_requirements_to_swap = {}
 
           [*manifest_files, *path_dependency_files].each do |manifest|
-            parsed_manifest = TomlParser.parse(manifest.content)
+            parsed_manifest = TomlParser.parse(T.must(manifest.content))
 
             Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
               (parsed_manifest[type] || {}).each do |_, details|

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -10,6 +10,7 @@ require "dependabot/cargo/file_updater/manifest_updater"
 require "dependabot/cargo/file_parser"
 require "dependabot/cargo/helpers"
 require "dependabot/shared_helpers"
+require "dependabot/cargo/toml_parser"
 module Dependabot
   module Cargo
     class FileUpdater
@@ -192,11 +193,11 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def git_previous_version
-          TomlRB.parse(lockfile.content)
-                .fetch("package", [])
-                .select { |p| p["name"] == dependency.name }
-                .find { |p| p["source"].end_with?(dependency.previous_version) }
-                &.fetch("version")
+          TomlParser.parse(lockfile.content)
+                    .fetch("package", [])
+                    .select { |p| p["name"] == dependency.name }
+                    .find { |p| p["source"].end_with?(dependency.previous_version) }
+                    &.fetch("version")
         end
 
         sig { returns(T.nilable(String)) }
@@ -370,7 +371,7 @@ module Dependabot
 
         sig { params(content: String).returns(String) }
         def pin_version(content)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
             next unless (req = parsed_manifest.dig(type, dependency.name))
@@ -419,14 +420,14 @@ module Dependabot
 
         sig { params(content: String).returns(String) }
         def remove_binary_specifications(content)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
           parsed_manifest.delete("bin")
           TomlRB.dump(parsed_manifest)
         end
 
         sig { params(content: String).returns(String) }
         def remove_default_run_specification(content)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
           parsed_manifest["package"].delete("default-run") if parsed_manifest.dig("package", "default-run")
           TomlRB.dump(parsed_manifest)
         end
@@ -448,7 +449,7 @@ module Dependabot
           @git_ssh_requirements_to_swap = {}
 
           [*manifest_files, *path_dependency_files].each do |manifest|
-            parsed_manifest = TomlRB.parse(manifest.content)
+            parsed_manifest = TomlParser.parse(manifest.content)
 
             Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
               (parsed_manifest[type] || {}).each do |_, details|

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "toml-rb"
+require "dependabot/cargo/toml_parser"
 
 module Dependabot
   module Cargo
@@ -33,7 +34,7 @@ module Dependabot
       # transparently, we remove these so Cargo makes plain unauthenticated requests that the proxy can intercept.
       sig { params(config_content: String).returns(String) }
       def self.sanitize_cargo_config(config_content)
-        parsed = TomlRB.parse(config_content)
+        parsed = TomlParser.parse(config_content)
         return config_content unless parsed.is_a?(Hash)
 
         registries = parsed["registries"]

--- a/cargo/lib/dependabot/cargo/toml_parser.rb
+++ b/cargo/lib/dependabot/cargo/toml_parser.rb
@@ -114,7 +114,6 @@ module Dependabot
       end
 
       # This parser is intentionally a character-level state machine.
-      # rubocop:disable Metrics/PerceivedComplexity
       sig { params(content: String).returns(String) }
       def self.squish_whitespace_outside_strings(content)
         output = +""
@@ -122,24 +121,20 @@ module Dependabot
         quote_char = T.let(nil, T.nilable(String))
         escaped = T.let(false, T::Boolean)
         pending_space = T.let(false, T::Boolean)
+        index = T.let(0, Integer)
 
-        content.each_char do |char|
+        while index < content.length
+          char = T.must(content[index])
+
           if in_string
             output << char
-            if escaped
-              escaped = false
-            elsif char == "\\"
-              escaped = true
-            elsif char == quote_char
-              in_string = false
-            end
+            escaped, in_string = update_string_state(char, quote_char, escaped, in_string)
+            index += 1
             next
           end
 
-          if char.match?(/\s/)
-            pending_space = true
-            next
-          end
+          index, pending_space, consumed = consume_comment_or_whitespace(content, index, char, pending_space)
+          next if consumed
 
           output << " " if pending_space && !output.empty?
           pending_space = false
@@ -150,11 +145,51 @@ module Dependabot
           end
 
           output << char
+          index += 1
         end
 
         output
       end
-      # rubocop:enable Metrics/PerceivedComplexity
+
+      sig do
+        params(
+          char: String,
+          quote_char: T.nilable(String),
+          escaped: T::Boolean,
+          in_string: T::Boolean
+        ).returns([T::Boolean, T::Boolean])
+      end
+      def self.update_string_state(char, quote_char, escaped, in_string)
+        if escaped
+          [false, in_string]
+        elsif char == "\\"
+          [true, in_string]
+        elsif char == quote_char
+          [false, false]
+        else
+          [false, in_string]
+        end
+      end
+
+      sig do
+        params(
+          content: String,
+          index: Integer,
+          char: String,
+          pending_space: T::Boolean
+        ).returns([Integer, T::Boolean, T::Boolean])
+      end
+      def self.consume_comment_or_whitespace(content, index, char, pending_space)
+        if char == "#"
+          next_newline = content.index("\n", index)
+          new_index = next_newline ? next_newline + 1 : content.length
+          return [new_index, true, true]
+        end
+
+        return [index + 1, true, true] if char.match?(/\s/)
+
+        [index, pending_space, false]
+      end
     end
   end
 end

--- a/cargo/lib/dependabot/cargo/toml_parser.rb
+++ b/cargo/lib/dependabot/cargo/toml_parser.rb
@@ -1,0 +1,160 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "toml-rb"
+
+module Dependabot
+  module Cargo
+    module TomlParser
+      extend T::Sig
+
+      sig { params(content: String).returns(T::Hash[T.untyped, T.untyped]) }
+      def self.parse(content)
+        TomlRB.parse(content)
+      rescue TomlRB::ParseError
+        TomlRB.parse(normalize_multiline_inline_tables(content))
+      end
+
+      sig { params(content: String).returns(String) }
+      def self.normalize_multiline_inline_tables(content)
+        replacement_ranges = T.let([], T::Array[[Integer, Integer, String]])
+
+        index = T.let(0, Integer)
+        while index < content.length
+          unless content[index] == "="
+            index += 1
+            next
+          end
+
+          open_brace = skip_whitespace(content, index + 1)
+          unless open_brace < content.length && content[open_brace] == "{"
+            index += 1
+            next
+          end
+
+          close_brace = find_matching_brace(content, open_brace)
+          unless close_brace
+            index += 1
+            next
+          end
+
+          segment = T.must(content[open_brace..close_brace])
+          replacement_ranges << [open_brace, close_brace, normalize_inline_table(segment)] if segment.include?("\n")
+
+          index = close_brace + 1
+        end
+
+        return content if replacement_ranges.empty?
+
+        normalized_content = content.dup
+        replacement_ranges.reverse_each do |start_idx, end_idx, replacement|
+          normalized_content[start_idx..end_idx] = replacement
+        end
+
+        normalized_content
+      end
+
+      sig { params(content: String, index: Integer).returns(Integer) }
+      def self.skip_whitespace(content, index)
+        index += 1 while index < content.length && T.must(content[index]).match?(/\s/)
+
+        index
+      end
+
+      # This parser is intentionally a character-level state machine.
+      # rubocop:disable Metrics/PerceivedComplexity
+      sig { params(content: String, open_brace_index: Integer).returns(T.nilable(Integer)) }
+      def self.find_matching_brace(content, open_brace_index)
+        depth = T.let(0, Integer)
+        in_string = T.let(false, T::Boolean)
+        quote_char = T.let(nil, T.nilable(String))
+        escaped = T.let(false, T::Boolean)
+
+        index = T.let(open_brace_index, Integer)
+        while index < content.length
+          char = content[index]
+
+          if in_string
+            if escaped
+              escaped = false
+            elsif char == "\\"
+              escaped = true
+            elsif char == quote_char
+              in_string = false
+            end
+          elsif char == '"' || char == "'"
+            in_string = true
+            quote_char = char
+          elsif char == "{"
+            depth += 1
+          elsif char == "}"
+            depth -= 1
+            return index if depth.zero?
+          elsif char == "#"
+            next_newline = content.index("\n", index)
+            index = next_newline || content.length
+            next
+          end
+
+          index += 1
+        end
+
+        nil
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      sig { params(segment: String).returns(String) }
+      def self.normalize_inline_table(segment)
+        inner = T.must(segment[1...-1])
+        squished_inner = squish_whitespace_outside_strings(inner)
+        squished_inner = squished_inner.sub(/,\s*\z/, "")
+
+        "{ #{squished_inner.strip} }"
+      end
+
+      # This parser is intentionally a character-level state machine.
+      # rubocop:disable Metrics/PerceivedComplexity
+      sig { params(content: String).returns(String) }
+      def self.squish_whitespace_outside_strings(content)
+        output = +""
+        in_string = T.let(false, T::Boolean)
+        quote_char = T.let(nil, T.nilable(String))
+        escaped = T.let(false, T::Boolean)
+        pending_space = T.let(false, T::Boolean)
+
+        content.each_char do |char|
+          if in_string
+            output << char
+            if escaped
+              escaped = false
+            elsif char == "\\"
+              escaped = true
+            elsif char == quote_char
+              in_string = false
+            end
+            next
+          end
+
+          if char.match?(/\s/)
+            pending_space = true
+            next
+          end
+
+          output << " " if pending_space && !output.empty?
+          pending_space = false
+
+          if char == '"' || char == "'"
+            in_string = true
+            quote_char = char
+          end
+
+          output << char
+        end
+
+        output
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+    end
+  end
+end

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -284,7 +284,7 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          TomlParser.parse(T.must(lockfile).content)
+          TomlParser.parse(T.must(T.must(lockfile).content))
                     .fetch("package", [])
                     .select { |p| p["name"] == dependency.name }
                     .find { |p| p["source"].end_with?(dependency.version) }

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -7,6 +7,7 @@ require "toml-rb"
 require "dependabot/dependency_file"
 require "dependabot/cargo/file_parser"
 require "dependabot/cargo/update_checker"
+require "dependabot/cargo/toml_parser"
 
 module Dependabot
   module Cargo
@@ -101,7 +102,7 @@ module Dependabot
         # we're only using the manifest to find the latest resolvable version
         sig { params(content: String, filename: String).returns(String) }
         def replace_version_constraint(content, filename)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
             dependency_names_for_type(parsed_manifest, type).each do |name|
@@ -169,7 +170,7 @@ module Dependabot
 
         sig { params(content: String).returns(String) }
         def replace_git_pin(content)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
             dependency_names_for_type(parsed_manifest, type).each do |name|
@@ -219,7 +220,7 @@ module Dependabot
 
         sig { params(content: String).returns(String) }
         def replace_ssh_urls(content)
-          parsed_manifest = TomlRB.parse(content)
+          parsed_manifest = TomlParser.parse(content)
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
             (parsed_manifest[type] || {}).each do |_, details|
@@ -283,11 +284,11 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          TomlRB.parse(T.must(lockfile).content)
-                .fetch("package", [])
-                .select { |p| p["name"] == dependency.name }
-                .find { |p| p["source"].end_with?(dependency.version) }
-                .fetch("version")
+          TomlParser.parse(T.must(lockfile).content)
+                    .fetch("package", [])
+                    .select { |p| p["name"] == dependency.name }
+                    .find { |p| p["source"].end_with?(dependency.version) }
+                    .fetch("version")
         end
 
         sig { params(parsed_manifest: T::Hash[String, T.untyped], type: String).returns(T::Array[String]) }

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -9,6 +9,7 @@ require "dependabot/cargo/update_checker"
 require "dependabot/cargo/file_parser"
 require "dependabot/cargo/version"
 require "dependabot/errors"
+require "dependabot/cargo/toml_parser"
 module Dependabot
   module Cargo
     class UpdateChecker
@@ -102,8 +103,8 @@ module Dependabot
         def fetch_version_from_new_lockfile
           check_rust_workspace_root unless File.exist?("Cargo.lock")
           lockfile_content = File.read("Cargo.lock")
-          versions = TomlRB.parse(lockfile_content).fetch("package")
-                           .select { |p| p["name"] == dependency.name }
+          versions = TomlParser.parse(lockfile_content).fetch("package")
+                               .select { |p| p["name"] == dependency.name }
 
           updated_version =
             if dependency.top_level?
@@ -227,7 +228,7 @@ module Dependabot
           cargo_toml = original_dependency_files
                        .select { |f| f.name.end_with?("../Cargo.toml") }
                        .max_by { |f| f.name.length }
-          return unless TomlRB.parse(T.must(cargo_toml).content)["workspace"]
+          return unless TomlParser.parse(T.must(cargo_toml).content)["workspace"]
 
           msg = "This project is part of a Rust workspace but is not the " \
                 "workspace root." \
@@ -446,7 +447,7 @@ module Dependabot
           return false unless message.include?("native library")
 
           library_count = T.must(prepared_manifest_files).count do |file|
-            package_name = TomlRB.parse(file.content).dig("package", "name")
+            package_name = TomlParser.parse(file.content).dig("package", "name")
             next false unless package_name
 
             message.include?("depended on by `#{package_name} ")
@@ -484,11 +485,11 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          TomlRB.parse(T.must(lockfile).content)
-                .fetch("package", [])
-                .select { |p| p["name"] == dependency.name }
-                .find { |p| p["source"].end_with?(dependency.version) }
-                .fetch("version")
+          TomlParser.parse(T.must(lockfile).content)
+                    .fetch("package", [])
+                    .select { |p| p["name"] == dependency.name }
+                    .find { |p| p["source"].end_with?(dependency.version) }
+                    .fetch("version")
         end
 
         sig { returns(T.nilable(String)) }
@@ -505,7 +506,7 @@ module Dependabot
 
         sig { params(content: String).returns(String) }
         def sanitized_manifest_content(content)
-          object = TomlRB.parse(content)
+          object = TomlParser.parse(content)
 
           object.delete("bin")
 

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -228,7 +228,7 @@ module Dependabot
           cargo_toml = original_dependency_files
                        .select { |f| f.name.end_with?("../Cargo.toml") }
                        .max_by { |f| f.name.length }
-          return unless TomlParser.parse(T.must(cargo_toml).content)["workspace"]
+          return unless TomlParser.parse(T.must(T.must(cargo_toml).content))["workspace"]
 
           msg = "This project is part of a Rust workspace but is not the " \
                 "workspace root." \
@@ -447,7 +447,7 @@ module Dependabot
           return false unless message.include?("native library")
 
           library_count = T.must(prepared_manifest_files).count do |file|
-            package_name = TomlParser.parse(file.content).dig("package", "name")
+            package_name = TomlParser.parse(T.must(file.content)).dig("package", "name")
             next false unless package_name
 
             message.include?("depended on by `#{package_name} ")
@@ -485,7 +485,7 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          TomlParser.parse(T.must(lockfile).content)
+          TomlParser.parse(T.must(T.must(lockfile).content))
                     .fetch("package", [])
                     .select { |p| p["name"] == dependency.name }
                     .find { |p| p["source"].end_with?(dependency.version) }

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -826,9 +826,9 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         )
     end
 
-    it "does not raise a DependencyFileNotParseable error" do
-      expect { file_fetcher_instance.files }
-        .not_to raise_error
+    it "fetches files successfully" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to include("Cargo.toml")
     end
   end
 

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -808,6 +808,30 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
   end
 
+  context "with a Cargo.toml using TOML 1.1 multiline inline tables" do
+    before do
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_with_lockfile.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_manifest_toml_1_1_multiline_inline_table.json"),
+          headers: json_header
+        )
+    end
+
+    it "does not raise a DependencyFileNotParseable error" do
+      expect { file_fetcher_instance.files }
+        .not_to raise_error
+    end
+  end
+
   context "without a Cargo.toml" do
     before do
       stub_request(:get, url + "?ref=sha")

--- a/cargo/spec/dependabot/cargo/file_parser_edge_cases_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_edge_cases_spec.rb
@@ -280,4 +280,36 @@ RSpec.describe Dependabot::Cargo::FileParser do
       end
     end
   end
+
+  context "with TOML 1.1 multiline inline tables" do
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Cargo.toml",
+          content: <<~TOML
+            [package]
+            name = "toml11"
+            version = "0.1.0"
+
+            [dependencies]
+            windows-sys = {
+              version = "0.61.2",
+              features = [
+                "Win32_System_Environment",
+                "Win32_Storage_FileSystem",
+                "Win32_System_Memory",
+              ],
+            }
+          TOML
+        )
+      ]
+    end
+
+    it "parses dependency declarations defined with multiline inline tables" do
+      dependency = parser.parse.find { |dep| dep.name == "windows-sys" }
+
+      expect(dependency).not_to be_nil
+      expect(T.must(dependency).requirements.first[:requirement]).to eq("0.61.2")
+    end
+  end
 end

--- a/cargo/spec/fixtures/github/contents_cargo_manifest_toml_1_1_multiline_inline_table.json
+++ b/cargo/spec/fixtures/github/contents_cargo_manifest_toml_1_1_multiline_inline_table.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cargo.toml",
+  "path": "Cargo.toml",
+  "sha": "cb9ddc34d2c13ca51bd54ec7374d89cbad814d78",
+  "size": 428,
+  "url": "https://api.github.com/repos/runconduit/conduit/contents/Cargo.toml?ref=master",
+  "html_url": "https://github.com/runconduit/conduit/blob/master/Cargo.toml",
+  "git_url": "https://api.github.com/repos/runconduit/conduit/git/blobs/cb9ddc34d2c13ca51bd54ec7374d89cbad814d78",
+  "download_url": "https://raw.githubusercontent.com/runconduit/conduit/master/Cargo.toml",
+  "type": "file",
+  "content": "W3BhY2thZ2VdCm5hbWUgPSAiZGVwZW5kYWJvdCIKdmVyc2lvbiA9ICIwLjEuMCIKYXV0aG9ycyA9IFsic3VwcG9ydEBkZXBlbmRhYm90LmNvbSJdCgpbZGVwZW5kZW5jaWVzXQp3aW5kb3dzLXN5cyA9IHsKICAgIHZlcnNpb24gPSAiMC42MS4yIiwKICAgIGZlYXR1cmVzID0gWwogICAgICAgICJXaW4zMl9TeXN0ZW1fRW52aXJvbm1lbnQiLAogICAgICAgICJXaW4zMl9TdG9yYWdlX0ZpbGVTeXN0ZW0iLAogICAgICAgICJXaW4zMl9TeXN0ZW1fTWVtb3J5IiwKICAgICAgICAiV2luMzJfVUlfV2luZG93c0FuZE1lc3NhZ2luZyIsCiAgICAgICAgIldpbjMyX1N5c3RlbV9UaHJlYWRpbmciLAogICAgICAgICJXaW4zMl9TZWN1cml0eSIsCiAgICAgICAgIldpbjMyX1N5c3RlbV9JTyIsCiAgICAgICAgIldpbjMyX1N5c3RlbV9Db25zb2xlIiwKICAgIF0sCn0K",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/runconduit/conduit/contents/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/runconduit/conduit/git/blobs/cb9ddc34d2c13ca51bd54ec7374d89cbad814d78",
+    "html": "https://github.com/runconduit/conduit/blob/master/Cargo.toml"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Add a centralized TOML compatibility parser that gracefully handles `TOML 1.1` multiline inline table syntax (with trailing commas and newlines) by normalizing to a format compatible with the toml-rb gem.

The parser attempts normal parsing first, then on `TomlRB::ParseError` normalizes multiline inline tables to single-line format and retries, preserving existing error handling if parsing still fails.

Switch all Cargo parsing call sites (file fetcher, file parser, file updater, update checker, lockfile updater, and helpers) to use this compatibility parser for consistent support across all dependency resolution phases.

Fixes error: "Cargo.toml not parseable" for repositories using multiline inline table syntax in dependency declarations, such as:
```
windows-sys = {
    version = "0.61.2",
    features = [
      "Win32_System_Environment",
      "Win32_Storage_FileSystem",
    ],
  }
```

Add regression test fixtures and specs to ensure parseability is maintained for both file fetching and dependency extraction phases.

### Anything you want to highlight for special attention from reviewers?

Fixes: https://github.com/dependabot/dependabot-core/issues/14746

### How will you know you've accomplished your goal?

I validated the fix by running Dependabot CLI against the same job from this workflow run: 
https://github.com/vrc-get/vrc-get/actions/runs/24519521166/job/71673025030

Before this change, the run failed with a `dependency_file_not_parseable` error for `/vrc-get-gui/windows-installer-wrapper/Cargo.toml`:
```
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-----------------------------------------------------------------------------------------------------------------+
updater | |                                                     Errors                                                      |
updater | +-------------------------------+---------------------------------------------------------------------------------+
updater | | Type                          | Details                                                                         |
updater | +-------------------------------+---------------------------------------------------------------------------------+
updater | | dependency_file_not_parseable | {                                                                               |
updater | |                               |   "message": "/vrc-get-gui/windows-installer-wrapper/Cargo.toml not parseable", |
updater | |                               |   "file-path": "/vrc-get-gui/windows-installer-wrapper/Cargo.toml"              |
updater | |                               | }                                                                               |
updater | +-------------------------------+---------------------------------------------------------------------------------+
```

After this change, the same flow completed successfully and the job was marked as processed:
```
{"data":{"base-commit-sha":"5887c5631c9cb83f3ee394312d08869730a54aed"},"type":"mark_as_processed"}
updater | 2026/04/23 14:12:11 INFO Finished job processing
updater | 2026/04/23 14:12:11 INFO Results:
updater | +-------------------------------------+
updater | | Changes to Dependabot Pull Requests |
updater | +--------------------+----------------+
updater | | closed: up_to_date | tokio          |
updater | +--------------------+----------------+
```

This demonstrates that Cargo.toml parsing no longer fails on the previously problematic manifest format.


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
