### PR TITLE
feat(python): add widen_ranges support for setup.py and setup.cfg

### DIFF
--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -79,6 +79,7 @@ module Dependabot
         def updated_setup_requirement(req)
           return req unless latest_resolvable_version
           return req unless req.fetch(:requirement)
+          return widen_requirement(req) if update_strategy == RequirementsUpdateStrategy::WidenRanges
           return req if new_version_satisfies?(req)
 
           req_strings = req[:requirement].split(",").map(&:strip)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -357,6 +357,29 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
         end
       end
+
+      context "with the widen_ranges update strategy" do
+        let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
+        let(:latest_resolvable_version) { "1.5.0" }
+
+        context "when the requirement is already satisfied" do
+          let(:setup_py_req_string) { ">=1.3.0,<1.6" }
+
+          it { is_expected.to eq(setup_py_req) }
+        end
+
+        context "when the upper bound needs to be widened" do
+          let(:setup_py_req_string) { ">=1.3.0,<1.5" }
+
+          its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+        end
+
+        context "when lower bound is kept unchanged after widening" do
+          let(:setup_py_req_string) { ">=1.0.0,<1.5" }
+
+          its([:requirement]) { is_expected.to eq(">=1.0.0,<1.6") }
+        end
+      end
     end
 
     context "when dealing with a setup.cfg dependency" do
@@ -471,6 +494,29 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
 
             its([:requirement]) { is_expected.to eq("==1.5.0") }
           end
+        end
+      end
+
+      context "with the widen_ranges update strategy" do
+        let(:update_strategy) { Dependabot::RequirementsUpdateStrategy::WidenRanges }
+        let(:latest_resolvable_version) { "1.5.0" }
+
+        context "when the requirement is already satisfied" do
+          let(:setup_cfg_req_string) { ">=1.3.0,<1.6" }
+
+          it { is_expected.to eq(setup_cfg_req) }
+        end
+
+        context "when the upper bound needs to be widened" do
+          let(:setup_cfg_req_string) { ">=1.3.0,<1.5" }
+
+          its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+        end
+
+        context "when lower bound is kept unchanged after widening" do
+          let(:setup_cfg_req_string) { ">=1.0.0,<1.5" }
+
+          its([:requirement]) { is_expected.to eq(">=1.0.0,<1.6") }
         end
       end
     end


### PR DESCRIPTION
## Summary

The `WidenRanges` strategy was already implemented for `pyproject.toml` and `requirements.txt`/`.in` files, but `setup.py` and `setup.cfg` were silently falling through to the `BumpVersions` logic regardless of the configured update strategy.

This also unblocks officially supporting `versioning-strategy: widen` for the `pip` ecosystem in `dependabot.yml`. Currently the GitHub service rejects `widen` as an invalid value for pip, but the underlying implementation is nearly complete.

## Changes

- `updated_setup_requirement`: delegate to `widen_requirement` when `WidenRanges` strategy is set, consistent with how `updated_requirement` handles `.txt`/`.in` files
- Add tests for `setup.py` and `setup.cfg` with `widen_ranges` strategy

## Related

- dependabot/dependabot-core#6685 — root cause: `auto` strategy heuristic for pip
- dependabot/dependabot-core#14702 — regression that made the misclassification harmful