### PR TITLE
force all invocations of `dotnet msbuild` to ignore response files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -894,5 +894,65 @@ public partial class DiscoveryWorkerTests
                 }
             );
         }
+
+        [Fact]
+        public async Task MSBuildResponseFileDoesNotCauseDiscoveryFailure()
+        {
+            await TestDiscoveryAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0"),
+                ],
+                workspacePath: "",
+                files: [
+                    ("myproj.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net9.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Package" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("Directory.Build.props", "<Project />"),
+                    ("Directory.Build.targets", "<Project />"),
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageVersion Include="Some.Package" Version="1.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                    ("Directory.Build.rsp", """
+                        /this-is-not-a-supported-switch-and-would-normally-cause-a-discovery-failure
+                        """)
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "myproj.csproj",
+                            Dependencies = [
+                                new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            TargetFrameworks = ["net9.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "Directory.Build.props",
+                                "Directory.Build.targets",
+                                "Directory.Packages.props",
+                            ],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                }
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -318,7 +318,7 @@ namespace NuGetUpdater.Core.Test
                     </Project>
                     """
                 );
-                var (exitCode, stdout, stderr) = ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["msbuild", projectPath, "/t:_ReportCurrentSdkVersion"], projectDir.FullName).Result;
+                var (exitCode, stdout, stderr) = ProcessEx.RunDotNetMSBuildSafely([projectPath, "/t:_ReportCurrentSdkVersion"], projectDir.FullName).Result;
                 if (exitCode != 0)
                 {
                     throw new Exception($"Failed to report the current SDK version:\n{stdout}\n{stderr}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/MockNuGetPackage.cs
@@ -318,7 +318,7 @@ namespace NuGetUpdater.Core.Test
                     </Project>
                     """
                 );
-                var (exitCode, stdout, stderr) = ProcessEx.RunDotNetMSBuildSafely([projectPath, "/t:_ReportCurrentSdkVersion"], projectDir.FullName).Result;
+                var (exitCode, stdout, stderr) = ProcessEx.RunDotnetMSBuildSafelyAsync([projectPath, "/t:_ReportCurrentSdkVersion"], projectDir.FullName).Result;
                 if (exitCode != 0)
                 {
                     throw new Exception($"Failed to report the current SDK version:\n{stdout}\n{stderr}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -195,7 +195,7 @@ internal static class SdkProjectDiscovery
                 args.Add("/p:MSBuildTreatWarningsAsErrors=false");
                 args.Add($"/bl:{binLogPath}");
 
-                var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, startingProjectDirectory);
+                var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, startingProjectDirectory);
                 if (exitCode != 0 && stdOut.Contains("error : Object reference not set to an instance of an object."))
                 {
                     // https://github.com/NuGet/Home/issues/11761#issuecomment-1105218996
@@ -203,7 +203,7 @@ internal static class SdkProjectDiscovery
                     // but this argument can't always be added; it can cause problems in other instances, so we're taking the approach of not using it
                     // unless we have to.
                     args.Add("/RestoreProperty:__Unused__=__Unused__");
-                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, startingProjectDirectory);
+                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, startingProjectDirectory);
                 }
 
                 MSBuildHelper.ThrowOnError(stdOut);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -144,7 +144,7 @@ internal static class SdkProjectDiscovery
             try
             {
                 // when using single restore, we can directly invoke the relevant targets...
-                var args = new List<string>() { "msbuild", startingProjectPath };
+                var args = new List<string>() { startingProjectPath };
 
                 // ...but determining what the relevant targets are can be complicated
 
@@ -195,7 +195,7 @@ internal static class SdkProjectDiscovery
                 args.Add("/p:MSBuildTreatWarningsAsErrors=false");
                 args.Add($"/bl:{binLogPath}");
 
-                var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, startingProjectDirectory);
+                var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, startingProjectDirectory);
                 if (exitCode != 0 && stdOut.Contains("error : Object reference not set to an instance of an object."))
                 {
                     // https://github.com/NuGet/Home/issues/11761#issuecomment-1105218996
@@ -203,7 +203,7 @@ internal static class SdkProjectDiscovery
                     // but this argument can't always be added; it can cause problems in other instances, so we're taking the approach of not using it
                     // unless we have to.
                     args.Add("/RestoreProperty:__Unused__=__Unused__");
-                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, startingProjectDirectory);
+                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, startingProjectDirectory);
                 }
 
                 MSBuildHelper.ThrowOnError(stdOut);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -118,7 +118,7 @@ internal static class PackageReferenceUpdater
             // generate project.assets.json
             var parsedTargetFramework = NuGetFramework.Parse(targetFramework);
             var tempProject = await MSBuildHelper.CreateTempProjectAsync(tempDir, repoRoot, projectPath, targetFramework, topLevelDependencies, logger, importDependencyTargets: true);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely([tempProject, "/t:Restore,GenerateBuildDependencyFile"], tempDir.FullName);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync([tempProject, "/t:Restore,GenerateBuildDependencyFile"], tempDir.FullName);
             var assetsJsonPath = Path.Join(tempDir.FullName, "obj", "project.assets.json");
             var assetsJsonContent = await File.ReadAllTextAsync(assetsJsonPath);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -118,7 +118,7 @@ internal static class PackageReferenceUpdater
             // generate project.assets.json
             var parsedTargetFramework = NuGetFramework.Parse(targetFramework);
             var tempProject = await MSBuildHelper.CreateTempProjectAsync(tempDir, repoRoot, projectPath, targetFramework, topLevelDependencies, logger, importDependencyTargets: true);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["msbuild", tempProject, "/t:Restore,GenerateBuildDependencyFile"], tempDir.FullName);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely([tempProject, "/t:Restore,GenerateBuildDependencyFile"], tempDir.FullName);
             var assetsJsonPath = Path.Join(tempDir.FullName, "obj", "project.assets.json");
             var assetsJsonContent = await File.ReadAllTextAsync(assetsJsonPath);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -406,9 +406,8 @@ internal static partial class MSBuildHelper
         var (exitCode, stdOut, stdErr) = await HandleGlobalJsonAsync(projectDirectory, repoRoot, async () =>
         {
             var targetsHelperPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "TargetFrameworkReporter.targets");
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(
                 [
-                    "msbuild",
                     projectPath,
                     "/t:ReportTargetFramework",
                     $"/p:CustomAfterMicrosoftCommonCrossTargetingTargets={targetsHelperPath}",
@@ -524,11 +523,10 @@ internal static partial class MSBuildHelper
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
         var args = new[]
         {
-            "msbuild",
             projectPath,
             "-targets"
         };
-        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
+        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
         if (exitCode != 0)
         {
             logger.Warn($"Unable to determine targets for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
@@ -555,12 +553,11 @@ internal static partial class MSBuildHelper
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
         var args = new[]
         {
-            "msbuild",
             projectPath,
             $"-getProperty:{propertyName}"
         };
 
-        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
+        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
         if (exitCode != 0)
         {
             if (stdOut.Contains("error MSB1001: Unknown switch."))
@@ -580,12 +577,11 @@ internal static partial class MSBuildHelper
 
                     // do it
                     args = [
-                        "msbuild",
                         projectPath,
                         $"/p:CustomAfterMicrosoftCommonTargets={tempTargetsPath}",
                         "/t:_Dependabot_GetProperty",
                     ];
-                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
+                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
                     if (exitCode == 0)
                     {
                         var match = Regex.Match(stdOut, "__PROPERTY_VALUE:(?<PropertyValue>[^$]*)$", RegexOptions.Multiline);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -406,7 +406,7 @@ internal static partial class MSBuildHelper
         var (exitCode, stdOut, stdErr) = await HandleGlobalJsonAsync(projectDirectory, repoRoot, async () =>
         {
             var targetsHelperPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "TargetFrameworkReporter.targets");
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(
                 [
                     projectPath,
                     "/t:ReportTargetFramework",
@@ -526,7 +526,7 @@ internal static partial class MSBuildHelper
             projectPath,
             "-targets"
         };
-        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
+        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
         if (exitCode != 0)
         {
             logger.Warn($"Unable to determine targets for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
@@ -557,7 +557,7 @@ internal static partial class MSBuildHelper
             $"-getProperty:{propertyName}"
         };
 
-        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
+        var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
         if (exitCode != 0)
         {
             if (stdOut.Contains("error MSB1001: Unknown switch."))
@@ -581,7 +581,7 @@ internal static partial class MSBuildHelper
                         $"/p:CustomAfterMicrosoftCommonTargets={tempTargetsPath}",
                         "/t:_Dependabot_GetProperty",
                     ];
-                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotNetMSBuildSafely(args, projectDirectory);
+                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
                     if (exitCode == 0)
                     {
                         var match = Regex.Match(stdOut, "__PROPERTY_VALUE:(?<PropertyValue>[^$]*)$", RegexOptions.Multiline);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -6,6 +6,21 @@ namespace NuGetUpdater.Core;
 public static class ProcessEx
 {
     /// <summary>
+    /// Run `dotnet msbuild` with the given additional arguments.  The argument `-noAutoResponse` is always appended to
+    /// suppress `Directory.Build.rsp` inclusion.  This new set of arguments is then passed to the function
+    /// `RunDotnetWithoutMSBuildEnvironmentVariablesAsync` to prevent MSBuild from inheriting certain environment
+    /// variables.
+    /// </summary>
+    public static Task<(int ExitCode, string Output, string Error)> RunDotNetMSBuildSafely(
+        IEnumerable<string> arguments,
+        string workingDirectory,
+        IEnumerable<(string Name, string? Value)>? extraEnvironmentVariables = null
+    )
+    {
+        return RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["msbuild", .. arguments, "-noAutoResponse"], workingDirectory, extraEnvironmentVariables);
+    }
+
+    /// <summary>
     /// Run the `dotnet` command with the given values.  This will exclude all `MSBuild*` environment variables from the execution.
     /// </summary>
     public static Task<(int ExitCode, string Output, string Error)> RunDotnetWithoutMSBuildEnvironmentVariablesAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ProcessExtensions.cs
@@ -11,7 +11,7 @@ public static class ProcessEx
     /// `RunDotnetWithoutMSBuildEnvironmentVariablesAsync` to prevent MSBuild from inheriting certain environment
     /// variables.
     /// </summary>
-    public static Task<(int ExitCode, string Output, string Error)> RunDotNetMSBuildSafely(
+    public static Task<(int ExitCode, string Output, string Error)> RunDotnetMSBuildSafelyAsync(
         IEnumerable<string> arguments,
         string workingDirectory,
         IEnumerable<(string Name, string? Value)>? extraEnvironmentVariables = null


### PR DESCRIPTION
Fixes #10943

The special file `Directory.Build.rsp` is used to inject additional command line arguments to invocations of MSBuild but that can cause problems for dependabot if certain environmental assumptions are made.  E.g., it's not uncommon for that file to look like:

```
%SomeTelemetryCommand%
```

Where that Windows-style environment variable is expected to exist.  Since dependabot runs in a Linux container any call to `dotnet msbuild ...` will fail with `Unknown switch` complaining about that variable because it couldn't be expanded.

The approach taken here is to force all calls to `dotnet msbuild ...` through another helper that always appends the arugment `-noAutoResponse` which prevents the loading of `Directory.Build.rsp` files.

I've audited all calls to `dotnet msbuild ...` and updated them appropriately.  There are a few direct calls to the helper method `RunDotnetWithoutMSBuildEnvironmentVariablesAsync` but those instances are all done in a temporary directory and won't have `Directory.Build.rsp` upstream from them.

There is a small possibility that a given repo absolutely depended on some property getting set in the response file and now dependabot would fail, but I'm willing to bet that's very rare.  What's not all that rare, however, is dependabot failing because certain environmental assumptions are being made in this file that don't hold up for dependabot, so we can get better coverage by excluding the file entirely.