### PR TITLE
don't warn on deprecated framework

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscoveryTargetingPacks.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyDiscoveryTargetingPacks.props
@@ -8,5 +8,7 @@
     <NoWarn>$(NoWarn);MSB3644</NoWarn>
     <!-- A package downgrade warning shouldn't be lifted to an error because that would prevent discovery. -->
     <NoWarn>$(NoWarn);NU1605</NoWarn>
+    <!-- Deprecated MonoAndroid framework shouldn't cause a warning because we'll do nothing about it here. -->
+    <NoWarn>$(NoWarn);NU1703</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The MonoAndroid framework is marked as deprecated in some .NET 11 SDKs and we don't want to unnecessarily report the warning because it's irrelevant to dependency discovery and there's nothing that we'd do about it anyway.

https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1703