### PR TITLE
fix: bump terraform version in Dockerfile

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -3,13 +3,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/
-ARG TERRAFORM_VERSION=1.14.4
+ARG TERRAFORM_VERSION=1.15.0
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ARG TERRAFORM_AMD64_CHECKSUM=4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+ARG TERRAFORM_AMD64_CHECKSUM=dcd4b31225dd960404f744315c0c3823a7deeda43bca0256a17fc762092d7e1b
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_arm64.zip"
-ARG TERRAFORM_ARM64_CHECKSUM=dcbc9d4b9fcd47e76ae194d5d569bfbf9f15bf1c59ca692aff6d2a92eb8e8994
+ARG TERRAFORM_ARM64_CHECKSUM=7d9b8ab81790771b5c872c06a8982bc25b66971928dccb244fe0a41e2451770a
 
 RUN cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Update the Terraform version from 1.14.4 to 1.15.0 so Dependabot can recognize and support the newer release. This fixes the current limitation where Terraform updates fail for versions greater than 1.14.0, which prevents teams from bumping required terraform beyond 1.14.4.

<!-- What issues does this affect or fix? -->

Issue similar to this https://github.com/dependabot/dependabot-core/pull/14100

### Anything you want to highlight for special attention from reviewers?

This is a targeted version bump to unblock Terraform updates for newer versions.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
