### PR TITLE
Rescue errors in metadata_cascades_for_dep to prevent PR message loss

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -801,6 +801,9 @@ module Dependabot
           vulnerabilities_fixed: vulnerabilities_fixed[dependency.name],
           github_redirection_service: github_redirection_service
         ).to_s
+      rescue StandardError => e
+        suppress_error("metadata cascades for #{dependency.name}", e)
+        ""
       end
 
       sig { returns(String) }

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1122,9 +1122,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           stub_request(:any, /.*/).to_raise(SocketError)
         end
 
-        it "has a blank message" do
+        it "still builds the pr_message without the metadata cascade" do
           expect(pr_message)
-            .to eq("")
+            .to include("Bumps [business](https://github.com/gocardless/business) from 1.4.0 to 1.5.0.")
         end
       end
 
@@ -1153,6 +1153,20 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "#{commits}" \
               "<br />\n"
             )
+        end
+      end
+
+      context "when github.com is unreachable while fetching metadata" do
+        before do
+          allow_any_instance_of(Dependabot::PullRequestCreator::MessageBuilder::MetadataPresenter)
+            .to receive(:to_s)
+            .and_raise(SocketError, "Connection refused - connect(2) for \"api.github.com\" port 443")
+        end
+
+        it "still builds the pr_message without the metadata cascade" do
+          expect(pr_message).to include(
+            "Bumps [business](https://github.com/gocardless/business) from 1.4.0 to 1.5.0."
+          )
         end
       end
 
@@ -1935,6 +1949,27 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "</details>\n" \
               "<br />\n"
             )
+        end
+
+        context "when one dependency's metadata cascade raises" do
+          before do
+            stub_request(
+              :get,
+              "https://api.github.com/repos/gocardless/statesman/contents/CHANGELOG.md?ref=master"
+            ).to_raise(SocketError, "Connection refused - connect(2) for \"api.github.com\" port 443")
+          end
+
+          it "still renders the PR message with the unaffected dependency's metadata" do
+            expect(pr_message).to include(
+              "Bumps [business](https://github.com/gocardless/business) " \
+              "and [statesman](https://github.com/gocardless/statesman). " \
+              "These dependencies needed to be updated together."
+            )
+            expect(pr_message).to include("Updates `business` from 1.4.0 to 1.5.0")
+            expect(pr_message).to include("business's changelog")
+            expect(pr_message).to include("Updates `statesman` from 1.6.0 to 1.7.0")
+            expect(pr_message).not_to include("statesman's changelog")
+          end
         end
 
         context "when dealing with a property dependency (e.g., with Maven)" do


### PR DESCRIPTION
### What are you trying to accomplish?

When `metadata_cascades_for_dep` encounters a network error (e.g., GitHub API timeout), it now gracefully handles the failure by returning an empty string and logging the error via `suppress_error`. This allows the PR message to be assembled without the metadata cascade sections (changelog, commits, releases) but still includes the important intro line and message content.

Previously, any error in metadata fetching would propagate up to `pr_message`'s top-level rescue, causing the entire PR body to be discarded and replaced with just the header and footer (or an empty string).

Fixes #14904

### Reproduction steps

**Minimal setup** - a Maven project with a public GitHub-hosted dependency:

```xml
<!-- pom.xml -->
<project>
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.example</groupId>
  <artifactId>app</artifactId>
  <version>1.0.0</version>
  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>31.0-jre</version>
    </dependency>
  </dependencies>
</project>
```

**How to trigger the bug** - block `api.github.com` during PR message generation to simulate a GitHub API timeout:

```bash
# In a shell where you'll run the updater, add a hosts entry to block GitHub API:
echo "0.0.0.0 api.github.com" >> /etc/hosts
```

**Updater CLI flow:**

```bash
# Run the updater against a real or test repo with the above pom.xml
bin/dependabot update maven --repo <owner>/<repo> --dependency guava
```

**Observed pr-body before this patch:**

```
(empty string. The entire body was discarded.)
```

The error `SocketError: Failed to open TCP connection to api.github.com:443` was raised inside `MetadataPresenter#to_s`, propagated through `metadata_cascades_for_dep` up to `pr_message`'s top-level rescue, which returned only `suffixed_pr_message_header + prefixed_pr_message_footer`. When no custom header/footer is configured, this produces an empty string.

**Observed pr-body after this patch:**

```
Bumps [guava](https://github.com/google/guava) from 31.0-jre to 32.0-jre.
```

The intro line is preserved. Metadata sections (changelog, commits, releases) are omitted for the affected dependency only.

**Test-level reproduction** (no network blocking needed):

```ruby
# Stubs MetadataPresenter#to_s to raise for a single-dependency PR
allow_any_instance_of(MetadataPresenter).to receive(:to_s)
  .and_raise(SocketError, 'Connection refused for api.github.com')

# In a grouped PR, one dependency's cascade raises while the other renders normally
stub_request(:get, "https://api.github.com/repos/.../CHANGELOG.md?ref=master")
  .to_raise(SocketError, 'Connection refused for api.github.com')
```

Both cases are covered by the new regression tests in `message_builder_spec.rb`.

### Anything you want to highlight for special attention from reviewers?

- The rescue is scoped to `metadata_cascades_for_dep`, not `pr_message`, so only the enrichment content (changelog, commits, releases) for the failing dependency is dropped. The intro/body is preserved.
- For grouped PRs, a failure in one dependency's metadata cascade does not affect other dependencies' metadata sections.

### How will you know you've accomplished your goal?

The existing and new tests pass, including:
- Single dependency: `metadata_cascades_for_dep` raises, PR message retains intro
- Single dependency: `MetadataPresenter#to_s` raises directly, PR message retains intro
- Grouped PR: one dependency's metadata raises, other dependency's metadata still renders

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.