### PR TITLE
Mount nix sources in docker-dev-shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -240,6 +240,11 @@ docker run --rm -ti \
   -v "$(pwd)/maven/lib:$CODE_DIR/maven/lib" \
   -v "$(pwd)/maven/script:$CODE_DIR/maven/script" \
   -v "$(pwd)/maven/spec:$CODE_DIR/maven/spec" \
+  -v "$(pwd)/nix/.rubocop.yml:$CODE_DIR/nix/.rubocop.yml" \
+  -v "$(pwd)/nix/dependabot-nix.gemspec:$CODE_DIR/nix/dependabot-nix.gemspec" \
+  -v "$(pwd)/nix/lib:$CODE_DIR/nix/lib" \
+  -v "$(pwd)/nix/script:$CODE_DIR/nix/script" \
+  -v "$(pwd)/nix/spec:$CODE_DIR/nix/spec" \
   -v "$(pwd)/npm_and_yarn/.rubocop.yml:$CODE_DIR/npm_and_yarn/.rubocop.yml" \
   -v "$(pwd)/npm_and_yarn/dependabot-npm_and_yarn.gemspec:$CODE_DIR/npm_and_yarn/dependabot-npm_and_yarn.gemspec" \
   -v "$(pwd)/npm_and_yarn/helpers:$CODE_DIR/npm_and_yarn/helpers" \


### PR DESCRIPTION
### What are you trying to accomplish?

Add `nix` to the volume mounts in `bin/docker-dev-shell` so local changes to `nix/lib`, `nix/spec`, and the gemspec are picked up inside the container. Right now the nix ecosystem is the only one missing from the mount list, which means `bin/test nix` runs against the baked-in image code instead of your working tree. I noticed this while working on #14829.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

`bin/test nix spec/...` runs against host source instead of the baked image

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.