### PR TITLE
chore: Remove group_membership_enforcement experiment flag

### DIFF
--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -193,12 +193,27 @@ module Dependabot
       contains_checker = proc { |g, dep, _dir| g.contains?(dep) }
       applies_to = group.applies_to if group.respond_to?(:applies_to)
 
+      # Groups with update-types rules are complementary, not competing.
+      # Filter out groups with non-overlapping update-types so they don't
+      # prevent each other from receiving dependencies during assignment.
+      current_update_types = group.rules["update-types"]
+      eligible_groups = if current_update_types
+                          @dependency_groups.reject do |other|
+                            other_update_types = other.rules["update-types"]
+                            next false unless other_update_types
+
+                            !current_update_types.intersect?(other_update_types)
+                          end
+                        else
+                          @dependency_groups
+                        end
+
       Dependabot.logger.info(
         "Checking specificity for #{dependency.name} in group '#{group.name}' (applies_to: #{applies_to || 'nil'})"
       )
 
       more_specific_group_name = specificity_calculator.find_most_specific_group_name(
-        group, dependency, @dependency_groups, contains_checker, dependency.directory, applies_to:
+        group, dependency, eligible_groups, contains_checker, dependency.directory, applies_to:
       )
 
       if more_specific_group_name

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -196,10 +196,10 @@ module Dependabot
       # Groups with update-types rules are complementary, not competing.
       # Filter out groups with non-overlapping update-types so they don't
       # prevent each other from receiving dependencies during assignment.
-      current_update_types = group.rules["update-types"]
+      current_update_types = T.cast(group.rules["update-types"], T.nilable(T::Array[String]))
       eligible_groups = if current_update_types
                           @dependency_groups.reject do |other|
-                            other_update_types = other.rules["update-types"]
+                            other_update_types = T.cast(other.rules["update-types"], T.nilable(T::Array[String]))
                             next false unless other_update_types
 
                             !current_update_types.intersect?(other_update_types)

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -190,8 +190,6 @@ module Dependabot
       ).returns(T::Boolean)
     end
     def should_skip_due_to_specificity?(group, dependency, specificity_calculator)
-      return false unless Dependabot::Experiments.enabled?(:group_membership_enforcement)
-
       contains_checker = proc { |g, dep, _dir| g.contains?(dep) }
       applies_to = group.applies_to if group.respond_to?(:applies_to)
 

--- a/updater/lib/dependabot/updater/group_dependency_selector.rb
+++ b/updater/lib/dependabot/updater/group_dependency_selector.rb
@@ -27,8 +27,6 @@ module Dependabot
     # The class implements a two-layer filtering system:
     # 1. Group membership check via group.contains_dependency?
     # 2. Configuration compliance check via job.allowed_update?
-    #
-    # Note: Filtering requires the :group_membership_enforcement feature to be enabled.
     class GroupDependencySelector
       include UpdateTypeHelper
       extend T::Sig
@@ -95,8 +93,6 @@ module Dependabot
 
       sig { params(dependency_change: Dependabot::DependencyChange).void }
       def filter_to_group!(dependency_change)
-        return unless Dependabot::Experiments.enabled?(:group_membership_enforcement)
-
         Dependabot.logger.info("Applying GroupDependencySelector filtering for group '#{group.name}'")
 
         original_count = dependency_change.updated_dependencies.length
@@ -116,8 +112,6 @@ module Dependabot
 
       sig { params(dependency_change: Dependabot::DependencyChange).void }
       def annotate_dependency_drift!(dependency_change)
-        return unless Dependabot::Experiments.enabled?(:group_membership_enforcement)
-
         dependency_drift = T.let([], T::Array[String])
         directory = dependency_change.job.source.directory || "."
 

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -283,23 +283,23 @@ RSpec.describe Dependabot::DependencyGroupEngine do
         specific_group = dependency_group_engine.find_group(name: "specific-group")
         very_specific_group = dependency_group_engine.find_group(name: "very-specific-group")
 
-          # dummy-pkg-a should only be in the most specific group (very-specific-group)
-          expect(very_specific_group.dependencies).to include(dummy_pkg_a)
-          expect(specific_group.dependencies).not_to include(dummy_pkg_a)
-          expect(generic_group.dependencies).not_to include(dummy_pkg_a)
+        # dummy-pkg-a should only be in the most specific group (very-specific-group)
+        expect(very_specific_group.dependencies).to include(dummy_pkg_a)
+        expect(specific_group.dependencies).not_to include(dummy_pkg_a)
+        expect(generic_group.dependencies).not_to include(dummy_pkg_a)
 
-          # dummy-pkg-b should be in specific-group (most specific match)
-          expect(specific_group.dependencies).to include(dummy_pkg_b)
-          expect(generic_group.dependencies).not_to include(dummy_pkg_b)
+        # dummy-pkg-b should be in specific-group (most specific match)
+        expect(specific_group.dependencies).to include(dummy_pkg_b)
+        expect(generic_group.dependencies).not_to include(dummy_pkg_b)
 
-          # ungrouped_pkg should be in generic-group (only match)
-          expect(generic_group.dependencies).to include(ungrouped_pkg)
-        end
+        # ungrouped_pkg should be in generic-group (only match)
+        expect(generic_group.dependencies).to include(ungrouped_pkg)
+      end
 
-        it "keeps dependencies ungrouped if they don't match any patterns" do
-          # All dependencies should be grouped in this test case
-          expect(dependency_group_engine.ungrouped_dependencies).to be_empty
-        end
+      it "keeps dependencies ungrouped if they don't match any patterns" do
+        # All dependencies should be grouped in this test case
+        expect(dependency_group_engine.ungrouped_dependencies).to be_empty
+      end
 
       describe "#should_skip_due_to_specificity?" do
         let(:generic_group) { dependency_group_engine.find_group(name: "generic-group") }

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -275,23 +275,13 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       let(:dependencies) { [dummy_pkg_a, dummy_pkg_b, ungrouped_pkg] }
 
       before do
-        allow(Dependabot::Experiments).to receive(:enabled?).and_call_original
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement)
-          .and_return(experiment_enabled)
+        dependency_group_engine.assign_to_groups!(dependencies: dependencies)
       end
 
-      context "when experiment is enabled" do
-        let(:experiment_enabled) { true }
-
-        before do
-          dependency_group_engine.assign_to_groups!(dependencies: dependencies)
-        end
-
-        it "assigns dependencies to most specific matching groups only" do
-          generic_group = dependency_group_engine.find_group(name: "generic-group")
-          specific_group = dependency_group_engine.find_group(name: "specific-group")
-          very_specific_group = dependency_group_engine.find_group(name: "very-specific-group")
+      it "assigns dependencies to most specific matching groups only" do
+        generic_group = dependency_group_engine.find_group(name: "generic-group")
+        specific_group = dependency_group_engine.find_group(name: "specific-group")
+        very_specific_group = dependency_group_engine.find_group(name: "very-specific-group")
 
           # dummy-pkg-a should only be in the most specific group (very-specific-group)
           expect(very_specific_group.dependencies).to include(dummy_pkg_a)
@@ -310,33 +300,6 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           # All dependencies should be grouped in this test case
           expect(dependency_group_engine.ungrouped_dependencies).to be_empty
         end
-      end
-
-      context "when experiment is disabled" do
-        let(:experiment_enabled) { false }
-
-        before do
-          dependency_group_engine.assign_to_groups!(dependencies: dependencies)
-        end
-
-        it "assigns dependencies to all matching groups (legacy behavior)" do
-          generic_group = dependency_group_engine.find_group(name: "generic-group")
-          specific_group = dependency_group_engine.find_group(name: "specific-group")
-          very_specific_group = dependency_group_engine.find_group(name: "very-specific-group")
-
-          # dummy-pkg-a should be in all matching groups
-          expect(very_specific_group.dependencies).to include(dummy_pkg_a)
-          expect(specific_group.dependencies).to include(dummy_pkg_a)
-          expect(generic_group.dependencies).to include(dummy_pkg_a)
-
-          # dummy-pkg-b should be in matching groups
-          expect(specific_group.dependencies).to include(dummy_pkg_b)
-          expect(generic_group.dependencies).to include(dummy_pkg_b)
-
-          # ungrouped_pkg should be in generic-group
-          expect(generic_group.dependencies).to include(ungrouped_pkg)
-        end
-      end
 
       describe "#should_skip_due_to_specificity?" do
         let(:generic_group) { dependency_group_engine.find_group(name: "generic-group") }
@@ -344,83 +307,48 @@ RSpec.describe Dependabot::DependencyGroupEngine do
         let(:very_specific_group) { dependency_group_engine.find_group(name: "very-specific-group") }
         let(:specificity_calculator) { Dependabot::Updater::PatternSpecificityCalculator.new }
 
-        context "when experiment is enabled" do
-          let(:experiment_enabled) { true }
-
-          it "returns true when dependency belongs to more specific group" do
-            # dummy-pkg-a belongs to very-specific-group, so should skip generic and specific groups
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                generic_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(true)
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                specific_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(true)
-          end
-
-          it "returns false when dependency belongs to most specific group" do
-            # dummy-pkg-a in very-specific-group (most specific) should not be skipped
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                very_specific_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(false)
-          end
-
-          it "returns false when no more specific group exists" do
-            # ungrouped_pkg only matches generic-group, so should not be skipped
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                generic_group,
-                ungrouped_pkg,
-                specificity_calculator
-              )
-            ).to be(false)
-          end
+        it "returns true when dependency belongs to more specific group" do
+          # dummy-pkg-a belongs to very-specific-group, so should skip generic and specific groups
+          expect(
+            dependency_group_engine.send(
+              :should_skip_due_to_specificity?,
+              generic_group,
+              dummy_pkg_a,
+              specificity_calculator
+            )
+          ).to be(true)
+          expect(
+            dependency_group_engine.send(
+              :should_skip_due_to_specificity?,
+              specific_group,
+              dummy_pkg_a,
+              specificity_calculator
+            )
+          ).to be(true)
         end
 
-        context "when experiment is disabled" do
-          let(:experiment_enabled) { false }
+        it "returns false when dependency belongs to most specific group" do
+          # dummy-pkg-a in very-specific-group (most specific) should not be skipped
+          expect(
+            dependency_group_engine.send(
+              :should_skip_due_to_specificity?,
+              very_specific_group,
+              dummy_pkg_a,
+              specificity_calculator
+            )
+          ).to be(false)
+        end
 
-          it "always returns false regardless of specificity" do
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                generic_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(false)
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                specific_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(false)
-            expect(
-              dependency_group_engine.send(
-                :should_skip_due_to_specificity?,
-                very_specific_group,
-                dummy_pkg_a,
-                specificity_calculator
-              )
-            ).to be(false)
-          end
+        it "returns false when no more specific group exists" do
+          # ungrouped_pkg only matches generic-group, so should not be skipped
+          expect(
+            dependency_group_engine.send(
+              :should_skip_due_to_specificity?,
+              generic_group,
+              ungrouped_pkg,
+              specificity_calculator
+            )
+          ).to be(false)
         end
       end
     end
@@ -494,12 +422,6 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           }
         }
       ]
-    end
-
-    before do
-      allow(Dependabot::Experiments).to receive(:enabled?)
-        .with(:group_membership_enforcement)
-        .and_return(false)
     end
 
     describe "#assign_to_groups!" do
@@ -809,13 +731,6 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       )
     end
 
-    before do
-      allow(Dependabot::Experiments).to receive(:enabled?).and_call_original
-      allow(Dependabot::Experiments).to receive(:enabled?)
-        .with(:group_membership_enforcement)
-        .and_return(false)
-    end
-
     describe "::from_job_config" do
       it "creates groups with group_by attribute set" do
         expect(dependency_group_engine.dependency_groups.length).to eq(1)
@@ -931,13 +846,6 @@ RSpec.describe Dependabot::DependencyGroupEngine do
             }
           }
         ]
-      end
-
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?).and_call_original
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement)
-          .and_return(false)
       end
 
       describe "#assign_to_groups!" do

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -193,9 +193,11 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           dependency_group_engine.assign_to_groups!(dependencies: dependencies)
         end
 
-        it "adds dependencies to every group they match" do
+        it "assigns dependencies to the most specific matching group" do
           group_a = dependency_group_engine.find_group(name: "group-a")
-          expect(group_a.dependencies).to eql([dummy_pkg_a, dummy_pkg_c])
+          # dummy-pkg-c matches both groups but group-b has an exact pattern match,
+          # so with specificity enforcement it only goes to group-b
+          expect(group_a.dependencies).to eql([dummy_pkg_a])
 
           group_b = dependency_group_engine.find_group(name: "group-b")
           expect(group_b.dependencies).to eql([dummy_pkg_b, dummy_pkg_c])

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       end
     end
 
-    context "with group membership enforcement experiment" do
+    context "with pattern specificity enforcement" do
       let(:dependency_groups_config) do
         [
           {

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -114,9 +114,6 @@ RSpec.describe Dependabot::DependencySnapshot do
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:allow_refresh_for_existing_pr_dependencies)
       .and_return(true)
-    allow(Dependabot::Experiments).to receive(:enabled?)
-      .with(:group_membership_enforcement)
-      .and_return(false)
   end
 
   after do

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       )
     end
 
-    context "when feature flag is enabled" do
+    context "when filtering dependencies" do
       before do
         allow(Dependabot::Utils).to receive(:version_class_for_package_manager).and_return(Dependabot::Version)
 

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -552,8 +552,8 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
           end
 
           allow(generic_group).to receive_messages(contains?: true, dependencies: [])
-          allow(docker_group).to receive(:contains?) { |dep| dep.name.start_with?(\"docker\") }
-          allow(exact_group).to receive(:contains?) { |dep| dep.name == \"nginx\" }
+          allow(docker_group).to receive(:contains?) { |dep| dep.name.start_with?("docker") }
+          allow(exact_group).to receive(:contains?) { |dep| dep.name == "nginx" }
 
           allow(job).to receive_messages(ignore_conditions_for: [], allowed_update?: true)
 

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -205,25 +205,9 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       )
     end
 
-    context "when feature flag is disabled" do
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(false)
-      end
-
-      it "does not modify the dependency change" do
-        original_deps = dependency_change.updated_dependencies.dup
-        selector.filter_to_group!(dependency_change)
-        expect(dependency_change.updated_dependencies).to eq(original_deps)
-      end
-    end
-
     context "when feature flag is enabled" do
       before do
         allow(Dependabot::Utils).to receive(:version_class_for_package_manager).and_return(Dependabot::Version)
-
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
 
         allow(dependency_group).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
         allow(dependency_group).to receive(:respond_to?).with(:applies_to).and_return(false)
@@ -270,9 +254,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
     context "with fallback group membership logic" do
       before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
-
         allow(dependency_group).to receive(:respond_to?)
           .with(:contains_dependency?).and_return(false)
         allow(dependency_group).to receive(:respond_to?)
@@ -305,24 +286,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       )
     end
 
-    context "when feature flag is disabled" do
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(false)
-      end
-
-      it "does not annotate dependency drift" do
-        expect(selector).not_to receive(:detect_file_dependency_drift)
-        selector.annotate_dependency_drift!(dependency_change)
-      end
-    end
-
-    context "when feature flag is enabled" do
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
-      end
-
+    context "when processing dependency drift" do
       it "processes files for dependency drift" do
         allow(selector).to receive(:detect_file_dependency_drift)
           .and_return(%w(transitive-dep-1 transitive-dep-2))
@@ -495,9 +459,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
-
         [generic_group, docker_group].each do |g|
           allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
           allow(g).to receive(:respond_to?).with(:applies_to).and_return(false)
@@ -542,9 +503,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?)
-            .with(:group_membership_enforcement).and_return(true)
-
           [generic_group, docker_group, exact_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(false)
@@ -588,17 +546,14 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?)
-            .with(:group_membership_enforcement).and_return(true)
-
           [generic_group, docker_group, exact_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(false)
           end
 
           allow(generic_group).to receive_messages(contains?: true, dependencies: [])
-          allow(docker_group).to receive(:contains?) { |dep| dep.name.start_with?("docker") }
-          allow(exact_group).to receive(:contains?) { |dep| dep.name == "nginx" }
+          allow(docker_group).to receive(:contains?) { |dep| dep.name.start_with?(\"docker\") }
+          allow(exact_group).to receive(:contains?) { |dep| dep.name == \"nginx\" }
 
           allow(job).to receive_messages(ignore_conditions_for: [], allowed_update?: true)
 
@@ -633,9 +588,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       before do
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
-
         [generic_group, docker_group, exact_group].each do |g|
           allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
           allow(g).to receive(:respond_to?).with(:applies_to).and_return(false)
@@ -735,9 +687,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
       before do
         allow(Dependabot::Utils).to receive(:version_class_for_package_manager).and_return(Dependabot::Version)
-
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement).and_return(true)
 
         [generic_group, security_group].each do |g|
           allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)
@@ -839,8 +788,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       before do
-        allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
         [generic_group, docker_minor_prod_group, docker_exact_group, docker_security_group, excluded_group,
          explicit_group].each do |g|
           allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
@@ -953,8 +900,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
           [generic_group, minor_updates_group, exact_rails_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)
@@ -1069,8 +1014,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
           [version_generic_group, security_rails_group, version_rails_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)
@@ -1170,8 +1113,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
           [generic_group, express_explicit_group, prod_deps_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)
@@ -1288,8 +1229,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
           [generic_group, minor_patch_only_group, major_only_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)
@@ -1383,8 +1322,6 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         before do
-          allow(Dependabot::Experiments).to receive(:enabled?).with(:group_membership_enforcement).and_return(true)
-
           [generic_group, rails_except_test_group].each do |g|
             allow(g).to receive(:respond_to?).with(:contains_dependency?).and_return(false)
             allow(g).to receive(:respond_to?).with(:applies_to).and_return(true)

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
         end
 
         before do
-          Dependabot::Experiments.register(:group_membership_enforcement, true)
           # Mock the job to allow all updates for simplicity
           allow(job).to receive(:allowed_update?).and_return(true)
         end
@@ -219,20 +218,6 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
 
           # Only dummy-pkg-a should remain after filtering (dummy-pkg-b should be filtered out)
           expect(result.updated_dependencies.map(&:name)).to eq(["dummy-pkg-a"])
-        end
-
-        it "does not filter when group_membership_enforcement is disabled" do
-          Dependabot::Experiments.register(:group_membership_enforcement, false)
-
-          # Override the dependency change builder to return our test change
-          allow(create_group_update_pull_request).to receive(:compile_all_dependency_changes_for)
-            .with(dependency_group)
-            .and_return(stub_dependency_change_with_multiple_deps)
-
-          result = create_group_update_pull_request.send(:dependency_change)
-
-          # Both dependencies should remain when filtering is disabled
-          expect(result.updated_dependencies.map(&:name)).to contain_exactly("dummy-pkg-a", "dummy-pkg-b")
         end
 
         it "handles empty dependency changes gracefully" do

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -213,12 +213,12 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
 
       before do
         stub_rubygems_calls
+        allow(mock_service).to receive(:close_pull_request)
       end
 
-      it "closes the PR since the generic group has no dependencies after specificity filtering" do
-        # With pattern specificity enforcement always on, the '*' group gets no dependencies
-        # because all deps match more specific groups ('dummy-pkg-*' and 'dummy-pkg-d').
-        # The refresh operation detects the empty group and closes the PR.
+      it "closes the PR since the generic group is empty after specificity filtering" do
+        # With specificity enforcement, the '*' group has no dependencies because
+        # all deps match the more specific 'dummy-pkg-*' and 'dummy-pkg-d' groups.
         expect(mock_service).to receive(:close_pull_request).with(anything, anything)
 
         refresh_group.perform
@@ -339,11 +339,10 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       end
 
       it "closes the PR since the generic group is empty after specificity filtering" do
-        # With specificity enforcement, the '*' group has no dependencies,
-        # so the refresh closes the PR rather than processing group dependencies.
+        # With specificity enforcement, the '*' group has no dependencies because
+        # all deps match the more specific 'dummy-pkg-*' and 'dummy-pkg-d' groups.
         refresh_group.perform
 
-        # The group is empty so mark_group_handled is never reached
         expect(dependency_snapshot).not_to have_received(:mark_group_handled).with(
           having_attributes(name: "overlapping-group"), anything
         )

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -536,37 +536,8 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       stub_rubygems_calls
     end
 
-    context "when group membership enforcement is disabled" do
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?).and_return(false)
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement)
-          .and_return(false)
-      end
-
-      it "creates GroupDependencySelector but does not filter" do
-        # When feature flag is disabled, GroupDependencySelector is created but filtering is skipped internally
-        mock_selector = instance_double(Dependabot::Updater::GroupDependencySelector)
-        allow(Dependabot::Updater::GroupDependencySelector).to receive(:new)
-          .and_return(mock_selector)
-        allow(mock_selector).to receive(:filter_to_group!) # No-op when feature flag disabled
-
-        refresh_group.send(:dependency_change)
-
-        expect(Dependabot::Updater::GroupDependencySelector).to have_received(:new)
-        expect(mock_selector).to have_received(:filter_to_group!)
-      end
-    end
-
-    context "when group membership enforcement is enabled" do
+    context "when filtering group dependencies" do
       let(:mock_selector) { instance_double(Dependabot::Updater::GroupDependencySelector) }
-
-      before do
-        allow(Dependabot::Experiments).to receive(:enabled?).and_return(false)
-        allow(Dependabot::Experiments).to receive(:enabled?)
-          .with(:group_membership_enforcement)
-          .and_return(true)
-      end
 
       it "creates and uses GroupDependencySelector to filter dependencies" do
         allow(Dependabot::Updater::GroupDependencySelector).to receive(:new)

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -215,19 +215,13 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
         stub_rubygems_calls
       end
 
-      it "considers the dependencies in the other PRs as handled, and closes the duplicate PR" do
-        # As per this implementation, if a dependency is part of overlapping groups
-        # Both the groups condition will be validated and the dependency will be updated in both the groups PRs.
-        # It is up to customer to decide which group should take precedence and update the dependency accordingly
-        expect(mock_service).not_to receive(:close_pull_request).with(["dummy-pkg-b"], :update_no_longer_possible)
+      it "closes the PR since the generic group has no dependencies after specificity filtering" do
+        # With pattern specificity enforcement always on, the '*' group gets no dependencies
+        # because all deps match more specific groups ('dummy-pkg-*' and 'dummy-pkg-d').
+        # The refresh operation detects the empty group and closes the PR.
+        expect(mock_service).to receive(:close_pull_request).with(anything, anything)
 
         refresh_group.perform
-
-        # It added all of the other existing grouped PRs to the handled list
-        expect(dependency_snapshot.handled_dependencies).to match_array(
-          %w(dummy-pkg-a dummy-pkg-b dummy-pkg-c
-             dummy-pkg-d)
-        )
       end
     end
 
@@ -305,6 +299,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
 
       before do
         stub_rubygems_calls
+        allow(mock_service).to receive(:close_pull_request)
         allow(dependency_snapshot).to receive(:mark_group_handled).and_call_original
         allow(job).to receive(:existing_group_pull_requests).and_return(
           [
@@ -343,13 +338,16 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
         )
       end
 
-      it "marks the overlapping groups as handled" do
+      it "closes the PR since the generic group is empty after specificity filtering" do
+        # With specificity enforcement, the '*' group has no dependencies,
+        # so the refresh closes the PR rather than processing group dependencies.
         refresh_group.perform
 
-        expect(dependency_snapshot).to have_received(:mark_group_handled).with(
+        # The group is empty so mark_group_handled is never reached
+        expect(dependency_snapshot).not_to have_received(:mark_group_handled).with(
           having_attributes(name: "overlapping-group"), anything
         )
-        expect(dependency_snapshot).to have_received(:mark_group_handled).with(
+        expect(dependency_snapshot).not_to have_received(:mark_group_handled).with(
           having_attributes(name: "something-else"), anything
         )
       end
@@ -366,6 +364,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
 
       before do
         stub_rubygems_calls
+        allow(mock_service).to receive(:close_pull_request)
         allow(dependency_snapshot).to receive(:mark_group_handled).and_call_original
         allow(job).to receive(:existing_group_pull_requests).and_return(
           [
@@ -392,13 +391,15 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
         )
       end
 
-      it "treats the existing PRs as matches and marks the groups as handled" do
+      it "closes the PR since the generic group is empty after specificity filtering" do
+        # With specificity enforcement, the '*' group has no dependencies,
+        # so the refresh closes the PR rather than processing group dependencies.
         refresh_group.perform
 
-        expect(dependency_snapshot).to have_received(:mark_group_handled).with(
+        expect(dependency_snapshot).not_to have_received(:mark_group_handled).with(
           having_attributes(name: "overlapping-group"), anything
         )
-        expect(dependency_snapshot).to have_received(:mark_group_handled).with(
+        expect(dependency_snapshot).not_to have_received(:mark_group_handled).with(
           having_attributes(name: "something-else"), anything
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

**What:** Remove the `:group_membership_enforcement` experiment flag gate, making `GroupDependencySelector` filtering, dependency drift annotation, and pattern specificity checking always-on.

**Why:** The flag has been rolled out to 100% of actors in production. Removing the gate is tech debt cleanup — the code paths behind the flag are already exercised by all users.

The flag was introduced in PRs #12911, #12968, #12969, and #13044 to address the "superset problem" where group PRs could include dependencies outside the group's scope. With the flag at full rollout, there's no reason to keep the conditional checks.

### Anything you want to highlight for special attention from reviewers?

**Flag gate removal** (3 locations):

1. **`GroupDependencySelector#filter_to_group!`** — was guarded by the flag; now always filters `updated_dependencies` to group-eligible deps
2. **`GroupDependencySelector#annotate_dependency_drift!`** — was guarded; now always annotates drift
3. **`DependencyGroupEngine#should_skip_due_to_specificity?`** — was guarded; now always prevents generic groups from capturing deps that belong to more specific groups

**Bug fix for complementary update-types groups:**

Removing the flag exposed a latent bug: groups with the same pattern but different `update-types` (e.g. `patch`, `minor`, `major` all with `patterns: ["*"]`) were incorrectly treated as competing for specificity. The first group processed would claim dependencies via `EXPLICIT_MEMBER_SCORE`, blocking all other groups from receiving them.

Fixed in `should_skip_due_to_specificity?` by excluding groups with non-overlapping `update-types` rules from the specificity comparison. These groups are complementary (handling different kinds of version changes), not competing.

**Test changes:**
- Removed "flag disabled" test contexts that tested legacy (pre-flag) behavior
- Removed experiment stubs from "flag enabled" test contexts
- Updated overlapping-group refresh tests: the `*` group correctly gets no deps when more specific groups (e.g. `dummy-pkg-*`) exist
- Updated `assign_to_groups!` test: deps now go only to the most specific matching group

### How will you know you've accomplished your goal?

- All existing tests pass (the "flag enabled" test paths are preserved with stubs removed)
- No references to `:group_membership_enforcement` remain in the codebase
- The `GroupDependencySelector` filtering behavior is unchanged from what's already running at 100%
- Groups with different `update-types` correctly receive all matching dependencies (not just the first group in iteration order)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
