### PR TITLE
Fix Python auto strategy to avoid unnecessary lower-bound bumps

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -115,8 +115,13 @@ module Dependabot
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy if @requirements_update_strategy
 
-        # Otherwise, check if this is a library or not
-        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
+        # Otherwise, check if this is a library or not.
+        # Libraries widen ranges so lower bounds are preserved (compatible with both old and new consumers).
+        # Non-libraries (applications) use BumpVersionsIfNecessary: only update the requirement when the
+        # current range no longer satisfies the new version, avoiding spurious lower-bound bumps for
+        # ranges that already include the resolved version (e.g. >=1.0.0,<3.0.0 should not become
+        # >=2.1.0,<3.0.0 just because 2.1.0 is the latest release).
+        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersionsIfNecessary
       end
 
       private

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -2031,6 +2031,34 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
           its([:requirement]) { is_expected.to eq("~=2.19.1") }
         end
+
+        context "when dealing with a non-library and the new version already satisfies the range" do
+          let(:dependency) do
+            Dependabot::Dependency.new(
+              name: "requests",
+              version: "1.2.3",
+              requirements: [{
+                file: "pyproject.toml",
+                requirement: ">=1.0.0,<3.0.0",
+                groups: [],
+                source: nil
+              }],
+              package_manager: "pip"
+            )
+          end
+
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
+          end
+
+          it "does not bump the lower bound when the resolved version already satisfies the range" do
+            expect(first_updated_requirements[:requirement]).to eq(">=1.0.0,<3.0.0")
+          end
+        end
       end
 
       context "when updating a dependency in an additional requirements file" do


### PR DESCRIPTION
### What are you trying to accomplish?

Adjust Python’s default auto requirements strategy to avoid unnecessary lower-bound bumps when the latest version already satisfies the existing range.

Fixes the regression behind issue #14798.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

RSpec added.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
