### PR TITLE
opentofu: accept terraform_registry credentials for private registries

### DIFF
--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -26,6 +26,13 @@ module Dependabot
       PUBLIC_HOSTNAME = "registry.opentofu.org"
       API_BASE_URL = "api.opentofu.org"
 
+      # The OpenTofu Module Registry HTTP API is wire-compatible with Terraform's,
+      # so credentials issued for either ecosystem are valid here.
+      ACCEPTED_CREDENTIAL_TYPES = T.let(
+        %w(opentofu_registry terraform_registry).freeze,
+        T::Array[String]
+      )
+
       sig { params(hostname: String, credentials: T::Array[Dependabot::Credential]).void }
       def initialize(hostname: PUBLIC_HOSTNAME, credentials: [])
         @hostname = hostname
@@ -35,7 +42,7 @@ module Dependabot
             # Only Bearer-token shaped creds belong here; OCI-only entries
             # (username/password) would otherwise store a nil token and
             # trigger a malformed `Authorization: Bearer ` header.
-            next unless %w(opentofu_registry terraform_registry).include?(item["type"]) && item["token"]
+            next unless ACCEPTED_CREDENTIAL_TYPES.include?(item["type"]) && item["token"]
 
             memo[item["host"]] = item["token"]
           end,

--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -35,7 +35,7 @@ module Dependabot
             # Only Bearer-token shaped creds belong here; OCI-only entries
             # (username/password) would otherwise store a nil token and
             # trigger a malformed `Authorization: Bearer ` header.
-            next unless item["type"] == "opentofu_registry" && item["token"]
+            next unless %w(opentofu_registry terraform_registry).include?(item["type"]) && item["token"]
 
             memo[item["host"]] = item["token"]
           end,

--- a/opentofu/spec/dependabot/opentofu/registry_client_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/registry_client_spec.rb
@@ -113,6 +113,26 @@ RSpec.describe Dependabot::Opentofu::RegistryClient do
       .with(headers: { "Authorization" => "Bearer #{token}" })
   end
 
+  it "also accepts terraform_registry credentials so existing configs keep working" do
+    hostname = "registry.example.org"
+    token = SecureRandom.hex(16)
+    credentials = [{ "type" => "terraform_registry", "host" => hostname, "token" => token }]
+
+    stub_request(:get, "https://#{hostname}/.well-known/terraform.json").and_return(
+      body: {
+        "modules.v1": "/v1/modules/",
+        "providers.v1": "/v1/providers/"
+      }.to_json
+    )
+    stub_request(:get, "https://#{hostname}/v1/providers/x/y/versions")
+      .and_return(body: { id: "x/y", versions: [{ version: "0.1.0" }] }.to_json)
+    client = described_class.new(hostname: hostname, credentials: credentials)
+
+    expect(client.all_provider_versions(identifier: "x/y")).to contain_exactly(Gem::Version.new("0.1.0"))
+    expect(WebMock).to have_requested(:get, "https://#{hostname}/v1/providers/x/y/versions")
+      .with(headers: { "Authorization" => "Bearer #{token}" })
+  end
+
   it "fetches module versions", :vcr do
     response = client.all_module_versions(identifier: "hashicorp/consul/aws")
     expect(response.max).to eq(Gem::Version.new("0.10.1"))


### PR DESCRIPTION
## Summary

- The OpenTofu `RegistryClient` previously only honored credentials typed `opentofu_registry`. That type isn't exposed in the dependabot.yml schema, so users with `terraform-registry` entries were effectively anonymous when their ecosystem was `opentofu`, hitting `private_source_authentication_failure` against private registries (e.g. `app.terraform.io`).
- Accept `terraform_registry` credentials too, so configs that work for the `terraform` ecosystem keep working when switched to `opentofu`. The registry HTTP API is the same between the two, so the bearer token is valid against either.