### PR TITLE
Add blocked versions support to dry-run script

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -170,6 +170,7 @@ $options = {
   security_updates_only: false,
   vendor_dependencies: false,
   ignore_conditions: [],
+  blocked_versions: [],
   pull_request: false,
   hostname: nil,
   cooldown: nil
@@ -223,6 +224,12 @@ unless ENV["IGNORE_CONDITIONS"].to_s.strip.empty?
   # For example:
   # [{"dependency-name":"ruby","version-requirement":">= 3.a, < 4"}]
   $options[:ignore_conditions] = JSON.parse(ENV.fetch("IGNORE_CONDITIONS", nil))
+end
+
+unless ENV["BLOCKED_VERSIONS"].to_s.strip.empty?
+  # For example:
+  # [{"dependency-name":"event-stream","version":"= 3.3.6","reason":"malware"}]
+  $options[:blocked_versions] = JSON.parse(ENV.fetch("BLOCKED_VERSIONS", nil))
 end
 
 if ENV.key?("COOLDOWN") && !ENV["COOLDOWN"].to_s.strip.empty?
@@ -701,20 +708,31 @@ begin
   end
 
   def ignored_versions_for(dep)
-    if $options[:ignore_conditions].any?
-      ignore_conditions = $options[:ignore_conditions].map do |ic|
-        Dependabot::Config::IgnoreCondition.new(
-          dependency_name: ic["dependency-name"],
-          versions: [ic["version-requirement"]].compact,
-          update_types: ic["update-types"]
-        )
-      end
-      Dependabot::Config::UpdateConfig.new(ignore_conditions: ignore_conditions)
-                                      .ignored_versions_for(dep,
-                                                            security_updates_only: $options[:security_updates_only])
-    else
-      $update_config.ignored_versions_for(dep)
-    end
+    versions = if $options[:ignore_conditions].any?
+                 ignore_conditions = $options[:ignore_conditions].map do |ic|
+                   Dependabot::Config::IgnoreCondition.new(
+                     dependency_name: ic["dependency-name"],
+                     versions: [ic["version-requirement"]].compact,
+                     update_types: ic["update-types"]
+                   )
+                 end
+                 Dependabot::Config::UpdateConfig.new(ignore_conditions: ignore_conditions)
+                                                 .ignored_versions_for(
+                                                   dep,
+                                                   security_updates_only: $options[:security_updates_only]
+                                                 )
+               else
+                 $update_config.ignored_versions_for(dep)
+               end
+
+    versions + blocked_versions_for(dep)
+  end
+
+  def blocked_versions_for(dep)
+    $options[:blocked_versions]
+      .select { |bv| bv["dependency-name"] && bv["version"] }
+      .select { |bv| bv["dependency-name"].casecmp(dep.name).zero? }
+      .map { |bv| bv["version"] }
   end
 
   def security_advisories
@@ -772,6 +790,15 @@ begin
   end
 
   puts "=> updating #{dependencies.count} dependencies: #{dependencies.map(&:name).join(', ')}"
+
+  if $options[:blocked_versions].any?
+    puts "=> blocked versions active:"
+    $options[:blocked_versions].each do |bv|
+      msg = "   #{bv['dependency-name']} #{bv['version']}"
+      msg += " (#{bv['reason']})" if bv["reason"]
+      puts msg
+    end
+  end
 
   # rubocop:disable Metrics/BlockLength
   checker_count = 0


### PR DESCRIPTION
## What

Add `BLOCKED_VERSIONS` environment variable support to `bin/dry-run.rb` so developers can simulate blocked dependency versions during local testing.

## Why

The blocked versions feature prevents Dependabot from suggesting updates to known-malicious dependency versions. To support local development and testing of this feature, the dry-run script needs a way to pass blocked versions without requiring access to the production API.

## What's Being Changed

- **`bin/dry-run.rb`**: Added `BLOCKED_VERSIONS` env var parsing (JSON array format), merged blocked versions into the ignored versions list as version requirement strings, and added startup logging when blocked versions are active.

## Example Usage

```bash
BLOCKED_VERSIONS='[{"dependency-name":"event-stream","version":"= 3.3.6","reason":"malware"}]' \
  bin/dry-run.rb npm_and_yarn dependabot/e2e-tests

# Version ranges are also supported:
BLOCKED_VERSIONS='[{"dependency-name":"lodash","version":"> 2.10","reason":"compromised"}]' \
  bin/dry-run.rb npm_and_yarn dependabot/e2e-tests
```

## How to Review

1. The env var format matches the job attribute schema: `dependency-name`, `version` (a requirement string like `"= 3.3.6"` or `"> 2.10"`), and optional `reason`.
2. Blocked versions use exact name matching (case-insensitive) — no wildcard support.
3. Entries missing `dependency-name` or `version` are defensively skipped.
4. Blocked versions are enforced for both regular and security updates (consistent with core implementation in #14915).
