### PR TITLE
Reduce noisy git config subprocess logging

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -95,12 +95,14 @@ module Dependabot
       begin
         T.unsafe(Open3).popen3(*env_cmd) do |stdin, stdout_io, stderr_io, wait_thr| # rubocop:disable Metrics/BlockLength
           pid = wait_thr.pid
+          command_string = command_string_for_logging(env_cmd)
+          log_level = short_git_config_command?(command_string) ? :debug : :info
           sanitized_env_cmd = if env_cmd.first.is_a?(Hash)
                                 [SharedHelpers.send(:sanitize_env_for_logging, env_cmd.first), *env_cmd[1..]]
                               else
                                 env_cmd
                               end
-          Dependabot.logger.info("Started process PID: #{pid} with command: #{sanitized_env_cmd.join(' ')}")
+          Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{sanitized_env_cmd.join(' ')}")
 
           # Write to stdin if input data is provided
           begin
@@ -179,7 +181,7 @@ module Dependabot
           end
 
           status = ProcessStatus.new(wait_thr.value)
-          Dependabot.logger.info("Process PID: #{pid} completed with status: #{status}")
+          Dependabot.logger.public_send(log_level, "Process PID: #{pid} completed with status: #{status}")
         end
       rescue Timeout::Error => e
         Dependabot.logger.error("Process PID: #{pid} failed due to timeout: #{e.message}")
@@ -195,7 +197,8 @@ module Dependabot
       end
 
       elapsed_time = Time.now - start_time
-      Dependabot.logger.info("Total execution time: #{elapsed_time.round(2)} seconds")
+      log_level = short_git_config_command?(command_string_for_logging(env_cmd)) ? :debug : :info
+      Dependabot.logger.public_send(log_level, "Total execution time: #{elapsed_time.round(2)} seconds")
       [stdout, stderr, status, elapsed_time]
     end
     # rubocop:enable Metrics/AbcSize
@@ -249,5 +252,19 @@ module Dependabot
       command_parts = command.split.map(&:strip).reject(&:empty?)
       Shellwords.join(command_parts)
     end
+
+    sig { params(env_cmd: T::Array[T.any(T::Hash[String, String], String)]).returns(T.nilable(String)) }
+    def self.command_string_for_logging(env_cmd)
+      env_cmd.find { |item| item.is_a?(String) }
+    end
+    private_class_method :command_string_for_logging
+
+    sig { params(command: T.nilable(String)).returns(T::Boolean) }
+    def self.short_git_config_command?(command)
+      return false if command.nil?
+
+      command.start_with?("git config --global ")
+    end
+    private_class_method :short_git_config_command?
   end
 end

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -23,6 +23,13 @@ module Dependabot
       T.nilable(T.proc.params(data: String).returns(T::Hash[Symbol, T.untyped]))
     end
 
+    EnvCmdItem = T.type_alias do
+      T.any(
+        String,
+        T::Hash[T.any(String, Symbol), T.untyped]
+      )
+    end
+
     class ProcessStatus
       extend T::Sig
 
@@ -72,7 +79,7 @@ module Dependabot
     # rubocop:disable Metrics/CyclomaticComplexity
     sig do
       params(
-        env_cmd: T::Array[T.any(T::Hash[String, String], String)],
+        env_cmd: T::Array[EnvCmdItem],
         stdin_data: T.nilable(String),
         stderr_to_stdout: T::Boolean,
         timeout: Integer,
@@ -102,7 +109,8 @@ module Dependabot
                               else
                                 env_cmd
                               end
-          Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{sanitized_env_cmd.join(' ')}")
+          command_for_log = sanitized_env_cmd.join(" ")
+          Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{command_for_log}")
 
           # Write to stdin if input data is provided
           begin
@@ -253,9 +261,9 @@ module Dependabot
       Shellwords.join(command_parts)
     end
 
-    sig { params(env_cmd: T::Array[T.any(T::Hash[String, String], String)]).returns(T.nilable(String)) }
+    sig { params(env_cmd: T::Array[EnvCmdItem]).returns(T.nilable(String)) }
     def self.command_string_for_logging(env_cmd)
-      env_cmd.find { |item| item.is_a?(String) }
+      T.cast(env_cmd.find { |item| item.is_a?(String) }, T.nilable(String))
     end
     private_class_method :command_string_for_logging
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -197,7 +197,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def commit
         resolved_cloned_commit = cloned_commit
-        return T.must(resolved_cloned_commit) if resolved_cloned_commit
+        return resolved_cloned_commit if resolved_cloned_commit
         return T.must(source.commit) if source.commit
 
         branch = target_branch || default_branch_for_repo

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -196,7 +196,8 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def commit
-        return T.must(cloned_commit) if cloned_commit
+        resolved_cloned_commit = cloned_commit
+        return T.must(resolved_cloned_commit) if resolved_cloned_commit
         return T.must(source.commit) if source.commit
 
         branch = target_branch || default_branch_for_repo

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -3,6 +3,7 @@
 
 require "spec_helper"
 require "dependabot/command_helpers"
+require "open3"
 
 RSpec.describe Dependabot::CommandHelpers do
   describe ".capture3_with_timeout" do
@@ -122,13 +123,43 @@ RSpec.describe Dependabot::CommandHelpers do
     end
 
     context "when logging subprocess lifecycle" do
-      let(:logger) { instance_double("Logger", info: nil, debug: nil, warn: nil, error: nil) }
+      let(:logger) { instance_double(Logger, info: nil, debug: nil, warn: nil, error: nil) }
 
       before do
         allow(Dependabot).to receive(:logger).and_return(logger)
       end
 
+      def stub_popen3_with_success
+        stdin = instance_double(IO, close: nil)
+        process_status = instance_double(
+          Process::Status,
+          success?: true,
+          exitstatus: 0,
+          pid: 12_345,
+          termsig: nil,
+          to_s: "pid 12345 exit 0"
+        )
+        wait_thr = instance_double(Process::Waiter, pid: 12_345, value: process_status)
+
+        allow(Open3).to receive(:popen3) do |*_args, &block|
+          stdout_read, stdout_write = IO.pipe
+          stderr_read, stderr_write = IO.pipe
+
+          stdout_write.close
+          stderr_write.close
+
+          begin
+            block.call(stdin, stdout_read, stderr_read, wait_thr)
+          ensure
+            stdout_read.close unless stdout_read.closed?
+            stderr_read.close unless stderr_read.closed?
+          end
+        end
+      end
+
       it "logs git config commands at debug level" do
+        stub_popen3_with_success
+
         described_class.capture3_with_timeout(
           ["git config --global --list"],
           timeout: timeout

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -120,5 +120,35 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(elapsed_time).to be < 6 # confirms early termination
       end
     end
+
+    context "when logging subprocess lifecycle" do
+      let(:logger) { instance_double("Logger", info: nil, debug: nil, warn: nil, error: nil) }
+
+      before do
+        allow(Dependabot).to receive(:logger).and_return(logger)
+      end
+
+      it "logs git config commands at debug level" do
+        described_class.capture3_with_timeout(
+          ["git config --global --list"],
+          timeout: timeout
+        )
+
+        expect(logger).to have_received(:debug).with(a_string_including("Started process PID"))
+        expect(logger).to have_received(:debug).with(a_string_including("Process PID"))
+        expect(logger).to have_received(:debug).with(a_string_including("Total execution time"))
+      end
+
+      it "logs non-git-config commands at info level" do
+        described_class.capture3_with_timeout(
+          [success_cmd],
+          timeout: timeout
+        )
+
+        expect(logger).to have_received(:info).with(a_string_including("Started process PID"))
+        expect(logger).to have_received(:info).with(a_string_including("Process PID"))
+        expect(logger).to have_received(:info).with(a_string_including("Total execution time"))
+      end
+    end
   end
 end

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -309,6 +309,12 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
       it { is_expected.to eq(head_sha) }
 
+      it "only checks cloned_commit once" do
+        expect(file_fetcher_instance).to receive(:cloned_commit).once.and_call_original
+
+        commit
+      end
+
       context "with warnings from git rev-parse" do
         before do
           # Git no longer allows you to create a branch or symbolic ref named HEAD


### PR DESCRIPTION
### What are you trying to accomplish?

Reduce noisy Dependabot updater logs by lowering verbosity for short-lived `git config --global ...` subprocess lifecycle messages, and remove one avoidable duplicate git setup path in commit resolution.

**Why:**
- Recent logs made normal git bootstrap behavior look like a regression because each tiny subprocess was logged at `INFO`.
- This obscures real `warnings/errors` and makes job output harder to scan.
- The duplicate [cloned_commit](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/file_fetchers/base.rb#L197C7-L209C10) lookup added extra repeated setup/log lines with no functional benefit.


**Impact:**
- Keeps detailed lifecycle logs available at `DEBUG` for troubleshooting.
- Preserves `INFO` visibility for non-git-config subprocesses.
- Reduces log noise and makes updater failures easier to spot quickly.

### Anything you want to highlight for special attention from reviewers?

Workflow: https://github.com/thavaahariharangit/npm-cooldown-fr-13245/actions/runs/25025816023/job/73296589148

before this fix
```
2026/04/29 14:34:55 INFO Process PID: 4596 completed with status: pid 4596 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:55 INFO Started process PID: 4599 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4599 completed with status: pid 4599 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.07 seconds
2026/04/29 14:34:55 INFO Started process PID: 4601 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:55 INFO Process PID: 4601 completed with status: pid 4601 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4603 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:55 INFO Process PID: 4603 completed with status: pid 4603 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4605 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4605 completed with status: pid 4605 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4607 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4607 completed with status: pid 4607 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:55 INFO Started process PID: 4609 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4609 completed with status: pid 4609 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4611 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:55 INFO Process PID: 4611 completed with status: pid 4611 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4613 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:55 INFO Process PID: 4613 completed with status: pid 4613 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:55 INFO Started process PID: 4615 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4615 completed with status: pid 4615 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:55 INFO Started process PID: 4617 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:55 INFO Process PID: 4617 completed with status: pid 4617 exit 0
2026/04/29 14:34:55 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:55 INFO Started process PID: 4619 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/thavaahariharangit/npm-cooldown-fr-13245 /home/dependabot/dependabot-updater/repo {}
2026/04/29 14:34:56 INFO Process PID: 4619 completed with status: pid 4619 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.8 seconds
2026/04/29 14:34:56 INFO Started process PID: 4653 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
2026/04/29 14:34:56 INFO Process PID: 4653 completed with status: pid 4653 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4658 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
2026/04/29 14:34:56 INFO Process PID: 4658 completed with status: pid 4658 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4661 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4661 completed with status: pid 4661 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4663 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4663 completed with status: pid 4663 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4665 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4665 completed with status: pid 4665 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4667 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4667 completed with status: pid 4667 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4669 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4669 completed with status: pid 4669 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4671 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4671 completed with status: pid 4671 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4673 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4673 completed with status: pid 4673 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4675 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4675 completed with status: pid 4675 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4677 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4677 completed with status: pid 4677 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4679 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4679 completed with status: pid 4679 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4681 with command: {} git lfs pull --include .yarn,./yarn/cache {}
2026/04/29 14:34:56 INFO Process PID: 4681 completed with status: pid 4681 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.06 seconds
2026/04/29 14:34:56 INFO Started process PID: 4711 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
2026/04/29 14:34:56 INFO Process PID: 4711 completed with status: pid 4711 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4714 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4714 completed with status: pid 4714 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4716 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4716 completed with status: pid 4716 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4718 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4718 completed with status: pid 4718 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4720 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4720 completed with status: pid 4720 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4722 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4722 completed with status: pid 4722 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4724 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4724 completed with status: pid 4724 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4726 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4726 completed with status: pid 4726 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4728 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4728 completed with status: pid 4728 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4730 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4730 completed with status: pid 4730 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4732 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4732 completed with status: pid 4732 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4734 with command: {} git rev-parse HEAD {}
2026/04/29 14:34:56 INFO Process PID: 4734 completed with status: pid 4734 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4739 with command: {} git config --global credential.helper '!/home/dependabot/common/lib/dependabot/../../bin/git-credential-store-immutable --file /home/dependabot/dependabot-updater/git.store' {}
2026/04/29 14:34:56 INFO Process PID: 4739 completed with status: pid 4739 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4742 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4742 completed with status: pid 4742 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4744 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4744 completed with status: pid 4744 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4746 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4746 completed with status: pid 4746 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4748 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4748 completed with status: pid 4748 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4750 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4750 completed with status: pid 4750 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Started process PID: 4752 with command: {} git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4752 completed with status: pid 4752 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4754 with command: {} git config --global --add url.https://github.com/.insteadOf ssh://git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4754 completed with status: pid 4754 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4756 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com: {}
2026/04/29 14:34:56 INFO Process PID: 4756 completed with status: pid 4756 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4758 with command: {} git config --global --add url.https://github.com/.insteadOf git@github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4758 completed with status: pid 4758 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4760 with command: {} git config --global --add url.https://github.com/.insteadOf git://github.com/ {}
2026/04/29 14:34:56 INFO Process PID: 4760 completed with status: pid 4760 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.01 seconds
2026/04/29 14:34:56 INFO Started process PID: 4762 with command: {} git rev-parse HEAD {}
2026/04/29 14:34:56 INFO Process PID: 4762 completed with status: pid 4762 exit 0
2026/04/29 14:34:56 INFO Total execution time: 0.0 seconds
2026/04/29 14:34:56 INFO Detected package manager: npm
```

After this fix:
```
2026/04/29 14:31:38 INFO Process PID: 4619 completed with status: pid 4619 exit 0
2026/04/29 14:31:38 INFO Total execution time: 0.86 seconds
2026/04/29 14:31:38 INFO Started process PID: 4653 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
2026/04/29 14:31:38 INFO Process PID: 4653 completed with status: pid 4653 exit 0
2026/04/29 14:31:38 INFO Total execution time: 0.01 seconds
2026/04/29 14:31:38 INFO Started process PID: 4681 with command: {} git lfs pull --include .yarn,./yarn/cache {}
2026/04/29 14:31:38 INFO Process PID: 4681 completed with status: pid 4681 exit 0
2026/04/29 14:31:38 INFO Total execution time: 0.16 seconds
2026/04/29 14:31:38 INFO Started process PID: 4734 with command: {} git rev-parse HEAD {}
2026/04/29 14:31:38 INFO Process PID: 4734 completed with status: pid 4734 exit 0
2026/04/29 14:31:38 INFO Total execution time: 0.0 seconds
2026/04/29 14:31:38 INFO Detected package manager: npm
```

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
