### PR TITLE
Fix Maven "No files changed!" error for externally managed dependency versions

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -60,6 +60,8 @@ module Dependabot
             next req if property_name && !properties_to_update.include?(property_name)
 
             new_req = update_requirement(req[:requirement])
+            next req if new_req == req[:requirement]
+
             req.merge(requirement: new_req, source: updated_source)
           end
         end

--- a/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
@@ -68,6 +68,35 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
         end
       end
 
+      context "when the latest version matches the current requirement" do
+        let(:pom_req_string) { "23.6-jre" }
+        let(:latest_version) { version_class.new("23.6-jre") }
+
+        it "does not update the requirement or source" do
+          expect(updater.updated_requirements.first).to eq(pom_req)
+        end
+      end
+
+      context "when only source metadata differs but requirement is unchanged" do
+        let(:pom_req) do
+          {
+            file: "pom.xml",
+            requirement: "1.46.0",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "jar" }
+          }
+        end
+        let(:pom_req_string) { "1.46.0" }
+        let(:latest_version) { version_class.new("1.46.0") }
+
+        it "returns the original requirement without updating source" do
+          result = updater.updated_requirements.first
+          expect(result).to eq(pom_req)
+          expect(result[:source]).to be_nil
+        end
+      end
+
       context "when the version is including capitals" do
         let(:pom_req_string) { "23.3.RELEASE" }
 
@@ -128,6 +157,28 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
                 requirement: "[23.0,)",
                 groups: [],
                 source: nil
+              }
+            )
+          end
+        end
+
+        context "when one requirement is already at the latest version" do
+          let(:pom_req_string) { "23.6-jre" }
+          let(:other_requirement_string) { "23.3-jre" }
+
+          it "only updates the outdated requirement" do
+            expect(updater.updated_requirements).to contain_exactly(
+              {
+                file: "pom.xml",
+                requirement: "23.6-jre",
+                groups: [],
+                source: nil
+              },
+              {
+                file: "another/pom.xml",
+                requirement: "23.6-jre",
+                groups: [],
+                source: { type: "maven_repo", url: "new_url" }
               }
             )
           end


### PR DESCRIPTION
## Summary

When Maven dependencies have versions managed externally (e.g., via a parent POM or BOM import), the `UpdateChecker` may determine a new version is available while the requirement string in the fetched POM files remains unchanged. Previously, `RequirementsUpdater` would still update the `source` metadata on these requirements, creating a superficial diff that caused `FileUpdater` to attempt an update, find no actual content change, and raise a `RuntimeError("No files changed!")` — which gets reported to Sentry as an unknown error.

## Root Cause

In `RequirementsUpdater#updated_requirements`, when `update_requirement` produces the same version string as the original, the code was still merging `source: updated_source` into the requirement hash. This meant `FileUpdater` saw a "changed" requirement pair (e.g., `source: nil` → `source: {type: "maven_repo", ...}`) and tried to update the POM, but the actual version content was identical — triggering the safety-net error.

## Fix

Added a guard in `RequirementsUpdater#updated_requirements`: if `update_requirement` returns the same string as the current requirement, return the original requirement unchanged (no source metadata update). This prevents phantom changes from flowing downstream to `FileUpdater`.

The `"No files changed!"` `RuntimeError` remains as a safety net for genuine bugs — it is intentionally not a handled `DependabotError` so it continues to report to Sentry.

## Example

Observed in [apache/camel](https://github.com/apache/camel/actions/runs/25051274995/job/73379414017) where dependencies like `com.google.auth:google-auth-library-oauth2-http` and `org.slf4j:jcl-over-slf4j` have versions managed via properties in `parent/pom.xml`, which Dependabot does not fetch.

## Changes

- **`maven/lib/dependabot/maven/update_checker/requirements_updater.rb`**: Skip updating source when the requirement string is unchanged
- **`maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb`**: Added 3 specs covering: version matches current requirement, source-only metadata diff, and multi-requirement with one already at latest version