### PR TITLE
Disable NuGetAudit in Directory.Build.props

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <Import Project="Directory.Common.props" />


### PR DESCRIPTION
The .NET code in this repo forces warnings as errors and NuGet restore can sometimes generate warnings for packages.  To keep the build as deterministic as possible, we should prevent NuGet from reporting errors during a package restore.  Perhaps some tool like dependabot could be used instead to ensure safe packages...