### PR TITLE
Add blocked versions support to updater job

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -57,6 +57,7 @@ module Dependabot
         cooldown
         repo_private
         multi_ecosystem_update
+        blocked_versions
       ).freeze,
       T::Array[Symbol]
     )
@@ -117,6 +118,9 @@ module Dependabot
 
     sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
     attr_reader :cooldown
+
+    sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+    attr_reader :blocked_versions
 
     sig { returns(Dependabot::Config::UpdateConfig) }
     attr_reader :update_config
@@ -220,6 +224,10 @@ module Dependabot
       @dependency_groups              = T.let(attributes.fetch(:dependency_groups, []) || [], T::Array[T.untyped])
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
+      @blocked_versions               = T.let(
+        attributes.fetch(:blocked_versions, []) || [],
+        T::Array[T::Hash[String, T.untyped]]
+      )
 
       @update_config = T.let(calculate_update_config, Dependabot::Config::UpdateConfig)
 
@@ -444,7 +452,7 @@ module Dependabot
       # allow update-types cannot be checked in allowed_update? because it runs
       # pre-resolution when only the current version is known. Version ranges
       # only need the current version — the same mechanism as ignore update-types.
-      conditions + ignored_versions_from_allowed_update_types(dependency)
+      conditions + ignored_versions_from_allowed_update_types(dependency) + blocked_versions_for(dependency)
     end
 
     # TODO: Present Dependabot::Config::IgnoreCondition in calling code
@@ -460,23 +468,54 @@ module Dependabot
     sig { params(dependency: Dependabot::Dependency).void }
     def log_ignore_conditions_for(dependency)
       conditions = ignore_conditions.select { |ic| name_match?(ic["dependency-name"], dependency.name) }
-      return if conditions.empty?
+      if conditions.any?
+        Dependabot.logger.info("Ignored versions:")
+        conditions.each do |ic|
+          unless ic["version-requirement"].nil?
+            Dependabot.logger.info("  #{ic['version-requirement']} - from #{ic['source']}")
+          end
 
-      Dependabot.logger.info("Ignored versions:")
-      conditions.each do |ic|
-        unless ic["version-requirement"].nil?
-          Dependabot.logger.info("  #{ic['version-requirement']} - from #{ic['source']}")
-        end
-
-        ic["update-types"]&.each do |update_type|
-          msg = "  #{update_type} - from #{ic['source']}"
-          msg += " (doesn't apply to security update)" if security_updates_only?
-          Dependabot.logger.info(msg)
+          ic["update-types"]&.each do |update_type|
+            msg = "  #{update_type} - from #{ic['source']}"
+            msg += " (doesn't apply to security update)" if security_updates_only?
+            Dependabot.logger.info(msg)
+          end
         end
       end
+
+      log_blocked_versions_for(dependency)
     end
 
     private
+
+    sig { params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
+    def blocked_versions_for(dependency)
+      normaliser = name_normaliser
+      normalized_dep_name = T.must(normaliser).call(dependency.name)
+
+      blocked_versions
+        .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
+        .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
+        .filter_map { |bv| bv["version"].strip.empty? ? nil : bv["version"].strip }
+    end
+
+    sig { params(dependency: Dependabot::Dependency).void }
+    def log_blocked_versions_for(dependency)
+      normaliser = name_normaliser
+      normalized_dep_name = T.must(normaliser).call(dependency.name)
+
+      blocks = blocked_versions
+               .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
+               .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
+      return if blocks.empty?
+
+      Dependabot.logger.info("Blocked versions (by GitHub Security):")
+      blocks.each do |bv|
+        msg = "  #{bv['version']}"
+        msg += " - reason: #{bv['reason']}" if bv["reason"]
+        Dependabot.logger.info(msg)
+      end
+    end
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
     def completely_ignored?(dependency)

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -225,7 +225,7 @@ module Dependabot
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
       @blocked_versions               = T.let(
-        (attributes.fetch(:blocked_versions, []) || []).grep(Hash),
+        attributes.fetch(:blocked_versions, []) || [],
         T::Array[T::Hash[String, T.untyped]]
       )
 

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -490,41 +490,40 @@ module Dependabot
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
     def blocked_versions_for(dependency)
+      matching_blocked_entries(dependency).filter_map do |bv|
+        version = bv["version"].strip
+        version.empty? ? nil : version
+      end
+    end
+
+    sig { params(dependency: Dependabot::Dependency).void }
+    def log_blocked_versions_for(dependency)
+      versions = blocked_versions_for(dependency)
+      return if versions.empty?
+
+      Dependabot.logger.info("Blocked versions (by GitHub Security):")
+      matching_blocked_entries(dependency).each do |bv|
+        version = bv["version"].strip
+        next if version.empty?
+
+        reason = bv["reason"].is_a?(String) ? bv["reason"].strip : nil
+        msg = "  #{version}"
+        msg += " - reason: #{reason}" if reason && !reason.empty?
+        Dependabot.logger.info(msg)
+      end
+    end
+
+    sig do
+      params(dependency: Dependabot::Dependency)
+        .returns(T::Array[T::Hash[String, T.untyped]])
+    end
+    def matching_blocked_entries(dependency)
       normaliser = name_normaliser
       normalized_dep_name = T.must(normaliser).call(dependency.name)
 
       blocked_versions
         .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
         .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
-        .filter_map { |bv| bv["version"].strip.empty? ? nil : bv["version"].strip }
-    end
-
-    sig { params(dependency: Dependabot::Dependency).void }
-    def log_blocked_versions_for(dependency)
-      normaliser = name_normaliser
-      normalized_dep_name = T.must(normaliser).call(dependency.name)
-
-      blocks = blocked_versions
-               .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
-               .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
-               .filter_map do |bv|
-                 version = bv["version"].strip
-                 next if version.empty?
-
-                 reason = bv["reason"]
-                 reason = reason.strip if reason.is_a?(String)
-                 reason = nil if reason == ""
-
-                 { "version" => version, "reason" => reason }
-               end
-      return if blocks.empty?
-
-      Dependabot.logger.info("Blocked versions (by GitHub Security):")
-      blocks.each do |bv|
-        msg = "  #{bv['version']}"
-        msg += " - reason: #{bv['reason']}" if bv["reason"].is_a?(String)
-        Dependabot.logger.info(msg)
-      end
     end
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -507,12 +507,22 @@ module Dependabot
       blocks = blocked_versions
                .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
                .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
+               .filter_map do |bv|
+                 version = bv["version"].strip
+                 next if version.empty?
+
+                 reason = bv["reason"]
+                 reason = reason.strip if reason.is_a?(String)
+                 reason = nil if reason == ""
+
+                 { "version" => version, "reason" => reason }
+               end
       return if blocks.empty?
 
       Dependabot.logger.info("Blocked versions (by GitHub Security):")
       blocks.each do |bv|
         msg = "  #{bv['version']}"
-        msg += " - reason: #{bv['reason']}" if bv["reason"]
+        msg += " - reason: #{bv['reason']}" if bv["reason"].is_a?(String)
         Dependabot.logger.info(msg)
       end
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -498,17 +498,19 @@ module Dependabot
 
     sig { params(dependency: Dependabot::Dependency).void }
     def log_blocked_versions_for(dependency)
-      versions = blocked_versions_for(dependency)
-      return if versions.empty?
-
-      Dependabot.logger.info("Blocked versions (by GitHub Security):")
-      matching_blocked_entries(dependency).each do |bv|
+      entries = matching_blocked_entries(dependency).filter_map do |bv|
         version = bv["version"].strip
         next if version.empty?
 
         reason = bv["reason"].is_a?(String) ? bv["reason"].strip : nil
-        msg = "  #{version}"
-        msg += " - reason: #{reason}" if reason && !reason.empty?
+        { version: version, reason: reason&.empty? ? nil : reason }
+      end
+      return if entries.empty?
+
+      Dependabot.logger.info("Blocked versions (by GitHub Security):")
+      entries.each do |entry|
+        msg = "  #{entry[:version]}"
+        msg += " - reason: #{entry[:reason]}" if entry[:reason]
         Dependabot.logger.info(msg)
       end
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -522,6 +522,7 @@ module Dependabot
       normalized_dep_name = T.must(normaliser).call(dependency.name)
 
       blocked_versions
+        .grep(Hash)
         .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
         .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -225,7 +225,7 @@ module Dependabot
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
       @blocked_versions               = T.let(
-        attributes.fetch(:blocked_versions, []) || [],
+        (attributes.fetch(:blocked_versions, []) || []).grep(Hash),
         T::Array[T::Hash[String, T.untyped]]
       )
 
@@ -522,7 +522,6 @@ module Dependabot
       normalized_dep_name = T.must(normaliser).call(dependency.name)
 
       blocked_versions
-        .grep(Hash)
         .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
         .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
     end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -1273,4 +1273,306 @@ RSpec.describe Dependabot::Job do
       end
     end
   end
+
+  describe "#ignore_conditions_for with blocked_versions" do
+    subject(:ignored) { job.ignore_conditions_for(dependency) }
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "event-stream",
+        package_manager: "bundler",
+        version: "3.3.5",
+        requirements: [{ file: "Gemfile", requirement: "~> 3.3", groups: [], source: nil }]
+      )
+    end
+
+    context "when blocked_versions contains a matching dependency" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            {
+              "dependency-name" => "event-stream",
+              "version" => "= 3.3.6",
+              "reason" => "malware - flatmap-stream injection"
+            }
+          ]
+        )
+      end
+
+      it "includes the blocked version as an ignore condition" do
+        expect(ignored).to include("= 3.3.6")
+      end
+    end
+
+    context "when blocked_versions contains multiple versions for the same package" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" },
+            { "dependency-name" => "event-stream", "version" => "= 4.0.0", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "includes all blocked versions" do
+        expect(ignored).to include("= 3.3.6", "= 4.0.0")
+      end
+    end
+
+    context "when blocked_versions contains a version range with greater-than" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "> 2.10", "reason" => "compromised" }
+          ]
+        )
+      end
+
+      it "passes the range through as an ignore requirement" do
+        expect(ignored).to include("> 2.10")
+      end
+    end
+
+    context "when blocked_versions contains a bounded range" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => ">= 3.0, < 4.0", "reason" => "compromised series" }
+          ]
+        )
+      end
+
+      it "passes the bounded range through" do
+        expect(ignored).to include(">= 3.0, < 4.0")
+      end
+    end
+
+    context "when blocked_versions contains a less-than range" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "< 2.0", "reason" => "deprecated" }
+          ]
+        )
+      end
+
+      it "passes the less-than range through" do
+        expect(ignored).to include("< 2.0")
+      end
+    end
+
+    context "when blocked_versions contains a pessimistic constraint" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "~> 3.3.0", "reason" => "vulnerable patch line" }
+          ]
+        )
+      end
+
+      it "passes the pessimistic constraint through" do
+        expect(ignored).to include("~> 3.3.0")
+      end
+    end
+
+    context "when blocked_versions mixes exact and range entries" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" },
+            { "dependency-name" => "event-stream", "version" => ">= 5.0", "reason" => "hijacked major" }
+          ]
+        )
+      end
+
+      it "includes both the exact version and the range" do
+        expect(ignored).to include("= 3.3.6", ">= 5.0")
+      end
+    end
+
+    context "when blocked_versions does not match the dependency name" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "other-package", "version" => "= 1.0.0", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "does not include the blocked version" do
+        expect(ignored).not_to include("= 1.0.0")
+      end
+    end
+
+    context "when blocked_versions uses exact name matching (not wildcard)" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream*", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "does not match wildcards in blocked version names" do
+        expect(ignored).not_to include("= 3.3.6")
+      end
+    end
+
+    context "when security_updates_only is true" do
+      let(:security_updates_only) { true }
+      let(:dependencies) { ["event-stream"] }
+
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "still includes the blocked version (blocks apply regardless of update type)" do
+        expect(ignored).to include("= 3.3.6")
+      end
+    end
+
+    context "when blocked_versions is empty" do
+      let(:attributes) do
+        super().merge(blocked_versions: [])
+      end
+
+      it "returns no additional conditions" do
+        expect(ignored).to be_empty
+      end
+    end
+
+    context "when blocked_versions contains malformed entries" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream" },
+            { "version" => "= 3.3.6" },
+            {},
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "ignores entries missing dependency-name or version" do
+        expect(ignored).to eq(["= 3.3.6"])
+      end
+    end
+
+    context "when blocked_versions contains non-string types" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => 123, "version" => "= 1.0.0" },
+            { "dependency-name" => "event-stream", "version" => nil },
+            { "dependency-name" => "event-stream", "version" => ["= 1.0"] },
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "ignores entries with non-string dependency-name or version" do
+        expect(ignored).to eq(["= 3.3.6"])
+      end
+    end
+
+    context "when blocked_versions contains empty string values" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "", "reason" => "empty" },
+            { "dependency-name" => "event-stream", "version" => "  ", "reason" => "whitespace" },
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "ignores entries with empty or whitespace-only version" do
+        expect(ignored).to eq(["= 3.3.6"])
+      end
+    end
+  end
+
+  describe "#log_ignore_conditions_for with blocked_versions" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "event-stream",
+        package_manager: "bundler",
+        version: "3.3.5",
+        requirements: [{ file: "Gemfile", requirement: "~> 3.3", groups: [], source: nil }]
+      )
+    end
+
+    context "when blocked_versions contains a matching dependency" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            {
+              "dependency-name" => "event-stream",
+              "version" => "= 3.3.6",
+              "reason" => "malware - flatmap-stream injection"
+            }
+          ]
+        )
+      end
+
+      it "logs the blocked version with reason" do
+        expect(Dependabot.logger).to receive(:info).with("Blocked versions (by GitHub Security):")
+        expect(Dependabot.logger).to receive(:info)
+          .with("  = 3.3.6 - reason: malware - flatmap-stream injection")
+        job.log_ignore_conditions_for(dependency)
+      end
+    end
+
+    context "when blocked_versions has no reason" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6" }
+          ]
+        )
+      end
+
+      it "logs the blocked version without reason" do
+        expect(Dependabot.logger).to receive(:info).with("Blocked versions (by GitHub Security):")
+        expect(Dependabot.logger).to receive(:info).with("  = 3.3.6")
+        job.log_ignore_conditions_for(dependency)
+      end
+    end
+
+    context "when blocked_versions contains a range" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version" => "> 2.10, < 4.0", "reason" => "compromised range" }
+          ]
+        )
+      end
+
+      it "logs the range requirement" do
+        expect(Dependabot.logger).to receive(:info).with("Blocked versions (by GitHub Security):")
+        expect(Dependabot.logger).to receive(:info)
+          .with("  > 2.10, < 4.0 - reason: compromised range")
+        job.log_ignore_conditions_for(dependency)
+      end
+    end
+
+    context "when no blocked versions match" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "other-pkg", "version" => "= 1.0.0", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "does not log blocked versions" do
+        expect(Dependabot.logger).not_to receive(:info).with("Blocked versions (by GitHub Security):")
+        job.log_ignore_conditions_for(dependency)
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -1494,6 +1494,24 @@ RSpec.describe Dependabot::Job do
         expect(ignored).to eq(["= 3.3.6"])
       end
     end
+
+    context "when blocked_versions contains non-Hash entries" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            nil,
+            42,
+            "not-a-hash",
+            [],
+            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "ignores non-Hash entries without raising" do
+        expect(ignored).to eq(["= 3.3.6"])
+      end
+    end
   end
 
   describe "#log_ignore_conditions_for with blocked_versions" do

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -1494,24 +1494,6 @@ RSpec.describe Dependabot::Job do
         expect(ignored).to eq(["= 3.3.6"])
       end
     end
-
-    context "when blocked_versions contains non-Hash entries" do
-      let(:attributes) do
-        super().merge(
-          blocked_versions: [
-            nil,
-            42,
-            "not-a-hash",
-            [],
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
-          ]
-        )
-      end
-
-      it "ignores non-Hash entries without raising" do
-        expect(ignored).to eq(["= 3.3.6"])
-      end
-    end
   end
 
   describe "#log_ignore_conditions_for with blocked_versions" do


### PR DESCRIPTION
### What are you trying to accomplish?

Add support for a `blocked_versions` job attribute that allows specific dependency versions or version ranges to be excluded from update candidates. This enables GitHub Security to prevent Dependabot from suggesting updates to known-malicious or critically vulnerable package versions (e.g., compromised packages with malware).

Blocked versions are passed into the job definition (same pattern as `ignore_conditions`) and merged into the existing ignore logic. This means all ecosystems automatically benefit without any ecosystem-specific changes.

### Anything you want to highlight for special attention from reviewers?

- **Version requirements**: The `version` field accepts any valid version requirement string (e.g., `"= 3.3.6"`, `"> 2.10"`, `">= 1.0, < 2.0"`). These are passed directly to the ignore logic, supporting both exact pins and ranges.

- **Exact name matching**: Unlike user-authored ignore conditions (which use wildcard matching via `WildcardMatcher`), blocked versions use **exact normalized name comparison**. This is intentional — blocks come from precise data and should never accidentally match unrelated packages.

- **Applies to all update types**: Blocked versions are enforced even during security updates. A malware-infested version should never be suggested regardless of update context.

- **No-op until wired**: This PR adds the dependabot-core side only. The feature becomes active when dependabot-api starts serializing `blocked_versions` into job definitions. A TODO marks the integration point in `update_files_command.rb`.

- **Defensive handling**: Malformed entries (missing `dependency-name` or `version`, or non-string values for those fields) are silently skipped rather than raising.

- **Follows existing Job class patterns**: `blocked_versions` follows the same initialization and validation approach as `ignore_conditions`, `security_advisories`, and other job attributes — trusting JSON-parsed input at initialization, with field-level validation at the point of use in `matching_blocked_entries`.

### Expected payload format

```json
[
  { "dependency-name": "event-stream", "version": "= 3.3.6", "reason": "malware" },
  { "dependency-name": "lodash", "version": "> 2.10", "reason": "compromised range" }
]
```

### How will you know you have accomplished your goal?

- All existing + new unit tests pass (verified in Docker container)
- Tests cover: matching, non-matching, multiple versions, version ranges, wildcard rejection, security update enforcement, malformed entries, and logging behavior
- The `version` field is passed through directly as a requirement string, compatible with all ecosystem version classes via `requirement_class.requirements_array`

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.