### PR TITLE
Use GitHub Repo Activity API to fetch Nix branch tips

### DIFF
--- a/nix/.rubocop.yml
+++ b/nix/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: ../.rubocop.yml
+Sorbet/ForbidTUnsafe:
+  Exclude:
+    - lib/dependabot/nix/package/package_details_fetcher.rb

--- a/nix/.rubocop.yml
+++ b/nix/.rubocop.yml
@@ -1,4 +1,1 @@
 inherit_from: ../.rubocop.yml
-Sorbet/ForbidTUnsafe:
-  Exclude:
-    - lib/dependabot/nix/package/package_details_fetcher.rb

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -99,7 +99,10 @@ module Dependabot
           )
           nil
         rescue StandardError => e
-          Dependabot.logger.error("Error fetching branch-tip history: #{e.message}")
+          Dependabot.logger.error(
+            "Error fetching branch-tip history for #{dependency.name} " \
+            "(#{e.class}: #{e.message})"
+          )
           nil
         end
 
@@ -113,8 +116,9 @@ module Dependabot
           )
         end
 
-        # Trim to entries newer than the currently locked SHA so we don't
-        # introduce candidates older than `dependency.version`.
+        # Trim to entries up to and including the currently locked SHA, stopping
+        # once that SHA is reached so we don't introduce candidates older than
+        # `dependency.version`.
         sig { params(entries: T::Array[T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         def trim_entries_to_locked_sha(entries)
           locked = dependency.version

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -102,7 +102,7 @@ module Dependabot
           locked = dependency.version
           result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
           entries.each do |e|
-            result << { tag: e[:after], release_date: format_timestamp(e[:timestamp]) }
+            result << { tag: e[:after], release_date: format_timestamp(e[:pushed_at]) }
             break if locked && (e[:after] == locked || e[:before] == locked)
           end
           result

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -66,7 +66,11 @@ module Dependabot
         TARGET_COMMITS_TO_FETCH = 500
         ACTIVITY_TYPES = "push,force_push"
         SHA_REGEX = /\A[0-9a-f]{40}\z/
-        private_constant :TARGET_COMMITS_TO_FETCH, :ACTIVITY_TYPES, :SHA_REGEX
+        # Heuristic for refs that look like a tag/version rather than a branch
+        # (e.g. `v1.2.3`, `1.2`, `2024.01`). Branch names like `nixos-25.05`
+        # don't match because they don't start with a digit or `v<digit>`.
+        TAG_LIKE_REF_REGEX = /\Av?\d+\./
+        private_constant :TARGET_COMMITS_TO_FETCH, :ACTIVITY_TYPES, :SHA_REGEX, :TAG_LIKE_REF_REGEX
 
         # Fetch branch-tip history via GitHub's Repo Activity API. Each entry's
         # `after` SHA was once the actual branch tip — for `nixpkgs` channels
@@ -93,7 +97,15 @@ module Dependabot
           )
           return nil unless entries.is_a?(Array) && entries.any?
 
-          entries.map { |e| { tag: e[:after], release_date: format_timestamp(e[:timestamp]) } }
+          # Trim to entries newer than the currently locked SHA so we don't
+          # introduce candidates older than `dependency.version`.
+          locked = dependency.version
+          result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+          entries.each do |e|
+            result << { tag: e[:after], release_date: format_timestamp(e[:timestamp]) }
+            break if locked && (e[:after] == locked || e[:before] == locked)
+          end
+          result
         rescue Octokit::Error => e
           Dependabot.logger.info(
             "Repo Activity API failed for #{dependency.name} (#{e.class}: #{e.message}), " \
@@ -117,6 +129,7 @@ module Dependabot
         def use_activity_api?(url, ref)
           return false unless url && ref
           return false if ref.match?(SHA_REGEX)
+          return false if ref.match?(TAG_LIKE_REF_REGEX)
 
           host = URI.parse(url).host
           host == "github.com"

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -3,12 +3,14 @@
 
 require "json"
 require "time"
+require "uri"
 require "sorbet-runtime"
 require "dependabot/nix"
 require "dependabot/package/package_release"
 require "dependabot/package/package_details"
 require "dependabot/git_commit_checker"
 require "dependabot/git_metadata_fetcher"
+require "dependabot/clients/github_with_retries"
 
 module Dependabot
   module Nix
@@ -35,7 +37,7 @@ module Dependabot
 
         sig { returns(T.nilable(T::Array[Dependabot::Package::PackageRelease])) }
         def available_versions
-          versions_metadata = fetch_tags_and_release_date
+          versions_metadata = fetch_branch_tip_history || fetch_tags_and_release_date
 
           versions_metadata = fetch_latest_tag_info if versions_metadata.empty?
 
@@ -62,7 +64,91 @@ module Dependabot
         private
 
         TARGET_COMMITS_TO_FETCH = 500
-        private_constant :TARGET_COMMITS_TO_FETCH
+        ACTIVITY_TYPES = "push,force_push"
+        SHA_REGEX = /\A[0-9a-f]{40}\z/
+        private_constant :TARGET_COMMITS_TO_FETCH, :ACTIVITY_TYPES, :SHA_REGEX
+
+        # Fetch branch-tip history via GitHub's Repo Activity API. Each entry's
+        # `after` SHA was once the actual branch tip — for `nixpkgs` channels
+        # that means it was Hydra-evaluated and is cache-backed. The /commits
+        # endpoint, by contrast, returns intermediate commits that were never
+        # branch tips and may not be cached.
+        #
+        # Returns nil when the activity API isn't usable (non-GitHub host,
+        # SHA-pinned ref, missing ref, HTTP error). Callers should fall back to
+        # the existing /commits walker in that case.
+        sig { returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
+        def fetch_branch_tip_history
+          url = source_url
+          ref = branch_ref
+          return nil unless use_activity_api?(url, ref)
+
+          Dependabot.logger.info("Fetching branch-tip history for Nix flake input: #{dependency.name}")
+          path = "/repos/#{github_repo_path(T.must(url))}/activity"
+          entries = T.unsafe(github_client).get(
+            path,
+            ref: "refs/heads/#{T.must(ref)}",
+            activity_type: ACTIVITY_TYPES,
+            per_page: 100
+          )
+          return nil unless entries.is_a?(Array) && entries.any?
+
+          entries.map { |e| { tag: e[:after], release_date: format_timestamp(e[:timestamp]) } }
+        rescue Octokit::Error => e
+          Dependabot.logger.info(
+            "Repo Activity API failed for #{dependency.name} (#{e.class}: #{e.message}), " \
+            "falling back to commits API"
+          )
+          nil
+        rescue StandardError => e
+          Dependabot.logger.error("Error fetching branch-tip history: #{e.message}")
+          nil
+        end
+
+        sig { params(timestamp: T.untyped).returns(T.nilable(String)) }
+        def format_timestamp(timestamp)
+          return nil if timestamp.nil?
+          return timestamp.iso8601 if timestamp.respond_to?(:iso8601)
+
+          timestamp.to_s
+        end
+
+        sig { params(url: T.nilable(String), ref: T.nilable(String)).returns(T::Boolean) }
+        def use_activity_api?(url, ref)
+          return false unless url && ref
+          return false if ref.match?(SHA_REGEX)
+
+          host = URI.parse(url).host
+          host == "github.com"
+        rescue URI::InvalidURIError
+          false
+        end
+
+        sig { params(url: String).returns(String) }
+        def github_repo_path(url)
+          T.must(URI.parse(url).path)
+           .delete_prefix("/")
+           .delete_suffix("/")
+           .delete_suffix(".git")
+        end
+
+        sig { returns(T.nilable(String)) }
+        def source_url
+          dependency.source_details(allowed_types: ["git"])&.fetch(:url, nil)
+        end
+
+        sig { returns(T.nilable(String)) }
+        def branch_ref
+          dependency.source_details(allowed_types: ["git"])&.fetch(:ref, nil)
+        end
+
+        sig { returns(Dependabot::Clients::GithubWithRetries) }
+        def github_client
+          @github_client ||= T.let(
+            Dependabot::Clients::GithubWithRetries.for_github_dot_com(credentials: credentials),
+            T.nilable(Dependabot::Clients::GithubWithRetries)
+          )
+        end
 
         sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         def fetch_latest_tag_info

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -88,24 +88,10 @@ module Dependabot
           return nil unless use_activity_api?(url, ref)
 
           Dependabot.logger.info("Fetching branch-tip history for Nix flake input: #{dependency.name}")
-          path = "/repos/#{github_repo_path(T.must(url))}/activity"
-          entries = T.unsafe(github_client).get(
-            path,
-            ref: "refs/heads/#{T.must(ref)}",
-            activity_type: ACTIVITY_TYPES,
-            per_page: 100
-          )
+          entries = fetch_activity_entries(T.must(url), T.must(ref))
           return nil unless entries.is_a?(Array) && entries.any?
 
-          # Trim to entries newer than the currently locked SHA so we don't
-          # introduce candidates older than `dependency.version`.
-          locked = dependency.version
-          result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
-          entries.each do |e|
-            result << { tag: e[:after], release_date: format_timestamp(e[:pushed_at]) }
-            break if locked && (e[:after] == locked || e[:before] == locked)
-          end
-          result
+          trim_entries_to_locked_sha(entries)
         rescue Octokit::Error => e
           Dependabot.logger.info(
             "Repo Activity API failed for #{dependency.name} (#{e.class}: #{e.message}), " \
@@ -115,6 +101,29 @@ module Dependabot
         rescue StandardError => e
           Dependabot.logger.error("Error fetching branch-tip history: #{e.message}")
           nil
+        end
+
+        sig { params(url: String, ref: String).returns(T.untyped) }
+        def fetch_activity_entries(url, ref)
+          T.unsafe(github_client).get(
+            "/repos/#{github_repo_path(url)}/activity",
+            ref: "refs/heads/#{ref}",
+            activity_type: ACTIVITY_TYPES,
+            per_page: 100
+          )
+        end
+
+        # Trim to entries newer than the currently locked SHA so we don't
+        # introduce candidates older than `dependency.version`.
+        sig { params(entries: T::Array[T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        def trim_entries_to_locked_sha(entries)
+          locked = dependency.version
+          result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+          entries.each do |e|
+            result << { tag: e[:after], release_date: format_timestamp(e[:pushed_at]) }
+            break if locked && (e[:after] == locked || e[:before] == locked)
+          end
+          result
         end
 
         sig { params(timestamp: T.untyped).returns(T.nilable(String)) }

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -108,7 +108,7 @@ module Dependabot
 
         sig { params(url: String, ref: String).returns(T.untyped) }
         def fetch_activity_entries(url, ref)
-          T.unsafe(github_client).get(
+          T.unsafe(github_client).get( # rubocop:disable Sorbet/ForbidTUnsafe
             "/repos/#{github_repo_path(url)}/activity",
             ref: "refs/heads/#{ref}",
             activity_type: ACTIVITY_TYPES,
@@ -124,8 +124,16 @@ module Dependabot
           locked = dependency.version
           result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
           entries.each do |e|
-            result << { tag: e[:after], release_date: format_timestamp(e[:pushed_at]) }
-            break if locked && (e[:after] == locked || e[:before] == locked)
+            after_sha = e[:after]
+            result << { tag: after_sha, release_date: format_timestamp(e[:timestamp]) }
+
+            next unless locked
+            break if after_sha == locked
+
+            if e[:before] == locked
+              result << { tag: locked, release_date: nil } unless result.last&.fetch(:tag) == locked
+              break
+            end
           end
           result
         end

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -1,0 +1,199 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "dependabot/dependency"
+require "dependabot/nix/package/package_details_fetcher"
+
+RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
+  let(:current_sha) { "6201e203d09599479a3b3450ed24fa81537ebc4e" }
+  let(:url) { "https://github.com/NixOS/nixpkgs" }
+  let(:ref) { "nixos-unstable" }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "nixpkgs",
+      version: current_sha,
+      requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        groups: [],
+        source: { type: "git", url: url, branch: nil, ref: ref }
+      }],
+      package_manager: "nix"
+    )
+  end
+  let(:credentials) do
+    [{ "type" => "git_source", "host" => "github.com", "username" => "x-access-token", "password" => "test-token" }]
+  end
+  let(:fetcher) { described_class.new(dependency: dependency, credentials: credentials) }
+
+  let(:activity_url) do
+    "https://api.github.com/repos/NixOS/nixpkgs/activity" \
+      "?activity_type=push,force_push&per_page=100&ref=refs/heads/nixos-unstable"
+  end
+  let(:activity_response) do
+    [
+      { "id" => 1, "before" => "b12141ef619e", "after" => "0726a0ec",
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
+      { "id" => 2, "before" => "4bd9165a9165", "after" => "b12141ef",
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
+      { "id" => 3, "before" => current_sha, "after" => "4bd9165a",
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
+    ]
+  end
+
+  describe "#available_versions" do
+    context "when activity API returns data" do
+      before do
+        stub_request(:get, activity_url).to_return(
+          status: 200,
+          body: activity_response.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      it "returns releases derived from branch-tip pushes" do
+        versions = fetcher.available_versions
+        expect(versions.map(&:tag)).to eq(%w(0726a0ec b12141ef 4bd9165a))
+        expect(versions.map(&:released_at)).to eq(
+          [
+            Time.parse("2026-04-24T20:30:00Z"),
+            Time.parse("2026-04-20T19:04:11Z"),
+            Time.parse("2026-04-15T18:15:58Z")
+          ]
+        )
+      end
+
+      it "assigns descending pseudo-versions" do
+        versions = fetcher.available_versions
+        expect(versions.map(&:version)).to eq(
+          [
+            Dependabot::Nix::Version.new("0.0.0-0.3"),
+            Dependabot::Nix::Version.new("0.0.0-0.2"),
+            Dependabot::Nix::Version.new("0.0.0-0.1")
+          ]
+        )
+      end
+
+      it "sends an Authorization header derived from credentials" do
+        fetcher.available_versions
+        expect(WebMock).to have_requested(:get, activity_url)
+          .with(headers: { "Authorization" => "token test-token" })
+      end
+    end
+
+    context "when activity API returns 403" do
+      before do
+        stub_request(:get, activity_url).to_return(
+          status: 403,
+          body: '{"message":"rate limited"}',
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      it "falls back to the commits-based fetcher" do
+        # Stub the GitCommitChecker to short-circuit the fallback path
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          ref_details_for_pinned_ref: instance_double(
+            Excon::Response,
+            status: 200,
+            body: "[]"
+          ),
+          head_commit_for_current_branch: "fallback_sha"
+        )
+
+        versions = fetcher.available_versions
+        expect(versions.map(&:tag)).to eq(["fallback_sha"])
+      end
+    end
+
+    context "when activity API returns an empty array" do
+      before do
+        stub_request(:get, activity_url).to_return(
+          status: 200,
+          body: "[]",
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      it "falls back to the commits-based fetcher" do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          ref_details_for_pinned_ref: instance_double(
+            Excon::Response,
+            status: 200,
+            body: "[]"
+          ),
+          head_commit_for_current_branch: "fallback_sha"
+        )
+
+        fetcher.available_versions
+        expect(WebMock).to have_requested(:get, activity_url)
+      end
+    end
+
+    context "when the ref is a 40-char SHA" do
+      let(:ref) { "0123456789abcdef0123456789abcdef01234567" }
+
+      it "skips the activity API and uses the commits walker" do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          ref_details_for_pinned_ref: instance_double(
+            Excon::Response,
+            status: 200,
+            body: "[]"
+          ),
+          head_commit_for_current_branch: "fallback_sha"
+        )
+
+        fetcher.available_versions
+        expect(WebMock).not_to have_requested(:get, /api\.github\.com/)
+      end
+    end
+
+    context "when the source URL is not on github.com" do
+      let(:url) { "https://gitlab.com/foo/bar" }
+
+      it "skips the activity API and uses the commits walker" do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          ref_details_for_pinned_ref: instance_double(
+            Excon::Response,
+            status: 200,
+            body: "[]"
+          ),
+          head_commit_for_current_branch: "fallback_sha"
+        )
+
+        fetcher.available_versions
+        expect(WebMock).not_to have_requested(:get, /api\.github\.com/)
+      end
+    end
+
+    context "when no github.com credential is present" do
+      let(:credentials) { [] }
+
+      before do
+        stub_request(:get, activity_url).to_return(
+          status: 200,
+          body: activity_response.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      it "still calls the activity API without an Authorization header" do
+        fetcher.available_versions
+        expect(WebMock).to(
+          have_requested(:get, activity_url)
+                    .with { |req| !req.headers.key?("Authorization") }
+        )
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
   let(:activity_response) do
     [
       { "id" => 1, "before" => "b12141ef619e", "after" => "0726a0ec",
-        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
+        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
       { "id" => 2, "before" => "4bd9165a9165", "after" => "b12141ef",
-        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
+        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
       { "id" => 3, "before" => current_sha, "after" => "4bd9165a",
-        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
+        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
     ]
   end
 
@@ -191,11 +191,11 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
       let(:activity_response) do
         [
           { "id" => 1, "after" => "newer_a", "before" => "older_a",
-            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T00:00:00Z" },
+            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-24T00:00:00Z" },
           { "id" => 2, "after" => current_sha, "before" => "older_b",
-            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T00:00:00Z" },
+            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-20T00:00:00Z" },
           { "id" => 3, "after" => "older_c", "before" => "older_d",
-            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T00:00:00Z" }
+            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-15T00:00:00Z" }
         ]
       end
 

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -24,14 +24,24 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
     )
   end
   let(:credentials) do
-    [{ "type" => "git_source", "host" => "github.com", "username" => "x-access-token", "password" => "test-token" }]
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "test-token"
+    }]
   end
   let(:fetcher) { described_class.new(dependency: dependency, credentials: credentials) }
 
-  let(:activity_url) do
-    "https://api.github.com/repos/NixOS/nixpkgs/activity" \
-      "?activity_type=push,force_push&per_page=100&ref=refs/heads/nixos-unstable"
+  let(:activity_base_url) { "https://api.github.com/repos/NixOS/nixpkgs/activity" }
+  let(:activity_query) do
+    {
+      "activity_type" => "push,force_push",
+      "per_page" => "100",
+      "ref" => "refs/heads/nixos-unstable"
+    }
   end
+  let(:activity_url_pattern) { %r{\Ahttps://api\.github\.com/repos/NixOS/nixpkgs/activity\?} }
   let(:activity_response) do
     [
       { "id" => 1, "before" => "b12141ef619e", "after" => "0726a0ec",
@@ -46,7 +56,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
   describe "#available_versions" do
     context "when activity API returns data" do
       before do
-        stub_request(:get, activity_url).to_return(
+        stub_request(:get, activity_base_url).with(query: activity_query).to_return(
           status: 200,
           body: activity_response.to_json,
           headers: { "Content-Type" => "application/json" }
@@ -78,14 +88,14 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
 
       it "sends an Authorization header derived from credentials" do
         fetcher.available_versions
-        expect(WebMock).to have_requested(:get, activity_url)
-          .with(headers: { "Authorization" => "token test-token" })
+        expect(WebMock).to have_requested(:get, activity_base_url)
+          .with(query: activity_query, headers: { "Authorization" => "token test-token" })
       end
     end
 
     context "when activity API returns 403" do
       before do
-        stub_request(:get, activity_url).to_return(
+        stub_request(:get, activity_base_url).with(query: activity_query).to_return(
           status: 403,
           body: '{"message":"rate limited"}',
           headers: { "Content-Type" => "application/json" }
@@ -112,7 +122,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
 
     context "when activity API returns an empty array" do
       before do
-        stub_request(:get, activity_url).to_return(
+        stub_request(:get, activity_base_url).with(query: activity_query).to_return(
           status: 200,
           body: "[]",
           headers: { "Content-Type" => "application/json" }
@@ -131,8 +141,9 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
           head_commit_for_current_branch: "fallback_sha"
         )
 
-        fetcher.available_versions
-        expect(WebMock).to have_requested(:get, activity_url)
+        versions = fetcher.available_versions
+        expect(WebMock).to have_requested(:get, activity_base_url).with(query: activity_query)
+        expect(versions.map(&:tag)).to eq(["fallback_sha"])
       end
     end
 
@@ -152,7 +163,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
         )
 
         fetcher.available_versions
-        expect(WebMock).not_to have_requested(:get, /api\.github\.com/)
+        expect(WebMock).not_to have_requested(:get, activity_url_pattern)
       end
     end
 
@@ -172,7 +183,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
         )
 
         fetcher.available_versions
-        expect(WebMock).not_to have_requested(:get, /api\.github\.com/)
+        expect(WebMock).not_to have_requested(:get, activity_url_pattern)
       end
     end
 
@@ -180,7 +191,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
       let(:credentials) { [] }
 
       before do
-        stub_request(:get, activity_url).to_return(
+        stub_request(:get, activity_base_url).with(query: activity_query).to_return(
           status: 200,
           body: activity_response.to_json,
           headers: { "Content-Type" => "application/json" }
@@ -190,7 +201,8 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
       it "still calls the activity API without an Authorization header" do
         fetcher.available_versions
         expect(WebMock).to(
-          have_requested(:get, activity_url)
+          have_requested(:get, activity_base_url)
+                    .with(query: activity_query)
                     .with { |req| !req.headers.key?("Authorization") }
         )
       end

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -167,6 +167,52 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when the ref looks like a tag/version" do
+      let(:ref) { "v1.2.3" }
+
+      it "skips the activity API and uses the commits walker" do
+        git_checker = instance_double(Dependabot::GitCommitChecker)
+        allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+        allow(git_checker).to receive_messages(
+          ref_details_for_pinned_ref: instance_double(
+            Excon::Response,
+            status: 200,
+            body: "[]"
+          ),
+          head_commit_for_current_branch: "fallback_sha"
+        )
+
+        fetcher.available_versions
+        expect(WebMock).not_to have_requested(:get, activity_url_pattern)
+      end
+    end
+
+    context "when activity entries extend past the locked SHA" do
+      let(:activity_response) do
+        [
+          { "id" => 1, "after" => "newer_a", "before" => "older_a",
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T00:00:00Z" },
+          { "id" => 2, "after" => current_sha, "before" => "older_b",
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T00:00:00Z" },
+          { "id" => 3, "after" => "older_c", "before" => "older_d",
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T00:00:00Z" }
+        ]
+      end
+
+      before do
+        stub_request(:get, activity_base_url).with(query: activity_query).to_return(
+          status: 200,
+          body: activity_response.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      it "stops at the locked SHA and excludes older entries" do
+        versions = fetcher.available_versions
+        expect(versions.map(&:tag)).to eq(%w(newer_a) + [current_sha])
+      end
+    end
+
     context "when the source URL is not on github.com" do
       let(:url) { "https://gitlab.com/foo/bar" }
 

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
   let(:activity_response) do
     [
       { "id" => 1, "before" => "b12141ef619e", "after" => "0726a0ec",
-        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
       { "id" => 2, "before" => "4bd9165a9165", "after" => "b12141ef",
-        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
       { "id" => 3, "before" => current_sha, "after" => "4bd9165a",
-        "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
+        "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
     ]
   end
 
@@ -65,12 +65,13 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
 
       it "returns releases derived from branch-tip pushes" do
         versions = fetcher.available_versions
-        expect(versions.map(&:tag)).to eq(%w(0726a0ec b12141ef 4bd9165a))
+        expect(versions.map(&:tag)).to eq(%w(0726a0ec b12141ef 4bd9165a) + [current_sha])
         expect(versions.map(&:released_at)).to eq(
           [
             Time.parse("2026-04-24T20:30:00Z"),
             Time.parse("2026-04-20T19:04:11Z"),
-            Time.parse("2026-04-15T18:15:58Z")
+            Time.parse("2026-04-15T18:15:58Z"),
+            nil
           ]
         )
       end
@@ -79,6 +80,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
         versions = fetcher.available_versions
         expect(versions.map(&:version)).to eq(
           [
+            Dependabot::Nix::Version.new("0.0.0-0.4"),
             Dependabot::Nix::Version.new("0.0.0-0.3"),
             Dependabot::Nix::Version.new("0.0.0-0.2"),
             Dependabot::Nix::Version.new("0.0.0-0.1")
@@ -191,11 +193,11 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
       let(:activity_response) do
         [
           { "id" => 1, "after" => "newer_a", "before" => "older_a",
-            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-24T00:00:00Z" },
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T00:00:00Z" },
           { "id" => 2, "after" => current_sha, "before" => "older_b",
-            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-20T00:00:00Z" },
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T00:00:00Z" },
           { "id" => 3, "after" => "older_c", "before" => "older_d",
-            "ref" => "refs/heads/nixos-unstable", "pushed_at" => "2026-04-15T00:00:00Z" }
+            "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T00:00:00Z" }
         ]
       end
 

--- a/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
+++ b/nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb
@@ -42,13 +42,16 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
     }
   end
   let(:activity_url_pattern) { %r{\Ahttps://api\.github\.com/repos/NixOS/nixpkgs/activity\?} }
+  let(:sha_a) { "0726a0ec1234567890abcdef1234567890abcdef" }
+  let(:sha_b) { "b12141ef619e1234567890abcdef1234567890ab" }
+  let(:sha_c) { "4bd9165a91651234567890abcdef1234567890ab" }
   let(:activity_response) do
     [
-      { "id" => 1, "before" => "b12141ef619e", "after" => "0726a0ec",
+      { "id" => 1, "before" => sha_b, "after" => sha_a,
         "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T20:30:00Z", "activity_type" => "push" },
-      { "id" => 2, "before" => "4bd9165a9165", "after" => "b12141ef",
+      { "id" => 2, "before" => sha_c, "after" => sha_b,
         "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T19:04:11Z", "activity_type" => "push" },
-      { "id" => 3, "before" => current_sha, "after" => "4bd9165a",
+      { "id" => 3, "before" => current_sha, "after" => sha_c,
         "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T18:15:58Z", "activity_type" => "push" }
     ]
   end
@@ -65,7 +68,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
 
       it "returns releases derived from branch-tip pushes" do
         versions = fetcher.available_versions
-        expect(versions.map(&:tag)).to eq(%w(0726a0ec b12141ef 4bd9165a) + [current_sha])
+        expect(versions.map(&:tag)).to eq([sha_a, sha_b, sha_c, current_sha])
         expect(versions.map(&:released_at)).to eq(
           [
             Time.parse("2026-04-24T20:30:00Z"),
@@ -190,13 +193,18 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
     end
 
     context "when activity entries extend past the locked SHA" do
+      let(:newer_sha) { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+      let(:older_a_sha) { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+      let(:older_b_sha) { "cccccccccccccccccccccccccccccccccccccccc" }
+      let(:older_c_sha) { "dddddddddddddddddddddddddddddddddddddddd" }
+      let(:older_d_sha) { "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" }
       let(:activity_response) do
         [
-          { "id" => 1, "after" => "newer_a", "before" => "older_a",
+          { "id" => 1, "after" => newer_sha, "before" => older_a_sha,
             "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-24T00:00:00Z" },
-          { "id" => 2, "after" => current_sha, "before" => "older_b",
+          { "id" => 2, "after" => current_sha, "before" => older_b_sha,
             "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-20T00:00:00Z" },
-          { "id" => 3, "after" => "older_c", "before" => "older_d",
+          { "id" => 3, "after" => older_c_sha, "before" => older_d_sha,
             "ref" => "refs/heads/nixos-unstable", "timestamp" => "2026-04-15T00:00:00Z" }
         ]
       end
@@ -211,7 +219,7 @@ RSpec.describe Dependabot::Nix::Package::PackageDetailsFetcher do
 
       it "stops at the locked SHA and excludes older entries" do
         versions = fetcher.available_versions
-        expect(versions.map(&:tag)).to eq(%w(newer_a) + [current_sha])
+        expect(versions.map(&:tag)).to eq([newer_sha, current_sha])
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

For Nix flake inputs that track a branch on GitHub, fetch update candidates from the Repo Activity API instead of paginating `/commits`. Each activity entry's `after` SHA was once the actual branch tip. For `nixpkgs` channels that means it was Hydra-evaluated and is cache-backed. The current `/commits` walker returns mostly intermediate `master` commits that were never branch tips and aren't covered by the binary cache, which means any code that picks *from* the candidate set (cooldown fallbacks, "pick an older commit" heuristics) risks handing users a flake.lock that builds the world from source.

Fixes #14836. Came up while reviewing #14829.

### Anything you want to highlight for special attention from reviewers?

- The existing `/commits` walker is kept as a fallback for non-GitHub URLs, SHA-pinned refs, empty results, and HTTP errors. No regression for any case that already worked.
- Auth and retries are handled by `Dependabot::Clients::GithubWithRetries.for_github_dot_com(credentials:)`, matching the pattern in `pre_commit/` and `bazel/`.
- `T.unsafe(github_client).get(...)` is needed because `GithubWithRetries` proxies via `method_missing`. Same pattern as `bazel/lib/dependabot/bazel/update_checker/registry_client.rb`, including the `Sorbet/ForbidTUnsafe` exclude in `nix/.rubocop.yml`.

### How will you know you've accomplished your goal?

- New spec at `nix/spec/dependabot/nix/package/package_details_fetcher_spec.rb` covers the happy path, pseudo-version ordering, auth header injection, 403 fallback, empty-response fallback, SHA-pinned skip, non-GitHub skip, and credentials-absent path.
- For a `nixpkgs` `nixos-unstable` input with cooldown enabled, the proposed update SHA appears in the first page of `/repos/NixOS/nixpkgs/activity?ref=refs/heads/nixos-unstable&activity_type=push,force_push`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.