### PR TITLE
Add API integration to fetch blocked versions at job construction

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -228,7 +228,7 @@ end
 
 unless ENV["BLOCKED_VERSIONS"].to_s.strip.empty?
   # For example:
-  # [{"dependency-name":"event-stream","version":"= 3.3.6","reason":"malware"}]
+  # [{"dependency-name":"event-stream","version-requirement":"= 3.3.6","reason":"malware"}]
   $options[:blocked_versions] = JSON.parse(ENV.fetch("BLOCKED_VERSIONS", nil))
 end
 
@@ -730,9 +730,9 @@ begin
 
   def blocked_versions_for(dep)
     $options[:blocked_versions]
-      .select { |bv| bv["dependency-name"] && bv["version"] }
+      .select { |bv| bv["dependency-name"] && bv["version-requirement"] }
       .select { |bv| bv["dependency-name"].casecmp(dep.name).zero? }
-      .map { |bv| bv["version"] }
+      .map { |bv| bv["version-requirement"] }
   end
 
   def security_advisories
@@ -794,7 +794,7 @@ begin
   if $options[:blocked_versions].any?
     puts "=> blocked versions active:"
     $options[:blocked_versions].each do |bv|
-      msg = "   #{bv['dependency-name']} #{bv['version']}"
+      msg = "   #{bv['dependency-name']} #{bv['version-requirement']}"
       msg += " (#{bv['reason']})" if bv["reason"]
       puts msg
     end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -402,7 +402,16 @@ module Dependabot
           return []
         end
 
-        JSON.parse(response.body).fetch("data", [])
+        parsed = JSON.parse(response.body)
+        data = parsed.fetch("data", [])
+        unless data.is_a?(Array)
+          Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")
+          return []
+        end
+        data
+      rescue JSON::ParserError => e
+        Dependabot.logger.warn("Failed to parse blocked versions response: #{e.message}, continuing without them")
+        []
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError => e
         Dependabot.logger.warn("Failed to fetch blocked versions: #{e.message}, continuing without them")
         []

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -408,7 +408,7 @@ module Dependabot
           return []
         end
         data = parsed.fetch("data", [])
-        unless data.is_a?(Array)
+        unless data.is_a?(Array) && data.all?(Hash)
           Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")
           return []
         end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -389,6 +389,26 @@ module Dependabot
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    sig { params(package_manager: String).returns(T::Array[T::Hash[String, T.untyped]]) }
+    def fetch_blocked_versions(package_manager)
+      ::Dependabot::OpenTelemetry.tracer.in_span("fetch_blocked_versions", kind: :internal) do |span|
+        span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
+
+        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/blocked_versions"
+        response = http_client.get(path: api_url, query: { "package-manager": package_manager })
+
+        if response.status >= 400
+          Dependabot.logger.warn("Failed to fetch blocked versions (HTTP #{response.status}), continuing without them")
+          return []
+        end
+
+        JSON.parse(response.body).fetch("data", [])
+      rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError => e
+        Dependabot.logger.warn("Failed to fetch blocked versions: #{e.message}, continuing without them")
+        []
+      end
+    end
+
     private
 
     # Update return type to allow returning a Hash or nil

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -403,6 +403,10 @@ module Dependabot
         end
 
         parsed = JSON.parse(response.body)
+        unless parsed.is_a?(Hash)
+          Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")
+          return []
+        end
         data = parsed.fetch("data", [])
         unless data.is_a?(Array)
           Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -491,25 +491,25 @@ module Dependabot
     sig { params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
     def blocked_versions_for(dependency)
       matching_blocked_entries(dependency).filter_map do |bv|
-        version = bv["version"].strip
-        version.empty? ? nil : version
+        req = bv["version-requirement"].strip
+        req.empty? ? nil : req
       end
     end
 
     sig { params(dependency: Dependabot::Dependency).void }
     def log_blocked_versions_for(dependency)
       entries = matching_blocked_entries(dependency).filter_map do |bv|
-        version = bv["version"].strip
-        next if version.empty?
+        req = bv["version-requirement"].strip
+        next if req.empty?
 
         reason = bv["reason"].is_a?(String) ? bv["reason"].strip : nil
-        { version: version, reason: reason&.empty? ? nil : reason }
+        { version_requirement: req, reason: reason&.empty? ? nil : reason }
       end
       return if entries.empty?
 
       Dependabot.logger.info("Blocked versions (by GitHub Security):")
       entries.each do |entry|
-        msg = "  #{entry[:version]}"
+        msg = "  #{entry[:version_requirement]}"
         msg += " - reason: #{entry[:reason]}" if entry[:reason]
         Dependabot.logger.info(msg)
       end
@@ -524,7 +524,7 @@ module Dependabot
       normalized_dep_name = T.must(normaliser).call(dependency.name)
 
       blocked_versions
-        .select { |bv| bv["dependency-name"].is_a?(String) && bv["version"].is_a?(String) }
+        .select { |bv| bv["dependency-name"].is_a?(String) && bv["version-requirement"].is_a?(String) }
         .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
     end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -40,7 +40,8 @@ module Dependabot
                    :record_ecosystem_versions,
                    :increment_metric,
                    :record_ecosystem_meta,
-                   :record_cooldown_meta
+                   :record_cooldown_meta,
+                   :fetch_blocked_versions
 
     sig { void }
     def wait_for_calls_to_finish

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -73,15 +73,14 @@ module Dependabot
           definition = JSON.parse(JSON.generate(Environment.job_definition))
           job_hash = definition["job"]
 
-          # Register experiments from the job definition early so experiment
-          # gates below can read flags that arrive via the job payload.
-          (job_hash["experiments"] || {}).each do |name, value|
-            Experiments.register(name.to_s.tr("-", "_"), value)
-          end
-
           # Fetch blocked versions from the API if the experiment is enabled.
+          # Check both the Experiments registry and the raw job definition since
+          # job-scoped experiments are not registered until Job construction.
           # Inject them into the job definition so they're available at construction time.
-          if Experiments.enabled?(:dependabot_blocked_versions)
+          experiments = job_hash["experiments"] || {}
+          if Experiments.enabled?(:dependabot_blocked_versions) ||
+             experiments["dependabot_blocked_versions"] ||
+             experiments["dependabot-blocked-versions"]
             package_manager = job_hash["package-manager"] || job_hash["package_manager"] || ""
             blocked = service.fetch_blocked_versions(package_manager)
             job_hash["blocked-versions"] = blocked

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -69,11 +69,24 @@ module Dependabot
     sig { override.returns(Dependabot::Job) }
     def job
       @job ||= T.let(
-        Job.new_update_job(
-          job_id: job_id,
-          job_definition: Environment.job_definition,
-          repo_contents_path: Environment.repo_contents_path
-        ),
+        begin
+          definition = Environment.job_definition
+          job_hash = definition["job"]
+
+          # Fetch blocked versions from the API if the experiment is enabled.
+          # Inject them into the job definition so they're available at construction time.
+          if Experiments.enabled?(:blocked_versions)
+            package_manager = job_hash["package-manager"] || job_hash["package_manager"] || ""
+            blocked = service.fetch_blocked_versions(package_manager)
+            job_hash["blocked-versions"] = blocked if blocked.any?
+          end
+
+          Job.new_update_job(
+            job_id: job_id,
+            job_definition: definition,
+            repo_contents_path: Environment.repo_contents_path
+          )
+        end,
         T.nilable(Dependabot::Job)
       )
     end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -73,12 +73,18 @@ module Dependabot
           definition = JSON.parse(JSON.generate(Environment.job_definition))
           job_hash = definition["job"]
 
+          # Register experiments from the job definition early so experiment
+          # gates below can read flags that arrive via the job payload.
+          (job_hash["experiments"] || {}).each do |name, value|
+            Experiments.register(name.to_s.tr("-", "_"), value)
+          end
+
           # Fetch blocked versions from the API if the experiment is enabled.
           # Inject them into the job definition so they're available at construction time.
           if Experiments.enabled?(:dependabot_blocked_versions)
             package_manager = job_hash["package-manager"] || job_hash["package_manager"] || ""
             blocked = service.fetch_blocked_versions(package_manager)
-            job_hash["blocked-versions"] = blocked if blocked.any?
+            job_hash["blocked-versions"] = blocked
           end
 
           Job.new_update_job(

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -70,12 +70,12 @@ module Dependabot
     def job
       @job ||= T.let(
         begin
-          definition = Environment.job_definition
+          definition = JSON.parse(JSON.generate(Environment.job_definition))
           job_hash = definition["job"]
 
           # Fetch blocked versions from the API if the experiment is enabled.
           # Inject them into the job definition so they're available at construction time.
-          if Experiments.enabled?(:blocked_versions)
+          if Experiments.enabled?(:dependabot_blocked_versions)
             package_manager = job_hash["package-manager"] || job_hash["package_manager"] || ""
             blocked = service.fetch_blocked_versions(package_manager)
             job_hash["blocked-versions"] = blocked if blocked.any?

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -921,5 +921,23 @@ RSpec.describe Dependabot::ApiClient do
         expect(result).to eq([])
       end
     end
+
+    context "when the API returns data entries that are not hashes" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(
+            status: 200,
+            body: { data: [1, "not-a-hash"] }.to_json,
+            headers: headers
+          )
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
   end
 end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -875,5 +875,37 @@ RSpec.describe Dependabot::ApiClient do
         expect(result).to eq([])
       end
     end
+
+    context "when the API returns invalid JSON" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(status: 200, body: "not json", headers: headers)
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Failed to parse blocked versions/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the API returns data that is not an array" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(
+            status: 200,
+            body: { data: "unexpected" }.to_json,
+            headers: headers
+          )
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
   end
 end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -800,4 +800,80 @@ RSpec.describe Dependabot::ApiClient do
       end
     end
   end
+
+  describe "fetch_blocked_versions" do
+    let(:blocked_versions_url) { "http://example.com/update_jobs/1/blocked_versions" }
+
+    context "when the API returns blocked versions" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(
+            status: 200,
+            body: {
+              data: [
+                { "dependency-name" => "event-stream", "version" => "3.3.6", "reason" => "malware" },
+                { "dependency-name" => "flatmap-stream", "version" => "0.1.1", "reason" => "malware" }
+              ]
+            }.to_json,
+            headers: headers
+          )
+      end
+
+      it "returns the blocked versions array" do
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq(
+          [
+            { "dependency-name" => "event-stream", "version" => "3.3.6", "reason" => "malware" },
+            { "dependency-name" => "flatmap-stream", "version" => "0.1.1", "reason" => "malware" }
+          ]
+        )
+      end
+    end
+
+    context "when the API returns an error" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(status: 500, body: "Internal Server Error", headers: headers)
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Failed to fetch blocked versions/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the API times out" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_timeout
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Failed to fetch blocked versions/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the API returns no blocked versions" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(
+            status: 200,
+            body: { data: [] }.to_json,
+            headers: headers
+          )
+      end
+
+      it "returns an empty array" do
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -907,5 +907,19 @@ RSpec.describe Dependabot::ApiClient do
         expect(result).to eq([])
       end
     end
+
+    context "when the API returns a non-object JSON body" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(status: 200, body: "[]", headers: headers)
+      end
+
+      it "returns an empty array and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
+        result = client.fetch_blocked_versions("npm_and_yarn")
+        expect(result).to eq([])
+      end
+    end
   end
 end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -812,8 +812,8 @@ RSpec.describe Dependabot::ApiClient do
             status: 200,
             body: {
               data: [
-                { "dependency-name" => "event-stream", "version" => "3.3.6", "reason" => "malware" },
-                { "dependency-name" => "flatmap-stream", "version" => "0.1.1", "reason" => "malware" }
+                { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" },
+                { "dependency-name" => "flatmap-stream", "version-requirement" => "= 0.1.1", "reason" => "malware" }
               ]
             }.to_json,
             headers: headers
@@ -824,8 +824,8 @@ RSpec.describe Dependabot::ApiClient do
         result = client.fetch_blocked_versions("npm_and_yarn")
         expect(result).to eq(
           [
-            { "dependency-name" => "event-stream", "version" => "3.3.6", "reason" => "malware" },
-            { "dependency-name" => "flatmap-stream", "version" => "0.1.1", "reason" => "malware" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" },
+            { "dependency-name" => "flatmap-stream", "version-requirement" => "= 0.1.1", "reason" => "malware" }
           ]
         )
       end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -1292,7 +1292,7 @@ RSpec.describe Dependabot::Job do
           blocked_versions: [
             {
               "dependency-name" => "event-stream",
-              "version" => "= 3.3.6",
+              "version-requirement" => "= 3.3.6",
               "reason" => "malware - flatmap-stream injection"
             }
           ]
@@ -1308,8 +1308,8 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" },
-            { "dependency-name" => "event-stream", "version" => "= 4.0.0", "reason" => "malware" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" },
+            { "dependency-name" => "event-stream", "version-requirement" => "= 4.0.0", "reason" => "malware" }
           ]
         )
       end
@@ -1323,7 +1323,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "> 2.10", "reason" => "compromised" }
+            { "dependency-name" => "event-stream", "version-requirement" => "> 2.10", "reason" => "compromised" }
           ]
         )
       end
@@ -1337,7 +1337,11 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => ">= 3.0, < 4.0", "reason" => "compromised series" }
+            {
+              "dependency-name" => "event-stream",
+              "version-requirement" => ">= 3.0, < 4.0",
+              "reason" => "compromised series"
+            }
           ]
         )
       end
@@ -1351,7 +1355,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "< 2.0", "reason" => "deprecated" }
+            { "dependency-name" => "event-stream", "version-requirement" => "< 2.0", "reason" => "deprecated" }
           ]
         )
       end
@@ -1365,7 +1369,11 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "~> 3.3.0", "reason" => "vulnerable patch line" }
+            {
+              "dependency-name" => "event-stream",
+              "version-requirement" => "~> 3.3.0",
+              "reason" => "vulnerable patch line"
+            }
           ]
         )
       end
@@ -1379,8 +1387,8 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" },
-            { "dependency-name" => "event-stream", "version" => ">= 5.0", "reason" => "hijacked major" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" },
+            { "dependency-name" => "event-stream", "version-requirement" => ">= 5.0", "reason" => "hijacked major" }
           ]
         )
       end
@@ -1394,7 +1402,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "other-package", "version" => "= 1.0.0", "reason" => "malware" }
+            { "dependency-name" => "other-package", "version-requirement" => "= 1.0.0", "reason" => "malware" }
           ]
         )
       end
@@ -1408,7 +1416,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream*", "version" => "= 3.3.6", "reason" => "malware" }
+            { "dependency-name" => "event-stream*", "version-requirement" => "= 3.3.6", "reason" => "malware" }
           ]
         )
       end
@@ -1425,7 +1433,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" }
           ]
         )
       end
@@ -1450,14 +1458,14 @@ RSpec.describe Dependabot::Job do
         super().merge(
           blocked_versions: [
             { "dependency-name" => "event-stream" },
-            { "version" => "= 3.3.6" },
+            { "version-requirement" => "= 3.3.6" },
             {},
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" }
           ]
         )
       end
 
-      it "ignores entries missing dependency-name or version" do
+      it "ignores entries missing dependency-name or version-requirement" do
         expect(ignored).to eq(["= 3.3.6"])
       end
     end
@@ -1466,15 +1474,15 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => 123, "version" => "= 1.0.0" },
-            { "dependency-name" => "event-stream", "version" => nil },
-            { "dependency-name" => "event-stream", "version" => ["= 1.0"] },
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+            { "dependency-name" => 123, "version-requirement" => "= 1.0.0" },
+            { "dependency-name" => "event-stream", "version-requirement" => nil },
+            { "dependency-name" => "event-stream", "version-requirement" => ["= 1.0"] },
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" }
           ]
         )
       end
 
-      it "ignores entries with non-string dependency-name or version" do
+      it "ignores entries with non-string dependency-name or version-requirement" do
         expect(ignored).to eq(["= 3.3.6"])
       end
     end
@@ -1483,14 +1491,14 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "", "reason" => "empty" },
-            { "dependency-name" => "event-stream", "version" => "  ", "reason" => "whitespace" },
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6", "reason" => "malware" }
+            { "dependency-name" => "event-stream", "version-requirement" => "", "reason" => "empty" },
+            { "dependency-name" => "event-stream", "version-requirement" => "  ", "reason" => "whitespace" },
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" }
           ]
         )
       end
 
-      it "ignores entries with empty or whitespace-only version" do
+      it "ignores entries with empty or whitespace-only version-requirement" do
         expect(ignored).to eq(["= 3.3.6"])
       end
     end
@@ -1512,7 +1520,7 @@ RSpec.describe Dependabot::Job do
           blocked_versions: [
             {
               "dependency-name" => "event-stream",
-              "version" => "= 3.3.6",
+              "version-requirement" => "= 3.3.6",
               "reason" => "malware - flatmap-stream injection"
             }
           ]
@@ -1531,7 +1539,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "= 3.3.6" }
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6" }
           ]
         )
       end
@@ -1547,7 +1555,11 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "event-stream", "version" => "> 2.10, < 4.0", "reason" => "compromised range" }
+            {
+              "dependency-name" => "event-stream",
+              "version-requirement" => "> 2.10, < 4.0",
+              "reason" => "compromised range"
+            }
           ]
         )
       end
@@ -1564,7 +1576,7 @@ RSpec.describe Dependabot::Job do
       let(:attributes) do
         super().merge(
           blocked_versions: [
-            { "dependency-name" => "other-pkg", "version" => "= 1.0.0", "reason" => "malware" }
+            { "dependency-name" => "other-pkg", "version-requirement" => "= 1.0.0", "reason" => "malware" }
           ]
         )
       end

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
     subject(:perform_job) { job.perform_job }
 
     before do
-      Dependabot::Experiments.register(:blocked_versions, true)
+      Dependabot::Experiments.register(:dependabot_blocked_versions, true)
       allow(service).to receive(:fetch_blocked_versions).and_return(blocked_versions)
     end
 
@@ -467,6 +467,9 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       expect(service).to receive(:fetch_blocked_versions).with("bundler")
 
       perform_job
+
+      job_instance = job.send(:job)
+      expect(job_instance.blocked_versions).to eq(blocked_versions)
     end
 
     context "when the API returns no blocked versions" do

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -472,10 +472,38 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       expect(job_instance.blocked_versions).to eq(blocked_versions)
     end
 
+    context "when the experiment is enabled via the job definition" do
+      let(:job_definition) do
+        definition = JSON.parse(fixture("jobs/job_without_credentials.json"))
+        definition["job"]["experiments"] = { "dependabot_blocked_versions" => true }
+        definition
+      end
+
+      before do
+        Dependabot::Experiments.reset!
+        allow(service).to receive(:fetch_blocked_versions).and_return(blocked_versions)
+      end
+
+      it "reads the experiment flag from the job definition and fetches blocked versions" do
+        dummy_runner = double(run: nil)
+        allow(Dependabot::Updater).to receive(:new).and_return(dummy_runner)
+        allow(dummy_runner).to receive(:run)
+        allow(service).to receive(:mark_job_as_processed)
+        allow(service).to receive(:update_dependency_list)
+
+        expect(service).to receive(:fetch_blocked_versions).with("bundler")
+
+        perform_job
+
+        job_instance = job.send(:job)
+        expect(job_instance.blocked_versions).to eq(blocked_versions)
+      end
+    end
+
     context "when the API returns no blocked versions" do
       let(:blocked_versions) { [] }
 
-      it "does not inject blocked versions into the job definition" do
+      it "assigns empty blocked versions to the job" do
         dummy_runner = double(run: nil)
         allow(Dependabot::Updater).to receive(:new).and_return(dummy_runner)
         allow(dummy_runner).to receive(:run)

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
 
     let(:blocked_versions) do
       [
-        { "dependency-name" => "rails", "version" => "7.0.0", "reason" => "vulnerability" }
+        { "dependency-name" => "rails", "version-requirement" => "= 7.0.0", "reason" => "vulnerability" }
       ]
     end
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -438,4 +438,53 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       end
     end
   end
+
+  describe "#perform_job with blocked versions experiment enabled" do
+    subject(:perform_job) { job.perform_job }
+
+    before do
+      Dependabot::Experiments.register(:blocked_versions, true)
+      allow(service).to receive(:fetch_blocked_versions).and_return(blocked_versions)
+    end
+
+    after do
+      Dependabot::Experiments.reset!
+    end
+
+    let(:blocked_versions) do
+      [
+        { "dependency-name" => "rails", "version" => "7.0.0", "reason" => "vulnerability" }
+      ]
+    end
+
+    it "fetches blocked versions and injects them into the job definition" do
+      dummy_runner = double(run: nil)
+      allow(Dependabot::Updater).to receive(:new).and_return(dummy_runner)
+      allow(dummy_runner).to receive(:run)
+      allow(service).to receive(:mark_job_as_processed)
+      allow(service).to receive(:update_dependency_list)
+
+      expect(service).to receive(:fetch_blocked_versions).with("bundler")
+
+      perform_job
+    end
+
+    context "when the API returns no blocked versions" do
+      let(:blocked_versions) { [] }
+
+      it "does not inject blocked versions into the job definition" do
+        dummy_runner = double(run: nil)
+        allow(Dependabot::Updater).to receive(:new).and_return(dummy_runner)
+        allow(dummy_runner).to receive(:run)
+        allow(service).to receive(:mark_job_as_processed)
+        allow(service).to receive(:update_dependency_list)
+
+        perform_job
+
+        # Job should still have empty blocked_versions (the default)
+        job_instance = job.send(:job)
+        expect(job_instance.blocked_versions).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Add the API client integration that fetches blocked versions from the API and injects them into the job definition at construction time. Blocked versions are globally managed (not per-job configuration), so they need to be fetched fresh at execution time. This ensures the updater always uses the latest blocked versions list.

This PR also renames the blocked versions field from `version` to `version-requirement` to align with `ignore_conditions` conventions and the API endpoint contract.

Stacks on #14915 which adds the `blocked_versions` attribute to the Job class.

### Anything you want to highlight for special attention from reviewers?

- The fetch is gated behind `Experiments.enabled?(:dependabot_blocked_versions)` — no behavior change without the flag.
- Experiments are pre-registered from the job definition (with hyphen-to-underscore normalization) before the gate, so the flag works when set via the job payload.
- The job definition is deep-copied (`JSON.parse(JSON.generate(...))`) to avoid mutating the memoized `Environment.job_definition`.
- On API failure (500, timeout, network error, invalid JSON, non-Hash/non-Array response), the updater continues without blocked versions (graceful degradation).
- `version-requirement` field name matches `ignore_conditions` conventions — the API endpoint transforms from the model's `version` field to `version-requirement` in the response.

### How will you know you've accomplished your goal?

- `api_client_spec.rb`: 6 tests covering success, error, timeout, empty response, invalid JSON, non-object JSON, and non-array data.
- `update_files_command_spec.rb`: 3 tests covering fetch + inject, experiment flag via job definition, and empty response handling.
- `job_spec.rb`: All blocked versions test data updated to use `version-requirement` field name.
- Once the `dependabot_blocked_versions` experiment is enabled, blocked versions will appear in updater logs as "Blocked versions (by GitHub Security)" for matching dependencies.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.