### PR TITLE
Fix Nix cooldown fallback for commit refs

### DIFF
--- a/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
@@ -25,11 +25,34 @@ module Dependabot
           end
 
           # Fallback so the current version is always in the candidate set
-          releases << Dependabot::Package::PackageRelease.new(
-            version: Nix::Version.new("0.0.0-0.0"),
-            tag: dependency.version
-          )
+          releases << current_dependency_release
           releases
+        end
+
+        sig do
+          override.params(releases: T::Array[Dependabot::Package::PackageRelease])
+                  .returns(T::Array[Dependabot::Package::PackageRelease])
+        end
+        def filter_by_cooldown(releases)
+          return releases unless cooldown_enabled?
+          return releases unless cooldown_options
+
+          filtered = releases.reject { |release| in_cooldown_period?(release) }
+
+          if releases.count > filtered.count
+            Dependabot.logger.info("Filtered out #{releases.count - filtered.count} versions due to cooldown")
+          end
+
+          if filtered.empty? && !releases.empty? && dependency.version
+            Dependabot.logger.info(
+              "All versions filtered by cooldown for #{dependency.name}, " \
+              "falling back to current version #{dependency.version}"
+            )
+
+            return [current_dependency_release]
+          end
+
+          filtered
         end
 
         # All Nix versions are pseudo-versions with prerelease segments (0.0.0-0.N),
@@ -52,6 +75,14 @@ module Dependabot
               ).available_versions || []
             ),
             T.nilable(Dependabot::Package::PackageDetails)
+          )
+        end
+
+        sig { returns(Dependabot::Package::PackageRelease) }
+        def current_dependency_release
+          Dependabot::Package::PackageRelease.new(
+            version: Nix::Version.new("0.0.0-0.0"),
+            tag: dependency.version
           )
         end
       end

--- a/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
@@ -18,21 +18,6 @@ module Dependabot
           override.params(releases: T::Array[Dependabot::Package::PackageRelease])
                   .returns(T::Array[Dependabot::Package::PackageRelease])
         end
-        def apply_post_fetch_latest_versions_filter(releases)
-          if releases.empty?
-            Dependabot.logger.info("No releases found for #{dependency.name} after applying filters.")
-            return releases
-          end
-
-          # Fallback so the current version is always in the candidate set
-          releases << current_dependency_release
-          releases
-        end
-
-        sig do
-          override.params(releases: T::Array[Dependabot::Package::PackageRelease])
-                  .returns(T::Array[Dependabot::Package::PackageRelease])
-        end
         def filter_by_cooldown(releases)
           return releases unless cooldown_enabled?
           return releases unless cooldown_options
@@ -63,6 +48,21 @@ module Dependabot
         end
 
         private
+
+        sig do
+          override.params(releases: T::Array[Dependabot::Package::PackageRelease])
+                  .returns(T::Array[Dependabot::Package::PackageRelease])
+        end
+        def apply_post_fetch_latest_versions_filter(releases)
+          if releases.empty?
+            Dependabot.logger.info("No releases found for #{dependency.name} after applying filters.")
+            return releases
+          end
+
+          # Fallback so the current version is always in the candidate set
+          releases << current_dependency_release
+          releases
+        end
 
         sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def package_details

--- a/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/latest_version_finder.rb
@@ -14,6 +14,15 @@ module Dependabot
       class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
 
+        # All Nix versions are pseudo-versions with prerelease segments (0.0.0-0.N),
+        # so we must always include prereleases to avoid filtering everything out.
+        sig { override.returns(T::Boolean) }
+        def wants_prerelease?
+          true
+        end
+
+        protected
+
         sig do
           override.params(releases: T::Array[Dependabot::Package::PackageRelease])
                   .returns(T::Array[Dependabot::Package::PackageRelease])
@@ -40,13 +49,6 @@ module Dependabot
           filtered
         end
 
-        # All Nix versions are pseudo-versions with prerelease segments (0.0.0-0.N),
-        # so we must always include prereleases to avoid filtering everything out.
-        sig { override.returns(T::Boolean) }
-        def wants_prerelease?
-          true
-        end
-
         private
 
         sig do
@@ -60,7 +62,8 @@ module Dependabot
           end
 
           # Fallback so the current version is always in the candidate set
-          releases << current_dependency_release
+          current_release = current_dependency_release
+          releases << current_release unless releases.any? { |r| r.version == current_release.version }
           releases
         end
 

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -213,6 +213,77 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         expect(checker.latest_version).to eq("ddd444")
       end
     end
+
+    context "with a branch-tracking input and cooldown filters every candidate" do
+      let(:current_sha) { "6201e203d09599479a3b3450ed24fa81537ebc4e" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: current_sha,
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "git",
+              url: "https://github.com/NixOS/nixpkgs",
+              branch: nil,
+              ref: "nixos-unstable"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+      let(:checker) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: [],
+          credentials: [],
+          update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+        )
+      end
+      let(:available_versions) do
+        [
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Nix::Version.new("0.0.0-0.2"),
+            tag: "a9503707cb403de2b9a974c27d89031c73b84455",
+            released_at: Time.now
+          ),
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Nix::Version.new("0.0.0-0.1"),
+            tag: "2a94098db537ad60347abdf0e4ba8f9434e37002",
+            released_at: Time.now
+          )
+        ]
+      end
+
+      before do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          git_dependency?: true,
+          pinned_ref_looks_like_version?: false
+        )
+
+        branch_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::VersionedBranchFinder,
+          versioned_branch?: false
+        )
+        allow(Dependabot::Nix::UpdateChecker::VersionedBranchFinder)
+          .to receive(:new).and_return(branch_finder)
+
+        package_details_fetcher = instance_double(
+          Dependabot::Nix::Package::PackageDetailsFetcher,
+          available_versions: available_versions
+        )
+        allow(Dependabot::Nix::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "falls back to the current commit SHA" do
+        expect(checker.latest_version).to eq(current_sha)
+      end
+    end
   end
 
   describe "#updated_requirements" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fix Nix updates for flake inputs that track commit refs, such as `nixpkgs` on `nixos-unstable`, when `cooldown` filters every candidate commit.

The shared cooldown fallback tried to parse the current locked SHA as a version, which raised `ArgumentError` and caused the update job to fail.

### Anything you want to highlight for special attention from reviewers?

Nix commit updates use pseudo-versions for sorting and keep the real SHA in `PackageRelease#tag`. This keeps that model and adds a Nix-specific cooldown fallback instead of making `Nix::Version` accept arbitrary SHAs.

### How will you know you've accomplished your goal?

Added a regression test for a branch-tracking input where every candidate is inside `cooldown.default-days`.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
