### PR TITLE
Remove uv-ecosystem multi-ecosystem-group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,4 @@
 version: 2
-multi-ecosystem-groups:
-  uv-ecosystem:
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "16:00"
-
 updates:
   - package-ecosystem: "bundler"
     directories:
@@ -187,12 +180,16 @@ updates:
       time: "16:00"
   - package-ecosystem: "docker"
     directory: "/uv"
-    multi-ecosystem-group: "uv-ecosystem"
-    patterns: ["*"]
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
   - package-ecosystem: "pip"
     directory: "/uv/helpers"
-    multi-ecosystem-group: "uv-ecosystem"
-    patterns: ["*"]
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
     ignore:
       # Ignore major updates as most major updates will need manual intervention
       - dependency-name: "*"


### PR DESCRIPTION
### What are you trying to accomplish?

The uv-ecosystem PR is bugged out and is not receiving updates correctly https://github.com/dependabot/dependabot-core/pull/13136

Removing the multi-ecosystem-group may help fix this.

### Anything you want to highlight for special attention from reviewers?

Another alternative is to rename the multi-ecosystem-group so it opens a new PR under a new group name.

### How will you know you've accomplished your goal?

We start receiving uv Dependabot updates again.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
