### PR TITLE
detect central package version scheme

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -107,6 +107,16 @@ public class DiscoveryWorkerTestBase : TestBase
 
             ValidateDependencies(expectedProject.Dependencies, actualDependencies);
             Assert.Equal(expectedProject.ExpectedDependencyCount ?? expectedProject.Dependencies.Length, actualDependencies.Length);
+
+            if (expectedProject.ExpectedPackageManagementKind is not null)
+            {
+                Assert.Equal(expectedProject.ExpectedPackageManagementKind.GetValueOrDefault(), actualProject.PackageManagementKind);
+            }
+
+            if (expectedProject.ExpectedPackageManagementSpecialFileRelativePath is not null)
+            {
+                Assert.Equal(expectedProject.ExpectedPackageManagementSpecialFileRelativePath, actualProject.PackageManagementSpecialFileRelativePath);
+            }
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1679,6 +1679,237 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task PackageManagementDetection_Default()
+    {
+        await TestDiscoveryAsync(
+            packages: [MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0")],
+            workspacePath: "src",
+            files: [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", "<Project />"),
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net9.0"],
+                        Dependencies = [new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"])],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Build.targets",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
+                        ExpectedPackageManagementKind = PackageManagementKind.Default,
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
+    public async Task PackageManagementDetection_CentralPackageVersions()
+    {
+        // to avoid a test dependency on a real NuGet package, we fake the basic shape of the central package versions SDK
+        await TestDiscoveryAsync(
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0"),
+                MockNuGetPackage.CreateMSBuildSdkPackage("Microsoft.Build.CentralPackageVersions.TEST", "2.1.3",
+                    // special file contents based on the real ones
+                    sdkPropsContent: """
+                        <Project>
+                          <PropertyGroup>
+                            <UsingMicrosoftCentralPackageVersionsSdk>true</UsingMicrosoftCentralPackageVersionsSdk>
+                          </PropertyGroup>
+                        </Project>
+                        """,
+                    sdkTargetsContent: """
+                        <Project>
+                          <PropertyGroup>
+                            <CentralPackagesFile>$([MSBuild]::GetPathOfFileAbove('Packages.props', $(MSBuildProjectDirectory)))</CentralPackagesFile>
+                          </PropertyGroup>
+
+                          <Import Project="$(CentralPackagesFile)" />
+                        </Project>
+                        """)
+            ],
+            workspacePath: "src",
+            files: [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", """
+                    <Project>
+                      <Sdk Name="Microsoft.Build.CentralPackageVersions.TEST" Version="2.1.3" />
+                    </Project>
+                    """),
+                ("Directory.Packages.props", "<Project />"),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net9.0"],
+                        Dependencies = [new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"])],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Build.targets",
+                            "../Directory.Packages.props",
+                            "../Packages.props",
+                        ],
+                        AdditionalFiles = [],
+                        ExpectedPackageManagementKind = PackageManagementKind.CentralPackageVersions,
+                        ExpectedPackageManagementSpecialFileRelativePath = "../Packages.props",
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
+    public async Task PackageManagementDetection_CentralPackageManagement()
+    {
+        await TestDiscoveryAsync(
+            packages: [MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0")],
+            workspacePath: "src",
+            files: [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net9.0"],
+                        Dependencies = [new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"])],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Build.targets",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
+                        ExpectedPackageManagementKind = PackageManagementKind.CentralPackageManagement,
+                        ExpectedPackageManagementSpecialFileRelativePath = "../Directory.Packages.props",
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
+    public async Task PackageManagementDetection_CentralPackageManagementWithTransitivePinning()
+    {
+        await TestDiscoveryAsync(
+            packages: [MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0")],
+            workspacePath: "src",
+            files: [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageVersion Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net9.0"],
+                        Dependencies = [new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"])],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [
+                            "../Directory.Build.props",
+                            "../Directory.Build.targets",
+                            "../Directory.Packages.props",
+                        ],
+                        AdditionalFiles = [],
+                        ExpectedPackageManagementKind = PackageManagementKind.CentralPackageManagementWithTransitivePinning,
+                        ExpectedPackageManagementSpecialFileRelativePath = "../Directory.Packages.props",
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
     public void MergeProjectDiscovery()
     {
         // project discovery is frequently merged with prior results (e.g., `packages.config` followed by `<PackageReference>`)
@@ -1695,6 +1926,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ImportedFiles = ["imported/a.props"],
             AdditionalFiles = ["a/packages.config"],
             PackageManagementKind = PackageManagementKind.Default,
+            PackageManagementSpecialFileRelativePath = null,
         };
         var result2 = new ProjectDiscoveryResult()
         {
@@ -1710,6 +1942,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             ImportedFiles = ["imported/b.props"],
             AdditionalFiles = ["b/app.config"],
             PackageManagementKind = PackageManagementKind.CentralPackageManagement,
+            PackageManagementSpecialFileRelativePath = "Directory.Packages.props",
         };
 
         // to make sure we're checking everything exactly, we'll explicitly check each item
@@ -1737,6 +1970,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         AssertEx.Equal(["imported/a.props", "imported/b.props"], merged.ImportedFiles);
         AssertEx.Equal(["a/packages.config", "b/app.config"], merged.AdditionalFiles);
         Assert.Equal(PackageManagementKind.CentralPackageManagement, merged.PackageManagementKind);
+        Assert.Equal("Directory.Packages.props", merged.PackageManagementSpecialFileRelativePath);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -22,6 +22,8 @@ public record ExpectedSdkProjectDiscoveryResult : ExpectedDependencyDiscoveryRes
     public required ImmutableArray<string> ImportedFiles { get; init; }
     public required ImmutableArray<string> AdditionalFiles { get; init; }
     public string? ErrorDetails { get; init; }
+    public PackageManagementKind? ExpectedPackageManagementKind { get; init; } = null;
+    public string? ExpectedPackageManagementSpecialFileRelativePath { get; init; } = null;
 }
 
 public record ExpectedDependencyDiscoveryResult : IDiscoveryResultWithDependencies

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -471,6 +471,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             ImportedFiles = mergedImportedFiles,
             AdditionalFiles = mergedAdditionalFiles,
             PackageManagementKind = (PackageManagementKind)Math.Max((int)result1.PackageManagementKind, (int)result2.PackageManagementKind),
+            PackageManagementSpecialFileRelativePath = result1.PackageManagementSpecialFileRelativePath ?? result2.PackageManagementSpecialFileRelativePath,
         };
         return mergedResult;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackageManagementKind.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/PackageManagementKind.cs
@@ -8,6 +8,11 @@ public enum PackageManagementKind
     Default,
 
     /// <summary>
+    /// The Central Package Versions feature has been deprecated in favor of Central Package Management, but it still exists.
+    /// </summary>
+    CentralPackageVersions,
+
+    /// <summary>
     /// Separate <code>&lt;PackageReference&gt;</code> and <code>&lt;PackageVersion&gt;</code> elements.  Set by the
     /// user by adding the property <code>&lt;ManagePackageVersionsCentrally&gt;true&lt;/ManagePackageVersionsCentrally&gt;</code>
     /// and commonly using the file <code>Directory.Packages.props</code>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -7,12 +7,13 @@ namespace NuGetUpdater.Core.Discover;
 public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
 {
     public required string FilePath { get; init; }
-    public required ImmutableArray<Dependency> Dependencies { get; init; }
     public bool IsSuccess { get; init; } = true;
     public JobErrorBase? Error { get; init; } = null;
     public ImmutableArray<string> TargetFrameworks { get; init; } = [];
+    public PackageManagementKind PackageManagementKind { get; init; } = PackageManagementKind.Default;
+    public string? PackageManagementSpecialFileRelativePath { get; init; } = null;
     public ImmutableArray<string> ReferencedProjectPaths { get; init; } = [];
     public required ImmutableArray<string> ImportedFiles { get; init; }
     public required ImmutableArray<string> AdditionalFiles { get; init; }
-    public PackageManagementKind PackageManagementKind { get; init; } = PackageManagementKind.Default;
+    public required ImmutableArray<Dependency> Dependencies { get; init; }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -630,7 +630,7 @@ internal static class SdkProjectDiscovery
                 .ThenBy(d => d.Version)
                 .ToImmutableArray();
 
-            // others
+            // other values
             var projectProperties = resolvedProperties[projectPath];
             var referenced = referencedProjects.GetOrAdd(projectPath, () => new(PathComparer.Instance))
                 .Select(p => Path.GetRelativePath(projectFullDirectory, p).NormalizePathToUnix())
@@ -643,19 +643,36 @@ internal static class SdkProjectDiscovery
                 .Select(p => p.NormalizePathToUnix())
                 .OrderBy(p => p)
                 .ToImmutableArray();
-            var projectLevelCpm =
-                projectProperties.TryGetValue("ManagePackageVersionsCentrally", out var useCpmString) &&
-                bool.TryParse(useCpmString, out var useCpm) &&
-                useCpm;
+
+            // package management special values
+            var projectLevelCpm = GetBooleanPropertyFromProjectProperties(projectProperties, "ManagePackageVersionsCentrally");
             var projectLevelCpmWithPinning =
                 projectLevelCpm &&
-                projectProperties.TryGetValue("CentralPackageTransitivePinningEnabled", out var useTransitivePinningString) &&
-                bool.TryParse(useTransitivePinningString, out var useTransitivePinning) &&
-                useTransitivePinning;
+                GetBooleanPropertyFromProjectProperties(projectProperties, "CentralPackageTransitivePinningEnabled");
+            var centralPackageVersions = GetBooleanPropertyFromProjectProperties(projectProperties, "UsingMicrosoftCentralPackageVersionsSdk");
             var packageManagementKind =
                 projectLevelCpmWithPinning ? PackageManagementKind.CentralPackageManagementWithTransitivePinning :
                 projectLevelCpm ? PackageManagementKind.CentralPackageManagement :
+                centralPackageVersions ? PackageManagementKind.CentralPackageVersions :
                 PackageManagementKind.Default;
+            var packageManagementFile = packageManagementKind switch
+            {
+                PackageManagementKind.CentralPackageVersions => GetStringPropertyFromProjectProperties(projectProperties, "CentralPackagesFile"),
+                PackageManagementKind.CentralPackageManagement or
+                PackageManagementKind.CentralPackageManagementWithTransitivePinning => GetStringPropertyFromProjectProperties(projectProperties, "DirectoryPackagesPropsPath"),
+                _ => null,
+            };
+
+            if (packageManagementFile is not null)
+            {
+                packageManagementFile = Path.GetRelativePath(projectFullDirectory, packageManagementFile).NormalizePathToUnix();
+            }
+
+            if (packageManagementKind != PackageManagementKind.Default && packageManagementFile is null)
+            {
+                logger.Warn($"Project [{projectRelativePath}] detected package management kind of {packageManagementKind} but no package management file found; forcing management kind to {PackageManagementKind.Default}.");
+                packageManagementKind = PackageManagementKind.Default;
+            }
 
             var projectDiscoveryResult = new ProjectDiscoveryResult()
             {
@@ -666,6 +683,7 @@ internal static class SdkProjectDiscovery
                 ImportedFiles = imported,
                 AdditionalFiles = additional,
                 PackageManagementKind = packageManagementKind,
+                PackageManagementSpecialFileRelativePath = packageManagementFile,
             };
             projectDiscoveryResults.Add(projectDiscoveryResult);
         }
@@ -964,5 +982,17 @@ internal static class SdkProjectDiscovery
         }
 
         return tfm;
+    }
+
+    private static bool GetBooleanPropertyFromProjectProperties(Dictionary<string, string> projectProperties, string propertyName)
+    {
+        return projectProperties.TryGetValue(propertyName, out var propertyStringValue) &&
+            bool.TryParse(propertyStringValue, out var propertyValue) &&
+            propertyValue;
+    }
+
+    private static string? GetStringPropertyFromProjectProperties(Dictionary<string, string> projectProperties, string propertyName)
+    {
+        return projectProperties.TryGetValue(propertyName, out var propertyValue) ? propertyValue : null;
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -189,8 +189,11 @@ public class XmlFileWriter : IFileWriter
                 var addPackageReferenceElementForPinnedPackages =
                     packageManagementKind switch
                     {
+                        PackageManagementKind.Default or
+                        PackageManagementKind.CentralPackageVersions or
+                        PackageManagementKind.CentralPackageManagement => true,
                         PackageManagementKind.CentralPackageManagementWithTransitivePinning => false,
-                        _ => true,
+                        _ => throw new NotSupportedException($"Unexpected package management kind {packageManagementKind}"),
                     };
                 if (addPackageReferenceElementForPinnedPackages)
                 {


### PR DESCRIPTION
Detect and report Central Package Versions scheme in projects.

The feature Central Package Versions is deprecated in general and not fully supported in dependabot, but it's still used in the wild and reporting its detection makes investigations easier.  This is done by looking at a special property set in that SDK's props file.

This PR also logs the package manager's special file path; for Central Package Versions this is usually `Packages.props`, for Central Package Management `Directory.Packages.props`, and `null` everywhere else.  This value isn't directly used, but again it makes investigations easier.

Along that line of reasoning, the order of properties in project discovery has been changed to put `Dependencies` at the bottom because when investigating logs it's easier to see the project path, a handful of other properties, then the potentially large list of dependencies at the end.