### PR TITLE
Add commit message support to PR update flow

### DIFF
--- a/common/lib/dependabot/pull_request_updater.rb
+++ b/common/lib/dependabot/pull_request_updater.rb
@@ -37,6 +37,9 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :signature_key
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :commit_message
+
     sig { returns(T::Hash[Symbol, T.untyped]) }
     attr_reader :provider_metadata
 
@@ -50,6 +53,7 @@ module Dependabot
         pull_request_number: Integer,
         author_details: T.nilable(T::Hash[Symbol, String]),
         signature_key: T.nilable(String),
+        commit_message: T.nilable(String),
         provider_metadata: T::Hash[Symbol, T.untyped]
       )
         .void
@@ -63,6 +67,7 @@ module Dependabot
       pull_request_number:,
       author_details: nil,
       signature_key: nil,
+      commit_message: nil,
       provider_metadata: {}
     )
       @source              = source
@@ -73,6 +78,7 @@ module Dependabot
       @pull_request_number = pull_request_number
       @author_details      = author_details
       @signature_key       = signature_key
+      @commit_message      = commit_message
       @provider_metadata   = provider_metadata
     end
 
@@ -100,7 +106,8 @@ module Dependabot
         credentials: credentials,
         pull_request_number: pull_request_number,
         author_details: author_details,
-        signature_key: signature_key
+        signature_key: signature_key,
+        commit_message: commit_message
       )
     end
 

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -46,7 +46,8 @@ module Dependabot
           credentials: T::Array[Dependabot::Credential],
           pull_request_number: Integer,
           author_details: T.nilable(T::Hash[Symbol, T.untyped]),
-          signature_key: T.nilable(String)
+          signature_key: T.nilable(String),
+          commit_message: T.nilable(String)
         )
           .void
       end
@@ -58,7 +59,8 @@ module Dependabot
         credentials:,
         pull_request_number:,
         author_details: nil,
-        signature_key: nil
+        signature_key: nil,
+        commit_message: nil
       )
         @source              = source
         @base_commit         = base_commit
@@ -68,6 +70,7 @@ module Dependabot
         @pull_request_number = pull_request_number
         @author_details      = author_details
         @signature_key       = signature_key
+        @commit_message      = T.let(commit_message, T.nilable(String))
       end
 
       sig { returns(T.nilable(Sawyer::Resource)) }
@@ -255,6 +258,9 @@ module Dependabot
 
       sig { returns(String) }
       def commit_message
+        msg = @commit_message
+        return msg unless msg.nil? || msg.empty?
+
         fallback_message =
           "#{pull_request.title}" \
           "\n\n" \

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -418,6 +418,68 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
       end
     end
 
+    context "with a custom commit message" do
+      subject(:updater) do
+        described_class.new(
+          source: source,
+          base_commit: base_commit,
+          old_commit: old_commit,
+          files: files,
+          credentials: credentials,
+          pull_request_number: pull_request_number,
+          commit_message: "chore: Bump business from 1.4.0 to 1.6.0\n\nUpdated commit message"
+        )
+      end
+
+      it "uses the custom commit message instead of the old one" do
+        updater.update
+
+        expect(WebMock)
+          .to have_requested(:post, "#{watched_repo_url}/git/commits")
+          .with(
+            body: {
+              parents: ["basecommitsha"],
+              tree: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+              message: "chore: Bump business from 1.4.0 to 1.6.0\n\nUpdated commit message"
+            }
+          )
+      end
+    end
+
+    context "with an empty custom commit message" do
+      subject(:updater) do
+        described_class.new(
+          source: source,
+          base_commit: base_commit,
+          old_commit: old_commit,
+          files: files,
+          credentials: credentials,
+          pull_request_number: pull_request_number,
+          commit_message: ""
+        )
+      end
+
+      it "falls back to the old commit message" do
+        updater.update
+
+        expect(WebMock)
+          .to have_requested(:post, "#{watched_repo_url}/git/commits")
+          .with(
+            body: {
+              parents: ["basecommitsha"],
+              tree: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
+              message: "Bump business from 1.4.0 to 1.5.0\n\n" \
+                       "Bumps [business](https://github.com/gocardless/business)" \
+                       " from 1.4.0 to 1.5.0.\n" \
+                       "- [Changelog](https://github.com/gocardless/business/blo" \
+                       "b/master/CHANGELOG.md)\n" \
+                       "- [Commits](https://github.com/gocardless/business/compa" \
+                       "re/v3.0.0...v1.5.0)"
+            }
+          )
+      end
+    end
+
     context "when the default branch has changed" do
       before do
         stub_request(:get, pull_request_url)

--- a/common/spec/dependabot/pull_request_updater_spec.rb
+++ b/common/spec/dependabot/pull_request_updater_spec.rb
@@ -47,10 +47,45 @@ RSpec.describe Dependabot::PullRequestUpdater do
             credentials: credentials,
             pull_request_number: pull_request_number,
             author_details: nil,
-            signature_key: nil
+            signature_key: nil,
+            commit_message: nil
           ).and_return(dummy_updater)
         expect(dummy_updater).to receive(:update)
         updater.update
+      end
+
+      context "with a custom commit message" do
+        subject(:updater) do
+          described_class.new(
+            source: source,
+            base_commit: base_commit,
+            old_commit: old_commit,
+            files: files,
+            credentials: credentials,
+            pull_request_number: pull_request_number,
+            provider_metadata: provider_metadata,
+            author_details: author_details,
+            commit_message: "Custom commit message"
+          )
+        end
+
+        it "passes commit_message to PullRequestUpdater::Github" do
+          expect(described_class::Github)
+            .to receive(:new)
+            .with(
+              source: source,
+              base_commit: base_commit,
+              old_commit: old_commit,
+              files: files,
+              credentials: credentials,
+              pull_request_number: pull_request_number,
+              author_details: nil,
+              signature_key: nil,
+              commit_message: "Custom commit message"
+            ).and_return(dummy_updater)
+          expect(dummy_updater).to receive(:update)
+          updater.update
+        end
       end
     end
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -71,6 +71,7 @@ module Dependabot
           "dependency-names": dependency_change.updated_dependencies.map(&:name),
           "updated-dependency-files": dependency_change.updated_dependency_files_hash,
           "base-commit-sha": base_commit_sha,
+          "commit-message": dependency_change.pr_message.commit_message,
           "pr-title": dependency_change.pr_message.pr_name,
           "pr-body": dependency_change.pr_message.pr_message
         }

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Dependabot::ApiClient do
                 ]
               )
               expect(data["base-commit-sha"]).to eql("sha")
-              expect(data).not_to have_key("commit-message")
+              expect(data["commit-message"]).to eq("Commit message")
               expect(data["pr-title"]).to eq("PR name")
               expect(data["pr-body"]).to eq("PR message")
             end)


### PR DESCRIPTION
### What are you trying to accomplish?

When Dependabot rebases or recreates an existing PR, the commit message was not being regenerated. This caused two issues:

- **#14484**: The `commit-message` prefix from `dependabot.yml` was ignored on PR updates
- **#14789**: Version references in commit messages became stale after rebasing (e.g., commit says "bump to 2.6.1" but file actually updates to v3)

This PR threads a new optional `commit-message` parameter through the update pull request flow (`ApiClient` → API route → `PullRequestUpdater` → `PullRequestUpdater::Github`), matching the pattern established in #14492 for `pr-title` and `pr-body`.

### Anything you want to highlight for special attention from reviewers?

- The `commit_message` parameter is **optional** (`nil` by default). When not provided, the existing fallback behavior is preserved (reuse old commit message, or PR title fallback).
- In `PullRequestUpdater::Github`, the param is stored as `@commit_message` instance variable (no public attr_reader) to avoid shadowing the existing private `commit_message` method.
- Companion API PR: github/dependabot-api#8218

### How will you know you have accomplished your goal?

- Specs cover: custom message passthrough, empty string fallback, nil fallback, delegation from parent updater
- Integration: when deployed alongside the API companion PR, `@dependabot rebase` will produce commits with fresh messages matching the current dependency state and user config.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.