### PR TITLE
Fix silent SKIPPED snapshots in dependabot graph

### DIFF
--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -167,7 +167,15 @@ module Dependabot
 
         begin
           files = ff.files
-        rescue Dependabot::DependencyFileNotFound
+        rescue Dependabot::DependencyFileNotFound => e
+          # The empty-files case is intentionally non-fatal for multi-directory and
+          # update_graph jobs (see `dependency_files_for_multi_directories` below),
+          # but we must surface *why* a directory was skipped so silent failures —
+          # particularly during `dependabot graph` runs — are diagnosable from logs.
+          Dependabot.logger.warn(
+            "Skipping directory '#{dir}': file fetcher raised " \
+            "#{e.class} (#{e.file_path || dir})"
+          )
           next
         end
         post_ecosystem_versions(ff) if should_record_ecosystem_versions?

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "pathname"
 require "sorbet-runtime"
 
 # Dependabot components
@@ -59,6 +60,22 @@ module Dependabot
     end
 
     private
+
+    # Normalizes a directory string for matching purposes, so that semantically
+    # equivalent paths (e.g. `"/."`, `"."`, `"/"`, `"/subproject/"`, `"/subproject"`)
+    # compare equal regardless of how they were spelled by the caller or the file
+    # fetcher.
+    #
+    # `Job#clean_directories` only does a leading-slash sub, so values like `"."`
+    # become `"/."` rather than `"/"`. The file fetcher base class then cleanpaths
+    # `"/."` to `"/"` before constructing each `DependencyFile`. Without
+    # normalization on both sides of the comparison in `dependency_files_for`,
+    # a job entry of `"/."` would not match files stored at `"/"` and the
+    # snapshot would silently come back empty (SKIPPED).
+    sig { params(directory: String).returns(String) }
+    def normalize_directory(directory)
+      Pathname.new("/").join(directory).cleanpath.to_path
+    end
 
     sig { returns(Dependabot::Service) }
     attr_reader :service
@@ -126,7 +143,8 @@ module Dependabot
 
     sig { params(directory: String).returns(T::Array[Dependabot::DependencyFile]) }
     def dependency_files_for(directory)
-      dependency_files.select { |f| f.directory == directory }
+      normalized = normalize_directory(directory)
+      dependency_files.select { |f| normalize_directory(f.directory) == normalized }
     end
 
     sig do

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -702,6 +702,15 @@ RSpec.describe Dependabot::FileFetcherCommand do
         # Root directory should be skipped since it has no dummy files
         expect(root_files).to be_empty
       end
+
+      it "logs a warning naming the skipped directory and the underlying error" do
+        allow(Dependabot.logger).to receive(:warn)
+
+        command.send(:files_from_multidirectories)
+
+        expect(Dependabot.logger).to have_received(:warn)
+          .with(a_string_matching(%r{Skipping directory '/':.*DependencyFileNotFound}))
+      end
     end
 
     context "when all directories have required files" do

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -747,6 +747,56 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     end
   end
 
+  context "when the source directories use unnormalized strings" do
+    let(:repo_contents_path) { build_tmp_repo("bundler/original", path: "") }
+
+    # `Job#clean_directories` only normalizes leading slashes, so a CLI input of
+    # `--directory=.` ends up as `"/."` in `job.source.directories`, while the file
+    # fetcher cleanpaths it to `"/"` before stamping it onto each `DependencyFile`.
+    # Without normalization in the processor, `dependency_files_for("/.")` returns
+    # an empty list and the snapshot is silently skipped.
+    [
+      ["/.", "/"],
+      [".", "/"],
+      ["./", "/"],
+      ["//", "/"],
+      ["/foo/.", "/foo"],
+      ["foo", "/foo"],
+      ["./bar", "/bar"]
+    ].each do |raw_dir, expected_dir|
+      context "with raw directory #{raw_dir.inspect}" do
+        let(:directories) { [raw_dir] }
+
+        let(:dependency_files) do
+          [
+            Dependabot::DependencyFile.new(
+              name: "Gemfile",
+              content: fixture("bundler/original/Gemfile"),
+              directory: expected_dir
+            ),
+            Dependabot::DependencyFile.new(
+              name: "Gemfile.lock",
+              content: fixture("bundler/original/Gemfile.lock"),
+              directory: expected_dir
+            )
+          ]
+        end
+
+        it "matches files under the normalized directory and emits a populated snapshot" do
+          expect(service).to receive(:create_dependency_submission) do |args|
+            payload = args[:dependency_submission].payload
+
+            expect(payload[:metadata][:status])
+              .to eql(GithubApi::DependencySubmission::SnapshotStatus::SUCCESS.serialize)
+            expect(payload[:manifests]).not_to be_empty
+          end
+
+          update_graph_processor.run
+        end
+      end
+    end
+  end
+
   context "when the dependency submission API is unavailable" do
     let(:directories) { [directory] }
     let(:directory) { "/" }


### PR DESCRIPTION
## Summary

Two bugs combined to make `dependabot graph` silently emit empty `manifests: {}` SKIPPED snapshots, with no signal in the logs about the underlying cause. Both are diagnostic correctness fixes — they don't change which directories succeed or fail, only how clearly the failures surface.

## Bug A — directory normalization mismatch in `UpdateGraphProcessor`

`Job#clean_directories` does a leading-slash sub on each directory but does not `cleanpath`, so a caller passing `.` ends up with `/.` on `job.source.directories`. The file-fetcher base class then `cleanpath`s `/.` to `/` before constructing each `DependencyFile`. `dependency_files_for` compared the raw job entry (`/.`) against the file's cleanpathed `directory` (`/`), got zero matches, and produced an empty submission with `status: skipped` / `reason: missing manifest files`.

Fix: normalize both sides of the comparison via `Pathname.new("/").join(dir).cleanpath`. The raw directory string still flows to `create_source_for` / `empty_submission` so user-visible `scanned_manifest_path` keeps its existing formatting (e.g. `rubygems::/subproject/`).

Introduced in #13128.

## Bug B — silent rescue in `FileFetcherCommand#list_files_in_directory`

The empty-files path is intentionally non-fatal for graph jobs (so one bad directory doesn't fail the whole job), but the `rescue Dependabot::DependencyFileNotFound; next` swallowed everything with no log line. Any ecosystem-side fetcher failure during graph runs presented as the generic "missing manifest files".

Fix: add a `Dependabot.logger.warn` identifying the directory, exception class, and missing file path before `next`. Behavior unchanged.

Introduced in #12922.

## Why both together

Bug B masked Bug A. Bug B also masks any other ecosystem fetcher failure, e.g. a Maven multi-module `pom.xml` referencing a `<module>` that isn't on disk. With this change, that failure surfaces as:

```
WARN Skipping directory '/': file fetcher raised Dependabot::DependencyFileNotFound (/some-module/pom.xml)
```

instead of an opaque empty snapshot.

## Reproducer

```sh
dependabot graph maven dsp-testing/sarah-and-some-maven --local=. --branch main
```

Before: `manifests: {}` / `status: skipped` / `reason: missing manifest files`. No log signal.
After: same skipped snapshot (because the underlying maven multi-module fetch genuinely fails), but with a `WARN` line pinpointing the missing pom. A separate fix to the maven fetcher is needed to make that case succeed.

## Tests

- New parameterized test in `update_graph_processor_spec.rb` covering 7 directory variants (`/.`, `.`, `./`, `//`, `/foo/.`, `foo`, `./bar`) — all assert SUCCESS status and a non-empty manifest.
- New `Dependabot.logger.warn` assertion in `file_fetcher_command_spec.rb` for the multi-directory skip path.

Existing tests (55 in the touched files) all pass; pre-existing snapshot formatting (`rubygems::/subproject/`) is preserved.

## Marked as draft

Opening as draft because the underlying maven multi-module fetcher fix is being scoped separately (broken-pom-with-missing-module is arguably "garbage in / garbage out" but the error message could be friendlier — TBD).
