### PR TITLE
chore: fix `FromAsCasing` linting issue in the Maven Docker build

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
 # This cannot be inlined below (e.g., COPY --from=maven:...) because Dependabot does not support that syntax yet
-FROM maven:3.9.14 as maven
+FROM maven:3.9.14 AS maven
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 


### PR DESCRIPTION
Replaces `as` -> `AS` and fixes the following warning 

```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
```
### What are you trying to accomplish?

Fix a distracting linting issue in the Maven Docker build


### How will you know you've accomplished your goal?

The linting error no longer appears 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
