### PR TITLE
[bun] Implement a first pass on graphing the bun package manager

### DIFF
--- a/bun/lib/dependabot/bun.rb
+++ b/bun/lib/dependabot/bun.rb
@@ -3,6 +3,7 @@
 
 # These all need to be required so the various classes can be registered in a
 # lookup table of package manager names to concrete classes.
+require "dependabot/bun/dependency_grapher"
 require "dependabot/bun/file_fetcher"
 require "dependabot/bun/file_parser"
 require "dependabot/bun/update_checker"

--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -1,0 +1,63 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency_graphers"
+require "dependabot/dependency_graphers/base"
+require "dependabot/bun/file_parser"
+require "dependabot/bun/bun_package_manager"
+
+module Dependabot
+  module Bun
+    class DependencyGrapher < Dependabot::DependencyGraphers::Base
+      extend T::Sig
+
+      sig { override.returns(Dependabot::DependencyFile) }
+      def relevant_dependency_file
+        lockfile || package_json
+      end
+
+      private
+
+      sig { override.params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
+      def fetch_subdependencies(dependency)
+        []
+      end
+
+      sig { override.params(_dependency: Dependabot::Dependency).returns(String) }
+      def purl_pkg_for(_dependency)
+        "npm"
+      end
+
+      sig { override.params(dependency: Dependabot::Dependency).returns(String) }
+      def purl_name_for(dependency)
+        dependency.name.sub(/^@/, "%40")
+      end
+
+      sig { returns(Dependabot::DependencyFile) }
+      def package_json
+        return T.must(@package_json) if defined?(@package_json)
+
+        T.must(
+          @package_json = T.let(
+            T.must(dependency_files.find { |f| f.name.end_with?("package.json") }),
+            T.nilable(Dependabot::DependencyFile)
+          )
+        )
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def lockfile
+        return @lockfile if defined?(@lockfile)
+
+        @lockfile = T.let(
+          dependency_files.find { |f| f.name.end_with?(BunPackageManager::LOCKFILE_NAME) },
+          T.nilable(Dependabot::DependencyFile)
+        )
+      end
+    end
+  end
+end
+
+Dependabot::DependencyGraphers.register("bun", Dependabot::Bun::DependencyGrapher)

--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 require "dependabot/dependency_graphers"
 require "dependabot/dependency_graphers/base"
 require "dependabot/bun/file_parser"
+require "dependabot/bun/file_parser/bun_lock"
 require "dependabot/bun/bun_package_manager"
 
 module Dependabot
@@ -22,7 +23,7 @@ module Dependabot
 
       sig { override.params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
       def fetch_subdependencies(dependency)
-        []
+        package_relationships.fetch(dependency.name, [])
       end
 
       sig { override.params(_dependency: Dependabot::Dependency).returns(String) }
@@ -55,6 +56,34 @@ module Dependabot
           dependency_files.find { |f| f.name.end_with?(BunPackageManager::LOCKFILE_NAME) },
           T.nilable(Dependabot::DependencyFile)
         )
+      end
+
+      sig { returns(T::Hash[String, T::Array[String]]) }
+      def package_relationships
+        @package_relationships ||= T.let(
+          fetch_package_relationships,
+          T.nilable(T::Hash[String, T::Array[String]])
+        )
+      end
+
+      sig { returns(T::Hash[String, T::Array[String]]) }
+      def fetch_package_relationships
+        return {} unless lockfile
+
+        parsed_lockfile = FileParser::BunLock.new(T.must(lockfile)).parsed
+        packages = parsed_lockfile.fetch("packages", nil)
+        return {} unless packages.is_a?(Hash)
+
+        # bun.lock entries are arrays: ["{name}@{version}", registry, {details}, integrity]
+        packages.each_with_object({}) do |(_key, entry), rels|
+          next unless entry.is_a?(Array) && entry.first.is_a?(String)
+
+          parent_name = T.must(T.cast(entry.first, String).split(/(?<=\w)\@/).first)
+          children = entry.dig(2, "dependencies")&.keys
+          next unless children&.any?
+
+          rels[parent_name] = children
+        end
       end
     end
   end

--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -19,6 +19,15 @@ module Dependabot
         lockfile || package_json
       end
 
+      sig { override.void }
+      def prepare!
+        if lockfile.nil?
+          Dependabot.logger.warn("No bun.lock found; dependency graph will be incomplete.")
+          errored_fetching_subdependencies!
+        end
+        super
+      end
+
       private
 
       sig { override.params(dependency: Dependabot::Dependency).returns(T::Array[String]) }

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -101,5 +101,60 @@ RSpec.describe Dependabot::Bun::DependencyGrapher do
         expect(scoped.runtime).to be(true)
       end
     end
+
+    context "with a lockfile containing subdependencies" do
+      let(:dependency_files) { project_dependency_files("bun/grapher_with_subdeps") }
+
+      it "includes subdependency edges for direct packages with children" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        fetch_factory = resolved_dependencies["pkg:npm/fetch-factory@0.0.1"]
+        expect(fetch_factory).not_to be_nil
+        expect(fetch_factory.direct).to be(true)
+        expect(fetch_factory.dependencies).to contain_exactly(
+          "pkg:npm/es6-promise@3.3.1",
+          "pkg:npm/isomorphic-fetch@2.2.1",
+          "pkg:npm/lodash@3.10.1"
+        )
+      end
+
+      it "includes subdependency edges for transitive packages with children" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        isomorphic_fetch = resolved_dependencies["pkg:npm/isomorphic-fetch@2.2.1"]
+        expect(isomorphic_fetch).not_to be_nil
+        expect(isomorphic_fetch.direct).to be(false)
+        expect(isomorphic_fetch.dependencies).to contain_exactly(
+          "pkg:npm/node-fetch@1.7.3",
+          "pkg:npm/whatwg-fetch@3.6.20"
+        )
+      end
+
+      it "reports leaf packages with empty dependencies" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        lodash = resolved_dependencies["pkg:npm/lodash@3.10.1"]
+        expect(lodash).not_to be_nil
+        expect(lodash.direct).to be(false)
+        expect(lodash.dependencies).to eq([])
+
+        safer_buffer = resolved_dependencies["pkg:npm/safer-buffer@2.1.2"]
+        expect(safer_buffer).not_to be_nil
+        expect(safer_buffer.direct).to be(false)
+        expect(safer_buffer.dependencies).to eq([])
+      end
+
+      it "correctly resolves deep dependency chains" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        node_fetch = resolved_dependencies["pkg:npm/node-fetch@1.7.3"]
+        expect(node_fetch).not_to be_nil
+        expect(node_fetch.direct).to be(false)
+        expect(node_fetch.dependencies).to contain_exactly(
+          "pkg:npm/encoding@0.1.13",
+          "pkg:npm/is-stream@1.1.0"
+        )
+      end
+    end
   end
 end

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -1,0 +1,105 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bun"
+require "dependabot/dependency_graphers"
+
+RSpec.describe Dependabot::Bun::DependencyGrapher do
+  subject(:grapher) do
+    Dependabot::DependencyGraphers.for_package_manager("bun").new(
+      file_parser: parser
+    )
+  end
+
+  let(:parser) do
+    Dependabot::FileParsers.for_package_manager("bun").new(
+      dependency_files: dependency_files,
+      repo_contents_path: nil,
+      source: source,
+      credentials: credentials
+    )
+  end
+
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "github",
+      repo: "test/bun-project",
+      directory: "/",
+      branch: "main"
+    )
+  end
+
+  let(:credentials) do
+    [
+      Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      )
+    ]
+  end
+
+  describe "#relevant_dependency_file" do
+    context "when a lockfile exists" do
+      let(:dependency_files) { project_dependency_files("bun/grapher_with_lockfile") }
+
+      it "returns the bun.lock file" do
+        expect(grapher.relevant_dependency_file.name).to eq("bun.lock")
+      end
+    end
+
+    context "when no lockfile exists" do
+      let(:dependency_files) { project_dependency_files("javascript/exact_version_requirements_no_lockfile") }
+
+      it "returns the package.json" do
+        expect(grapher.relevant_dependency_file.name).to eq("package.json")
+      end
+    end
+  end
+
+  describe "#resolved_dependencies" do
+    context "with a lockfile present" do
+      let(:dependency_files) { project_dependency_files("bun/grapher_with_lockfile") }
+
+      it "correctly serializes the resolved dependencies" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        expect(resolved_dependencies.count).to eq(3)
+      end
+
+      it "identifies direct runtime dependencies" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        is_number = resolved_dependencies["pkg:npm/is-number@7.0.0"]
+        expect(is_number).not_to be_nil
+        expect(is_number.package_url).to eq("pkg:npm/is-number@7.0.0")
+        expect(is_number.direct).to be(true)
+        expect(is_number.runtime).to be(true)
+      end
+
+      it "identifies direct dev dependencies" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        etag = resolved_dependencies["pkg:npm/etag@1.8.1"]
+        expect(etag).not_to be_nil
+        expect(etag.package_url).to eq("pkg:npm/etag@1.8.1")
+        expect(etag.direct).to be(true)
+        expect(etag.runtime).to be(false)
+      end
+
+      it "handles scoped package names in PURLs" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        scoped = resolved_dependencies["pkg:npm/%40scope/package@1.2.0"]
+        expect(scoped).not_to be_nil
+        expect(scoped.package_url).to eq("pkg:npm/%40scope/package@1.2.0")
+        expect(scoped.direct).to be(true)
+        expect(scoped.runtime).to be(true)
+      end
+    end
+  end
+end

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Dependabot::Bun::DependencyGrapher do
       it "returns the package.json" do
         expect(grapher.relevant_dependency_file.name).to eq("package.json")
       end
+
+      it "sets the errored_fetching_subdependencies flag" do
+        grapher.resolved_dependencies
+
+        expect(grapher.errored_fetching_subdependencies).to be(true)
+      end
+
+      it "returns dependencies with empty relationship data" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        expect(resolved_dependencies).not_to be_empty
+        resolved_dependencies.each_value do |dep|
+          expect(dep.dependencies).to eq([])
+        end
+      end
     end
   end
 

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -156,5 +156,46 @@ RSpec.describe Dependabot::Bun::DependencyGrapher do
         )
       end
     end
+
+    context "when the lockfile is corrupt" do
+      let(:dependency_files) { project_dependency_files("bun/grapher_with_subdeps") }
+
+      before do
+        # Pre-populate dependencies via the parser (which reads the valid lockfile)
+        grapher.send(:prepare!)
+        # Swap in a corrupt lockfile for relationship extraction
+        corrupt_lockfile = Dependabot::DependencyFile.new(
+          name: "bun.lock", content: "not valid {{{", directory: "/"
+        )
+        grapher.instance_variable_set(:@lockfile, corrupt_lockfile)
+      end
+
+      it "sets the errored_fetching_subdependencies flag" do
+        grapher.resolved_dependencies
+
+        expect(grapher.errored_fetching_subdependencies).to be(true)
+      end
+
+      it "stores the parse error as subdependency_error" do
+        grapher.resolved_dependencies
+
+        expect(grapher.subdependency_error).to be_a(Dependabot::DependencyFileNotParseable)
+      end
+
+      it "returns dependencies with empty relationship data" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        expect(resolved_dependencies).not_to be_empty
+        resolved_dependencies.each_value do |dep|
+          expect(dep.dependencies).to eq([])
+        end
+      end
+    end
+  end
+
+  describe "registration" do
+    it "registers as the grapher for the bun package manager" do
+      expect(Dependabot::DependencyGraphers.for_package_manager("bun")).to eq(described_class)
+    end
   end
 end

--- a/bun/spec/fixtures/projects/bun/grapher_with_lockfile/bun.lock
+++ b/bun/spec/fixtures/projects/bun/grapher_with_lockfile/bun.lock
@@ -1,0 +1,22 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "grapher-test",
+      "dependencies": {
+        "is-number": "^7.0.0",
+        "@scope/package": "^1.0.0",
+      },
+      "devDependencies": {
+        "etag": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@scope/package": ["@scope/package@1.2.0", "", {}, "sha512-abc123=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/grapher_with_lockfile/package.json
+++ b/bun/spec/fixtures/projects/bun/grapher_with_lockfile/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "grapher-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-number": "^7.0.0",
+    "@scope/package": "^1.0.0"
+  },
+  "devDependencies": {
+    "etag": "^1.0.0"
+  }
+}

--- a/bun/spec/fixtures/projects/bun/grapher_with_subdeps/bun.lock
+++ b/bun/spec/fixtures/projects/bun/grapher_with_subdeps/bun.lock
@@ -1,0 +1,37 @@
+{
+  "lockfileVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "grapher-subdeps-test",
+      "dependencies": {
+        "fetch-factory": "^0.0.1",
+      },
+      "devDependencies": {
+        "etag": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "fetch-factory": ["fetch-factory@0.0.1", "", { "dependencies": { "es6-promise": "^3.0.2", "isomorphic-fetch": "^2.1.1", "lodash": "^3.10.1" } }, "sha512-gexRwqIhwzDJ2pJvL0UYfiZwW06/bdYWxAmswFFts7C87CF8i6liApihTk7TZFYMDcQjvvDIvyHv0q379z0aWA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+
+    "isomorphic-fetch": ["isomorphic-fetch@2.2.1", "", { "dependencies": { "node-fetch": "^1.0.1", "whatwg-fetch": ">=0.10.0" } }, "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA=="],
+
+    "lodash": ["lodash@3.10.1", "", {}, "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="],
+
+    "node-fetch": ["node-fetch@1.7.3", "", { "dependencies": { "encoding": "^0.1.11", "is-stream": "^1.0.1" } }, "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/grapher_with_subdeps/package.json
+++ b/bun/spec/fixtures/projects/bun/grapher_with_subdeps/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "grapher-subdeps-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "fetch-factory": "^0.0.1"
+  },
+  "devDependencies": {
+    "etag": "^1.0.0"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

This follows our established pattern to implement a Dependency Grapher that can extract a snapshot from bun projects.

There's nothing especially novel or tricky about this one ✨ 

### Anything you want to highlight for special attention from reviewers?

The one nuance in this one is that I've made no attempt to generate a `bun.lock` if we're given only a package.json as that is an edge case for us right now - if we are analysing a directory which only has a `package.json` file then we would detect this as an 'npm' project and route it to that ecosystem instead.

This is good enough for a first pass, but I think it creates a gap in how graphing behaves for CLI users so I do plan to follow up and add this capability even though we may not use it when we run graphing jobs internally as part of the service.[^1]

[^1]: There's a further corner case here, if someone checks in a Dependabot config with `package_manager: bun` and private registries, but does not check in their `bun.lock` then unless we honour the configuration we'll fail to generate an ephemeral file properly since we will run the job with `package_manager: npm` configuration and drop the registry access. This makes it every unlikely we'll use ephemeral generation in the service imo.

### How will you know you've accomplished your goal?

I can use the Dependabot CLI to get a full dependency graph, including transitives, from a bun project[^2]

[^2]: Service event handlers are NYI for bun.lock changes so I will be testing this as a cli tool for now

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
