### PR TITLE
allow insecure feeds if explicitly requested

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -183,7 +183,12 @@ function Get-NuGetConfigContents([PSObject[]]$creds) {
         $sourceName = "nuget_source_$i"
         $i++
         $url = $cred.url
-        $customSourceLines += "    <add key=`"$sourceName`" value=`"$url`" />"
+        $insecureAttr = ""
+        if ($url.StartsWith("http://")) {
+            $insecureAttr = "allowInsecureConnections=`"true`" "
+        }
+
+        $customSourceLines += "    <add key=`"$sourceName`" value=`"$url`" $insecureAttr/>"
     }
 
     $lines = @()

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -153,6 +153,25 @@ try {
             '  </packageSources>',
             '</configuration>'
         )
+
+    Test-NuGetConfig `
+        -scenarioName "insecure-connections" `
+        -jobString @"
+{
+  "credentials-metadata": [
+    {"type":"nuget_feed", "url":"http://nuget.example.com/insecure/index.json"}
+  ]
+}
+"@ `
+        -expectedLines @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>',
+            '  <packageSources>',
+            '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />',
+            '    <add key="nuget_source_1" value="http://nuget.example.com/insecure/index.json" allowInsecureConnections="true" />',
+            '  </packageSources>',
+            '</configuration>'
+        )
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
A repo can specify custom NuGet feeds either directly with `dependabot.yml` or indirectly from their org configuration.  These values are then used to generate a `NuGet.Config` file that might be used during an update job.

If a feed uses `http://` instead of `https://` then NuGet can complain with `NU1803` about the insecure connection.  Since dependabot is simply honoring the user's feeds, we need to allow this.

The fix is to detect `http://` and add the `allowInsecureConnections` attribute.