### PR TITLE
Fix failing pre-commit and uv unit test failures

### DIFF
--- a/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/python_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/python_spec.rb
@@ -288,9 +288,9 @@ RSpec.describe Dependabot::PreCommit::AdditionalDependencyCheckers::Python do
 
       it "updates the upper bound when new version exceeds it" do
         updated = checker.updated_requirements("5.1.0")
-        # Python's RequirementsUpdater updates upper bound to next major version
-        expect(updated.first[:requirement]).to eq(">=4.0.0,<6.0.0")
-        expect(updated.first[:source][:original_string]).to eq("typing-extensions>=4.0.0,<6.0.0")
+        # Python's RequirementsUpdater bumps both bounds with bump_versions strategy
+        expect(updated.first[:requirement]).to eq(">=5.1.0,<6.0.0")
+        expect(updated.first[:source][:original_string]).to eq("typing-extensions>=5.1.0,<6.0.0")
       end
     end
 
@@ -323,8 +323,9 @@ RSpec.describe Dependabot::PreCommit::AdditionalDependencyCheckers::Python do
 
         it "bumps the lower bound" do
           # Pre-commit has no lockfile, so we always bump lower bounds
+          # Strict > becomes >= since the resolved version is the exact target
           updated = checker.updated_requirements("2.32.0")
-          expect(updated.first[:requirement]).to eq(">2.32.0")
+          expect(updated.first[:requirement]).to eq(">=2.32.0")
         end
       end
 

--- a/uv/spec/dependabot/uv/update_checker/requirements_updater_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker/requirements_updater_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker::RequirementsUpdater do
         context "when a range requirement was specified" do
           let(:requirement_txt_req_string) { ">=1.3.0" }
 
-          it { is_expected.to eq(requirement_txt_req) }
+          its([:requirement]) { is_expected.to eq(">=1.5.0") }
 
           context "when requirement version is too high" do
             let(:requirement_txt_req_string) { ">=2.0.0" }
@@ -135,24 +135,24 @@ RSpec.describe Dependabot::Uv::UpdateChecker::RequirementsUpdater do
           context "when requirement had a local version" do
             let(:requirement_txt_req_string) { ">=1.3.0+gc.1" }
 
-            it { is_expected.to eq(requirement_txt_req) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0") }
           end
 
           context "with an upper bound" do
             let(:requirement_txt_req_string) { ">=1.3.0, <=1.5.0" }
 
-            it { is_expected.to eq(requirement_txt_req) }
+            its([:requirement]) { is_expected.to eq(">=1.5.0,<=1.5.0") }
 
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq(">=1.9,<=1.10") }
+                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
               end
             end
           end

--- a/uv/spec/dependabot/uv/update_checker/requirements_updater_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker/requirements_updater_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker::RequirementsUpdater do
         context "when a range requirement was specified" do
           let(:requirement_txt_req_string) { ">=1.3.0" }
 
-          its([:requirement]) { is_expected.to eq(">=1.5.0") }
+          it { is_expected.to eq(requirement_txt_req.merge(requirement: ">=1.5.0")) }
 
           context "when requirement version is too high" do
             let(:requirement_txt_req_string) { ">=2.0.0" }
@@ -135,24 +135,24 @@ RSpec.describe Dependabot::Uv::UpdateChecker::RequirementsUpdater do
           context "when requirement had a local version" do
             let(:requirement_txt_req_string) { ">=1.3.0+gc.1" }
 
-            its([:requirement]) { is_expected.to eq(">=1.5.0") }
+            it { is_expected.to eq(requirement_txt_req.merge(requirement: ">=1.5.0")) }
           end
 
           context "with an upper bound" do
             let(:requirement_txt_req_string) { ">=1.3.0, <=1.5.0" }
 
-            its([:requirement]) { is_expected.to eq(">=1.5.0,<=1.5.0") }
+            it { is_expected.to eq(requirement_txt_req.merge(requirement: ">=1.5.0,<=1.5.0")) }
 
             context "when needing an update" do
               let(:requirement_txt_req_string) { ">=1.3.0, <1.5" }
 
-              its([:requirement]) { is_expected.to eq(">=1.5.0,<1.6") }
+              it { is_expected.to eq(requirement_txt_req.merge(requirement: ">=1.5.0,<1.6")) }
 
               context "when requirement version has more digits than the new version" do
                 let(:requirement_txt_req_string) { "<=1.9.2,>=1.9" }
                 let(:latest_resolvable_version) { "1.10" }
 
-                its([:requirement]) { is_expected.to eq("<=1.10,>=1.10") }
+                it { is_expected.to eq(requirement_txt_req.merge(requirement: "<=1.10,>=1.10")) }
               end
             end
           end


### PR DESCRIPTION
### What are you trying to accomplish?
This PR fixes the spec failures in `pre-commit` and `uv` which occurred due to the change in the `BumpVersions` behaviour in this PR https://github.com/dependabot/dependabot-core/pull/14785.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**UV spec:** Updated 5 test expectations for range requirements in `.txt` files to match the new `bump_versions` lower-bound bumping behavior
**Pre-commit spec:** Updated 2 test expectations — the range constraint test (`>=5.1.0,<6.0.0`) and the `>` operator test (`>=2.32.0`)
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
If all UV and pre-commit specs pass.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
