### PR TITLE
Add blob_oid metadata to manifests in dependency snapshots

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,8 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'main' }}
+  # TODO: revert to main after merging dependabot/smoke-tests#1234
+  SMOKE_TEST_BRANCH: juxtin/add-blob-oid-to-graph-snapshots
 permissions: {}
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,8 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # TODO: revert to main after merging dependabot/smoke-tests#1234
-  SMOKE_TEST_BRANCH: juxtin/add-blob-oid-to-graph-snapshots
+  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'main' }}
 permissions: {}
 
 jobs:

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -1,6 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "digest"
 require "pathname"
 require "sorbet-runtime"
 
@@ -207,6 +208,16 @@ module Dependabot
       return Base64.decode64(T.must(content)) if binary?
 
       T.must(content)
+    end
+
+    # Returns the Git blob OID (SHA-1) for this file's content,
+    # matching the value GitHub/Spokes uses for the same blob.
+    sig { returns(T.nilable(String)) }
+    def blob_oid
+      return nil unless content
+
+      raw = decoded_content.dup.force_encoding(Encoding::BINARY)
+      Digest::SHA1.hexdigest("blob #{raw.bytesize}\0#{raw}")
     end
 
     private

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -210,15 +210,19 @@ module Dependabot
       T.must(content)
     end
 
-    # Returns the Git blob OID (SHA-1) for this file's content,
+    # Returns the Git blob OID for this file's content,
     # matching the value GitHub/Spokes uses for the same blob.
-    sig { returns(T.nilable(String)) }
-    def blob_oid
+    # Accepts :sha1 (default) or :sha256 to match the repository's object format.
+    sig { params(algorithm: Symbol).returns(T.nilable(String)) }
+    def blob_oid(algorithm: :sha1)
       return nil unless content
 
       raw = decoded_content.dup.force_encoding(Encoding::BINARY)
       header = "blob #{raw.bytesize}\0".b
-      digest = Digest::SHA1.new
+      digest = case algorithm
+               when :sha256 then Digest::SHA256.new
+               else Digest::SHA1.new
+               end
       digest.update(header)
       digest.update(raw)
       digest.hexdigest

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -217,7 +217,11 @@ module Dependabot
       return nil unless content
 
       raw = decoded_content.dup.force_encoding(Encoding::BINARY)
-      Digest::SHA1.hexdigest("blob #{raw.bytesize}\0#{raw}")
+      header = "blob #{raw.bytesize}\0".b
+      digest = Digest::SHA1.new
+      digest.update(header)
+      digest.update(raw)
+      digest.hexdigest
     end
 
     private

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -370,6 +370,36 @@ RSpec.describe Dependabot::DependencyFile do
     end
   end
 
+  describe "#blob_oid" do
+    it "returns the Git blob SHA-1 matching git hash-object" do
+      # echo -n "a" | git hash-object --stdin
+      expect(file.blob_oid).to eq("2e65efe2a145dda7ee51d1741299f848e5bf752e")
+    end
+
+    context "when content is nil" do
+      let(:file) { described_class.new(name: "Gemfile", content: nil) }
+
+      it "returns nil" do
+        expect(file.blob_oid).to be_nil
+      end
+    end
+
+    context "when content is base64-encoded" do
+      let(:file) do
+        described_class.new(
+          name: "example.gem",
+          content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64,
+          content: "YWJj\n"
+        )
+      end
+
+      it "computes the blob OID from the decoded bytes" do
+        # echo -n "abc" | git hash-object --stdin
+        expect(file.blob_oid).to eq("f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f")
+      end
+    end
+  end
+
   describe "#vendored_file?" do
     it "is false by default" do
       expect(file.vendored_file?).to be false

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -398,6 +398,21 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.blob_oid).to eq("f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f")
       end
     end
+
+    context "when content is base64-encoded with non-ASCII bytes" do
+      let(:file) do
+        described_class.new(
+          name: "binary.dat",
+          content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64,
+          content: "gP8A/g=="
+        )
+      end
+
+      it "computes the blob OID without encoding errors" do
+        # printf '\x80\xff\x00\xfe' | git hash-object --stdin
+        expect(file.blob_oid).to eq("4edea47ba105055cdec8a27d3ba236f576b59059")
+      end
+    end
   end
 
   describe "#vendored_file?" do

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -413,6 +413,28 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.blob_oid).to eq("4edea47ba105055cdec8a27d3ba236f576b59059")
       end
     end
+
+    context "with algorithm: :sha256" do
+      it "returns a SHA-256 blob OID" do
+        expect(file.blob_oid(algorithm: :sha256))
+          .to eq("eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7")
+      end
+
+      context "when content is base64-encoded with non-ASCII bytes" do
+        let(:file) do
+          described_class.new(
+            name: "binary.dat",
+            content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64,
+            content: "gP8A/g=="
+          )
+        end
+
+        it "computes the SHA-256 blob OID without encoding errors" do
+          expect(file.blob_oid(algorithm: :sha256))
+            .to eq("99955a54a0e195e06a6a74e7573046a935f74d5d1f4c10ae2ff27ce02dcdebc6")
+        end
+      end
+    end
   end
 
   describe "#vendored_file?" do

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -174,8 +174,9 @@ module GithubApi
             source_location: manifest_file.path.gsub(%r{^/}, "")
           },
           metadata: {
-            ecosystem: GithubApi::EcosystemMapper.ecosystem_for(package_manager)
-          },
+            ecosystem: GithubApi::EcosystemMapper.ecosystem_for(package_manager),
+            blob_oid: manifest_file.blob_oid
+          }.compact,
           resolved: resolved_dependencies.transform_values do |resolved|
             {
               package_url: resolved.package_url,

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -175,7 +175,7 @@ module GithubApi
           },
           metadata: {
             ecosystem: GithubApi::EcosystemMapper.ecosystem_for(package_manager),
-            blob_oid: manifest_file.blob_oid
+            blob_oid: manifest_file.blob_oid(algorithm: blob_hash_algorithm)
           }.compact,
           resolved: resolved_dependencies.transform_values do |resolved|
             {
@@ -198,6 +198,13 @@ module GithubApi
     end
     def scanned_manifest_path
       "#{GithubApi::EcosystemMapper.ecosystem_for(package_manager)}::#{manifest_file.directory}"
+    end
+
+    # Infers the repository's Git object format from the commit SHA length.
+    # SHA-1 produces 40 hex chars, SHA-256 produces 64.
+    sig { returns(Symbol) }
+    def blob_hash_algorithm
+      sha.length >= 64 ? :sha256 : :sha1
     end
   end
 end

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -174,6 +174,9 @@ RSpec.shared_examples "dependency_submission" do |empty|
       # Ecosystem is mapped from the package manager
       expect(lockfile[:metadata][:ecosystem]).to eq("rubygems")
 
+      # Blob OID matches the Git blob SHA-1 of the fixture file
+      expect(lockfile[:metadata][:blob_oid]).to eq("1f21c435958a7c58ef0b4021e1f981017e6d49f2")
+
       # Resolved dependencies are correct
       expect(lockfile[:resolved].length).to eq(2)
 

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -203,4 +203,42 @@ RSpec.describe GithubApi::DependencySubmission do
   context "without resolved dependencies" do
     it_behaves_like "dependency_submission", true
   end
+
+  context "when the commit SHA is 64 characters (SHA-256 repo)" do
+    let(:sha256_sha) { "a" * 64 }
+    let(:lockfile) do
+      Dependabot::DependencyFile.new(
+        name: "Gemfile.lock",
+        content: fixture("bundler/original/Gemfile.lock"),
+        directory: "/"
+      )
+    end
+    let(:resolved_dependencies) do
+      {
+        "dummy-pkg-a" => Dependabot::DependencyGraphers::ResolvedDependency.new(
+          package_url: "pkg:gem/dummy-pkg-a@2.0.0",
+          direct: true,
+          runtime: true,
+          dependencies: []
+        )
+      }
+    end
+
+    subject(:dependency_submission) do
+      described_class.new(
+        job_id: "9999",
+        branch: "main",
+        sha: sha256_sha,
+        package_manager: "bundler",
+        manifest_file: lockfile,
+        resolved_dependencies: resolved_dependencies
+      )
+    end
+
+    it "uses SHA-256 for the blob OID" do
+      manifest = dependency_submission.payload[:manifests].fetch("/Gemfile.lock")
+      expect(manifest[:metadata][:blob_oid])
+        .to eq("54bf0378f9dd16ad2b60250c6156132f3ec9232e85b6ef87958aa439e29a4cec")
+    end
+  end
 end

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -205,6 +205,17 @@ RSpec.describe GithubApi::DependencySubmission do
   end
 
   context "when the commit SHA is 64 characters (SHA-256 repo)" do
+    subject(:dependency_submission) do
+      described_class.new(
+        job_id: "9999",
+        branch: "main",
+        sha: sha256_sha,
+        package_manager: "bundler",
+        manifest_file: lockfile,
+        resolved_dependencies: resolved_dependencies
+      )
+    end
+
     let(:sha256_sha) { "a" * 64 }
     let(:lockfile) do
       Dependabot::DependencyFile.new(
@@ -222,17 +233,6 @@ RSpec.describe GithubApi::DependencySubmission do
           dependencies: []
         )
       }
-    end
-
-    subject(:dependency_submission) do
-      described_class.new(
-        job_id: "9999",
-        branch: "main",
-        sha: sha256_sha,
-        package_manager: "bundler",
-        manifest_file: lockfile,
-        resolved_dependencies: resolved_dependencies
-      )
     end
 
     it "uses SHA-256 for the blob OID" do


### PR DESCRIPTION
### What are you trying to accomplish?

In order to support Dependency Review with Dependabot snapshots, we're going to need to track the git blob OIDs for each manifest that we submit.

This PR adds the OID as metadata to the manifest object.

For now at least, we're getting the OID by hashing the file in memory in a way that matches what git does. This is verified by tests (with the caveat that the comparison hash was computed manually and pasted in, see comment).

#### Broken smoke tests

This changes the expected snapshots for smoke tests, so I've opened https://github.com/dependabot/smoke-tests/pull/487 to fix them. We should merge these PRs pretty much at the same time.

In the interest of safety, I did add (and revert) a [commit here](https://github.com/dependabot/dependabot-core/pull/14857/commits/03d001858c77f0e49ab07e02e7a594286e7e6ee8) pointed at the smoke-tests PR to show that everything passes when the PRs are consistent.

#### SHA-1 vs SHA-256

We're in the middle of a transition in hashing algorithms from sha1 to sha256. We need to be careful to match whatever is used by the git repo, so this PR uses the commit hash length to infer which algorithm is in use. If the commit sha is 40 bytes, it's sha1. If the commit sha is 64 bytes, it's sha256.

<!-- What issues does this affect or fix? -->

Closes https://github.com/github/dependency-graph/issues/10626

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Apart from tests, the real validation will come when we start to demo Dependency Review using Dependabot data. That's probably sometime next week or the week after.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
