### PR TITLE
fix(uv): prefer uv.lock versions over requirements.txt in file parser

### DIFF
--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -55,7 +55,7 @@ module Dependabot
 
         dependency_set += pyproject_file_dependencies if pyproject
         dependency_set += uv_lock_file_dependencies
-        dependency_set += requirement_dependencies if requirement_files.any?
+        dependency_set += requirement_dependencies if requirement_files.any? && uv_lock_files.empty?
 
         dependency_set.dependencies
       end

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -945,6 +945,27 @@ RSpec.describe Dependabot::Uv::FileParser do
           end
         end
       end
+
+      context "when a requirements.txt with stale versions is also present" do
+        let(:files) { [pyproject, uv_lock, stale_requirements] }
+        let(:stale_requirements) do
+          Dependabot::DependencyFile.new(
+            name: "third-party/requirements.txt",
+            content: "requests==2.28.0\n"
+          )
+        end
+
+        it "uses the version from uv.lock, not requirements.txt" do
+          requests_dep = dependencies.find { |d| d.name == "requests" }
+          expect(requests_dep.version).to eq("2.32.3")
+        end
+
+        it "does not include requirements from the txt file" do
+          requests_dep = dependencies.find { |d| d.name == "requests" }
+          req_files = requests_dep.requirements.map { |r| r[:file] }
+          expect(req_files).not_to include("third-party/requirements.txt")
+        end
+      end
     end
 
     context "with uv workspace member pyprojects" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a bug where the uv file parser uses dependency versions from `requirements.txt` files instead of the resolved versions in `uv.lock`, causing incorrect versions to be submitted to the dependency graph.

When both `uv.lock` and `requirements.txt` files exist in a repository, the parser adds dependencies from all sources. Due to how `DependencySet.combined_version` resolves duplicates (preferring entries with `top_level? == true`), the `requirements.txt` versions override the `uv.lock` versions — because `uv.lock` entries have empty `requirements: []` (making `top_level?` return `false`), while `requirements.txt` entries have populated requirements (making `top_level?` return `true`).

This causes the dependency graph to report stale versions from `requirements.txt`, preventing Dependabot security alerts from auto-dismissing even when `uv.lock` already contains the patched version.

**Root cause trace:**

1. `FileFetcher` (inherited from `Python::SharedFileFetcher`) scans subdirectories for `.txt` files and discovers stale `requirements.txt` files (e.g., `third-party/requirements_darwin.txt`)
2. `FileParser.parse` adds deps from `uv.lock` then `requirement_files` — both sources contribute versions for the same packages
3. `DependencySet::DependencySlot#combined_version` resolves the duplicate by preferring the `top_level?` entry (`requirements.txt`), discarding the correct `uv.lock` version
4. `DependencyGrapher` submits the wrong (stale) version to the dependency graph, labeled as coming from `uv.lock`

**Evidence from a real repository:**

| Package | `requirements.txt` | `uv.lock` | Graph submission |
|---|---|---|---|
| litellm | 1.78.6 | 1.83.14 | **1.78.6** (wrong) |
| aiohttp | 3.13.1 | 3.13.4 | **3.13.1** (wrong) |
| pydantic | 2.12.3 | 2.12.5 | **2.12.3** (wrong) |
| openai | 1.109.1 | 2.24.0 | **1.109.1** (wrong) |

### Anything you want to highlight for special attention from reviewers?

The fix is intentionally minimal: when `uv.lock` exists, skip parsing `.txt` requirement files for dependency versions. The lockfile is the resolved source of truth in a uv project.

This preserves the existing behavior for projects without `uv.lock` (e.g., pip-compile workflows that use `requirements.txt` as the lockfile).

Note: PR #14518 ("fix(uv): grapher not preferring lockfile") addressed which file is tagged as the graph submission source, but did not fix the underlying version data — the versions still came from `requirements.txt` via the file parser.

### How will you know you've accomplished your goal?

- New test case verifies that when both `uv.lock` and a stale `requirements.txt` exist, the parser uses the `uv.lock` version
- Existing tests continue to pass (projects without `uv.lock` are unaffected)
- The dependency graph correctly reports resolved versions from `uv.lock`

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.