### PR TITLE
fix(python): make auto pyproject strategy use widen ranges

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -115,8 +115,11 @@ module Dependabot
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy if @requirements_update_strategy
 
-        # Otherwise, check if this is a library or not
-        library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
+        # In auto mode for pyproject updates, use a single conservative strategy
+        # regardless of whether the project is classified as a library or app.
+        return RequirementsUpdateStrategy::WidenRanges if updating_pyproject?
+
+        RequirementsUpdateStrategy::BumpVersions
       end
 
       private

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -1,16 +1,13 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "excon"
 require "toml-rb"
 require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/errors"
-require "dependabot/python/name_normaliser"
 require "dependabot/python/requirement_parser"
 require "dependabot/python/requirement"
-require "dependabot/registry_client"
 require "dependabot/requirements_update_strategy"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
@@ -401,36 +398,6 @@ module Dependabot
       end
 
       sig { returns(T::Boolean) }
-      def library?
-        return @is_library unless @is_library.nil?
-
-        @is_library = T.let(check_pypi_for_library_match, T.nilable(T::Boolean))
-        @is_library || false
-      end
-
-      sig { returns(T::Boolean) }
-      def check_pypi_for_library_match
-        return false unless updating_pyproject?
-
-        library_details_temp = library_details
-        return false unless library_details_temp && !library_details_temp["name"].nil?
-
-        has_library_metadata = !library_details_temp["description"].nil?
-
-        response = Dependabot::RegistryClient.get(
-          url: "https://pypi.org/pypi/#{normalised_name(library_details_temp['name'])}/json/"
-        )
-        return has_library_metadata unless response.status == 200
-
-        local_description = library_details_temp["description"]
-        return true if local_description.nil?
-
-        (JSON.parse(response.body)["info"] || {})["summary"] == local_description
-      rescue Excon::Error::Timeout, Excon::Error::Socket, URI::InvalidURIError
-        has_library_metadata
-      end
-
-      sig { returns(T::Boolean) }
       def updating_pipfile?
         requirement_files.any?("Pipfile")
       end
@@ -458,11 +425,6 @@ module Dependabot
       sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
       def requirements
         dependency.requirements
-      end
-
-      sig { params(name: String).returns(String) }
-      def normalised_name(name)
-        NameNormaliser.normalise(name)
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -1890,29 +1890,29 @@ RSpec.describe Dependabot::Python::UpdateChecker do
               )
           end
 
-          its([:requirement]) { is_expected.to eq("~2.19.1") }
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
         context "when dealing with a poetry in non-package mode" do
           let(:pyproject_fixture_name) { "poetry_non_package_mode.toml" }
 
-          its([:requirement]) { is_expected.to eq("~2.19.1") }
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when checking library status multiple times" do
+        context "when checking auto strategy multiple times" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
           end
 
-          it "caches the PyPI check result to avoid redundant calls" do
+          it "does not call PyPI while selecting auto requirements strategy" do
             # Call requirements_update_strategy multiple times
             checker.send(:requirements_update_strategy)
             checker.send(:requirements_update_strategy)
 
-            # Verify PyPI was only called once (memoization working)
+            # Auto strategy should not rely on package classification.
             expect(a_request(:get, "https://pypi.org/pypi/pendulum/json/"))
-              .to have_been_made.once
+              .not_to have_been_made
           end
         end
 
@@ -2029,7 +2029,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
               )
           end
 
-          its([:requirement]) { is_expected.to eq("~=2.19.1") }
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
       end
 
@@ -2112,7 +2112,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
               )
           end
 
-          its([:requirement]) { is_expected.to eq("~=2.19.1") }
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
       end
 

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -1846,52 +1846,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           fixture("pypi", "pypi_simple_response_requests.html")
         end
 
-        context "when dealing with a library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is not on PyPI but has library metadata" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(status: 404)
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is on PyPI but description is not in pyproject.toml" do
-          let(:pyproject_fixture_name) { "poetry_missing_description.toml" }
-
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when dealing with a non-library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: { info: { summary: "A completely different package" } }.to_json
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
+        its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
 
         context "when dealing with a poetry in non-package mode" do
           let(:pyproject_fixture_name) { "poetry_non_package_mode.toml" }
@@ -1900,11 +1855,6 @@ RSpec.describe Dependabot::Python::UpdateChecker do
         end
 
         context "when checking auto strategy multiple times" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(status: 404)
-          end
-
           it "does not call PyPI while selecting auto requirements strategy" do
             # Call requirements_update_strategy multiple times
             checker.send(:requirements_update_strategy)
@@ -1913,39 +1863,6 @@ RSpec.describe Dependabot::Python::UpdateChecker do
             # Auto strategy should not rely on package classification.
             expect(a_request(:get, "https://pypi.org/pypi/pendulum/json/"))
               .not_to have_been_made
-          end
-        end
-
-        context "when PyPI request raises Excon::Error::Timeout" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_raise(Excon::Error::Timeout.new("connection timeout"))
-          end
-
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
-          end
-        end
-
-        context "when PyPI request raises Excon::Error::Socket" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_raise(Excon::Error::Socket.new(SocketError.new("getaddrinfo failed")))
-          end
-
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
-          end
-        end
-
-        context "when PyPI request raises URI::InvalidURIError" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_raise(URI::InvalidURIError.new("bad URI"))
-          end
-
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
           end
         end
       end
@@ -1985,52 +1902,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           fixture("pypi", "pypi_simple_response_requests.html")
         end
 
-        context "when dealing with a library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is not on PyPI but has library metadata" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(status: 404)
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is on PyPI but description is dynamic" do
-          let(:pyproject_fixture_name) { "standard_python_dynamic_description.toml" }
-
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when dealing with a non-library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: { info: { summary: "A completely different package" } }.to_json
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
+        its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
       end
 
       context "when updating a dependency in an additional requirements file" do
@@ -2068,52 +1940,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           fixture("pypi", "pypi_simple_response_requests.html")
         end
 
-        context "when dealing with a library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is not on PyPI but has library metadata" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(status: 404)
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when the project is on PyPI but description is dynamic" do
-          let(:pyproject_fixture_name) { "build_system_dynamic_description.toml" }
-
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: fixture("pypi", "pypi_response_pendulum.json")
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
-
-        context "when dealing with a non-library" do
-          before do
-            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-              .to_return(
-                status: 200,
-                body: { info: { summary: "A completely different package" } }.to_json
-              )
-          end
-
-          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
-        end
+        its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
       end
 
       context "when updating a dependency in an additional requirements file" do


### PR DESCRIPTION
### What are you trying to accomplish?

Make Python auto behavior for pyproject updates use one non-increase strategy for both app and library cases, so auto no longer depends on library vs app classification.

This avoids unnecessary lower-bound bumps and removes inconsistent auto behavior.

Fixes #14798.

### Anything you want to highlight for special attention from reviewers?

This only changes implicit auto behavior for pyproject updates. Explicit requirements-update-strategy values are unchanged.

### How will you know you've accomplished your goal?

Updated specs confirm non-library pyproject cases now widen ranges, and strategy selection no longer relies on PyPI classification checks.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
