### PR TITLE
Update Python runtime pins (latest patches) and pyenv

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,14 +3,14 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.2
-ARG PY_3_13=3.13.11
-ARG PY_3_12=3.12.12
-ARG PY_3_11=3.11.14
-ARG PY_3_10=3.10.19
-ARG PY_3_9=3.9.24
+ARG PY_3_14=3.14.4
+ARG PY_3_13=3.13.13
+ARG PY_3_12=3.12.13
+ARG PY_3_11=3.11.15
+ARG PY_3_10=3.10.20
+ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.16
+ARG PYENV_VERSION=v2.6.29
 
 FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
 ARG PY_3_14

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,7 +3,7 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.4
+ARG PY_3_14=3.14.5
 ARG PY_3_13=3.13.13
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -10,7 +10,7 @@ ARG PY_3_11=3.11.15
 ARG PY_3_10=3.10.20
 ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.29
+ARG PYENV_VERSION=v2.6.31
 
 FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
 ARG PY_3_14

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -16,12 +16,12 @@ module Dependabot
       # ARG PY_3_13=3.13.2
       # Note: uv ecosystem aliases this class, so updates here apply to both ecosystems.
       PRE_INSTALLED_PYTHON_VERSIONS_RAW = %w(
-        3.14.2
-        3.13.11
-        3.12.12
-        3.11.14
-        3.10.19
-        3.9.24
+        3.14.4
+        3.13.13
+        3.12.13
+        3.11.15
+        3.10.20
+        3.9.25
       ).freeze
 
       PRE_INSTALLED_PYTHON_VERSIONS = T.let(

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -16,7 +16,7 @@ module Dependabot
       # ARG PY_3_13=3.13.2
       # Note: uv ecosystem aliases this class, so updates here apply to both ecosystems.
       PRE_INSTALLED_PYTHON_VERSIONS_RAW = %w(
-        3.14.4
+        3.14.5
         3.13.13
         3.12.13
         3.11.15

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -2,7 +2,7 @@
 # This list must match the versions specified in
 # uv/lib/dependabot/uv/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.4
+ARG PY_3_14=3.14.5
 ARG PY_3_13=3.13.13
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -9,7 +9,7 @@ ARG PY_3_11=3.11.15
 ARG PY_3_10=3.10.20
 ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.29
+ARG PYENV_VERSION=v2.6.31
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
 FROM ghcr.io/astral-sh/uv:0.11.8 AS uv

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -2,14 +2,14 @@
 # This list must match the versions specified in
 # uv/lib/dependabot/uv/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.2
-ARG PY_3_13=3.13.11
-ARG PY_3_12=3.12.12
-ARG PY_3_11=3.11.14
-ARG PY_3_10=3.10.19
-ARG PY_3_9=3.9.24
+ARG PY_3_14=3.14.4
+ARG PY_3_13=3.13.13
+ARG PY_3_12=3.12.13
+ARG PY_3_11=3.11.15
+ARG PY_3_10=3.10.20
+ARG PY_3_9=3.9.25
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.16
+ARG PYENV_VERSION=v2.6.29
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
 FROM ghcr.io/astral-sh/uv:0.11.8 AS uv

--- a/uv/spec/dependabot/uv/file_updater/lock_file_error_handler_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_error_handler_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileErrorHandler do
 
       let(:git_fetch_credential_error) do
         <<~ERROR
-          Using CPython 3.11.14 interpreter at: /usr/local/.pyenv/versions/3.11.14/bin/python3.11
+          Using CPython 3.11.15 interpreter at: /usr/local/.pyenv/versions/3.11.15/bin/python3.11
              Updating https://github.com/org/private-repo (7a71bd9f5ae50ea4c8b4629a97ab35b95bba3c8f)
             × Failed to download and build `private-repo @
             │ git+https://github.com/org/private-repo@7a71bd9f5ae50ea4c8b4629a97ab35b95bba3c8f#subdirectory=pkg`
@@ -482,7 +482,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileErrorHandler do
 
       let(:conflicting_urls_error) do
         <<~ERROR
-          Using CPython 3.11.14 interpreter at: /usr/local/.pyenv/versions/3.11.14/bin/python3.11
+          Using CPython 3.11.15 interpreter at: /usr/local/.pyenv/versions/3.11.15/bin/python3.11
              Updating https://github.com/org/repo-a (HEAD)
              Updating https://github.com/org/repo-b (HEAD)
               Updated https://github.com/org/repo-a (c153cf38a632381e617475adff6f71cc9fe8087d)
@@ -516,7 +516,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileErrorHandler do
 
       let(:uv_lock_parse_error) do
         <<~ERROR
-          Using CPython 3.11.14 interpreter at: /usr/local/.pyenv/versions/3.11.14/bin/python3.11
+          Using CPython 3.11.15 interpreter at: /usr/local/.pyenv/versions/3.11.15/bin/python3.11
           error: Failed to parse `uv.lock`
             Caused by: Dependency `soupsieve` has missing `source` field but has more than one matching package
         ERROR
@@ -533,7 +533,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileErrorHandler do
     context "when error contains 'Using CPython' mid-message (not at start)" do
       let(:error) do
         Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-          message: "some other error\nUsing CPython 3.11.14 interpreter at: /usr/bin/python3.11\ndetails",
+          message: "some other error\nUsing CPython 3.11.15 interpreter at: /usr/bin/python3.11\ndetails",
           error_context: {}
         )
       end


### PR DESCRIPTION
Pin each supported Python 3.x version to the latest patch release. (Verified according to latest releases here: https://www.python.org/downloads/)
    
Bump PYENV_VERSION from v2.6.16 to [v2.6.31](https://github.com/pyenv/pyenv/releases/tag/v2.6.31).

### What are you trying to accomplish?

Resolves the problem that Dependabot does not support latest Python versions:
```
Dependabot does not support your Python version

Dependabot detected the following Python requirement for your project: '>=3.14.4,<3.15.0'.

Currently, the following Python versions are supported in Dependabot: 3.9.*, 3.10.*, 3.11.*, 3.12.*, 3.13.*, 3.14.*.
```

### Anything you want to highlight for special attention from reviewers?

This PR follows the same pattern as #13744, editing the same files, and including a pyenv patch version bump.

### How will you know you've accomplished your goal?

All tests pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
