### PR TITLE
Rename 'uv-ecosystem' to 'uv-and-helpers'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 multi-ecosystem-groups:
-  uv-ecosystem:
+  uv-and-helpers:
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -187,11 +187,11 @@ updates:
       time: "16:00"
   - package-ecosystem: "docker"
     directory: "/uv"
-    multi-ecosystem-group: "uv-ecosystem"
+    multi-ecosystem-group: "uv-and-helpers"
     patterns: ["*"]
   - package-ecosystem: "pip"
     directory: "/uv/helpers"
-    multi-ecosystem-group: "uv-ecosystem"
+    multi-ecosystem-group: "uv-and-helpers"
     patterns: ["*"]
     ignore:
       # Ignore major updates as most major updates will need manual intervention


### PR DESCRIPTION
### What are you trying to accomplish?

Trying to fix the broken/stuck uv-ecosystem multi-ecosystem group https://github.com/dependabot/dependabot-core/pull/13136 by renaming the group, which should create a new PR

### Anything you want to highlight for special attention from reviewers?

This is an alternative to https://github.com/dependabot/dependabot-core/pull/14853 

### How will you know you've accomplished your goal?

We start receiving uv Dependabot updates again.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
