### PR TITLE
Fix Maven released? check for non-jar packaging types (e.g., aar)

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -66,7 +66,7 @@ module Dependabot
           "#{dependency_base_url(repository_url)}/#{MAVEN_METADATA_XML}"
         end
 
-        # URL for a specific artifact file (JAR/POM).
+        # URL for a specific artifact file (JAR/AAR/etc).
         #
         # Example:
         #   "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
@@ -79,6 +79,15 @@ module Dependabot
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"
 
           "#{base_url}/#{version}/#{artifact_id}-#{version}#{actual_classifier}.#{type}"
+        end
+
+        # URL for the POM file of a specific version.
+        # Every published Maven artifact has a .pom file regardless of packaging type.
+        sig { params(repository_url: String, version: Dependabot::Version).returns(String) }
+        def dependency_pom_url(repository_url, version)
+          _, artifact_id = dependency_parts
+          base_url = dependency_base_url(repository_url)
+          "#{base_url}/#{version}/#{artifact_id}-#{version}.pom"
         end
 
         # -- Metadata Fetching (XML) --
@@ -304,7 +313,20 @@ module Dependabot
                 url: dependency_files_url(url, version),
                 headers: headers
               )
-              response.status < 400
+              next true if response.status < 400
+
+              # When the artifact file returns 404, fall back to checking the .pom file.
+              # This handles artifacts with non-jar packaging (e.g., aar, bundle) where
+              # the consumer POM omits <type>, causing the parser to default to "jar".
+              # Only fall back when there's no classifier (classifier artifacts are specific).
+              next false unless response.status == 404
+              next false if dependency.requirements.first&.dig(:metadata, :classifier)
+
+              pom_response = Dependabot::RegistryClient.head(
+                url: dependency_pom_url(url, version),
+                headers: headers
+              )
+              pom_response.status < 400
             rescue Excon::Error::Socket, Excon::Error::Timeout,
                    Excon::Error::TooManyRedirects
               false

--- a/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe Dependabot::Maven::Package::PackageDetailsFetcher do
       # Update the URL stub to simulate a 404 (not found) response for an unreleased version
       stub_request(:head, "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.7-jre/guava-23.7-jre.jar")
         .to_return(status: 404)
+      stub_request(:head, "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.7-jre/guava-23.7-jre.pom")
+        .to_return(status: 404)
 
       unreleased_version = Dependabot::Maven::Version.new("23.7-jre")
       expect(fetcher.released?(unreleased_version)).to be(false)

--- a/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
@@ -152,6 +152,16 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
     end
   end
 
+  describe "#dependency_pom_url" do
+    let(:version) { Dependabot::Maven::Version.new("23.6-jre") }
+
+    it "constructs the POM file URL" do
+      url = client.dependency_pom_url(maven_central, version)
+
+      expect(url).to eq("#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom")
+    end
+  end
+
   describe "#extract_metadata_from_xml" do
     let(:xml_body) do
       <<~XML
@@ -463,11 +473,63 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
     end
 
     context "when the artifact does not exist" do
+      let(:pom_url) { "#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom" }
+
+      before do
+        stub_request(:head, artifact_url).to_return(status: 404)
+        stub_request(:head, pom_url).to_return(status: 404)
+      end
+
+      it "returns false" do
+        expect(client.released?(version)).to be(false)
+      end
+    end
+
+    context "when the jar returns 404 but the pom exists (non-jar packaging like aar)" do
+      let(:pom_url) { "#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom" }
+
+      before do
+        stub_request(:head, artifact_url).to_return(status: 404)
+        stub_request(:head, pom_url).to_return(status: 200)
+      end
+
+      it "falls back to the pom check and returns true" do
+        expect(client.released?(version)).to be(true)
+      end
+    end
+
+    context "when the artifact returns a non-404 error" do
+      before do
+        stub_request(:head, artifact_url).to_return(status: 401)
+      end
+
+      it "does not fall back to the pom check" do
+        expect(client.released?(version)).to be(false)
+      end
+    end
+
+    context "when a classifier is present and jar returns 404" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: dependency_version,
+          requirements: [{
+            requirement: "23.3-jre",
+            file: "pom.xml",
+            groups: ["dependencies"],
+            source: nil,
+            metadata: { packaging_type: "jar", classifier: "sources" }
+          }],
+          package_manager: "maven"
+        )
+      end
+      let(:artifact_url) { "#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre-sources.jar" }
+
       before do
         stub_request(:head, artifact_url).to_return(status: 404)
       end
 
-      it "returns false" do
+      it "does not fall back to the pom check" do
         expect(client.released?(version)).to be(false)
       end
     end
@@ -498,8 +560,11 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
     end
 
     context "when the result is false" do
+      let(:pom_url) { "#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom" }
+
       before do
         stub_request(:head, artifact_url).to_return(status: 404)
+        stub_request(:head, pom_url).to_return(status: 404)
       end
 
       it "caches false results without re-requesting" do
@@ -513,6 +578,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
     context "with multiple repositories" do
       let(:private_repo) { "https://private.repo.example.com/maven2" }
       let(:private_artifact_url) { "#{private_repo}/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar" }
+      let(:private_pom_url) { "#{private_repo}/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom" }
       let(:repositories) do
         [
           { "url" => private_repo, "auth_headers" => {} },
@@ -522,6 +588,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
 
       before do
         stub_request(:head, private_artifact_url).to_return(status: 404)
+        stub_request(:head, private_pom_url).to_return(status: 404)
         stub_request(:head, artifact_url).to_return(status: 200)
       end
 

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -148,6 +148,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       before do
         stub_request(:head, maven_central_version_files_url)
           .to_return(status: 404)
+        stub_request(:head, maven_central_version_files_url.sub(/\.jar$/, ".pom"))
+          .to_return(status: 404)
         stub_request(:head, old_maven_central_version_files_url)
           .to_return(status: 200)
       end
@@ -461,6 +463,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
           stub_request(:head, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/10.0/guava-10.0-jre.jar")
             .to_return(status: 200)
           stub_request(:head, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/23.6-jre/guava-23.6-jre.jar")
+            .to_return(status: 404)
+          stub_request(:head, "https://repo.jenkins-ci.org/releases/com/google/guava/guava/23.6-jre/guava-23.6-jre.pom")
             .to_return(status: 404)
 
           # In central, we have a newer version
@@ -824,6 +828,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
 
       before do
         stub_request(:head, maven_central_version_files_url)
+          .to_return(status: 404)
+        stub_request(:head, maven_central_version_files_url.sub(/\.jar$/, ".pom"))
           .to_return(status: 404)
         stub_request(:head, next_maven_central_version_files_url)
           .to_return(status: 200)


### PR DESCRIPTION
### What are you trying to accomplish?

When a Maven artifact uses non-jar packaging (e.g., `aar`), but the consumer POM omits `<type>`, the parser defaults to `"jar"`. This causes `released?()` to HEAD-check `.jar` URLs that always return 404, wasting ~2 minutes per run.

For example, `io.grpc:grpc-cronet` is packaged as `aar` — the `.jar` never exists, but the `.pom` always does.

Now `released?` falls back to a `.pom` HEAD check when the artifact returns 404 (only when no classifier is present).

Fixes https://github.com/dependabot/dependabot-core/issues/14843

### Anything you want to highlight for special attention from reviewers?

The fallback is intentionally narrow:
- Only triggers on 404 (not 401/403/500)
- Skipped when a classifier is present
- Uses `.pom` since every published Maven artifact has one

### How will you know you have accomplished your goal?

All related Maven tests pass (133 examples, 0 failures), including 4 new test cases covering the fallback behavior.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.