### PR TITLE
opentofu: support OCI modules end-to-end

### DIFF
--- a/opentofu/Dockerfile
+++ b/opentofu/Dockerfile
@@ -4,19 +4,27 @@ ARG TARGETARCH
 
 # See https://github.com/opentofu/opentofu/releases
 ARG TOFU_VERSION=1.11.4
+ARG ORAS_VERSION=1.3.0
 
 # curl "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" | grep "tofu_${TOFU_VERSION}_linux_amd64.zip"
 ARG TOFU_AMD64_CHECKSUM=f3907e96b5a9f2fce311078ca273bcdf1e13980dac150b2549932c26b515c61b
+ARG ORAS_AMD64_CHECKSUM=6cdc692f929100feb08aa8de584d02f7bcc30ec7d88bc2adc2054d782db57c64
 
 # curl "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS" | grep "tofu_${TOFU_VERSION}_linux_arm64.zip"
 ARG TOFU_ARM64_CHECKSUM=f877d46cb911d40bc0b81818d1940afdd356f632bcac48ca19dd8f7802a86701
-
+ARG ORAS_ARM64_CHECKSUM=7649738b48fde10542bcc8b0e9b460ba83936c75fb5be01ee6d4443764a14352
 
 RUN cd /tmp \
   && curl -L -o tofu-${TARGETARCH}.tar.gz https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${TARGETARCH}.zip \
   && printf "$TOFU_AMD64_CHECKSUM tofu-amd64.tar.gz\n$TOFU_ARM64_CHECKSUM tofu-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
   && unzip -d /usr/local/bin tofu-${TARGETARCH}.tar.gz \
   && rm tofu-${TARGETARCH}.tar.gz
+
+RUN cd /tmp \
+  && curl -L -o oras-${TARGETARCH}.tar.gz https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz \
+  && printf "$ORAS_AMD64_CHECKSUM oras-amd64.tar.gz\n$ORAS_ARM64_CHECKSUM oras-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
+  && tar -xvzf oras-${TARGETARCH}.tar.gz -C /usr/local/bin/ \
+  && rm oras-${TARGETARCH}.tar.gz
 
 USER dependabot
 COPY --chown=dependabot:dependabot opentofu/helpers /opt/opentofu/helpers

--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -75,18 +75,18 @@ module Dependabot
             details = details.first
 
             source = source_from(details)
-            # Cannot update local path modules, skip
-            next if source && source[:type] == "path"
+            # nil sources are unpinned (e.g. OCI without a tag/digest); paths are local.
+            next if source.nil? || source[:type] == "path"
 
             # Cannot update modules using early evaluation yet
-            if T.must(source)[:type] == "interpolation"
+            if source[:type] == "interpolation"
               Dependabot.logger.warn(
                 "Cannot parse module source name with early evaluation for #{name} in #{file.name}."
               )
               next
             end
 
-            dependency_set << build_opentofu_dependency(file, name, T.must(source), details)
+            dependency_set << build_opentofu_dependency(file, name, source, details)
           end
 
           parsed_file(file).fetch("terraform", []).each do |opentofu|
@@ -137,6 +137,7 @@ module Dependabot
         version_req = details["version"]&.strip
         version =
           if source[:type] == "git" then version_from_ref(source[:ref])
+          elsif source[:type] == "oci" then source[:version]
           elsif version_req&.match?(/^\d/) then version_req
           end
 
@@ -230,18 +231,21 @@ module Dependabot
 
         source_details =
           case source_type
-          # TODO: add support for OCI Registries https://opentofu.org/docs/cli/oci_registries/
           when :http_archive, :path, :mercurial, :s3
             { type: source_type.to_s, url: bare_source }
           when :github, :bitbucket, :git
             git_source_details_from(bare_source)
+          when :oci
+            oci_source_details_from(bare_source)
           when :registry
             registry_source_details_from(bare_source)
           when :interpolation
             { type: source_type.to_s, name: bare_source }
           end
 
-        T.must(source_details)[:proxy_url] = raw_source if raw_source != bare_source
+        return nil if source_details.nil?
+
+        source_details[:proxy_url] = raw_source if raw_source != bare_source
         source_details
       end
 
@@ -258,6 +262,36 @@ module Dependabot
           (matches[:namespace] || DEFAULT_NAMESPACE).downcase,
           (matches[:name] || name).downcase
         ]
+      end
+
+      sig { params(source_string: T.untyped).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
+      def oci_source_details_from(source_string)
+        uri_part, query_part = source_string.split("oci://").last.split("?", 2)
+
+        # Sources with no query string are unpinned — nothing to update.
+        return nil if query_part.nil?
+
+        # `//` (not preceded by `:`) separates the bare repository from a
+        # sub-module path; only the bare repo is queryable for tags.
+        artifact_identifier, subdirectory = uri_part.split(%r{(?<!:)//}, 2)
+
+        qs = CGI.parse(query_part)
+        tag = qs["tag"].first
+        digest = qs["digest"].first
+
+        if tag && digest
+          raise DependencyFileNotEvaluatable,
+                "Invalid OCI source '#{source_string}': only one of `tag` or `digest` may be specified"
+        end
+
+        {
+          type: "oci",
+          artifact_identifier: artifact_identifier,
+          subdirectory: subdirectory,
+          tag: tag || nil,
+          digest: digest || nil,
+          version: tag || digest || nil
+        }
       end
 
       sig { params(source_string: T.untyped).returns(T::Hash[Symbol, String]) }
@@ -333,7 +367,7 @@ module Dependabot
       # rubocop:disable Metrics/CyclomaticComplexity
       sig { params(source_string: String).returns(Symbol) }
       def source_type(source_string)
-        # TODO: add support for OCI Registries https://opentofu.org/docs/cli/oci_registries/
+        return :oci if source_string.include?("oci://")
         return :interpolation if source_string.include?("${")
         return :path if source_string.start_with?(".")
         return :github if source_string.start_with?("github.com/")

--- a/opentofu/lib/dependabot/opentofu/file_parser.rb
+++ b/opentofu/lib/dependabot/opentofu/file_parser.rb
@@ -276,8 +276,10 @@ module Dependabot
         artifact_identifier, subdirectory = uri_part.split(%r{(?<!:)//}, 2)
 
         qs = CGI.parse(query_part)
-        tag = qs["tag"].first
-        digest = qs["digest"].first
+        # Treat `?tag=` or `?digest=` (empty value) the same as the param
+        # being absent, so we don't propagate "" as a usable version.
+        tag = qs["tag"].first&.then { |v| v.empty? ? nil : v }
+        digest = qs["digest"].first&.then { |v| v.empty? ? nil : v }
 
         if tag && digest
           raise DependencyFileNotEvaluatable,
@@ -288,9 +290,9 @@ module Dependabot
           type: "oci",
           artifact_identifier: artifact_identifier,
           subdirectory: subdirectory,
-          tag: tag || nil,
-          digest: digest || nil,
-          version: tag || digest || nil
+          tag: tag,
+          digest: digest,
+          version: tag || digest
         }
       end
 

--- a/opentofu/lib/dependabot/opentofu/file_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/file_updater.rb
@@ -92,6 +92,8 @@ module Dependabot
             update_git_declaration(new_req, old_req, content, file.name)
           when "registry", "provider"
             update_registry_declaration(new_req, old_req, content)
+          when "oci"
+            update_oci_declaration(new_req, old_req, content)
           else
             raise "Don't know how to update a #{new_req[:source][:type]} " \
                   "declaration!"
@@ -122,6 +124,29 @@ module Dependabot
             url_match.sub(old_req&.dig(:source, :ref), new_req[:source][:ref])
           end
         end
+      end
+
+      sig do
+        params(
+          new_req: T::Hash[Symbol, T.untyped],
+          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          updated_content: String
+        )
+          .void
+      end
+      def update_oci_declaration(new_req, old_req, updated_content)
+        old_tag = old_req&.dig(:source, :tag)
+        new_tag = new_req[:source][:tag]
+        artifact = old_req&.dig(:source, :artifact_identifier)
+        return if old_tag.nil? || new_tag.nil? || artifact.nil? || old_tag == new_tag
+
+        # Scoped to this artifact's source string so unrelated modules with
+        # the same tag value aren't touched.
+        oci_source_re = %r{
+          (["']oci://#{Regexp.escape(artifact)}(?://[^"'?]*)?\?[^"']*\btag=)
+          #{Regexp.escape(old_tag)}
+        }x
+        updated_content.gsub!(oci_source_re) { T.must(Regexp.last_match(1)) + new_tag }
       end
 
       sig do

--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "base64"
+
 require "dependabot/dependency"
 require "dependabot/errors"
 require "dependabot/registry_client"
@@ -68,6 +70,52 @@ module Dependabot
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
+
+      # Fetch all tags for an OCI module artifact via the Distribution v2
+      # `GET /v2/<repo>/tags/list` endpoint. Returns Version objects whose
+      # to_s preserves the original tag string (so `v1.0.0` round-trips).
+      #
+      # @param artifact_identifier [String] "<host[:port]>/<repo>"
+      # @param credentials [Array<Dependabot::Credential>]
+      # @return [Array<Dependabot::Opentofu::Version>]
+      sig do
+        params(
+          artifact_identifier: String,
+          credentials: T::Array[Dependabot::Credential]
+        ).returns(T::Array[Dependabot::Opentofu::Version])
+      end
+      def self.all_oci_tags(artifact_identifier:, credentials: [])
+        host, _, repo = artifact_identifier.partition("/")
+        if host.empty? || repo.empty?
+          raise Dependabot::DependabotError, "Invalid OCI artifact: '#{artifact_identifier}'"
+        end
+
+        scheme = oci_scheme_for(host)
+        next_url = T.let("#{scheme}://#{host}/v2/#{repo}/tags/list", T.nilable(String))
+        tags = T.let([], T::Array[String])
+
+        while next_url
+          response = oci_get(next_url, host: host, credentials: credentials)
+          case response.status
+          when 200
+            body = JSON.parse(response.body)
+            tags.concat(Array(body["tags"]))
+          when 401, 403
+            raise Dependabot::PrivateSourceAuthenticationFailure, host
+          when 404
+            raise Dependabot::DependabotError,
+                  "OCI repository '#{repo}' not found on registry '#{host}'"
+          else
+            raise Dependabot::DependabotError,
+                  "OCI registry '#{host}' returned HTTP #{response.status} listing tags for '#{repo}'"
+          end
+          next_url = oci_next_page_url(response.headers["Link"], base: "#{scheme}://#{host}")
+        end
+
+        tags.filter_map { |t| Version.new(t) if Version.correct?(t) }
+      rescue Excon::Error::Socket, Excon::Error::Timeout
+        raise Dependabot::PrivateSourceBadResponse, host
+      end
 
       # Fetch all the versions of a provider, and return a Version
       # representation of them.
@@ -155,6 +203,61 @@ module Dependabot
               "Registry at #{hostname} does not support required service '#{service_key}'. " \
               "Available services: #{available}"
       end
+
+      # localhost registries are commonly served over plain HTTP in dev.
+      sig { params(host: String).returns(String) }
+      def self.oci_scheme_for(host)
+        bare_host = host.split(":").first
+        %w(localhost 127.0.0.1).include?(bare_host) ? "http" : "https"
+      end
+      private_class_method :oci_scheme_for
+
+      sig do
+        params(
+          url: String,
+          host: String,
+          credentials: T::Array[Dependabot::Credential]
+        ).returns(Excon::Response)
+      end
+      def self.oci_get(url, host:, credentials:)
+        cred = credentials.find do |c|
+          c["type"] == "opentofu_registry" && (c["host"] == host || c["registry"] == host)
+        end
+
+        headers = {}
+        headers["Authorization"] = oci_auth_header(cred) if cred
+
+        Dependabot::RegistryClient.get(url: url, headers: headers)
+      end
+      private_class_method :oci_get
+
+      # Basic for username/password pairs (OCI Distribution v2), Bearer for
+      # token-only creds (existing OpenTofu HTTP registry behaviour).
+      sig { params(cred: Dependabot::Credential).returns(String) }
+      def self.oci_auth_header(cred)
+        if cred["username"] && cred["password"]
+          "Basic " + Base64.strict_encode64("#{cred['username']}:#{cred['password']}")
+        else
+          "Bearer #{cred['token']}"
+        end
+      end
+      private_class_method :oci_auth_header
+
+      # Parses RFC 5988 `Link: <…>; rel="next"` from /tags/list responses.
+      sig { params(link_header: T.nilable(String), base: String).returns(T.nilable(String)) }
+      def self.oci_next_page_url(link_header, base:)
+        return nil if link_header.nil? || link_header.empty?
+
+        link_header.split(",").each do |part|
+          match = part.strip.match(/\A<([^>]+)>\s*;\s*rel="?next"?\z/)
+          next unless match
+
+          target = T.must(match[1])
+          return target.start_with?("http") ? target : "#{base}#{target}"
+        end
+        nil
+      end
+      private_class_method :oci_next_page_url
 
       private
 

--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "uri"
 
 require "dependabot/dependency"
 require "dependabot/errors"
@@ -31,7 +32,12 @@ module Dependabot
         @api_base_url = T.let(API_BASE_URL, String)
         @tokens = T.let(
           credentials.each_with_object({}) do |item, memo|
-            memo[item["host"]] = item["token"] if item["type"] == "opentofu_registry"
+            # Only Bearer-token shaped creds belong here; OCI-only entries
+            # (username/password) would otherwise store a nil token and
+            # trigger a malformed `Authorization: Bearer ` header.
+            next unless item["type"] == "opentofu_registry" && item["token"]
+
+            memo[item["host"]] = item["token"]
           end,
           T::Hash[String, String]
         )
@@ -227,9 +233,72 @@ module Dependabot
         headers = {}
         headers["Authorization"] = oci_auth_header(cred) if cred
 
-        Dependabot::RegistryClient.get(url: url, headers: headers)
+        response = Dependabot::RegistryClient.get(url: url, headers: headers)
+
+        # OCI Distribution Spec: on 401 without explicit credentials, attempt the
+        # WWW-Authenticate Bearer challenge to access public registries anonymously.
+        if response.status == 401 && cred.nil?
+          token = oci_anonymous_bearer_token(response.headers["WWW-Authenticate"])
+          if token
+            response = Dependabot::RegistryClient.get(
+              url: url,
+              headers: { "Authorization" => "Bearer #{token}" }
+            )
+          end
+        end
+
+        response
       end
       private_class_method :oci_get
+
+      sig { params(www_authenticate: T.nilable(String)).returns(T.nilable(String)) }
+      def self.oci_anonymous_bearer_token(www_authenticate)
+        token_url = oci_bearer_token_url(www_authenticate)
+        return nil unless token_url
+
+        cached = oci_token_cache[token_url]
+        return cached[:token] if cached && T.cast(cached[:expires_at], Float) > Time.now.to_f
+
+        token_response = Dependabot::RegistryClient.get(url: token_url, headers: {})
+        return nil unless token_response.status == 200
+
+        body = JSON.parse(token_response.body)
+        token = body["token"]
+        expires_in = body.fetch("expires_in", 60).to_i
+        oci_token_cache[token_url] = { token: token, expires_at: Time.now.to_f + expires_in - 10 } if token
+        token
+      rescue StandardError
+        nil
+      end
+      private_class_method :oci_anonymous_bearer_token
+
+      # Parses a `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
+      # challenge and returns the token endpoint URL, or nil if not a Bearer challenge.
+      sig { params(www_authenticate: T.nilable(String)).returns(T.nilable(String)) }
+      def self.oci_bearer_token_url(www_authenticate)
+        return nil unless www_authenticate&.start_with?("Bearer ")
+
+        realm   = www_authenticate[/realm="([^"]+)"/, 1]
+        service = www_authenticate[/service="([^"]+)"/, 1]
+        scope   = www_authenticate[/scope="([^"]+)"/, 1]
+        return nil unless realm
+
+        params = {}
+        params["service"] = service if service
+        params["scope"]   = scope   if scope
+        "#{realm}?#{URI.encode_www_form(params)}"
+      end
+      private_class_method :oci_bearer_token_url
+
+      sig { returns(T::Hash[String, T::Hash[Symbol, T.untyped]]) }
+      def self.oci_token_cache
+        @oci_token_cache = T.let(
+          @oci_token_cache,
+          T.nilable(T::Hash[String, T::Hash[Symbol, T.untyped]])
+        )
+        @oci_token_cache ||= {}
+      end
+      private_class_method :oci_token_cache
 
       # Basic for username/password pairs (OCI Distribution v2), Bearer for
       # token-only creds (existing OpenTofu HTTP registry behaviour).

--- a/opentofu/lib/dependabot/opentofu/requirements_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/requirements_updater.rb
@@ -84,6 +84,7 @@ module Dependabot
           case req.dig(:source, :type)
           when "git" then update_git_requirement(req)
           when "registry", "provider" then update_registry_requirement(req)
+          when "oci" then update_oci_requirement(req)
           else req
           end
         end
@@ -106,6 +107,20 @@ module Dependabot
         return req unless tag_for_latest_version
 
         req.merge(source: req[:source].merge(ref: tag_for_latest_version))
+      end
+
+      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      def update_oci_requirement(req)
+        return req unless defined?(@latest_version) && @latest_version
+        return req if req.dig(:source, :digest)
+        return req unless req.dig(:source, :tag)
+
+        new_tag = latest_version.to_s
+        return req if req.dig(:source, :tag) == new_tag
+
+        req.merge(
+          source: req[:source].merge(tag: new_tag, version: new_tag)
+        )
       end
 
       sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -19,7 +19,7 @@ module Dependabot
       require_relative "update_checker/latest_version_resolver"
 
       ELIGIBLE_SOURCE_TYPES = T.let(
-        %w(git provider registry).freeze,
+        %w(git provider registry oci).freeze,
         T::Array[String]
       )
 
@@ -27,6 +27,7 @@ module Dependabot
       def latest_version
         return latest_version_for_git_dependency if git_dependency?
         return latest_version_for_registry_dependency if registry_dependency?
+        return latest_version_for_oci_dependency if oci_dependency?
 
         latest_version_for_provider_dependency if provider_dependency?
         # Other sources (mercurial, path dependencies) just return `nil`
@@ -211,6 +212,29 @@ module Dependabot
         return false if dependency_source_details.nil?
 
         dependency_source_details&.fetch(:type) == "provider"
+      end
+
+      sig { returns(T::Boolean) }
+      def oci_dependency?
+        return false if dependency_source_details.nil?
+
+        dependency_source_details&.fetch(:type) == "oci"
+      end
+
+      sig { returns(T.nilable(Dependabot::Opentofu::Version)) }
+      def latest_version_for_oci_dependency
+        return unless oci_dependency?
+        # Digest pins are immutable; nothing to update to without a tag.
+        return if dependency_source_details&.fetch(:digest)
+
+        identifier = T.must(dependency_source_details).fetch(:artifact_identifier)
+        versions = RegistryClient.all_oci_tags(
+          artifact_identifier: identifier,
+          credentials: credentials
+        )
+        versions.reject!(&:prerelease?) unless wants_prerelease?
+        versions.reject! { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
+        versions.max
       end
 
       sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -227,6 +227,9 @@ module Dependabot
         # Digest pins are immutable; nothing to update to without a tag.
         return if dependency_source_details&.fetch(:digest)
 
+        @latest_oci_version = T.let(@latest_oci_version, T.nilable(Dependabot::Opentofu::Version))
+        return @latest_oci_version if @latest_oci_version
+
         identifier = T.must(dependency_source_details).fetch(:artifact_identifier)
         versions = RegistryClient.all_oci_tags(
           artifact_identifier: identifier,
@@ -234,7 +237,7 @@ module Dependabot
         )
         versions.reject!(&:prerelease?) unless wants_prerelease?
         versions.reject! { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
-        versions.max
+        @latest_oci_version = versions.max
       end
 
       sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }

--- a/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_parser_spec.rb
@@ -1016,6 +1016,137 @@ RSpec.describe Dependabot::Opentofu::FileParser do
       end
     end
 
+    context "with an oci module with a tag" do
+      let(:files) { project_dependency_files("modules_oci") }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "oci",
+            digest: nil,
+            tag: "v1.0.0",
+            version: "v1.0.0",
+            artifact_identifier: "example.com/repository-name",
+            subdirectory: nil
+          }
+        }]
+      end
+
+      it "has the right details" do
+        expect(dependencies.length).to eq(1)
+        dependency = dependencies.find { |d| d.source_type == "oci" }
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.version).to eq("v1.0.0")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
+    context "with an oci module without a tag or digest" do
+      let(:files) { project_dependency_files("modules_oci_no_tag") }
+
+      it "skips the dependency since there is nothing to update" do
+        expect(dependencies.length).to eq(0)
+      end
+    end
+
+    context "with an oci module with a digest" do
+      let(:files) { project_dependency_files("modules_oci_digest") }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "oci",
+            digest: "sha256:abc123",
+            tag: nil,
+            version: "sha256:abc123",
+            artifact_identifier: "example.com/repository-name",
+            subdirectory: nil
+          }
+        }]
+      end
+
+      it "has the right details" do
+        expect(dependencies.length).to eq(1)
+        dependency = dependencies.find { |d| d.source_type == "oci" }
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.version).to eq("sha256:abc123")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
+    context "with an oci module that selects a sub-directory" do
+      let(:files) { project_dependency_files("modules_oci_subdir") }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "oci",
+            digest: nil,
+            tag: "v1.2.0",
+            version: "v1.2.0",
+            artifact_identifier: "example.com/repository-name",
+            subdirectory: "modules/vpc"
+          }
+        }]
+      end
+
+      it "splits the bare repository from the sub-directory" do
+        expect(dependencies.length).to eq(1)
+        dependency = dependencies.find { |d| d.source_type == "oci" }
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.version).to eq("v1.2.0")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
+    context "with an oci module that pins both a tag and a digest" do
+      let(:files) { project_dependency_files("modules_oci_tag_and_digest") }
+
+      it "raises a DependencyFileNotEvaluatable error" do
+        expect { dependencies }.to raise_error(
+          Dependabot::DependencyFileNotEvaluatable,
+          /only one of `tag` or `digest`/
+        )
+      end
+    end
+
+    context "with an oci module pointing at a local registry (host:port)" do
+      let(:files) { project_dependency_files("modules_oci_localhost") }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "oci",
+            digest: nil,
+            tag: "v1.0.0",
+            version: "v1.0.0",
+            artifact_identifier: "localhost:5001/example-module",
+            subdirectory: nil
+          }
+        }]
+      end
+
+      it "parses host:port and the pinned tag" do
+        expect(dependencies.length).to eq(1)
+        dependency = dependencies.find { |d| d.source_type == "oci" }
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.version).to eq("v1.0.0")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
     context "with a private module proxy that can't be reached", :vcr do
       before do
         artifactory_repo_url = "http://artifactory.dependabot.com/artifactory/tf-modules/azurerm"
@@ -1082,6 +1213,14 @@ RSpec.describe Dependabot::Opentofu::FileParser do
             expect(source_type).to eq(:http_archive)
           end
         end
+      end
+    end
+
+    context "when the source type is an oci" do
+      let(:source_string) { "oci://local-registry/module-name" }
+
+      it "returns the correct source type" do
+        expect(source_type).to eq(:oci)
       end
     end
 

--- a/opentofu/spec/dependabot/opentofu/file_updater_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_updater_spec.rb
@@ -122,6 +122,57 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
       end
     end
 
+    context "with an oci module" do
+      let(:project_name) { "modules_oci" }
+
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "example.com/repository-name",
+            version: "v2.0.0",
+            previous_version: "v1.0.0",
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "oci",
+                artifact_identifier: "example.com/repository-name",
+                subdirectory: nil,
+                tag: "v2.0.0",
+                digest: nil,
+                version: "v2.0.0"
+              }
+            }],
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "oci",
+                artifact_identifier: "example.com/repository-name",
+                subdirectory: nil,
+                tag: "v1.0.0",
+                digest: nil,
+                version: "v1.0.0"
+              }
+            }],
+            package_manager: "opentofu"
+          )
+        ]
+      end
+
+      it "rewrites the tag in the oci:// source" do
+        updated_file = updated_dependency_files.find { |file| file.name == "main.tf" }
+
+        expect(updated_file.content).to include(<<~HCL)
+          module "s3-webapp" {
+            source  = "oci://example.com/repository-name?tag=v2.0.0"
+          }
+        HCL
+      end
+    end
+
     context "with private modules with different versions" do
       let(:project_name) { "private_modules_with_different_versions" }
 

--- a/opentofu/spec/fixtures/projects/modules_oci/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci/main.tf
@@ -1,0 +1,3 @@
+module "s3-webapp" {
+  source  = "oci://example.com/repository-name?tag=v1.0.0"
+}

--- a/opentofu/spec/fixtures/projects/modules_oci_digest/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci_digest/main.tf
@@ -1,0 +1,3 @@
+module "s3-webapp" {
+  source  = "oci://example.com/repository-name?digest=sha256:abc123"
+}

--- a/opentofu/spec/fixtures/projects/modules_oci_localhost/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci_localhost/main.tf
@@ -1,0 +1,3 @@
+module "example" {
+  source = "oci://localhost:5001/example-module?tag=v1.0.0"
+}

--- a/opentofu/spec/fixtures/projects/modules_oci_no_tag/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci_no_tag/main.tf
@@ -1,0 +1,3 @@
+module "s3-webapp" {
+  source  = "oci://example.com/repository-name"
+}

--- a/opentofu/spec/fixtures/projects/modules_oci_subdir/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci_subdir/main.tf
@@ -1,0 +1,3 @@
+module "vpc" {
+  source  = "oci://example.com/repository-name//modules/vpc?tag=v1.2.0"
+}

--- a/opentofu/spec/fixtures/projects/modules_oci_tag_and_digest/main.tf
+++ b/opentofu/spec/fixtures/projects/modules_oci_tag_and_digest/main.tf
@@ -1,0 +1,3 @@
+module "s3-webapp" {
+  source  = "oci://example.com/repository-name?tag=v1.0.0&digest=sha256:abc123"
+}


### PR DESCRIPTION
Adds OCI module support for the opentofu ecosystem. Resolves https://github.com/opentofu/opentofu/issues/3526.

- `file_parser.rb`: parses `oci://host[:port]/repo[//subdir]?tag=…` / `?digest=…`. Splits the bare repository from the optional `//submodule` path. Raises `DependencyFileNotEvaluatable` if both `tag` and `digest` are set.
- `registry_client.rb`: `RegistryClient.all_oci_tags` calls the OCI Distribution v2 `/v2/<repo>/tags/list` with `Link`-header pagination. Auth via `opentofu_registry` credentials — Basic when `username`/`password` set, Bearer when `token` set. `localhost`/`127.0.0.1` defaults to `http://`.
- `update_checker.rb`: adds `"oci"` to `ELIGIBLE_SOURCE_TYPES` and dispatches to `latest_version_for_oci_dependency`. Digest-pinned sources return `nil`.
- `requirements_updater.rb`: rewrites `:tag` and `:version` on the source hash for OCI requirements.
- `file_updater.rb`: `update_oci_declaration` swaps the `?tag=` value scoped to the matching `oci://<artifact>` source.
- `opentofu/Dockerfile`: ORAS CLI 1.3.0.
