### PR TITLE
log project file discovery status

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -28,7 +28,8 @@ public class DiscoveryWorkerTestBase : TestBase
             await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, directoryPath, includeCommonPackages: includeCommonPackages);
 
             repoContentsPath ??= directoryPath;
-            var worker = new DiscoveryWorker("TEST-JOB-ID", experimentsManager, new TestLogger());
+            var logger = new StringLogger();
+            var worker = new DiscoveryWorker("TEST-JOB-ID", experimentsManager, logger);
             var result = await worker.RunWithErrorHandlingAsync(repoContentsPath, workspacePath);
             return result;
         });

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1667,7 +1667,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 </Project>
                 """)
         );
-        var actualEntryPoints = (await DiscoveryWorker.ExpandEntryPointsIntoProjectsAsync([Path.Combine(tempDir.DirectoryPath, "src/dirs.proj")], new ExperimentsManager()))
+        var actualEntryPoints = (await DiscoveryWorker.ExpandEntryPointsIntoProjectsAsync([Path.Combine(tempDir.DirectoryPath, "src/dirs.proj")], new ExperimentsManager(), new TestLogger()))
             .Select(p => p.NormalizePathToUnix())
             .ToArray();
         var expectedEntryPoints = new[]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/StringLogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/StringLogger.cs
@@ -1,0 +1,13 @@
+namespace NuGetUpdater.Core.Test;
+
+public class StringLogger : ILogger
+{
+    private readonly List<string> _messages = [];
+
+    public IReadOnlyList<string> Messages => _messages;
+
+    public void LogRaw(string message)
+    {
+        _messages.Add(message);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -171,10 +171,11 @@ public partial class DiscoveryWorker : IDiscoveryWorker
     {
         _logger.Info($"  Discovering projects beneath [{Path.GetRelativePath(repoRootPath, workspacePath)}].");
         var entryPoints = FindEntryPoints(workspacePath);
+        _logger.Info($"    Entry points found: {string.Join(", ", entryPoints)}");
         ImmutableArray<string> projects;
         try
         {
-            projects = await ExpandEntryPointsIntoProjectsAsync(entryPoints, _experimentsManager);
+            projects = await ExpandEntryPointsIntoProjectsAsync(entryPoints, _experimentsManager, _logger);
         }
         catch (InvalidProjectFileException e)
         {
@@ -193,7 +194,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
         if (projects.IsEmpty)
         {
-            _logger.Info("  No project files found.");
+            _logger.Info("    No project files found.");
             return [];
         }
 
@@ -222,7 +223,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             .ToImmutableArray();
     }
 
-    internal async static Task<ImmutableArray<string>> ExpandEntryPointsIntoProjectsAsync(IEnumerable<string> entryPoints, ExperimentsManager experimentsManager)
+    internal async static Task<ImmutableArray<string>> ExpandEntryPointsIntoProjectsAsync(IEnumerable<string> entryPoints, ExperimentsManager experimentsManager, ILogger logger)
     {
         HashSet<string> expandedProjects = new(PathComparer.Instance);
         HashSet<string> seenProjects = new(PathComparer.Instance);
@@ -235,28 +236,34 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 string extension = Path.GetExtension(candidateEntryPoint).ToLowerInvariant();
                 if (extension == ".sln")
                 {
+                    logger.Info($"    Expanding solution: {candidateEntryPoint}:");
                     SolutionFile solution = SolutionFile.Parse(candidateEntryPoint);
                     foreach (ProjectInSolution project in solution.ProjectsInOrder)
                     {
+                        logger.Info($"      Expanded project: {project.AbsolutePath}");
                         filesToExpand.Push(project.AbsolutePath);
                     }
                 }
                 else if (extension == ".slnx")
                 {
+                    logger.Info($"    Expanding solution: {candidateEntryPoint}:");
                     SolutionModel solution = await SolutionSerializers.SlnXml.OpenAsync(candidateEntryPoint, CancellationToken.None);
                     string solutionPath = Path.GetDirectoryName(candidateEntryPoint) ?? string.Empty;
 
                     foreach (SolutionProjectModel project in solution.SolutionProjects)
                     {
                         string projectPath = Path.Combine(solutionPath, project.FilePath);
+                        logger.Info($"      Expanded project: {projectPath}");
                         filesToExpand.Push(projectPath);
                     }
                 }
                 else if (extension == ".proj")
                 {
+                    logger.Info($"    Expanding file: {candidateEntryPoint}:");
                     var foundProjects = ExpandItemGroupFilesFromProject(candidateEntryPoint, "ProjectFile", "ProjectReference");
                     foreach (var foundProject in foundProjects)
                     {
+                        logger.Info($"      Expanded project: {foundProject}");
                         filesToExpand.Push(foundProject);
                     }
                 }
@@ -337,7 +344,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         try
         {
             // get all packages.config results first
-            var expandedProjects = await ExpandEntryPointsIntoProjectsAsync(normalizedProjectPaths, _experimentsManager);
+            var expandedProjects = await ExpandEntryPointsIntoProjectsAsync(normalizedProjectPaths, _experimentsManager, _logger);
             foreach (var expandedProject in expandedProjects)
             {
                 var packagesConfigResult = await PackagesConfigDiscovery.Discover(repoRootPath, workspacePath, expandedProject, _logger);


### PR DESCRIPTION
Log all expansions from solution and `.proj` files; this should make it faster to determine why an update didn't process the expected projects.