### PR TITLE
fix(gradle): honor `replaces-base` for Maven Central fallback

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -168,10 +168,19 @@ module Dependabot
         sig { returns(String) }
         def central_repo_url
           base_credential = credentials.find do |cred|
-            cred["type"] == "maven_repository" && cred.replaces_base? && cred["url"]
+            cred["type"] == "maven_repository" && replaces_base?(cred) && cred["url"]
           end
 
           base_credential ? T.must(base_credential["url"]).gsub(%r{/+$}, "") : CENTRAL_REPO_URL
+        end
+
+        sig { params(credential: T.untyped).returns(T::Boolean) }
+        def replaces_base?(credential)
+          if credential.respond_to?(:replaces_base?)
+            credential.replaces_base?
+          else
+            credential["replaces-base"] == true
+          end
         end
 
         sig { params(string: String).returns(Integer) }

--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -32,11 +32,13 @@ module Dependabot
         sig do
           params(
             dependency_files: T::Array[Dependabot::DependencyFile],
-            target_dependency_file: T.nilable(Dependabot::DependencyFile)
+            target_dependency_file: T.nilable(Dependabot::DependencyFile),
+            credentials: T::Array[Dependabot::Credential]
           ).void
         end
-        def initialize(dependency_files:, target_dependency_file:)
+        def initialize(dependency_files:, target_dependency_file:, credentials: [])
           @dependency_files = T.let(dependency_files, T::Array[Dependabot::DependencyFile])
+          @credentials = T.let(credentials, T::Array[Dependabot::Credential])
           raise "No target file!" unless target_dependency_file
 
           @target_dependency_file = T.let(target_dependency_file, Dependabot::DependencyFile)
@@ -57,13 +59,16 @@ module Dependabot
 
           return repository_urls unless repository_urls.empty?
 
-          [CENTRAL_REPO_URL]
+          [central_repo_url]
         end
 
         private
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
 
         sig { returns(Dependabot::DependencyFile) }
         attr_reader :target_dependency_file
@@ -143,7 +148,7 @@ module Dependabot
           repository_blocks.each do |block|
             repository_urls << GOOGLE_MAVEN_REPO if block.match?(/\sgoogle\(/)
 
-            repository_urls << CENTRAL_REPO_URL if block.match?(/\smavenCentral\(/)
+            repository_urls << central_repo_url if block.match?(/\smavenCentral\(/)
 
             repository_urls << "https://jcenter.bintray.com/" if block.match?(/\sjcenter\(/)
 
@@ -158,6 +163,15 @@ module Dependabot
             .map { |url| url.strip.gsub(%r{/$}, "") }
             .select { |url| valid_url?(url) }
             .uniq
+        end
+
+        sig { returns(String) }
+        def central_repo_url
+          base_credential = credentials.find do |cred|
+            cred["type"] == "maven_repository" && cred.replaces_base? && cred["url"]
+          end
+
+          base_credential ? T.must(base_credential["url"]).gsub(%r{/+$}, "") : CENTRAL_REPO_URL
         end
 
         sig { params(string: String).returns(Integer) }

--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -269,7 +269,7 @@ module Dependabot
                 credentials: credentials
               ).repository_urls
                                                     .map do |url|
-                { "url" => url, "auth_headers" => {} }
+                { "url" => url, "auth_headers" => auth_headers(url) }
               end
             end.uniq
         end

--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -265,7 +265,8 @@ module Dependabot
             requirement_files.flat_map do |target_file|
               Gradle::FileParser::RepositoriesFinder.new(
                 dependency_files: dependency_files,
-                target_dependency_file: target_file
+                target_dependency_file: target_file,
+                credentials: credentials
               ).repository_urls
                                                     .map do |url|
                 { "url" => url, "auth_headers" => {} }

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
 
         it { is_expected.to eq(["https://registry.example.com/maven"]) }
       end
+
+      context "with multiple private registry credentials" do
+        let(:credentials) do
+          [
+            Dependabot::Credential.new(
+              {
+                "type" => "maven_repository",
+                "url" => "https://mirror.example.com/maven/",
+                "username" => "hello",
+                "password" => "world"
+              }
+            ),
+            Dependabot::Credential.new(
+              {
+                "type" => "maven_repository",
+                "url" => "https://registry.example.com/maven/",
+                "username" => "hello",
+                "password" => "world",
+                "replaces-base" => true
+              }
+            )
+          ]
+        end
+
+        it { is_expected.to eq(["https://registry.example.com/maven"]) }
+      end
     end
 
     context "when there are repository declarations" do

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
   let(:finder) do
     described_class.new(
       dependency_files: dependency_files,
-      target_dependency_file: target_dependency_file
+      target_dependency_file: target_dependency_file,
+      credentials: credentials
     )
   end
 
   let(:dependency_files) { [buildfile] }
   let(:target_dependency_file) { buildfile }
+  let(:credentials) { [] }
   let(:buildfile) do
     Dependabot::DependencyFile.new(
       name: "build.gradle",
@@ -30,6 +32,24 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
       let(:buildfile_fixture_name) { "basic_build.gradle" }
 
       it { is_expected.to eq(["https://repo.maven.apache.org/maven2"]) }
+
+      context "with a replaces-base credential" do
+        let(:credentials) do
+          [
+            Dependabot::Credential.new(
+              {
+                "type" => "maven_repository",
+                "url" => "https://registry.example.com/maven/",
+                "username" => "hello",
+                "password" => "world",
+                "replaces-base" => true
+              }
+            )
+          ]
+        end
+
+        it { is_expected.to eq(["https://registry.example.com/maven"]) }
+      end
     end
 
     context "when there are repository declarations" do
@@ -177,6 +197,31 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
               https://java-constructor.com
             )
           )
+        end
+      end
+
+      context "when the declaration uses mavenCentral" do
+        let(:buildfile_fixture_name) { "shortform_build.gradle" }
+
+        context "with a replaces-base credential" do
+          let(:credentials) do
+            [
+              Dependabot::Credential.new(
+                {
+                  "type" => "maven_repository",
+                  "url" => "https://registry.example.com/maven/",
+                  "username" => "hello",
+                  "password" => "world",
+                  "replaces-base" => true
+                }
+              )
+            ]
+          end
+
+          it "maps mavenCentral to the replacement registry" do
+            expect(repository_urls).to include("https://registry.example.com/maven")
+            expect(repository_urls).not_to include("https://repo.maven.apache.org/maven2")
+          end
         end
       end
 

--- a/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
@@ -109,6 +109,47 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
       end
     end
 
+    context "with multiple private registry credentials" do
+      let(:metadata_base_url) { "https://registry.example.com/maven" }
+      let(:mirror_metadata_url) do
+        "https://mirror.example.com/maven/" \
+          "com/google/guava/guava/maven-metadata.xml"
+      end
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "maven_repository",
+              "url" => "https://mirror.example.com/maven/",
+              "username" => "hello",
+              "password" => "world"
+            }
+          ),
+          Dependabot::Credential.new(
+            {
+              "type" => "maven_repository",
+              "url" => "https://registry.example.com/maven/",
+              "username" => "hello",
+              "password" => "world",
+              "replaces-base" => true
+            }
+          )
+        ]
+      end
+
+      before do
+        stub_request(:get, mirror_metadata_url).to_return(status: 404)
+      end
+
+      describe "the first version" do
+        subject { versions.first }
+
+        its([:source_url]) do
+          is_expected.to eq("https://registry.example.com/maven")
+        end
+      end
+    end
+
     context "with a plugin" do
       let(:dependency_requirements) do
         [{

--- a/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
@@ -45,8 +45,9 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
   let(:dependency_name) { "com.google.guava:guava" }
   let(:dependency_version) { "23.3-jre" }
 
+  let(:metadata_base_url) { "https://repo.maven.apache.org/maven2" }
   let(:maven_central_metadata_url) do
-    "https://repo.maven.apache.org/maven2/" \
+    "#{metadata_base_url}/" \
       "com/google/guava/guava/maven-metadata.xml"
   end
   let(:maven_central_releases) do
@@ -80,6 +81,31 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
 
       its([:source_url]) do
         is_expected.to eq("https://repo.maven.apache.org/maven2")
+      end
+    end
+
+    context "with a replaces-base credential" do
+      let(:metadata_base_url) { "https://registry.example.com/maven" }
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "maven_repository",
+              "url" => "https://registry.example.com/maven/",
+              "username" => "hello",
+              "password" => "world",
+              "replaces-base" => true
+            }
+          )
+        ]
+      end
+
+      describe "the first version" do
+        subject { versions.first }
+
+        its([:source_url]) do
+          is_expected.to eq("https://registry.example.com/maven")
+        end
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Before this change, teams often had to rely on `settings.gradle` to reliably prevent public fallback during Dependabot Gradle updates.

This fix makes that behavior explicit: when a Maven credential is marked with `replaces-base: true`, Dependabot treats that private registry as the base source and avoids default fallback to Maven Central.

**Note:**
If a project explicitly declares additional public repositories in Gradle configuration, those declarations still need to be governed by repository policy (for example, via `settings.gradle` repository mode).

### Anything you want to highlight for special attention from reviewers?

This PR ensures that `replaces-base: true` is honored for Gradle dependency resolution — when a private registry is configured with this flag, Dependabot will no longer fall back to the public Maven Central registry.

A follow-up PR is planned to improve the behavior further: even without replaces-base: true, Dependabot should prefer configured registries before falling back to maven central(default) ones. This is particularly important for projects with multiple registries, where the current behavior requires teams to rely on `settings.gradle` to control resolution order.

### How will you know you've accomplished your goal?

Validation was done using this workflow run:: https://github.com/thavaahariharangit/java-private-registry-test-13249-1/actions/runs/24915740405/job/72967316407

Before this change, even with `replaces-base: true`, Gradle resolution still fell back to the public registry and proposed an update to `1.3.6`:
```
updater | 2026/04/24 23:03:08 INFO Results:
+-----------------------------------------------------------------+
|               Changes to Dependabot Pull Requests               |
+---------+-------------------------------------------------------+
| created | commons-logging:commons-logging ( from 1.0 to 1.3.6 ) |
+---------+-------------------------------------------------------+
```

After this fix, with `replaces-base: true`, Dependabot no longer falls back to the public registry, and the proposed update comes from the private registry path (`1.2`):
```
updater | 2026/04/24 23:05:13 INFO Results:
updater | +---------------------------------------------------------------+
updater | |              Changes to Dependabot Pull Requests              |
updater | +---------+-----------------------------------------------------+
updater | | created | commons-logging:commons-logging ( from 1.0 to 1.2 ) |
updater | +---------+-----------------------------------------------------+
``` 


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
