### PR TITLE
add type for package management method

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1694,7 +1694,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ReferencedProjectPaths = ["referenced/a.csproj"],
             ImportedFiles = ["imported/a.props"],
             AdditionalFiles = ["a/packages.config"],
-            CentralPackageTransitivePinningEnabled = false,
+            PackageManagementKind = PackageManagementKind.Default,
         };
         var result2 = new ProjectDiscoveryResult()
         {
@@ -1709,7 +1709,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ReferencedProjectPaths = ["referenced/b.csproj"],
             ImportedFiles = ["imported/b.props"],
             AdditionalFiles = ["b/app.config"],
-            CentralPackageTransitivePinningEnabled = true,
+            PackageManagementKind = PackageManagementKind.CentralPackageManagement,
         };
 
         // to make sure we're checking everything exactly, we'll explicitly check each item
@@ -1736,7 +1736,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         AssertEx.Equal(["referenced/a.csproj", "referenced/b.csproj"], merged.ReferencedProjectPaths);
         AssertEx.Equal(["imported/a.props", "imported/b.props"], merged.ImportedFiles);
         AssertEx.Equal(["a/packages.config", "b/app.config"], merged.AdditionalFiles);
-        Assert.True(merged.CentralPackageTransitivePinningEnabled);
+        Assert.Equal(PackageManagementKind.CentralPackageManagement, merged.PackageManagementKind);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 
+using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Updater.FileWriters;
 
 using Xunit;
@@ -15,15 +16,14 @@ public abstract class FileWriterTestsBase
         ImmutableArray<string> initialProjectDependencyStrings,
         ImmutableArray<string> requiredDependencyStrings,
         (string path, string contents)[] expectedFiles,
-        bool useCentralPackageTransitivePinning = false
+        PackageManagementKind packageManagementKind = PackageManagementKind.Default
     )
     {
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(files);
         var repoContentsPath = new DirectoryInfo(tempDir.DirectoryPath);
         var initialProjectDependencies = initialProjectDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
         var requiredDependencies = requiredDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
-        var addPackageReferenceElementForPinnedPackages = !useCentralPackageTransitivePinning;
-        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, addPackageReferenceElementForPinnedPackages);
+        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind);
         Assert.True(success, "Expected UpdatePackageVersionsAsync to succeed.");
 
         var expectedFileNames = expectedFiles.Select(f => f.path).ToHashSet();
@@ -39,15 +39,14 @@ public abstract class FileWriterTestsBase
         (string path, string contents)[] files,
         ImmutableArray<string> initialProjectDependencyStrings,
         ImmutableArray<string> requiredDependencyStrings,
-        bool useCentralPackageTransitivePinning = false
+        PackageManagementKind packageManagementKind = PackageManagementKind.Default
     )
     {
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(files);
         var repoContentsPath = new DirectoryInfo(tempDir.DirectoryPath);
         var initialProjectDependencies = initialProjectDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
         var requiredDependencies = requiredDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
-        var addPackageReferenceElementForPinnedPackages = !useCentralPackageTransitivePinning;
-        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, addPackageReferenceElementForPinnedPackages);
+        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind);
         Assert.False(success);
 
         var expectedFileNames = files.Select(f => f.path).ToHashSet();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/TestFileWriterReturnsConstantResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/TestFileWriterReturnsConstantResult.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 
+using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Updater.FileWriters;
 
 namespace NuGetUpdater.Core.Test.Update.FileWriters;
@@ -13,7 +14,7 @@ internal class TestFileWriterReturnsConstantResult : IFileWriter
         Result = result;
     }
 
-    public Task<bool> UpdatePackageVersionsAsync(DirectoryInfo repoContentsPath, ImmutableArray<string> relativeFilePaths, ImmutableArray<Dependency> originalDependencies, ImmutableArray<Dependency> requiredPackageVersions, bool addPackageReferenceElementForPinnedPackages)
+    public Task<bool> UpdatePackageVersionsAsync(DirectoryInfo repoContentsPath, ImmutableArray<string> relativeFilePaths, ImmutableArray<Dependency> originalDependencies, ImmutableArray<Dependency> requiredPackageVersions, PackageManagementKind packageManagementKind)
     {
         return Task.FromResult(Result);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1,3 +1,4 @@
+using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Updater.FileWriters;
 
 using Xunit;
@@ -1558,7 +1559,7 @@ public class XmlFileWriterTests : FileWriterTestsBase
     public async Task SingleDependency_CentralPackageManagement_TransitiveIsPinned_NoExistingPackageVersionElement_TransitivePinningEnabled_OnlyPackagesPropsIsUpdated()
     {
         await TestAsync(
-            useCentralPackageTransitivePinning: true,
+            packageManagementKind: PackageManagementKind.CentralPackageManagementWithTransitivePinning,
             files: [
                 ("project.csproj", """
                     <Project Sdk="Microsoft.NET.Sdk">
@@ -1954,7 +1955,7 @@ public class XmlFileWriterTests : FileWriterTestsBase
     public async Task UpdatingAPinnedCentrallyManagedPackageUpdatesJustTheVersionNumberWhenDeclarationIsPresent()
     {
         await TestAsync(
-            useCentralPackageTransitivePinning: true,
+            packageManagementKind: PackageManagementKind.CentralPackageManagementWithTransitivePinning,
             files: [
                 ("src/project.csproj", """
                     <?xml version="1.0"?>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -470,7 +470,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             ReferencedProjectPaths = mergedReferencedProjects,
             ImportedFiles = mergedImportedFiles,
             AdditionalFiles = mergedAdditionalFiles,
-            CentralPackageTransitivePinningEnabled = result1.CentralPackageTransitivePinningEnabled || result2.CentralPackageTransitivePinningEnabled,
+            PackageManagementKind = (PackageManagementKind)Math.Max((int)result1.PackageManagementKind, (int)result2.PackageManagementKind),
         };
         return mergedResult;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackageManagementKind.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackageManagementKind.cs
@@ -1,0 +1,23 @@
+namespace NuGetUpdater.Core.Discover;
+
+public enum PackageManagementKind
+{
+    /// <summary>
+    /// The default for SDK-style projects, e.g., <code>&lt;PackageReference Include="Some.Package" Version="1.0.0" /&gt;</code>
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Separate <code>&lt;PackageReference&gt;</code> and <code>&lt;PackageVersion&gt;</code> elements.  Set by the
+    /// user by adding the property <code>&lt;ManagePackageVersionsCentrally&gt;true&lt;/ManagePackageVersionsCentrally&gt;</code>
+    /// and commonly using the file <code>Directory.Packages.props</code>
+    /// </summary>
+    CentralPackageManagement,
+
+    /// <summary>
+    /// Similar to <see cref="CentralPackageManagement"/> but with the additional property
+    /// <code>&lt;CentralPackageTransitivePinningEnabled&gt;true&lt;/CentralPackageTransitivePinningEnabled&gt;</code> which applies
+    /// <code>&lt;PackageVersion&gt;</code> elements for all transitive dependencies as well.
+    /// </summary>
+    CentralPackageManagementWithTransitivePinning,
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -14,5 +14,5 @@ public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
     public ImmutableArray<string> ReferencedProjectPaths { get; init; } = [];
     public required ImmutableArray<string> ImportedFiles { get; init; }
     public required ImmutableArray<string> AdditionalFiles { get; init; }
-    public bool CentralPackageTransitivePinningEnabled { get; init; } = false;
+    public PackageManagementKind PackageManagementKind { get; init; } = PackageManagementKind.Default;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -643,13 +643,19 @@ internal static class SdkProjectDiscovery
                 .Select(p => p.NormalizePathToUnix())
                 .OrderBy(p => p)
                 .ToImmutableArray();
-            var useCpmTransitivePinning =
+            var projectLevelCpm =
                 projectProperties.TryGetValue("ManagePackageVersionsCentrally", out var useCpmString) &&
                 bool.TryParse(useCpmString, out var useCpm) &&
-                useCpm &&
+                useCpm;
+            var projectLevelCpmWithPinning =
+                projectLevelCpm &&
                 projectProperties.TryGetValue("CentralPackageTransitivePinningEnabled", out var useTransitivePinningString) &&
                 bool.TryParse(useTransitivePinningString, out var useTransitivePinning) &&
                 useTransitivePinning;
+            var packageManagementKind =
+                projectLevelCpmWithPinning ? PackageManagementKind.CentralPackageManagementWithTransitivePinning :
+                projectLevelCpm ? PackageManagementKind.CentralPackageManagement :
+                PackageManagementKind.Default;
 
             var projectDiscoveryResult = new ProjectDiscoveryResult()
             {
@@ -659,7 +665,7 @@ internal static class SdkProjectDiscovery
                 ReferencedProjectPaths = referenced,
                 ImportedFiles = imported,
                 AdditionalFiles = additional,
-                CentralPackageTransitivePinningEnabled = useCpmTransitivePinning,
+                PackageManagementKind = packageManagementKind,
             };
             projectDiscoveryResults.Add(projectDiscoveryResult);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
@@ -408,8 +408,7 @@ public class FileWriterWorker
             .ToImmutableArray();
 
         // try update
-        var addPackageReferenceElementForPinnedPackages = !projectDiscovery.CentralPackageTransitivePinningEnabled;
-        var success = await fileWriter.UpdatePackageVersionsAsync(repoContentsPath, relativeFilePaths, projectDiscovery.Dependencies, requiredPackageVersions, addPackageReferenceElementForPinnedPackages);
+        var success = await fileWriter.UpdatePackageVersionsAsync(repoContentsPath, relativeFilePaths, projectDiscovery.Dependencies, requiredPackageVersions, projectDiscovery.PackageManagementKind);
         var updatedFiles = new List<string>();
         foreach (var (filePath, originalContents) in originalFileContents)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/IFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/IFileWriter.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGetUpdater.Core.Discover;
+
 namespace NuGetUpdater.Core.Updater.FileWriters;
 
 public interface IFileWriter
@@ -9,6 +11,6 @@ public interface IFileWriter
         ImmutableArray<string> relativeFilePaths,
         ImmutableArray<Dependency> originalDependencies,
         ImmutableArray<Dependency> requiredPackageVersions,
-        bool addPackageReferenceElementForPinnedPackages
+        PackageManagementKind packageManagementKind
     );
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -5,6 +5,7 @@ using Microsoft.Language.Xml;
 
 using NuGet.Versioning;
 
+using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core.Updater.FileWriters;
@@ -51,7 +52,7 @@ public class XmlFileWriter : IFileWriter
         ImmutableArray<string> relativeFilePaths,
         ImmutableArray<Dependency> originalDependencies,
         ImmutableArray<Dependency> requiredPackageVersions,
-        bool addPackageReferenceElementForPinnedPackages
+        PackageManagementKind packageManagementKind
     )
     {
         if (relativeFilePaths.IsDefaultOrEmpty)
@@ -185,6 +186,12 @@ public class XmlFileWriter : IFileWriter
                     .WithAttribute(IncludeAttributeName, requiredPackageVersion.Name);
 
                 // ...add the `<PackageReference>` element if and where appropriate...
+                var addPackageReferenceElementForPinnedPackages =
+                    packageManagementKind switch
+                    {
+                        PackageManagementKind.CentralPackageManagementWithTransitivePinning => false,
+                        _ => true,
+                    };
                 if (addPackageReferenceElementForPinnedPackages)
                 {
                     addItemGroup();


### PR DESCRIPTION
For SDK-style projects we currently only track a single boolean value; whether Central Package Management is enabled wtih transitive pinning.

To make future planned work easier, this is being turned into an enum with the following values/meanings:

- `Default` - regular SDK-style references like `<PackageReference Include="Some.Package" Version="1.0.0" />`
- `CentralPackageManagement` - `<PackageReference>` and `<PackageVersion>` elements are separate, commonly by using the file `Directory.Packages.props`.  Enabled by the user with the global property `ManagePackageVersionsCentrally`.
- `CentralPackageManagementWithPinning` - same as above but `<PackageReferences>` elements aren't always explicitly required.  Enabled by the user with the additional global property `CentralPackageTransitivePinningEnabled`.