### PR TITLE
fix(helm): support digest-pinned image tags in values.yaml

### DIFF
--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -123,14 +123,26 @@ module Dependabot
             next unless req[:metadata][:type] == :docker_image
 
             tag_value = req[:source][:tag]
+            next if tag_value.nil?
+
+            # The YAML scalar may be either the bare tag (e.g. "v1.6.41") or a
+            # digest-pinned tag (e.g. "v1.6.41@sha256:..."). Match both shapes
+            # so digest-pinned values still get updated. The digest portion is
+            # left intact -- we don't have a new digest to swap in here, and
+            # silently dropping the user's pin would be worse than producing a
+            # clearly-stale digest the user can refresh manually.
             version_scalar = value_node.children.find do |node|
-              node.is_a?(Psych::Nodes::Scalar) && node.value == tag_value
+              next false unless node.is_a?(Psych::Nodes::Scalar)
+
+              node.value == tag_value || node.value.start_with?("#{tag_value}@")
             end
 
-            if version_scalar
-              line = version_scalar.start_line
-              content[line] = T.must(content[line]).gsub(tag_value, dependency_version)
-            end
+            next unless version_scalar
+
+            line = version_scalar.start_line
+            old_scalar = version_scalar.value
+            new_scalar = old_scalar.sub(tag_value, dependency_version)
+            content[line] = T.must(content[line]).sub(old_scalar, new_scalar)
           end
 
           content

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -40,7 +40,11 @@ module Dependabot
 
         sig { params(yaml_stream: Psych::Nodes::Stream, content: String).returns(String) }
         def update_image_tags_recursive(yaml_stream, content)
-          updated_content = content.dup.split("\n")
+          # Use a -1 limit so split preserves trailing empty fields. Without
+          # this, "foo\n".split("\n") returns ["foo"] and the join below drops
+          # the trailing newline, producing a spurious diff that masks the
+          # "no change" guard below.
+          updated_content = content.dup.split("\n", -1)
 
           yaml_stream.children.each do |document|
             document.children.each do |root_node|

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -100,8 +100,7 @@ module Dependabot
           has_dependency = contains_dependency?(value_node, dependency_name)
           return content unless has_dependency
 
-          dependency_version = T.must(dependency.version)
-          update_version_tags(value_node, content, dependency_version)
+          update_version_tags(value_node, content)
         end
 
         sig { params(node: Psych::Nodes::Node, dependency_name: String).returns(T::Boolean) }
@@ -114,38 +113,70 @@ module Dependabot
         sig do
           params(
             value_node: Psych::Nodes::Mapping,
-            content: T::Array[String],
-            dependency_version: String
+            content: T::Array[String]
           ).returns(T::Array[String])
         end
-        def update_version_tags(value_node, content, dependency_version)
-          dependency.requirements.each do |req|
-            next unless req[:metadata][:type] == :docker_image
+        def update_version_tags(value_node, content)
+          dependency.requirements.each do |new_req|
+            next unless new_req.dig(:metadata, :type) == :docker_image
 
-            tag_value = req[:source][:tag]
-            next if tag_value.nil?
-
-            # The YAML scalar may be either the bare tag (e.g. "v1.6.41") or a
-            # digest-pinned tag (e.g. "v1.6.41@sha256:..."). Match both shapes
-            # so digest-pinned values still get updated. The digest portion is
-            # left intact -- we don't have a new digest to swap in here, and
-            # silently dropping the user's pin would be worse than producing a
-            # clearly-stale digest the user can refresh manually.
-            version_scalar = value_node.children.find do |node|
-              next false unless node.is_a?(Psych::Nodes::Scalar)
-
-              node.value == tag_value || node.value.start_with?("#{tag_value}@")
-            end
-
-            next unless version_scalar
-
-            line = version_scalar.start_line
-            old_scalar = version_scalar.value
-            new_scalar = old_scalar.sub(tag_value, dependency_version)
-            content[line] = T.must(content[line]).sub(old_scalar, new_scalar)
+            apply_image_requirement(new_req, value_node, content)
           end
 
           content
+        end
+
+        sig do
+          params(
+            new_req: T::Hash[Symbol, T.untyped],
+            value_node: Psych::Nodes::Mapping,
+            content: T::Array[String]
+          ).void
+        end
+        def apply_image_requirement(new_req, value_node, content)
+          old_req = matching_previous_requirement(new_req) || new_req
+          old_tag = old_req.dig(:source, :tag)
+          return if old_tag.nil?
+
+          version_scalar = find_version_scalar(value_node, old_tag)
+          return unless version_scalar
+
+          new_tag = new_req.dig(:source, :tag) || T.must(dependency.version)
+          old_digest = old_req.dig(:source, :digest)
+          new_digest = new_req.dig(:source, :digest)
+
+          old_scalar = version_scalar.value
+          new_scalar = old_scalar.sub(old_tag, new_tag)
+          new_scalar = new_scalar.sub(old_digest, new_digest) if old_digest && new_digest
+
+          line = version_scalar.start_line
+          content[line] = T.must(content[line]).sub(old_scalar, new_scalar)
+        end
+
+        # Match scalars of the bare tag (e.g. "v1.6.41") and the digest-pinned
+        # form (e.g. "v1.6.41@sha256:..."). In the latter case the caller
+        # replaces the tag and the digest in lockstep so the user's pin keeps
+        # pointing at the new image.
+        sig do
+          params(
+            value_node: Psych::Nodes::Mapping,
+            old_tag: String
+          ).returns(T.nilable(Psych::Nodes::Scalar))
+        end
+        def find_version_scalar(value_node, old_tag)
+          match = value_node.children.find do |node|
+            next false unless node.is_a?(Psych::Nodes::Scalar)
+
+            node.value == old_tag || node.value.start_with?("#{old_tag}@")
+          end
+          T.cast(match, T.nilable(Psych::Nodes::Scalar))
+        end
+
+        sig { params(new_req: T::Hash[Symbol, T.untyped]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        def matching_previous_requirement(new_req)
+          (dependency.previous_requirements || []).find do |req|
+            req[:file] == new_req[:file] && req.dig(:metadata, :type) == :docker_image
+          end
         end
       end
     end

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -44,6 +44,7 @@ module Dependabot
           updated_metadata = req.fetch(:metadata).dup
           updated_req = req.dup
           updated_req[:requirement] = latest_version.to_s if updated_metadata.key?(:type)
+          updated_req[:source] = updated_image_source(req.fetch(:source)) if updated_metadata[:type] == :docker_image
 
           updated_req
         end
@@ -304,38 +305,83 @@ module Dependabot
 
       sig { returns(T.nilable(Gem::Version)) }
       def fetch_latest_image_version
-        docker_dependency = build_docker_dependency
+        checker = docker_checker
+        return nil unless checker
 
-        Dependabot.logger.info("Delegating to Docker UpdateChecker for image: #{docker_dependency.name}")
-
-        docker_checker = if cooldown_enabled?
-                           Dependabot::UpdateCheckers.for_package_manager("docker").new(
-                             dependency: docker_dependency,
-                             dependency_files: dependency_files,
-                             credentials: credentials,
-                             ignored_versions: ignored_versions,
-                             security_advisories: security_advisories,
-                             raise_on_ignored: raise_on_ignored,
-                             update_cooldown: update_cooldown
-                           )
-                         else
-                           Dependabot::UpdateCheckers.for_package_manager("docker").new(
-                             dependency: docker_dependency,
-                             dependency_files: dependency_files,
-                             credentials: credentials,
-                             ignored_versions: ignored_versions,
-                             security_advisories: security_advisories,
-                             raise_on_ignored: raise_on_ignored
-                           )
-                         end
-
-        latest_version = docker_checker.latest_version
-
+        latest_version = checker.latest_version
         Dependabot.logger.info("Docker UpdateChecker found latest version: #{latest_version || 'none'}")
 
-        return unless docker_checker.can_update?(requirements_to_unlock: :none)
+        return unless checker.can_update?(requirements_to_unlock: :none)
 
         version_class.new(latest_version)
+      end
+
+      # Memoized docker UpdateChecker used both for the version lookup and for
+      # resolving a fresh digest via #updated_image_source. Calling
+      # #updated_requirements on it triggers a manifest_digest call against the
+      # registry, so we want to share one instance per Helm checker.
+      sig { returns(T.nilable(Dependabot::UpdateCheckers::Base)) }
+      def docker_checker
+        return @docker_checker if defined?(@docker_checker)
+
+        Dependabot.logger.info("Delegating to Docker UpdateChecker for image: #{dependency.name}")
+        klass = Dependabot::UpdateCheckers.for_package_manager("docker")
+        args = {
+          dependency: build_docker_dependency,
+          dependency_files: dependency_files,
+          credentials: credentials,
+          ignored_versions: ignored_versions,
+          security_advisories: security_advisories,
+          raise_on_ignored: raise_on_ignored
+        }
+        args[:update_cooldown] = update_cooldown if cooldown_enabled?
+
+        @docker_checker = T.let(klass.new(**args), T.nilable(Dependabot::UpdateCheckers::Base))
+      end
+
+      # Asks the docker UpdateChecker for the new tag (and new digest, if the
+      # original source was digest-pinned).
+      #
+      # The DependencyFileNotResolvable raise below is a defensive guard. In
+      # practice the docker UpdateChecker treats "couldn't resolve a digest"
+      # as "up-to-date" (see Dependabot::Docker::UpdateChecker#digest_up_to_date?),
+      # so #latest_version returns nil and we never reach this method when the
+      # registry isn't returning digest headers. But if that contract ever
+      # changes -- or if the docker checker resolves a tag bump but somehow
+      # produces a source without :digest -- emitting a YAML update that
+      # bumps only the tag would be wrong: Docker resolves `tag@digest`
+      # references by digest, so the new pull would still resolve to the old
+      # image. Fail loudly rather than produce a misleading diff.
+      sig { params(old_source: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      def updated_image_source(old_source)
+        new_source = old_source.dup
+        new_source[:tag] = latest_version.to_s
+
+        return new_source unless old_source[:digest]
+
+        new_digest = fetch_new_image_digest
+        if new_digest.nil?
+          raise Dependabot::DependencyFileNotResolvable,
+                "Cannot update digest-pinned image #{dependency.name} to #{latest_version}: " \
+                "registry did not return a manifest digest for the new tag"
+        end
+
+        new_source[:digest] = new_digest
+        new_source
+      end
+
+      sig { returns(T.nilable(String)) }
+      def fetch_new_image_digest
+        checker = docker_checker
+        return nil unless checker
+
+        docker_req = checker.updated_requirements.first
+        docker_req&.dig(:source, :digest)
+      rescue StandardError => e
+        Dependabot.logger.warn(
+          "Failed to fetch new digest for #{dependency.name}: #{e.class}: #{e.message}"
+        )
+        nil
       end
 
       sig { params(tags: T::Array[String], repo_url: String).returns(T::Array[GitTagWithDetail]) }
@@ -384,6 +430,12 @@ module Dependabot
 
         registry = source[:registry] || nil
 
+        # Propagate any digest the parser found so the docker UpdateChecker
+        # resolves a fresh digest in #updated_requirements (it gates digest
+        # lookup on `digest || pin_digests?`).
+        docker_source = { registry: registry, tag: version }
+        docker_source[:digest] = source[:digest] if source[:digest]
+
         Dependency.new(
           name: name,
           version: version,
@@ -391,10 +443,7 @@ module Dependabot
             requirement: nil,
             groups: [],
             file: T.must(dependency.requirements.first)[:file],
-            source: {
-              registry: registry,
-              tag: version
-            }
+            source: docker_source
           }],
           package_manager: "docker"
         )

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -327,9 +327,47 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
         YAML
       end
 
-      it "processes the image tag and preserving complex structures" do
-        updated_content = updater.updated_values_yaml_content("values.yaml")
-        expect(updated_content).to include("- 1.20.0")
+      # Arrays of tags aren't a real Helm pattern -- there's no scalar tag to
+      # update -- so the updater should fail loudly rather than silently
+      # producing a no-op diff (which the trailing-newline guard previously
+      # allowed through as a spurious newline-only PR).
+      it "raises rather than producing a no-op diff" do
+        expect { updater.updated_values_yaml_content("values.yaml") }
+          .to raise_error("Expected content to change!")
+      end
+    end
+
+    context "when the input ends with a trailing newline and no tag matches" do
+      # Regression test: previously the split("\n").join("\n") round-trip
+      # silently dropped the trailing newline, producing a non-empty diff
+      # even when no tag scalar matched. The guard would then fail to fire
+      # and dependabot would open a spurious newline-only PR.
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            registry: "docker.io",
+            repository: "nginx",
+            tag: "wrong-tag"
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) do
+        <<~YAML
+          image:
+            repository: nginx
+            tag: 1.20.0
+        YAML
+      end
+
+      it "raises rather than producing a no-op diff" do
+        expect { updater.updated_values_yaml_content("values.yaml") }
+          .to raise_error("Expected content to change!")
       end
     end
   end

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -370,5 +370,62 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
           .to raise_error("Expected content to change!")
       end
     end
+
+    context "with a digest-pinned tag (tag@sha256:...)" do
+      let(:digest) { "sha256:ef895fdef7a8ea2a12cf421cd56b13c3bb65c806a09ea75a8284a78736ae5da5" }
+
+      let(:fixture_content) do
+        <<~YAML
+          image:
+            repository: nginx
+            tag: "1.20.0@#{digest}"
+            pullPolicy: IfNotPresent
+        YAML
+      end
+
+      it "updates only the tag portion and preserves the digest" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+        expect(updated_content).to include(%(tag: "1.21.0@#{digest}"))
+        expect(updated_content).not_to include("1.20.0@")
+      end
+
+      it "preserves the trailing newline" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+        expect(updated_content).to end_with("\n")
+      end
+
+      context "when the tag is unquoted" do
+        let(:fixture_content) do
+          <<~YAML
+            image:
+              repository: nginx
+              tag: 1.20.0@#{digest}
+          YAML
+        end
+
+        it "updates only the tag portion and preserves the digest" do
+          updated_content = updater.updated_values_yaml_content("values.yaml")
+          expect(updated_content).to include("tag: 1.21.0@#{digest}")
+          expect(updated_content).not_to include("1.20.0@")
+        end
+      end
+
+      context "when the tag line has a trailing comment" do
+        let(:fixture_content) do
+          <<~YAML
+            image:
+              repository: nginx
+              tag: "1.20.0@#{digest}"  # keep in lockstep with upstream
+          YAML
+        end
+
+        it "updates the tag and preserves the trailing comment" do
+          updated_content = updater.updated_values_yaml_content("values.yaml")
+          expect(updated_content)
+            .to include(%(tag: "1.21.0@#{digest}"  # keep in lockstep with upstream))
+          expect(updated_content).not_to include("1.20.0@")
+        end
+      end
+    end
   end
 end

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
   let(:dependency_name) { "nginx" }
   let(:dependency_version) { "1.21.0" }
   let(:dependency_previous_version) { "1.20.0" }
+  let(:dependency_new_digest) { nil }
+  let(:dependency_old_digest) { nil }
   let(:dependency_requirements) do
     [{
       file: "values.yaml",
@@ -32,8 +34,9 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
         type: "docker_registry",
         registry: "docker.io",
         repository: "nginx",
-        tag: dependency_previous_version
-      },
+        tag: dependency_version,
+        digest: dependency_new_digest
+      }.compact,
       metadata: { type: :docker_image }
     }]
   end
@@ -46,8 +49,9 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
         type: "docker_registry",
         registry: "docker.io",
         repository: "nginx",
-        tag: dependency_previous_version
-      },
+        tag: dependency_previous_version,
+        digest: dependency_old_digest
+      }.compact,
       metadata: { type: :docker_image }
     }]
   end
@@ -211,8 +215,11 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
       end
     end
 
-    context "when tag does not match" do
-      let(:dependency_requirements) do
+    context "when the recorded previous tag is not present in the YAML" do
+      # The file updater matches the YAML scalar against the OLD tag
+      # (previous_requirements), so a previous tag that doesn't appear in the
+      # values file should produce no change and trigger the guard.
+      let(:dependency_previous_requirements) do
         [{
           file: "values.yaml",
           requirement: nil,
@@ -342,7 +349,7 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
       # silently dropped the trailing newline, producing a non-empty diff
       # even when no tag scalar matched. The guard would then fail to fire
       # and dependabot would open a spurious newline-only PR.
-      let(:dependency_requirements) do
+      let(:dependency_previous_requirements) do
         [{
           file: "values.yaml",
           requirement: nil,
@@ -372,21 +379,23 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
     end
 
     context "with a digest-pinned tag (tag@sha256:...)" do
-      let(:digest) { "sha256:ef895fdef7a8ea2a12cf421cd56b13c3bb65c806a09ea75a8284a78736ae5da5" }
+      let(:dependency_old_digest) { "sha256:ef895fdef7a8ea2a12cf421cd56b13c3bb65c806a09ea75a8284a78736ae5da5" }
+      let(:dependency_new_digest) { "sha256:abc123aaaa00000000000000000000000000000000000000000000000000000a" }
 
       let(:fixture_content) do
         <<~YAML
           image:
             repository: nginx
-            tag: "1.20.0@#{digest}"
+            tag: "1.20.0@#{dependency_old_digest}"
             pullPolicy: IfNotPresent
         YAML
       end
 
-      it "updates only the tag portion and preserves the digest" do
+      it "updates the tag and replaces the old digest with the new one" do
         updated_content = updater.updated_values_yaml_content("values.yaml")
-        expect(updated_content).to include(%(tag: "1.21.0@#{digest}"))
+        expect(updated_content).to include(%(tag: "1.21.0@#{dependency_new_digest}"))
         expect(updated_content).not_to include("1.20.0@")
+        expect(updated_content).not_to include(dependency_old_digest)
       end
 
       it "preserves the trailing newline" do
@@ -399,14 +408,15 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
           <<~YAML
             image:
               repository: nginx
-              tag: 1.20.0@#{digest}
+              tag: 1.20.0@#{dependency_old_digest}
           YAML
         end
 
-        it "updates only the tag portion and preserves the digest" do
+        it "updates the tag and the digest" do
           updated_content = updater.updated_values_yaml_content("values.yaml")
-          expect(updated_content).to include("tag: 1.21.0@#{digest}")
+          expect(updated_content).to include("tag: 1.21.0@#{dependency_new_digest}")
           expect(updated_content).not_to include("1.20.0@")
+          expect(updated_content).not_to include(dependency_old_digest)
         end
       end
 
@@ -415,15 +425,16 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
           <<~YAML
             image:
               repository: nginx
-              tag: "1.20.0@#{digest}"  # keep in lockstep with upstream
+              tag: "1.20.0@#{dependency_old_digest}"  # keep in lockstep with upstream
           YAML
         end
 
-        it "updates the tag and preserves the trailing comment" do
+        it "updates the tag and digest while preserving the trailing comment" do
           updated_content = updater.updated_values_yaml_content("values.yaml")
           expect(updated_content)
-            .to include(%(tag: "1.21.0@#{digest}"  # keep in lockstep with upstream))
+            .to include(%(tag: "1.21.0@#{dependency_new_digest}"  # keep in lockstep with upstream))
           expect(updated_content).not_to include("1.20.0@")
+          expect(updated_content).not_to include(dependency_old_digest)
         end
       end
     end

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -199,6 +199,63 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
         end
       end
     end
+
+    context "when the docker_image source is digest-pinned" do
+      let(:dependency_type) { { type: :docker_image } }
+      let(:repo_fixture_name) { "ubuntu_no_latest.json" }
+      let(:dependency_name) { "ubuntu" }
+      let(:version) { "17.04" }
+      let(:repo_tags) { fixture("docker", "registry_tags", repo_fixture_name) }
+      let(:repo_url) { "https://registry.hub.docker.com/v2/library/ubuntu/" }
+      let(:source) do
+        { tag: version, digest: "ef895fdef7a8ea2a12cf421cd56b13c3bb65c806a09ea75a8284a78736ae5da5" }
+      end
+
+      before do
+        auth_url = "https://auth.docker.io/token?service=registry.docker.io"
+        stub_request(:get, auth_url)
+          .and_return(status: 200, body: { token: "token" }.to_json)
+
+        stub_request(:get, repo_url + "tags/list")
+          .and_return(status: 200, body: repo_tags)
+      end
+
+      context "when the registry returns a digest for the new tag" do
+        let(:new_digest) { "abc123aaaa00000000000000000000000000000000000000000000000000000a" }
+
+        before do
+          stub_request(:head, repo_url + "manifests/17.10")
+            .and_return(status: 200, body: "", headers: { "docker-content-digest" => "sha256:#{new_digest}" })
+        end
+
+        it "writes the new tag and the new digest into the source" do
+          source = checker.updated_requirements.first.fetch(:source)
+          expect(source[:tag]).to eq("17.10")
+          expect(source[:digest]).to eq(new_digest)
+        end
+      end
+
+      context "when the registry can't resolve a digest for the new tag" do
+        # The docker UpdateChecker treats "no digest available" as "up-to-date"
+        # for digest-pinned sources (see Docker::UpdateChecker#digest_up_to_date?),
+        # so the helm checker reports no update available and updated_requirements
+        # leaves the source untouched. This is the right outcome -- emitting a
+        # tag-only bump on a digest-pinned source would be misleading because
+        # Docker resolves `tag@digest` references by digest.
+        before do
+          stub_request(:head, repo_url + "manifests/17.10")
+            .and_return(status: 200, body: "", headers: {})
+        end
+
+        it "does not offer an update" do
+          expect(checker.latest_version).to be_nil
+        end
+
+        it "leaves the original requirements unchanged" do
+          expect(checker.updated_requirements).to eq(dependency.requirements)
+        end
+      end
+    end
   end
 
   describe "#filter_valid_releases" do


### PR DESCRIPTION
### What are you trying to accomplish?

```yaml
image:
  repository: cubejs/cubestore
  tag: "v1.6.41@sha256:ef895fdef7a8ea2a12cf421cd56b13c3bb65c806a09ea75a8284a78736ae5da5"
```

Dependabot detects an update is available, opens a PR, but the only diff is a trailing-newline change on `values.yaml` — the tag is never actually bumped. Two compounding bugs and one missing feature were responsible:

1. `update_image_tags_recursive` was splitting and rejoining content on `"\n"` without a `-1` limit, silently dropping a trailing newline. That made the post-update content compare unequal to the input even when no tag scalar had been replaced, defeating the `"Expected content to change!"` guard. The user-visible result is a "successful" PR with a meaningless diff.

2. The Helm parser splits a value like `"v1.6.41@sha256:..."` into `:tag` (`"v1.6.41"`) and `:digest` (`"sha256:..."`), so the scalar in the YAML — `"v1.6.41@sha256:..."` — never equals the bare `:tag` value. The find returned nil, no replacement happened, and bug #1 then masked it as a non-trivial diff.

3. Even after fixing the matching, leaving the old digest in place would produce a misleading PR — Docker resolves `tag@digest` references *by digest*, so the new pull would still resolve to the old image while the YAML claimed otherwise. The Docker `UpdateChecker` already resolves manifest digests for tag bumps; we just weren't wiring it through.

After all three commits, the example above becomes:

```yaml
tag: "1.6.43@sha256:<freshly-resolved-digest>"
```

### Anything you want to highlight for special attention from reviewers?

Docker's `UpdateChecker#digest_up_to_date?` already treats "couldn't resolve a digest" as "up-to-date" for digest-pinned sources — defensively, since emitting a tag-only bump on `tag@digest` would produce a PR that still pulls the old image. Following that convention, when the helm checker delegates and the docker checker reports up-to-date, `Helm::UpdateChecker#latest_version` returns `nil` and `updated_requirements` short-circuits, leaving the source untouched.

### How will you know you've accomplished your goal?

I added tests for both the update checker and the image updater that test the behavior with a stubbed registry response.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
