### PR TITLE
Use a minimal PR description for squash-only repos

### DIFF
--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -10,6 +10,8 @@ module Dependabot
     class File
       extend T::Sig
 
+      ALLOWED_PR_DESCRIPTIONS = %w(auto short full).freeze
+
       sig { returns(T::Array[T::Hash[Symbol, String]]) }
       attr_reader :updates
 
@@ -26,6 +28,7 @@ module Dependabot
       def initialize(updates:, registries: nil)
         @updates = T.let(updates || [], T::Array[T::Hash[Symbol, String]])
         @registries = T.let(registries || {}, T::Hash[Symbol, T::Hash[Symbol, String]])
+        validate_updates
       end
 
       sig do
@@ -42,7 +45,8 @@ module Dependabot
         UpdateConfig.new(
           ignore_conditions: ignore_conditions(cfg),
           commit_message_options: commit_message_options(cfg),
-          exclude_paths: exclude_paths(cfg)
+          exclude_paths: exclude_paths(cfg),
+          pull_request_description: cfg&.dig(:"pull-request-description")
         )
       end
 
@@ -128,6 +132,18 @@ module Dependabot
       sig { params(cfg: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Array[String]) }
       def exclude_paths(cfg)
         Array(cfg&.dig(:"exclude-paths") || [])
+      end
+
+      sig { void }
+      def validate_updates
+        @updates.each do |update|
+          desc = update[:"pull-request-description"]
+          next if desc.nil?
+
+          unless ALLOWED_PR_DESCRIPTIONS.include?(desc)
+            raise InvalidConfigError, "invalid pull-request-description: #{desc}"
+          end
+        end
       end
     end
   end

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -19,17 +19,27 @@ module Dependabot
       sig { returns(T.nilable(T::Array[String])) }
       attr_reader :exclude_paths
 
+      sig { returns(String) }
+      attr_reader :pull_request_description
+
       sig do
         params(
           ignore_conditions: T.nilable(T::Array[IgnoreCondition]),
           commit_message_options: T.nilable(CommitMessageOptions),
-          exclude_paths: T.nilable(T::Array[String])
+          exclude_paths: T.nilable(T::Array[String]),
+          pull_request_description: T.nilable(String)
         ).void
       end
-      def initialize(ignore_conditions: nil, commit_message_options: nil, exclude_paths: nil)
+      def initialize(
+        ignore_conditions: nil,
+        commit_message_options: nil,
+        exclude_paths: nil,
+        pull_request_description: nil
+      )
         @ignore_conditions = T.let(ignore_conditions || [], T::Array[IgnoreCondition])
         @commit_message_options = commit_message_options
         @exclude_paths = exclude_paths
+        @pull_request_description = T.let(pull_request_description || "auto", String)
       end
 
       sig { params(dependency: Dependency, security_updates_only: T::Boolean).returns(T::Array[String]) }

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -86,7 +86,8 @@ module Dependabot
           pr_message_max_length: T.nilable(Integer),
           pr_message_encoding: T.nilable(Encoding),
           ignore_conditions: T::Array[T::Hash[String, String]],
-          notices: T.nilable(T::Array[Dependabot::Notice])
+          notices: T.nilable(T::Array[Dependabot::Notice]),
+          pull_request_description: T.nilable(String)
         )
           .void
       end
@@ -104,7 +105,8 @@ module Dependabot
         pr_message_max_length: nil,
         pr_message_encoding: nil,
         ignore_conditions: [],
-        notices: nil
+        notices: nil,
+        pull_request_description: nil
       )
         @dependencies               = dependencies
         @files                      = files
@@ -120,6 +122,8 @@ module Dependabot
         @pr_message_encoding        = pr_message_encoding
         @ignore_conditions          = ignore_conditions
         @notices                    = notices
+        @pull_request_description   = T.let(pull_request_description || "auto", String)
+        @is_squash_merge            = T.let(nil, T.nilable(T::Boolean))
       end
 
       sig { params(pr_message_max_length: Integer).returns(Integer) }
@@ -142,7 +146,7 @@ module Dependabot
         msg = "#{pr_notices}" \
               "#{suffixed_pr_message_header}" \
               "#{commit_message_intro}" \
-              "#{metadata_cascades}" \
+              "#{short_description? ? metadata_links : metadata_cascades}" \
               "#{ignore_conditions_table}" \
               "#{prefixed_pr_message_footer}"
 
@@ -963,6 +967,33 @@ module Dependabot
           T.must(dependencies.first).package_manager,
           T.nilable(String)
         )
+      end
+
+      sig { returns(T::Boolean) }
+      def short_description?
+        return false if @pull_request_description == "full"
+        return true if @pull_request_description == "short"
+
+        auto_detect_squash_merge?
+      end
+
+      sig { returns(T::Boolean) }
+      def auto_detect_squash_merge?
+        return false unless source.provider == "github"
+        return @is_squash_merge unless @is_squash_merge.nil?
+
+        @is_squash_merge = check_squash_merge_from_api
+      end
+
+      sig { returns(T::Boolean) }
+      def check_squash_merge_from_api
+        client = Dependabot::Clients::GithubWithRetries.for_source(source: source, credentials: credentials)
+        repo_method = :repository
+        repo_info = client.public_send(repo_method, source.repo)
+        !!(repo_info.allow_squash_merge && !repo_info.allow_merge_commit && !repo_info.allow_rebase_merge)
+      rescue StandardError => e
+        Dependabot.logger.error("Failed to detect squash merge settings: #{e.message}")
+        false
       end
 
       sig { params(method: String, err: StandardError).void }

--- a/common/spec/dependabot/config/file_spec.rb
+++ b/common/spec/dependabot/config/file_spec.rb
@@ -61,5 +61,50 @@ RSpec.describe Dependabot::Config::File do
         expect(types_ignore.update_types).to eq(["version-update:semver-patch"])
       end
     end
+
+    describe "#update_config pull-request-description" do
+      it "parses pull-request-description" do
+        yaml = <<~YAML
+          version: 2
+          updates:
+            - package-ecosystem: "npm"
+              directory: "/"
+              schedule:
+                interval: "weekly"
+              pull-request-description: "short"
+        YAML
+        cfg = described_class.parse(yaml)
+        update_config = cfg.update_config("npm_and_yarn")
+        expect(update_config.pull_request_description).to eq("short")
+      end
+
+      it "defaults pull-request-description to auto" do
+        yaml = <<~YAML
+          version: 2
+          updates:
+            - package-ecosystem: "npm"
+              directory: "/"
+              schedule:
+                interval: "weekly"
+        YAML
+        cfg = described_class.parse(yaml)
+        update_config = cfg.update_config("npm_and_yarn")
+        expect(update_config.pull_request_description).to eq("auto")
+      end
+
+      it "raises an error for invalid pull-request-description" do
+        yaml = <<~YAML
+          version: 2
+          updates:
+            - package-ecosystem: "npm"
+              directory: "/"
+              schedule:
+                interval: "weekly"
+              pull-request-description: "garbage"
+        YAML
+        expect { described_class.parse(yaml) }
+          .to raise_error(Dependabot::Config::InvalidConfigError, /invalid pull-request-description/)
+      end
+    end
   end
 end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -3561,6 +3561,85 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         expect(pr_message.scan(markdown).count).to eq(1)
       end
     end
+
+    context "with pull_request_description options" do
+      let(:builder) do
+        described_class.new(
+          source: source,
+          dependencies: dependencies,
+          files: files,
+          credentials: credentials,
+          pr_message_header: pr_message_header,
+          pr_message_footer: pr_message_footer,
+          commit_message_options: commit_message_options,
+          vulnerabilities_fixed: vulnerabilities_fixed,
+          github_redirection_service: github_redirection_service,
+          dependency_group: dependency_group,
+          ignore_conditions: ignore_conditions,
+          notices: notices,
+          pull_request_description: pull_request_description
+        )
+      end
+
+      context "when configured to 'short'" do
+        let(:pull_request_description) { "short" }
+
+        it "uses short description (links) in pr_message" do
+          expect(pr_message).to include("- [Changelog]")
+          expect(pr_message).not_to include("business's changelog")
+        end
+      end
+
+      context "when configured to 'full'" do
+        let(:pull_request_description) { "full" }
+
+        it "uses full description in pr_message" do
+          expect(pr_message).to include("business's changelog")
+        end
+      end
+
+      context "when configured to 'auto'" do
+        let(:pull_request_description) { "auto" }
+
+        context "when the repo strictly enforces squash merge" do
+          before do
+            stub_request(:get, watched_repo_url)
+              .to_return(
+                status: 200,
+                body: {
+                  allow_squash_merge: true,
+                  allow_merge_commit: false,
+                  allow_rebase_merge: false
+                }.to_json,
+                headers: json_header
+              )
+          end
+
+          it "automatically uses short description" do
+            expect(pr_message).to include("- [Changelog]")
+          end
+        end
+
+        context "when the repo allows other merge methods" do
+          before do
+            stub_request(:get, watched_repo_url)
+              .to_return(
+                status: 200,
+                body: {
+                  allow_squash_merge: true,
+                  allow_merge_commit: true,
+                  allow_rebase_merge: false
+                }.to_json,
+                headers: json_header
+              )
+          end
+
+          it "defaults to full description" do
+            expect(pr_message).to include("business's changelog")
+          end
+        end
+      end
+    end
   end
 
   describe "#commit_message", :vcr do

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -96,7 +96,8 @@ module Dependabot
         pr_message_max_length: pr_message_max_length,
         pr_message_encoding: pr_message_encoding,
         ignore_conditions: job.ignore_conditions,
-        notices: notices
+        notices: notices,
+        pull_request_description: job.update_config.pull_request_description
       ).message
 
       @pr_message = message

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -57,6 +57,7 @@ module Dependabot
         cooldown
         repo_private
         multi_ecosystem_update
+        pull_request_description
       ).freeze,
       T::Array[Symbol]
     )
@@ -220,6 +221,7 @@ module Dependabot
       @dependency_groups              = T.let(attributes.fetch(:dependency_groups, []) || [], T::Array[T.untyped])
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
+      @pull_request_description       = T.let(attributes.fetch(:pull_request_description, nil), T.nilable(String))
 
       @update_config = T.let(calculate_update_config, Dependabot::Config::UpdateConfig)
 
@@ -686,7 +688,8 @@ module Dependabot
 
       update_config = Dependabot::Config::UpdateConfig.new(
         ignore_conditions: T.let(update_config_ignore_conditions, T::Array[Dependabot::Config::IgnoreCondition]),
-        exclude_paths: T.let(exclude_paths, T.nilable(T::Array[String]))
+        exclude_paths: T.let(exclude_paths, T.nilable(T::Array[String])),
+        pull_request_description: @pull_request_description
       )
       T.let(update_config, Dependabot::Config::UpdateConfig)
     end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Dependabot::ApiClient do
         commit_message_options: [],
         updating_a_pull_request?: false,
         ignore_conditions: [],
-        cooldown: cooldown
+        cooldown: cooldown,
+        update_config: instance_double(Dependabot::Config::UpdateConfig, pull_request_description: "auto")
       )
     end
     let(:cooldown) do
@@ -286,7 +287,8 @@ RSpec.describe Dependabot::ApiClient do
         credentials: [],
         commit_message_options: [],
         updating_a_pull_request?: true,
-        ignore_conditions: []
+        ignore_conditions: [],
+        update_config: instance_double(Dependabot::Config::UpdateConfig, pull_request_description: "auto")
       )
     end
     let(:dependency) do

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe Dependabot::DependencyChange do
       }
     end
 
+    let(:update_config) do
+      instance_double(Dependabot::Config::UpdateConfig, pull_request_description: "auto")
+    end
+
     let(:message_builder_mock) do
       instance_double(
         Dependabot::PullRequestCreator::MessageBuilder,
@@ -102,7 +106,8 @@ RSpec.describe Dependabot::DependencyChange do
       allow(job).to receive_messages(
         source: github_source,
         credentials: job_credentials,
-        commit_message_options: commit_message_options
+        commit_message_options: commit_message_options,
+        update_config: update_config
       )
       allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder_mock)
     end
@@ -119,7 +124,8 @@ RSpec.describe Dependabot::DependencyChange do
           pr_message_encoding: nil,
           pr_message_max_length: 65_535,
           ignore_conditions: [],
-          notices: []
+          notices: [],
+          pull_request_description: "auto"
         )
 
       expect(dependency_change.pr_message.pr_message).to eql("Hello World!")
@@ -147,7 +153,8 @@ RSpec.describe Dependabot::DependencyChange do
             pr_message_encoding: nil,
             pr_message_max_length: 65_535,
             ignore_conditions: [],
-            notices: []
+            notices: [],
+            pull_request_description: "auto"
           )
 
         expect(dependency_change.pr_message&.pr_message).to eql("Hello World!")


### PR DESCRIPTION
### What are you trying to accomplish?

Add a configuration setting to determine whether to use a minimal or full PR description. If the repository only permits squash merges, then default to minimal PR descriptions. Otherwise, default to full PR descriptions.

Fixes #1986

### Anything you want to highlight for special attention from reviewers?

It'd be great to include the full message as a PR comment, but I don't think I can do that without a change to the dependabot API. So for now the full description is not included in the PR for a squash-only repository.

This also doesn't detect the case where the repository is effectively squash-only due to a branch protection rule that enforces use of a squash-only merge queue, but that information appears inaccessible from dependabot's access token.

### How will you know you've accomplished your goal?

Manually tested using the dry-run mode against repositories with squash-only and not-squash-only setups.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Assisted-by: Gemini via Antigravity