### PR TITLE
[bun] Add lockfile generator for bun

### DIFF
--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -14,16 +14,20 @@ module Dependabot
     class DependencyGrapher < Dependabot::DependencyGraphers::Base
       extend T::Sig
 
+      require_relative "dependency_grapher/lockfile_generator"
+
       sig { override.returns(Dependabot::DependencyFile) }
       def relevant_dependency_file
+        return package_json if @ephemeral_lockfile_generated
+
         lockfile || package_json
       end
 
       sig { override.void }
       def prepare!
         if lockfile.nil?
-          Dependabot.logger.warn("No bun.lock found; dependency graph will be incomplete.")
-          errored_fetching_subdependencies!
+          Dependabot.logger.info("No bun.lock found, generating ephemeral lockfile for dependency graphing")
+          generate_ephemeral_lockfile!
         end
         super
       end
@@ -43,6 +47,33 @@ module Dependabot
       sig { override.params(dependency: Dependabot::Dependency).returns(String) }
       def purl_name_for(dependency)
         dependency.name.sub(/^@/, "%40")
+      end
+
+      sig { void }
+      def generate_ephemeral_lockfile!
+        generator = LockfileGenerator.new(
+          dependency_files: dependency_files,
+          credentials: file_parser.credentials
+        )
+
+        ephemeral_lockfile = generator.generate
+        inject_ephemeral_lockfile(ephemeral_lockfile)
+        @ephemeral_lockfile_generated = T.let(true, T.nilable(T::Boolean))
+
+        Dependabot.logger.info("Successfully generated ephemeral bun.lock for dependency graphing")
+      rescue StandardError => e
+        errored_fetching_subdependencies!
+        @subdependency_error = e
+        Dependabot.logger.warn(
+          "Failed to generate ephemeral bun.lock: #{e.message}. " \
+          "Dependency versions may not be resolved."
+        )
+      end
+
+      sig { params(ephemeral_lockfile: Dependabot::DependencyFile).void }
+      def inject_ephemeral_lockfile(ephemeral_lockfile)
+        dependency_files << ephemeral_lockfile
+        remove_instance_variable(:@lockfile) if instance_variable_defined?(:@lockfile)
       end
 
       sig { returns(Dependabot::DependencyFile) }

--- a/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
@@ -1,0 +1,94 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+require "dependabot/shared_helpers"
+require "dependabot/bun/helpers"
+require "dependabot/bun/bun_package_manager"
+
+module Dependabot
+  module Bun
+    class DependencyGrapher < Dependabot::DependencyGraphers::Base
+      class LockfileGenerator
+        extend T::Sig
+
+        sig do
+          params(
+            dependency_files: T::Array[Dependabot::DependencyFile],
+            credentials: T::Array[Dependabot::Credential]
+          ).void
+        end
+        def initialize(dependency_files:, credentials:)
+          @dependency_files = dependency_files
+          @credentials = credentials
+        end
+
+        sig { returns(Dependabot::DependencyFile) }
+        def generate
+          SharedHelpers.in_a_temporary_directory do
+            write_temporary_files
+            run_lockfile_generation
+            read_generated_lockfile
+          end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          handle_generation_error(e)
+          raise
+        end
+
+        private
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
+
+        sig { void }
+        def write_temporary_files
+          dependency_files.each do |file|
+            next unless file.name.end_with?("package.json", ".npmrc")
+
+            path = file.name
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, file.content)
+          end
+        end
+
+        sig { void }
+        def run_lockfile_generation
+          Dependabot.logger.info("Generating bun.lock for dependency graphing")
+          Helpers.run_bun_command("install --ignore-scripts", fingerprint: "install --ignore-scripts")
+        end
+
+        sig { returns(Dependabot::DependencyFile) }
+        def read_generated_lockfile
+          lockfile_name = BunPackageManager::LOCKFILE_NAME
+
+          unless File.exist?(lockfile_name)
+            Dependabot.logger.error("#{lockfile_name} was not generated")
+            raise Dependabot::DependencyFileNotEvaluatable, "#{lockfile_name} was not generated"
+          end
+
+          Dependabot::DependencyFile.new(
+            name: lockfile_name,
+            content: File.read(lockfile_name),
+            directory: package_json_directory
+          )
+        end
+
+        sig { returns(String) }
+        def package_json_directory
+          package_json = dependency_files.find { |f| f.name.end_with?("package.json") }
+          package_json&.directory || "/"
+        end
+
+        sig { params(error: SharedHelpers::HelperSubprocessFailed).void }
+        def handle_generation_error(error)
+          Dependabot.logger.error("Failed to generate bun.lock: #{error.message}")
+        end
+      end
+    end
+  end
+end

--- a/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher/lockfile_generator.rb
@@ -7,6 +7,7 @@ require "dependabot/dependency_file"
 require "dependabot/shared_helpers"
 require "dependabot/bun/helpers"
 require "dependabot/bun/bun_package_manager"
+require "dependabot/bun/file_updater/npmrc_builder"
 
 module Dependabot
   module Bun
@@ -54,6 +55,20 @@ module Dependabot
             FileUtils.mkdir_p(File.dirname(path))
             File.write(path, file.content)
           end
+
+          write_npmrc_from_credentials unless dependency_files.any? { |f| f.name.end_with?(".npmrc") }
+        end
+
+        sig { void }
+        def write_npmrc_from_credentials
+          npmrc_content = FileUpdater::NpmrcBuilder.new(
+            credentials: credentials,
+            dependency_files: dependency_files
+          ).npmrc_content
+
+          return if npmrc_content.strip.empty?
+
+          File.write(".npmrc", npmrc_content)
         end
 
         sig { void }

--- a/bun/spec/dependabot/bun/dependency_grapher/lockfile_generator_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher/lockfile_generator_spec.rb
@@ -1,0 +1,145 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bun/dependency_grapher"
+require "dependabot/bun/dependency_grapher/lockfile_generator"
+
+RSpec.describe Dependabot::Bun::DependencyGrapher::LockfileGenerator do
+  subject(:generator) do
+    described_class.new(
+      dependency_files: dependency_files,
+      credentials: credentials
+    )
+  end
+
+  let(:credentials) do
+    [
+      Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      )
+    ]
+  end
+
+  let(:dependency_files) { project_dependency_files("javascript/exact_version_requirements_no_lockfile") }
+
+  describe "#generate" do
+    context "when lockfile generation succeeds" do
+      let(:lockfile_content) do
+        fixture("projects", "bun", "grapher_with_lockfile", "bun.lock")
+      end
+
+      it "runs bun install with --ignore-scripts" do
+        allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_return("")
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with("bun.lock").and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with("bun.lock").and_return(lockfile_content)
+
+        generator.generate
+
+        expect(Dependabot::Bun::Helpers).to have_received(:run_bun_command)
+          .with("install --ignore-scripts", fingerprint: "install --ignore-scripts")
+      end
+
+      it "returns a DependencyFile with the generated lockfile" do
+        allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_return("")
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with("bun.lock").and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with("bun.lock").and_return(lockfile_content)
+
+        result = generator.generate
+
+        expect(result).to be_a(Dependabot::DependencyFile)
+        expect(result.name).to eq("bun.lock")
+        expect(result.content).to eq(lockfile_content)
+      end
+    end
+
+    context "when lockfile generation fails" do
+      it "re-raises the error after logging" do
+        allow(Dependabot::Bun::Helpers).to receive(:run_bun_command)
+          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                       message: "bun install failed: authentication required",
+                       error_context: {}
+                     ))
+
+        expect(Dependabot.logger).to receive(:error).with(/Failed to generate bun.lock/)
+
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      end
+    end
+
+    context "when bun.lock is not generated" do
+      it "raises DependencyFileNotEvaluatable" do
+        allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_return("")
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with("bun.lock").and_return(false)
+
+        expect { generator.generate }.to raise_error(
+          Dependabot::DependencyFileNotEvaluatable,
+          /bun.lock was not generated/
+        )
+      end
+    end
+  end
+
+  describe "file writing" do
+    it "writes package.json and .npmrc files to the temporary directory" do
+      npmrc_file = Dependabot::DependencyFile.new(
+        name: ".npmrc",
+        content: "registry=https://npm.pkg.github.com",
+        directory: "/"
+      )
+      files_with_npmrc = dependency_files + [npmrc_file]
+
+      generator_with_npmrc = described_class.new(
+        dependency_files: files_with_npmrc,
+        credentials: credentials
+      )
+
+      allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_return("")
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("bun.lock").and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with("bun.lock").and_return("{}")
+
+      # Verify files are written during generation
+      expect(File).to receive(:write).with("package.json", anything)
+      expect(File).to receive(:write).with(".npmrc", "registry=https://npm.pkg.github.com")
+
+      generator_with_npmrc.generate
+    end
+
+    it "does not write lockfiles or other non-manifest files" do
+      lockfile = Dependabot::DependencyFile.new(
+        name: "bun.lock",
+        content: "{}",
+        directory: "/"
+      )
+      files_with_lock = dependency_files + [lockfile]
+
+      generator_with_lock = described_class.new(
+        dependency_files: files_with_lock,
+        credentials: credentials
+      )
+
+      allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_return("")
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("bun.lock").and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with("bun.lock").and_return("{}")
+
+      expect(File).to receive(:write).with("package.json", anything)
+      expect(File).not_to receive(:write).with("bun.lock", anything)
+
+      generator_with_lock.generate
+    end
+  end
+end

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -55,22 +55,68 @@ RSpec.describe Dependabot::Bun::DependencyGrapher do
     context "when no lockfile exists" do
       let(:dependency_files) { project_dependency_files("javascript/exact_version_requirements_no_lockfile") }
 
-      it "returns the package.json" do
-        expect(grapher.relevant_dependency_file.name).to eq("package.json")
+      context "when lockfile generation succeeds" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::Bun::DependencyGrapher::LockfileGenerator,
+            generate: Dependabot::DependencyFile.new(
+              name: "bun.lock",
+              content: fixture("projects", "bun", "grapher_with_lockfile", "bun.lock"),
+              directory: "/"
+            )
+          )
+          allow(Dependabot::Bun::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
+
+        it "returns the package.json as the relevant file" do
+          grapher.resolved_dependencies
+          expect(grapher.relevant_dependency_file.name).to eq("package.json")
+        end
+
+        it "does not set the error flag" do
+          grapher.resolved_dependencies
+
+          expect(grapher.errored_fetching_subdependencies).to be(false)
+        end
       end
 
-      it "sets the errored_fetching_subdependencies flag" do
-        grapher.resolved_dependencies
+      context "when lockfile generation fails" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::Bun::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "bun install failed: authentication required",
+                error_context: {}
+              )
+            )
+          end
+          allow(Dependabot::Bun::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
 
-        expect(grapher.errored_fetching_subdependencies).to be(true)
-      end
+        it "sets the errored_fetching_subdependencies flag" do
+          grapher.resolved_dependencies
 
-      it "returns dependencies with empty relationship data" do
-        resolved_dependencies = grapher.resolved_dependencies
+          expect(grapher.errored_fetching_subdependencies).to be(true)
+        end
 
-        expect(resolved_dependencies).not_to be_empty
-        resolved_dependencies.each_value do |dep|
-          expect(dep.dependencies).to eq([])
+        it "preserves the original error as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          expect(grapher.subdependency_error.message).to include("bun install failed")
+        end
+
+        it "returns dependencies with empty relationship data" do
+          resolved_dependencies = grapher.resolved_dependencies
+
+          expect(resolved_dependencies).not_to be_empty
+          resolved_dependencies.each_value do |dep|
+            expect(dep.dependencies).to eq([])
+          end
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

In my previous PR I implemented a bun Dependency Grapher component:
- https://github.com/dependabot/dependabot-core/pull/14881

In this first past I elected not to implement the "ephemeral lockfile" behaviour as we are not likely to actually use this behaviour as part of the service - for now we just treat `package.json` only directories as npm and use that ecosystem to 'fill in the blanks'.

Our support for bun in Dependency Graph is currently 'package.json' only, so we aren't heavily using this ecosystem but it leaves a capability gap in this ecosystem to not round out the behaviour with this - and we may need it in future once we clarify configuration that allows users to prefer bun over npm in all their dependency workflows.

### Anything you want to highlight for special attention from reviewers?

Nothing in particular, this is fairly self-contained and treads the same path we've used in npm and Python.

### How will you know you've accomplished your goal?

I can point the Dependabot cli at a project with only a package.json and have it use bun to extrapolate the transitive dependency list on the fly.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
