### PR TITLE
Remove duplicate call to create a new path

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -73,7 +73,6 @@ module Dependabot
     def self.in_a_temporary_directory(directory = "/", &_block)
       FileUtils.mkdir_p(Utils::BUMP_TMP_DIR_PATH)
       tmp_dir = Dir.mktmpdir(Utils::BUMP_TMP_FILE_PREFIX, Utils::BUMP_TMP_DIR_PATH)
-      path = Pathname.new(File.join(tmp_dir, directory)).expand_path
 
       begin
         path = Pathname.new(File.join(tmp_dir, directory)).expand_path


### PR DESCRIPTION


### What are you trying to accomplish?

This seems unnecessary and likely a bug

### Anything you want to highlight for special attention from reviewers?

Refer to 

https://github.com/dependabot/dependabot-core/blob/4f3aaf4c094964c5dc5baca329b5153a16f74a86/common/lib/dependabot/shared_helpers.rb#L76-L84

`path` is defined (what I deleted) and then wrapped in a try-catch with the same content shortly after. The initial definition is not used and it is redundant 

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
