### PR TITLE
Add trailing slash when listing directories for Maven repositories

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -136,8 +136,11 @@ module Dependabot
         def fetch_dependency_metadata_from_html(repository_details)
           url = repository_details.fetch(URL_KEY)
           headers = repository_details.fetch(AUTH_HEADERS_KEY)
+          # Add trailing slash for directory listing
+          base_directory_url = dependency_base_url(url)
+          base_directory_url += "/" unless base_directory_url.end_with?("/")
           response = Dependabot::RegistryClient.get(
-            url: dependency_base_url(url),
+            url: base_directory_url,
             headers: headers
           )
           check_response(response, url)

--- a/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::Maven::Package::PackageDetailsFetcher do
   before do
     stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/maven-metadata.xml")
       .to_return(status: 200, body: fixture("maven_central_metadata", "with_release.xml"))
-    stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava")
+    stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/")
       .to_return(status: 200, body: fixture("maven_central_metadata", "with_release.html"))
     stub_request(:head, "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar")
       .to_return(status: 200)

--- a/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
@@ -485,11 +485,12 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
   describe "#fetch_dependency_metadata_from_html" do
     let(:base_url) { "#{maven_central}/com/google/guava/guava" }
+    let(:base_url_with_slash) { "#{base_url}/" }
     let(:repository_details) { { "url" => maven_central, "auth_headers" => {} } }
 
     context "when the registry returns a valid HTML response" do
       before do
-        stub_request(:get, base_url)
+        stub_request(:get, base_url_with_slash)
           .to_return(status: 200, body: fixture("maven_central_metadata", "with_release.html"))
       end
 
@@ -502,13 +503,27 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
     context "when the registry returns a 404" do
       before do
-        stub_request(:get, base_url).to_return(status: 404)
+        stub_request(:get, base_url_with_slash).to_return(status: 404)
       end
 
       it "returns nil" do
         result = client.fetch_dependency_metadata_from_html(repository_details)
 
         expect(result).to be_nil
+      end
+    end
+
+    context "when fetching HTML directory listing" do
+      before do
+        stub_request(:get, base_url_with_slash)
+          .to_return(status: 200, body: fixture("maven_central_metadata", "with_release.html"))
+      end
+
+      it "adds a trailing slash to the base URL for directory listing" do
+        result = client.fetch_dependency_metadata_from_html(repository_details)
+
+        expect(result).to be_a(Nokogiri::HTML::Document)
+        expect(WebMock).to have_requested(:get, base_url_with_slash).once
       end
     end
   end
@@ -738,10 +753,11 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
   describe "#dependency_metadata_from_html" do
     let(:base_url) { "#{maven_central}/com/google/guava/guava" }
+    let(:base_url_with_slash) { "#{base_url}/" }
     let(:repository_details) { { "url" => maven_central, "auth_headers" => {} } }
 
     before do
-      stub_request(:get, base_url)
+      stub_request(:get, base_url_with_slash)
         .to_return(status: 200, body: fixture("maven_central_metadata", "with_release.html"))
     end
 
@@ -757,6 +773,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
   describe "#versions" do
     let(:metadata_url) { "#{maven_central}/com/google/guava/guava/maven-metadata.xml" }
     let(:base_url) { "#{maven_central}/com/google/guava/guava" }
+    let(:base_url_with_slash) { "#{base_url}/" }
 
     before do
       stub_request(:get, metadata_url)
@@ -764,7 +781,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
           status: 200,
           body: fixture("maven_central_metadata", "with_release.xml")
         )
-      stub_request(:get, base_url)
+      stub_request(:get, base_url_with_slash)
         .to_return(
           status: 200,
           body: fixture("maven_central_metadata", "with_release.html")
@@ -798,7 +815,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
     context "when HTML fetch fails" do
       before do
-        stub_request(:get, base_url).to_raise(StandardError.new("boom"))
+        stub_request(:get, base_url_with_slash).to_raise(StandardError.new("boom"))
       end
 
       it "still returns versions from XML" do
@@ -857,10 +874,11 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
   describe "#versions_details_hash_from_html" do
     let(:base_url) { "#{maven_central}/com/google/guava/guava" }
+    let(:base_url_with_slash) { "#{base_url}/" }
 
     context "when the repository returns valid HTML" do
       before do
-        stub_request(:get, base_url)
+        stub_request(:get, base_url_with_slash)
           .to_return(
             status: 200,
             body: fixture("maven_central_metadata", "with_release.html")
@@ -879,7 +897,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
     context "when no HTML data is found" do
       before do
-        stub_request(:get, base_url).to_return(status: 404)
+        stub_request(:get, base_url_with_slash).to_return(status: 404)
       end
 
       it "returns an empty hash" do

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     "https://repo.maven.apache.org/maven2/" \
       "com/google/guava/guava/maven-metadata.xml"
   end
-  let(:maven_central_base_url) do
+  let(:maven_central_base_url_with_slash) do
     "https://repo.maven.apache.org/maven2/" \
-      "com/google/guava/guava"
+      "com/google/guava/guava/"
   end
   let(:maven_central_metadata_url_mockk) do
     "https://repo.maven.apache.org/maven2/io/mockk/mockk/maven-metadata.xml"
@@ -87,7 +87,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
   before do
     stub_request(:get, maven_central_metadata_url)
       .to_return(status: 200, body: maven_central_releases)
-    stub_request(:get, maven_central_base_url)
+    stub_request(:get, maven_central_base_url_with_slash)
       .to_return(status: 200, body: maven_central_release_base)
     stub_request(:head, maven_central_version_files_url)
       .to_return(status: 200)
@@ -751,7 +751,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
             status: 200,
             body: fixture("maven_central_metadata", "with_release.xml")
           )
-        stub_request(:get, jboss_base_url)
+        stub_request(:get, "#{jboss_base_url}/")
           .to_return(
             status: 200,
             body: fixture("maven_central_metadata", "with_release.html")


### PR DESCRIPTION
fixes #14842
it avoids having 302 redirects.
it should save around 100ms for each Maven Java dependency check.

co-authored-by: IBM Bob IDE 1.0.1

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
