### PR TITLE
Align npm ephemeral lockfile handling with recent Python improvements

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
@@ -101,7 +101,6 @@ module Dependabot
         )
 
         ephemeral_lockfile = generator.generate
-        return unless ephemeral_lockfile
 
         # Inject the ephemeral lockfile into the dependency files
         # so the file parser can use it
@@ -112,6 +111,8 @@ module Dependabot
           "Successfully generated ephemeral #{ephemeral_lockfile.name} for dependency graphing"
         )
       rescue StandardError => e
+        errored_fetching_subdependencies!
+        @subdependency_error = e
         Dependabot.logger.warn(
           "Failed to generate ephemeral lockfile: #{e.message}. " \
           "Dependency versions may not be resolved."

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
@@ -18,7 +18,10 @@ module Dependabot
 
       sig { override.returns(Dependabot::DependencyFile) }
       def relevant_dependency_file
-        # Prefer lockfile if present, otherwise use package.json
+        # An ephemerally generated lockfile should not be reported as the
+        # relevant file since it doesn't exist in the repository.
+        return package_json if @ephemeral_lockfile_generated
+
         lockfile || package_json
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
@@ -28,7 +28,7 @@ module Dependabot
           @credentials = credentials
         end
 
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
+        sig { returns(Dependabot::DependencyFile) }
         def generate
           SharedHelpers.in_a_temporary_directory do
             write_temporary_files
@@ -37,7 +37,7 @@ module Dependabot
           end
         rescue SharedHelpers::HelperSubprocessFailed => e
           handle_generation_error(e)
-          nil
+          raise
         end
 
         private
@@ -145,13 +145,13 @@ module Dependabot
           Helpers.run_pnpm_command(command, fingerprint: command)
         end
 
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
+        sig { returns(Dependabot::DependencyFile) }
         def read_generated_lockfile
           lockfile_name = expected_lockfile_name
 
           unless File.exist?(lockfile_name)
-            Dependabot.logger.warn("Lockfile #{lockfile_name} was not generated")
-            return nil
+            Dependabot.logger.error("#{lockfile_name} was not generated")
+            raise Dependabot::DependencyFileNotEvaluatable, "#{lockfile_name} was not generated"
           end
 
           content = File.read(lockfile_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
@@ -159,8 +159,14 @@ module Dependabot
           Dependabot::DependencyFile.new(
             name: lockfile_name,
             content: content,
-            directory: "/"
+            directory: package_json_directory
           )
+        end
+
+        sig { returns(String) }
+        def package_json_directory
+          package_json = dependency_files.find { |f| f.name.end_with?("package.json") }
+          package_json&.directory || "/"
         end
 
         sig { returns(String) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
       it "attempts to generate a package-lock.json" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command).and_return("")
 
-        # Mock file existence check
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with("package-lock.json").and_return(false)
+        allow(File).to receive(:exist?).with("package-lock.json").and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with("package-lock.json").and_return("{}")
 
         generator.generate
 
@@ -82,7 +83,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
       end
 
       context "when lockfile generation fails" do
-        it "returns nil and logs an error" do
+        it "re-raises the error after logging" do
           allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
             .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                          message: "npm ERR! ERESOLVE could not resolve",
@@ -91,8 +92,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
 
           expect(Dependabot.logger).to receive(:error).at_least(:once)
 
-          result = generator.generate
-          expect(result).to be_nil
+          expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
         end
       end
     end
@@ -107,7 +107,9 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
           allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_return("")
 
           allow(File).to receive(:exist?).and_call_original
-          allow(File).to receive(:exist?).with("yarn.lock").and_return(false)
+          allow(File).to receive(:exist?).with("yarn.lock").and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with("yarn.lock").and_return("")
 
           generator.generate
 
@@ -128,7 +130,9 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
           allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command).and_return("")
 
           allow(File).to receive(:exist?).and_call_original
-          allow(File).to receive(:exist?).with("yarn.lock").and_return(false)
+          allow(File).to receive(:exist?).with("yarn.lock").and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with("yarn.lock").and_return("")
 
           generator.generate
 
@@ -146,7 +150,9 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
 
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with("pnpm-lock.yaml").and_return(false)
+        allow(File).to receive(:exist?).with("pnpm-lock.yaml").and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with("pnpm-lock.yaml").and_return("")
 
         generator.generate
 
@@ -192,7 +198,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
     let(:dependency_files) { project_dependency_files("grapher/npm_no_lockfile") }
 
     context "with ERESOLVE error" do
-      it "logs a helpful error message about peer dependencies" do
+      it "logs a helpful error message about peer dependencies and re-raises" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: "npm ERR! ERESOLVE could not resolve peer dependencies",
@@ -204,12 +210,12 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         expect(Dependabot.logger).to receive(:error)
           .with(/conflicting peer dependencies/)
 
-        generator.generate
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
 
     context "with network error" do
-      it "logs a helpful error message about network issues" do
+      it "logs a helpful error message about network issues and re-raises" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: "npm ERR! ENOTFOUND registry.npmjs.org",
@@ -221,12 +227,12 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         expect(Dependabot.logger).to receive(:error)
           .with(/Network error/)
 
-        generator.generate
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
 
     context "with authentication error" do
-      it "logs a helpful error message about credentials" do
+      it "logs a helpful error message about credentials and re-raises" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: "npm ERR! 401 Unauthorized",
@@ -238,7 +244,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         expect(Dependabot.logger).to receive(:error)
           .with(/Authentication error/)
 
-        generator.generate
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
   end
@@ -270,7 +276,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with("package-lock.json").and_return(false)
 
-        generator.generate
+        expect { generator.generate }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
@@ -63,17 +63,14 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       let(:dependency_files) { project_dependency_files("grapher/npm_exact_versions_no_lockfile") }
 
       before do
-        # Mock lockfile generation to simulate failure
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
-        ).tap do |gen|
-          allow(gen).to receive(:generate).and_raise(
-            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-              message: "npm install failed",
-              error_context: {}
-            )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
+          generate: Dependabot::DependencyFile.new(
+            name: "package-lock.json",
+            content: { "lockfileVersion" => 3, "packages" => {} }.to_json,
+            directory: "/"
           )
-        end
+        )
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -105,17 +102,14 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       let(:dependency_files) { project_dependency_files("grapher/npm_exact_versions_no_lockfile") }
 
       before do
-        # Mock lockfile generation to simulate failure
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
-        ).tap do |gen|
-          allow(gen).to receive(:generate).and_raise(
-            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-              message: "npm install failed",
-              error_context: {}
-            )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
+          generate: Dependabot::DependencyFile.new(
+            name: "package-lock.json",
+            content: { "lockfileVersion" => 3, "packages" => {} }.to_json,
+            directory: "/"
           )
-        end
+        )
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -183,18 +177,14 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       end
 
       context "when lockfile generation succeeds" do
-        let(:ephemeral_lockfile) do
-          Dependabot::DependencyFile.new(
-            name: "package-lock.json",
-            content: { "lockfileVersion" => 3, "packages" => {} }.to_json,
-            directory: "/"
-          )
-        end
-
         before do
           lockfile_generator = instance_double(
             Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-            generate: ephemeral_lockfile
+            generate: Dependabot::DependencyFile.new(
+              name: "package-lock.json",
+              content: { "lockfileVersion" => 3, "packages" => {} }.to_json,
+              directory: "/"
+            )
           )
           allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
             .to receive(:new).and_return(lockfile_generator)
@@ -241,15 +231,13 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
-        ).tap do |gen|
-          allow(gen).to receive(:generate).and_raise(
-            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-              message: "npm install failed",
-              error_context: {}
-            )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
+          generate: Dependabot::DependencyFile.new(
+            name: "package-lock.json",
+            content: "{}",
+            directory: "/"
           )
-        end
+        )
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -281,15 +269,13 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
-        ).tap do |gen|
-          allow(gen).to receive(:generate).and_raise(
-            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-              message: "yarn install failed",
-              error_context: {}
-            )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
+          generate: Dependabot::DependencyFile.new(
+            name: "yarn.lock",
+            content: "",
+            directory: "/"
           )
-        end
+        )
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -321,15 +307,13 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
-        ).tap do |gen|
-          allow(gen).to receive(:generate).and_raise(
-            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-              message: "pnpm install failed",
-              error_context: {}
-            )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
+          generate: Dependabot::DependencyFile.new(
+            name: "pnpm-lock.yaml",
+            content: "",
+            directory: "/"
           )
-        end
+        )
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
@@ -63,11 +63,17 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       let(:dependency_files) { project_dependency_files("grapher/npm_exact_versions_no_lockfile") }
 
       before do
-        # Mock lockfile generation to avoid network calls
+        # Mock lockfile generation to simulate failure
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-          generate: nil
-        )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+        ).tap do |gen|
+          allow(gen).to receive(:generate).and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "npm install failed",
+              error_context: {}
+            )
+          )
+        end
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -99,11 +105,17 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       let(:dependency_files) { project_dependency_files("grapher/npm_exact_versions_no_lockfile") }
 
       before do
-        # Mock lockfile generation to avoid network calls
+        # Mock lockfile generation to simulate failure
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-          generate: nil
-        )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+        ).tap do |gen|
+          allow(gen).to receive(:generate).and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "npm install failed",
+              error_context: {}
+            )
+          )
+        end
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -125,9 +137,15 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       context "when lockfile generation fails" do
         before do
           lockfile_generator = instance_double(
-            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-            generate: nil
-          )
+            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "npm install failed: authentication required",
+                error_context: {}
+              )
+            )
+          end
           allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
             .to receive(:new).and_return(lockfile_generator)
         end
@@ -140,6 +158,27 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
           expect(Dependabot.logger).to have_received(:info).with(/No lockfile found/)
           expect(Dependabot.logger).not_to have_received(:warn).with(/No lockfile was found/)
+        end
+
+        it "sets the error flag for degraded status" do
+          grapher.resolved_dependencies
+
+          expect(grapher.errored_fetching_subdependencies).to be(true)
+        end
+
+        it "preserves the original error as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          expect(grapher.subdependency_error.message).to include("npm install failed")
+        end
+
+        it "returns dependencies without relationship data" do
+          resolved_dependencies = grapher.resolved_dependencies
+
+          resolved_dependencies.each_value do |dep|
+            expect(dep.dependencies).to eq([])
+          end
         end
       end
 
@@ -197,9 +236,15 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-          generate: nil
-        )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+        ).tap do |gen|
+          allow(gen).to receive(:generate).and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "npm install failed",
+              error_context: {}
+            )
+          )
+        end
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -231,9 +276,15 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-          generate: nil
-        )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+        ).tap do |gen|
+          allow(gen).to receive(:generate).and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "yarn install failed",
+              error_context: {}
+            )
+          )
+        end
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end
@@ -265,9 +316,15 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
 
       before do
         lockfile_generator = instance_double(
-          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator,
-          generate: nil
-        )
+          Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+        ).tap do |gen|
+          allow(gen).to receive(:generate).and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "pnpm install failed",
+              error_context: {}
+            )
+          )
+        end
         allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
           .to receive(:new).and_return(lockfile_generator)
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
@@ -209,6 +209,11 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
           expect(Dependabot.logger).to have_received(:info).with(/No lockfile found/)
           expect(Dependabot.logger).to have_received(:warn).with(/No lockfile was found/)
         end
+
+        it "reports package.json as the relevant dependency file, not the ephemeral lockfile" do
+          grapher.resolved_dependencies
+          expect(grapher.relevant_dependency_file.name).to eq("package.json")
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

We've recently shipped dependency analysis for Python which put our 'ephemeral lockfile' strategy into production for the first time and we learned two things from this:
- We should attribute the dependencies to a _checked in file_ and not the file we generated on the file for consistency with existing DG behaviour
- We should *not* swallow ephemeral file generation errors, they should be propagated as a failure to fetch subdependencies for purposes of the graph job since it means we'll have direct dependencies and no futher information

We actually built this function out in npm first, so this PR backports our learnings into that implementation.

### Anything you want to highlight for special attention from reviewers?

There are a few things I have deferred doing in this PR but will follow up with:
- This case has highlighted that we could do better with some guided messaging when we are compensating for missing lockfiles - expanding our 'subdependencies failed' flag into a `failed, :reason` tuple would give us better handling
- Now that we have two cases using ephemeral lock generation we are starting to reach the point where adding the behaviour to the base class to ensure we are consistent on lifecycle and error handling might make sense

This is nuanced enough, I'd rather take a pass at this separately and we're still on the wrong side of the 'rule of threes' so I don't want to start making it generic too soon.

### How will you know you've accomplished your goal?

My test repository will now attribute its dependencies to `subproject/package.json` instead of a non-existing `package-lock.json`

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
