### PR TITLE
Extract Maven requirement into shared requirement class which can be reused by Gradle and Sbt

### DIFF
--- a/gradle/lib/dependabot/gradle/requirement.rb
+++ b/gradle/lib/dependabot/gradle/requirement.rb
@@ -19,6 +19,16 @@ module Dependabot
       # Like PATTERN, but the leading operator is required
       RUBY_STYLE_PATTERN = /\A\s*(#{quoted})\s*(#{Gradle::Version::VERSION_PATTERN})\s*\z/
 
+      sig { override.returns(Regexp) }
+      def self.pattern
+        PATTERN
+      end
+
+      sig { override.returns(Regexp) }
+      def self.ruby_style_pattern
+        RUBY_STYLE_PATTERN
+      end
+
       sig { override.params(obj: T.any(Gem::Version, String)).returns([String, Gem::Version]) }
       def self.parse(obj)
         return ["=", Gradle::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)

--- a/gradle/lib/dependabot/gradle/requirement.rb
+++ b/gradle/lib/dependabot/gradle/requirement.rb
@@ -5,12 +5,12 @@ require "sorbet-runtime"
 
 require "dependabot/requirement"
 require "dependabot/utils"
-require "dependabot/maven/requirement"
+require "dependabot/maven/shared/shared_requirement"
 require "dependabot/gradle/version"
 
 module Dependabot
   module Gradle
-    class Requirement < Dependabot::Requirement
+    class Requirement < Dependabot::Maven::Shared::SharedRequirement
       extend T::Sig
 
       quoted = OPS.keys.map { |k| Regexp.quote k }.join("|")
@@ -40,95 +40,10 @@ module Dependabot
         end
       end
 
-      sig { params(requirements: T.any(T.nilable(String), T::Array[T.nilable(String)])).void }
-      def initialize(*requirements)
-        requirements = requirements.flatten.flat_map do |req_string|
-          convert_java_constraint_to_ruby_constraint(req_string)
-        end
-
-        super(requirements)
-      end
-
       sig { override.params(version: Gem::Version).returns(T::Boolean) }
       def satisfied_by?(version)
         version = Gradle::Version.new(version.to_s)
         super
-      end
-
-      private
-
-      sig { params(req_string: T.nilable(String)).returns(T::Array[T.nilable(String)]) }
-      def self.split_java_requirement(req_string)
-        return [req_string] unless req_string&.match?(Maven::Requirement::OR_SYNTAX)
-
-        req_string.split(Maven::Requirement::OR_SYNTAX).flat_map do |str|
-          next str if str.start_with?("(", "[")
-
-          exacts, *rest = str.split(/,(?=\[|\()/)
-          [*T.must(exacts).split(","), *rest]
-        end
-      end
-      private_class_method :split_java_requirement
-
-      sig { params(req_string: T.nilable(String)).returns(T.nilable(T::Array[String])) }
-      def convert_java_constraint_to_ruby_constraint(req_string)
-        return unless req_string
-
-        if self.class.send(:split_java_requirement, req_string).count > 1
-          raise "Can't convert multiple Java reqs to a single Ruby one"
-        end
-
-        version_reqs = req_string.split(",").map(&:strip)
-        if version_reqs.length > 1 && !version_reqs.all? { |s| PATTERN.match?(s) }
-          return convert_java_range_to_ruby_range(req_string)
-        end
-
-        version_reqs.map do |r|
-          # if an operator is already provided, use it
-          next r if r.match?(RUBY_STYLE_PATTERN)
-
-          convert_java_equals_req_to_ruby(r)
-        end
-      end
-
-      sig { params(req_string: String).returns(T::Array[String]) }
-      def convert_java_range_to_ruby_range(req_string)
-        lower_b, upper_b = req_string.split(",").map(&:strip)
-
-        lower_b =
-          if ["(", "["].include?(lower_b) then nil
-          elsif T.must(lower_b).start_with?("(") then "> #{T.must(lower_b).sub(/\(\s*/, '')}"
-          else
-            ">= #{T.must(lower_b).sub(/\[\s*/, '').strip}"
-          end
-
-        upper_b =
-          if [")", "]"].include?(upper_b) then nil
-          elsif T.must(upper_b).end_with?(")") then "< #{T.must(upper_b).sub(/\s*\)/, '')}"
-          else
-            "<= #{T.must(upper_b).sub(/\s*\]/, '').strip}"
-          end
-
-        [lower_b, upper_b].compact
-      end
-
-      sig { params(req_string: String).returns(String) }
-      def convert_java_equals_req_to_ruby(req_string)
-        return convert_wildcard_req(req_string) if req_string.include?("+")
-
-        # If a soft requirement is being used, treat it as an equality matcher
-        return req_string unless req_string.start_with?("[")
-
-        req_string.gsub(/[\[\]\(\)]/, "")
-      end
-
-      sig { params(req_string: String).returns(String) }
-      def convert_wildcard_req(req_string)
-        version = req_string.split("+").first
-        return ">= 0" if version.nil? || version.empty?
-
-        version += "0" if version.end_with?(".")
-        "~> #{version}"
       end
     end
   end

--- a/maven/lib/dependabot/maven/requirement.rb
+++ b/maven/lib/dependabot/maven/requirement.rb
@@ -19,6 +19,16 @@ module Dependabot
       # Like PATTERN, but the leading operator is required
       RUBY_STYLE_PATTERN = T.let(/\A\s*(#{quoted})\s*(#{Maven::Version::VERSION_PATTERN})\s*\z/, Regexp)
 
+      sig { override.returns(Regexp) }
+      def self.pattern
+        PATTERN
+      end
+
+      sig { override.returns(Regexp) }
+      def self.ruby_style_pattern
+        RUBY_STYLE_PATTERN
+      end
+
       sig { params(obj: T.any(String, Gem::Version)).returns(T::Array[T.any(String, T.untyped)]) }
       def self.parse(obj)
         return ["=", Maven::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)

--- a/maven/lib/dependabot/maven/requirement.rb
+++ b/maven/lib/dependabot/maven/requirement.rb
@@ -6,14 +6,14 @@ require "sorbet-runtime"
 require "dependabot/requirement"
 require "dependabot/utils"
 require "dependabot/maven/version"
+require "dependabot/maven/shared/shared_requirement"
 
 module Dependabot
   module Maven
-    class Requirement < Dependabot::Requirement
+    class Requirement < Dependabot::Maven::Shared::SharedRequirement
       extend T::Sig
 
       quoted = OPS.keys.map { |k| Regexp.quote k }.join("|")
-      OR_SYNTAX = T.let(/(?<=\]|\)),/, Regexp)
       PATTERN_RAW = T.let("\\s*(#{quoted})?\\s*(#{Maven::Version::VERSION_PATTERN})\\s*".freeze, String)
       PATTERN = T.let(/\A#{PATTERN_RAW}\z/, Regexp)
       # Like PATTERN, but the leading operator is required
@@ -40,104 +40,10 @@ module Dependabot
         end
       end
 
-      sig { params(requirements: T.untyped).void }
-      def initialize(*requirements)
-        requirements = requirements.flatten.flat_map do |req_string|
-          convert_java_constraint_to_ruby_constraint(req_string)
-        end
-
-        super(requirements)
-      end
-
       sig { params(version: T.untyped).returns(T::Boolean) }
       def satisfied_by?(version)
         version = Maven::Version.new(version.to_s)
         super
-      end
-
-      private
-
-      sig { params(req_string: T.nilable(String)).returns(T::Array[String]) }
-      def self.split_java_requirement(req_string)
-        return [req_string || ""] unless req_string&.match?(OR_SYNTAX)
-
-        req_string.split(OR_SYNTAX).flat_map do |str|
-          next str if str.start_with?("(", "[")
-
-          exacts, *rest = str.split(/,(?=\[|\()/)
-          [*T.must(exacts).split(","), *rest]
-        end
-      end
-      private_class_method :split_java_requirement
-
-      sig do
-        params(
-          req_string: T.nilable(String)
-        )
-          .returns(T.nilable(T.any(T::Array[String], T::Array[T.nilable(String)])))
-      end
-      def convert_java_constraint_to_ruby_constraint(req_string)
-        return unless req_string
-
-        if self.class.send(:split_java_requirement, req_string).count > 1
-          raise "Can't convert multiple Java reqs to a single Ruby one"
-        end
-
-        version_reqs = req_string.split(",").map(&:strip)
-        if version_reqs.length > 1 && !version_reqs.all? { |s| PATTERN.match?(s) }
-          return convert_java_range_to_ruby_range(req_string)
-        end
-
-        version_reqs.map do |r|
-          # if an operator is already provided, use it
-          next r if r.match?(RUBY_STYLE_PATTERN)
-
-          convert_java_equals_req_to_ruby(r)
-        end
-      end
-
-      # rubocop:disable Metrics/PerceivedComplexity
-      sig { params(req_string: String).returns(T::Array[T.nilable(String)]) }
-      def convert_java_range_to_ruby_range(req_string)
-        parts = req_string.split(",").map(&:strip)
-        lower_b = T.let(parts[0], T.nilable(String))
-        upper_b = T.let(parts[1], T.nilable(String))
-
-        lower_b =
-          if lower_b && ["(", "["].include?(lower_b) then nil
-          elsif lower_b&.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
-          elsif lower_b
-            ">= #{lower_b.sub(/\[\s*/, '').strip}"
-          end
-
-        upper_b =
-          if upper_b && [")", "]"].include?(upper_b) then nil
-          elsif upper_b&.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
-          elsif upper_b
-            "<= #{upper_b.sub(/\s*\]/, '').strip}"
-          end
-
-        [lower_b, upper_b].compact
-      end
-      # rubocop:enable Metrics/PerceivedComplexity
-
-      sig { params(req_string: T.nilable(String)).returns(T.nilable(String)) }
-      def convert_java_equals_req_to_ruby(req_string)
-        return convert_wildcard_req(req_string) if req_string&.end_with?("+")
-
-        # If a soft requirement is being used, treat it as an equality matcher
-        return req_string unless req_string&.start_with?("[")
-
-        req_string.gsub(/[\[\]\(\)]/, "")
-      end
-
-      sig { params(req_string: T.nilable(String)).returns(String) }
-      def convert_wildcard_req(req_string)
-        version = req_string&.split("+")&.first
-        return ">= 0" if version.nil? || version.empty?
-
-        version += "0" if version.end_with?(".")
-        "~> #{version}"
       end
     end
   end

--- a/maven/lib/dependabot/maven/shared/shared_requirement.rb
+++ b/maven/lib/dependabot/maven/shared/shared_requirement.rb
@@ -16,6 +16,12 @@ module Dependabot
 
         OR_SYNTAX = T.let(/(?<=\]|\)),/, Regexp)
 
+        sig { abstract.returns(Regexp) }
+        def self.pattern; end
+
+        sig { abstract.returns(Regexp) }
+        def self.ruby_style_pattern; end
+
         sig { params(requirements: T.untyped).void }
         def initialize(*requirements)
           requirements = requirements.flatten.flat_map do |req_string|
@@ -54,16 +60,14 @@ module Dependabot
           end
 
           version_reqs = req_string.split(",").map(&:strip)
-          pattern = self.class.const_get(:PATTERN)
-          ruby_style_pattern = self.class.const_get(:RUBY_STYLE_PATTERN)
 
-          if version_reqs.length > 1 && !version_reqs.all? { |s| pattern.match?(s) }
+          if version_reqs.length > 1 && !version_reqs.all? { |s| self.class.pattern.match?(s) }
             return convert_java_range_to_ruby_range(req_string)
           end
 
           version_reqs.map do |r|
             # if an operator is already provided, use it
-            next r if r.match?(ruby_style_pattern)
+            next r if r.match?(self.class.ruby_style_pattern)
 
             convert_java_equals_req_to_ruby(r)
           end
@@ -72,24 +76,25 @@ module Dependabot
         sig { params(req_string: String).returns(T::Array[T.nilable(String)]) }
         def convert_java_range_to_ruby_range(req_string)
           parts = req_string.split(",").map(&:strip)
-          lower_b = T.let(parts[0], T.nilable(String))
-          upper_b = T.let(parts[1], T.nilable(String))
-
-          lower_b =
-            if lower_b && ["(", "["].include?(lower_b) then nil
-            elsif lower_b&.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
-            elsif lower_b
-              ">= #{lower_b.sub(/\[\s*/, '').strip}"
-            end
-
-          upper_b =
-            if upper_b && [")", "]"].include?(upper_b) then nil
-            elsif upper_b&.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
-            elsif upper_b
-              "<= #{upper_b.sub(/\s*\]/, '').strip}"
-            end
-
+          lower_b = parse_lower_bound(parts[0])
+          upper_b = parse_upper_bound(parts[1])
           [lower_b, upper_b].compact
+        end
+
+        sig { params(bound: T.nilable(String)).returns(T.nilable(String)) }
+        def parse_lower_bound(bound)
+          return nil if bound.nil? || ["(", "["].include?(bound)
+          return "> #{bound.sub(/\(\s*/, '')}" if bound.start_with?("(")
+
+          ">= #{bound.sub(/\[\s*/, '').strip}"
+        end
+
+        sig { params(bound: T.nilable(String)).returns(T.nilable(String)) }
+        def parse_upper_bound(bound)
+          return nil if bound.nil? || [")", "]"].include?(bound)
+          return "< #{bound.sub(/\s*\)/, '')}" if bound.end_with?(")")
+
+          "<= #{bound.sub(/\s*\]/, '').strip}"
         end
 
         sig { params(req_string: T.nilable(String)).returns(T.nilable(String)) }

--- a/maven/lib/dependabot/maven/shared/shared_requirement.rb
+++ b/maven/lib/dependabot/maven/shared/shared_requirement.rb
@@ -1,0 +1,116 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/requirement"
+
+module Dependabot
+  module Maven
+    module Shared
+      class SharedRequirement < Dependabot::Requirement
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        OR_SYNTAX = T.let(/(?<=\]|\)),/, Regexp)
+
+        sig { params(requirements: T.untyped).void }
+        def initialize(*requirements)
+          requirements = requirements.flatten.flat_map do |req_string|
+            convert_java_constraint_to_ruby_constraint(req_string)
+          end
+
+          super(requirements)
+        end
+
+        private
+
+        sig { params(req_string: T.nilable(String)).returns(T::Array[String]) }
+        def self.split_java_requirement(req_string)
+          return [req_string || ""] unless req_string&.match?(OR_SYNTAX)
+
+          req_string.split(OR_SYNTAX).flat_map do |str|
+            next str if str.start_with?("(", "[")
+
+            exacts, *rest = str.split(/,(?=\[|\()/)
+            [*T.must(exacts).split(","), *rest]
+          end
+        end
+        private_class_method :split_java_requirement
+
+        sig do
+          params(
+            req_string: T.nilable(String)
+          )
+            .returns(T.nilable(T.any(T::Array[String], T::Array[T.nilable(String)])))
+        end
+        def convert_java_constraint_to_ruby_constraint(req_string)
+          return unless req_string
+
+          if self.class.send(:split_java_requirement, req_string).count > 1
+            raise "Can't convert multiple Java reqs to a single Ruby one"
+          end
+
+          version_reqs = req_string.split(",").map(&:strip)
+          pattern = self.class.const_get(:PATTERN)
+          ruby_style_pattern = self.class.const_get(:RUBY_STYLE_PATTERN)
+
+          if version_reqs.length > 1 && !version_reqs.all? { |s| pattern.match?(s) }
+            return convert_java_range_to_ruby_range(req_string)
+          end
+
+          version_reqs.map do |r|
+            # if an operator is already provided, use it
+            next r if r.match?(ruby_style_pattern)
+
+            convert_java_equals_req_to_ruby(r)
+          end
+        end
+
+        sig { params(req_string: String).returns(T::Array[T.nilable(String)]) }
+        def convert_java_range_to_ruby_range(req_string)
+          parts = req_string.split(",").map(&:strip)
+          lower_b = T.let(parts[0], T.nilable(String))
+          upper_b = T.let(parts[1], T.nilable(String))
+
+          lower_b =
+            if lower_b && ["(", "["].include?(lower_b) then nil
+            elsif lower_b&.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
+            elsif lower_b
+              ">= #{lower_b.sub(/\[\s*/, '').strip}"
+            end
+
+          upper_b =
+            if upper_b && [")", "]"].include?(upper_b) then nil
+            elsif upper_b&.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
+            elsif upper_b
+              "<= #{upper_b.sub(/\s*\]/, '').strip}"
+            end
+
+          [lower_b, upper_b].compact
+        end
+
+        sig { params(req_string: T.nilable(String)).returns(T.nilable(String)) }
+        def convert_java_equals_req_to_ruby(req_string)
+          return convert_wildcard_req(req_string) if req_string&.end_with?("+")
+
+          # If a soft requirement is being used, treat it as an equality matcher
+          return req_string unless req_string&.start_with?("[")
+
+          req_string.gsub(/[\[\]\(\)]/, "")
+        end
+
+        sig { params(req_string: T.nilable(String)).returns(String) }
+        def convert_wildcard_req(req_string)
+          version = req_string&.split("+")&.first
+          return ">= 0" if version.nil? || version.empty?
+
+          version += "0" if version.end_with?(".")
+          "~> #{version}"
+        end
+      end
+    end
+  end
+end

--- a/maven/spec/dependabot/maven/shared/shared_requirement_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_requirement_spec.rb
@@ -1,0 +1,188 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/maven/shared/shared_requirement"
+require "dependabot/maven/version"
+
+RSpec.describe Dependabot::Maven::Shared::SharedRequirement do
+  # Define a concrete subclass inside the describe block to avoid superclass mismatch
+  # when multiple spec files are loaded in the same process.
+  let(:test_requirement_class) do
+    quoted = Gem::Requirement::OPS.keys.map { |k| Regexp.quote k }.join("|")
+    version_pattern = Dependabot::Maven::Version::VERSION_PATTERN
+    pattern_raw = "\\s*(#{quoted})?\\s*(#{version_pattern})\\s*".freeze
+    pattern = /\A#{pattern_raw}\z/
+    ruby_style_pattern = /\A\s*(#{quoted})\s*(#{version_pattern})\s*\z/
+
+    Class.new(described_class) do
+      const_set(:PATTERN_RAW, pattern_raw)
+      const_set(:PATTERN, pattern)
+      const_set(:RUBY_STYLE_PATTERN, ruby_style_pattern)
+
+      define_singleton_method(:parse) do |obj|
+        return ["=", Dependabot::Maven::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
+
+        unless (matches = const_get(:PATTERN).match(obj.to_s))
+          msg = "Illformed requirement [#{obj.inspect}]"
+          raise Gem::Requirement::BadRequirementError, msg
+        end
+
+        return Gem::Requirement::DefaultRequirement if matches[1] == ">=" && matches[2] == "0"
+
+        [matches[1] || "=", Dependabot::Maven::Version.new(matches[2])]
+      end
+
+      define_singleton_method(:requirements_array) do |requirement_string|
+        split_java_requirement(requirement_string).map { |str| new(str) }
+      end
+
+      define_method(:satisfied_by?) do |version|
+        version = Dependabot::Maven::Version.new(version.to_s)
+        super(version)
+      end
+    end
+  end
+
+  subject(:requirement) { test_requirement_class.new(requirement_string) }
+
+  let(:requirement_string) { ">=1.0.0" }
+
+  describe "OR_SYNTAX" do
+    it "is defined on the shared class" do
+      expect(described_class::OR_SYNTAX).to eq(/(?<=\]|\)),/)
+    end
+  end
+
+  describe ".split_java_requirement" do
+    subject(:split) { test_requirement_class.send(:split_java_requirement, requirement_string) }
+
+    context "with a simple version" do
+      let(:requirement_string) { "1.0.0" }
+
+      it { is_expected.to eq(["1.0.0"]) }
+    end
+
+    context "with nil" do
+      let(:requirement_string) { nil }
+
+      it { is_expected.to eq([""]) }
+    end
+
+    context "with two range requirements separated by OR_SYNTAX" do
+      let(:requirement_string) { "(,1.0.0),(1.0.0,)" }
+
+      it { is_expected.to contain_exactly("(,1.0.0)", "(1.0.0,)") }
+    end
+
+    context "with a single range requirement" do
+      let(:requirement_string) { "[1.0.0,2.0.0)" }
+
+      it { is_expected.to eq(["[1.0.0,2.0.0)"]) }
+    end
+  end
+
+  describe "#initialize (convert_java_constraint_to_ruby_constraint)" do
+    context "with a range requirement" do
+      let(:requirement_string) { "[1.0.0,)" }
+
+      it { is_expected.to eq(Gem::Requirement.new(">= 1.0.0")) }
+    end
+
+    context "with an exclusive lower bound" do
+      let(:requirement_string) { "(1.0.0,)" }
+
+      it { is_expected.to eq(Gem::Requirement.new("> 1.0.0")) }
+    end
+
+    context "with both bounds" do
+      let(:requirement_string) { "(1.0.0, 2.0.0)" }
+
+      it { is_expected.to eq(Gem::Requirement.new("> 1.0.0", "< 2.0.0")) }
+    end
+
+    context "with inclusive both bounds" do
+      let(:requirement_string) { "[ 1.0.0,2.0.0 ]" }
+
+      it { is_expected.to eq(Gem::Requirement.new(">= 1.0.0", "<= 2.0.0")) }
+    end
+
+    context "with a soft requirement" do
+      let(:requirement_string) { "1.0.0" }
+
+      it { is_expected.to eq(Gem::Requirement.new("= 1.0.0")) }
+    end
+
+    context "with a hard requirement" do
+      let(:requirement_string) { "[1.0.0]" }
+
+      it { is_expected.to eq(Gem::Requirement.new("= 1.0.0")) }
+    end
+
+    context "with a dynamic version requirement (wildcard)" do
+      let(:requirement_string) { "1.+" }
+
+      its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0").to_s) }
+    end
+
+    context "with just a + wildcard" do
+      let(:requirement_string) { "+" }
+
+      its(:to_s) { is_expected.to eq(Gem::Requirement.new(">= 0").to_s) }
+    end
+
+    context "with a comma-separated ruby style version requirement" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+
+      it { is_expected.to eq(test_requirement_class.new("~> 4.2.5", ">= 4.2.5.1")) }
+    end
+
+    context "when multiple Java reqs would be generated" do
+      let(:requirement_string) { "(,1.0.0),(1.0.0,)" }
+
+      it "raises an error" do
+        expect { requirement }.to raise_error("Can't convert multiple Java reqs to a single Ruby one")
+      end
+    end
+  end
+
+  describe ".requirements_array" do
+    subject(:array) { test_requirement_class.requirements_array(requirement_string) }
+
+    context "with exact requirement" do
+      let(:requirement_string) { "1.0.0" }
+
+      it { is_expected.to eq([test_requirement_class.new("= 1.0.0")]) }
+    end
+
+    context "with a range requirement" do
+      let(:requirement_string) { "[1.0.0,)" }
+
+      it { is_expected.to eq([test_requirement_class.new(">= 1.0.0")]) }
+    end
+
+    context "with two range requirements" do
+      let(:requirement_string) { "(,1.0.0),(1.0.0,)" }
+
+      it "builds the correct array of requirements" do
+        expect(array).to contain_exactly(test_requirement_class.new("> 1.0.0"), test_requirement_class.new("< 1.0.0"))
+      end
+    end
+  end
+
+  describe "#satisfied_by?" do
+    subject { requirement.satisfied_by?(version) }
+
+    context "with a satisfying version" do
+      let(:version) { Dependabot::Maven::Version.new("1.0.0") }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with an out-of-range version" do
+      let(:version) { Dependabot::Maven::Version.new("0.9.0") }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/maven/spec/dependabot/maven/shared/shared_requirement_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_requirement_spec.rb
@@ -6,24 +6,31 @@ require "dependabot/maven/shared/shared_requirement"
 require "dependabot/maven/version"
 
 RSpec.describe Dependabot::Maven::Shared::SharedRequirement do
+  subject(:requirement) { test_requirement_class.new(requirement_string) }
+
+  let(:requirement_string) { ">=1.0.0" }
+
   # Define a concrete subclass inside the describe block to avoid superclass mismatch
   # when multiple spec files are loaded in the same process.
   let(:test_requirement_class) do
     quoted = Gem::Requirement::OPS.keys.map { |k| Regexp.quote k }.join("|")
     version_pattern = Dependabot::Maven::Version::VERSION_PATTERN
     pattern_raw = "\\s*(#{quoted})?\\s*(#{version_pattern})\\s*".freeze
-    pattern = /\A#{pattern_raw}\z/
-    ruby_style_pattern = /\A\s*(#{quoted})\s*(#{version_pattern})\s*\z/
+    pat = /\A#{pattern_raw}\z/
+    rs_pattern = /\A\s*(#{quoted})\s*(#{version_pattern})\s*\z/
 
     Class.new(described_class) do
       const_set(:PATTERN_RAW, pattern_raw)
-      const_set(:PATTERN, pattern)
-      const_set(:RUBY_STYLE_PATTERN, ruby_style_pattern)
+      const_set(:PATTERN, pat)
+      const_set(:RUBY_STYLE_PATTERN, rs_pattern)
+
+      define_singleton_method(:pattern) { pat }
+      define_singleton_method(:ruby_style_pattern) { rs_pattern }
 
       define_singleton_method(:parse) do |obj|
         return ["=", Dependabot::Maven::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
-        unless (matches = const_get(:PATTERN).match(obj.to_s))
+        unless (matches = pat.match(obj.to_s))
           msg = "Illformed requirement [#{obj.inspect}]"
           raise Gem::Requirement::BadRequirementError, msg
         end
@@ -43,10 +50,6 @@ RSpec.describe Dependabot::Maven::Shared::SharedRequirement do
       end
     end
   end
-
-  subject(:requirement) { test_requirement_class.new(requirement_string) }
-
-  let(:requirement_string) { ">=1.0.0" }
 
   describe "OR_SYNTAX" do
     it "is defined on the shared class" do


### PR DESCRIPTION
### What are you trying to accomplish?
This PR extracts common Java/Maven requirement parsing logic from `Maven::Requirement` and `Gradle::Requirement` into a new abstract `Maven::Shared::SharedRequirement` base class, and slims down both ecosystem classes to inherit from it.
<!-- Provide both a what and a _why_ for the change. -->
Maven, Gradle, and the upcoming SBT ecosystem all use identical Java-style version requirement syntax (ranges like `[1.0,2.0)`, soft requirements, wildcards like `1.+`). Centralizing this logic avoids code duplication across all three ecosystems.

## Methods moved to `SharedRequirement`

| Method | Purpose |
|--------|---------|
| `initialize(*requirements)` | Flattens and converts Java constraints to Ruby constraints |
| `split_java_requirement(req_string)` | Splits OR-separated Java requirement strings (e.g., `(,1.0),(2.0,)`) |
| `convert_java_constraint_to_ruby_constraint(req_string)` | Dispatches to range or equality conversion |
| `convert_java_range_to_ruby_range(req_string)` | Converts `[1.0,2.0)` → `>= 1.0, < 2.0` |
| `convert_java_equals_req_to_ruby(req_string)` | Converts `[1.0.0]` → `= 1.0.0` |
| `convert_wildcard_req(req_string)` | Converts `1.+` → `~> 1.0` |
| `OR_SYNTAX` | Regex constant for splitting OR-separated requirements |

## What stays in subclasses

| Element | Why |
|---------|-----|
| `PATTERN` / `PATTERN_RAW` / `RUBY_STYLE_PATTERN` | Depend on ecosystem-specific `VERSION_PATTERN` |
| `parse(obj)` | Instantiates ecosystem-specific `Version` class |
| `requirements_array(requirement_string)` | Returns ecosystem-specific `Requirement` instances |
| `satisfied_by?(version)` | Wraps version in ecosystem-specific `Version` class |
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
## Changes

- `maven/lib/dependabot/maven/shared/shared_requirement.rb` — New abstract base class with all shared conversion logic
- `maven/lib/dependabot/maven/requirement.rb` — Now inherits from `SharedRequirement`, removed 6 methods + `OR_SYNTAX`
- `gradle/lib/dependabot/gradle/requirement.rb` — Now inherits from `SharedRequirement`, removed 6 methods + `Maven::Requirement::OR_SYNTAX` reference
- `maven/spec/dependabot/maven/shared/shared_requirement_spec.rb` — New unit tests covering all shared methods

## How SBT will reuse this
```ruby
class Requirement < Dependabot::Maven::Shared::SharedRequirement
  # Only needs: PATTERN, PATTERN_RAW, RUBY_STYLE_PATTERN,
  #             parse, requirements_array, satisfied_by?
end
```
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
If the existing requirement parsing logic in Maven works fine without any errors.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
