### PR TITLE
generate and submit dependency graphs

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -87,5 +87,8 @@ RUN chmod +x $DEPENDABOT_HOME/dependabot-updater/bin/run
 # .NET install targeting packs
 RUN pwsh $DEPENDABOT_HOME/dependabot-updater/bin/install-targeting-packs.ps1
 
+# Extract the Dependabot gem version for runtime use
+RUN sed -n 's/.*VERSION = "\(.*\)"/\1/p' $DEPENDABOT_HOME/common/lib/dependabot.rb > $DEPENDABOT_HOME/.dependabot-version
+
 # Enable MSBuild operations with a shallow clone for repos that use the Nerdbank.GitVersioning package
 ENV NBGV_GitEngine=Disabled

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="packageurl-dotnet" Version="2.0.0" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.3" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.3" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTestHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTestHelper.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using System.Text.Json;
+
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test;
+using NuGetUpdater.Core.Test.Update;
+
+using Xunit;
+
+namespace NuGetUpdater.Cli.Test;
+
+using TestFile = (string Path, string Content);
+
+internal static class EntryPointTestHelper
+{
+    internal static async Task RunAsync(
+        string commandName,
+        TestFile[] files,
+        Job job,
+        string[] expectedUrls,
+        MockNuGetPackage[]? packages = null,
+        string? repoContentsPath = null,
+        int expectedExitCode = 0)
+    {
+        using var tempDirectory = new TemporaryDirectory();
+
+        // write test files
+        foreach (var testFile in files)
+        {
+            var fullPath = Path.Join(tempDirectory.DirectoryPath, testFile.Path);
+            var directory = Path.GetDirectoryName(fullPath)!;
+            Directory.CreateDirectory(directory);
+            await File.WriteAllTextAsync(fullPath, testFile.Content);
+        }
+
+        // write job file
+        var jobPath = Path.Combine(tempDirectory.DirectoryPath, "job.json");
+        await File.WriteAllTextAsync(jobPath, JsonSerializer.Serialize(new { Job = job }, RunWorker.SerializerOptions));
+
+        // save packages
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, tempDirectory.DirectoryPath);
+
+        var actualUrls = new List<string>();
+        using var http = TestHttpServer.CreateTestStringServer((method, url) =>
+        {
+            actualUrls.Add($"{method} {new Uri(url).PathAndQuery}");
+            return (200, "ok");
+        });
+        var args = new List<string>()
+        {
+            commandName,
+            "--job-path",
+            jobPath,
+            "--repo-contents-path",
+            repoContentsPath ?? tempDirectory.DirectoryPath,
+            "--api-url",
+            http.BaseUrl,
+            "--job-id",
+            "TEST-ID",
+            "--base-commit-sha",
+            "BASE-COMMIT-SHA"
+        };
+
+        var output = new StringBuilder();
+        // redirect stdout
+        var originalOut = Console.Out;
+        Console.SetOut(new StringWriter(output));
+        int result = -1;
+        try
+        {
+            result = await Program.Main(args.ToArray());
+        }
+        catch
+        {
+            // restore stdout
+            Console.SetOut(originalOut);
+            throw;
+        }
+
+        Assert.True(result == expectedExitCode, $"Expected exit code {expectedExitCode} but got {result}.\nSTDOUT:\n" + output.ToString());
+        Assert.Equal(expectedUrls, actualUrls);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Graph.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Graph.cs
@@ -1,0 +1,65 @@
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test;
+
+using Xunit;
+
+namespace NuGetUpdater.Cli.Test;
+
+using TestFile = (string Path, string Content);
+
+public partial class EntryPointTests
+{
+    public class Graph
+    {
+        [Fact]
+        public async Task Graph_Simple()
+        {
+            // verify we can pass command line arguments for graph command
+            await RunAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                ],
+                files:
+                [
+                    ("Directory.Build.props", "<Project />"),
+                    ("Directory.Build.targets", "<Project />"),
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                          </PropertyGroup>
+                        </Project>
+                        """),
+                    ("src/project.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net8.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="1.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """)
+                ],
+                job: new Job()
+                {
+                    Source = new()
+                    {
+                        Provider = "github",
+                        Repo = "test",
+                        Directory = "src",
+                    }
+                },
+                expectedUrls:
+                [
+                    "POST /update_jobs/TEST-ID/create_dependency_submission",
+                    "PATCH /update_jobs/TEST-ID/mark_as_processed",
+                ]
+            );
+        }
+
+        private static Task RunAsync(TestFile[] files, Job job, string[] expectedUrls, MockNuGetPackage[]? packages = null, string? repoContentsPath = null, int expectedExitCode = 0)
+            => EntryPointTestHelper.RunAsync("graph", files, job, expectedUrls, packages, repoContentsPath, expectedExitCode);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTests.Run.cs
@@ -143,65 +143,7 @@ public partial class EntryPointTests
             );
         }
 
-        private static async Task RunAsync(TestFile[] files, Job job, string[] expectedUrls, MockNuGetPackage[]? packages = null, string? repoContentsPath = null, int expectedExitCode = 0)
-        {
-            using var tempDirectory = new TemporaryDirectory();
-
-            // write test files
-            foreach (var testFile in files)
-            {
-                var fullPath = Path.Join(tempDirectory.DirectoryPath, testFile.Path);
-                var directory = Path.GetDirectoryName(fullPath)!;
-                Directory.CreateDirectory(directory);
-                await File.WriteAllTextAsync(fullPath, testFile.Content);
-            }
-
-            // write job file
-            var jobPath = Path.Combine(tempDirectory.DirectoryPath, "job.json");
-            await File.WriteAllTextAsync(jobPath, JsonSerializer.Serialize(new { Job = job }, RunWorker.SerializerOptions));
-
-            // save packages
-            await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, tempDirectory.DirectoryPath);
-
-            var actualUrls = new List<string>();
-            using var http = TestHttpServer.CreateTestStringServer((method, url) =>
-            {
-                actualUrls.Add($"{method} {new Uri(url).PathAndQuery}");
-                return (200, "ok");
-            });
-            var args = new List<string>()
-            {
-                "run",
-                "--job-path",
-                jobPath,
-                "--repo-contents-path",
-                repoContentsPath ?? tempDirectory.DirectoryPath,
-                "--api-url",
-                http.BaseUrl,
-                "--job-id",
-                "TEST-ID",
-                "--base-commit-sha",
-                "BASE-COMMIT-SHA"
-            };
-
-            var output = new StringBuilder();
-            // redirect stdout
-            var originalOut = Console.Out;
-            Console.SetOut(new StringWriter(output));
-            int result = -1;
-            try
-            {
-                result = await Program.Main(args.ToArray());
-            }
-            catch
-            {
-                // restore stdout
-                Console.SetOut(originalOut);
-                throw;
-            }
-
-            Assert.True(result == expectedExitCode, $"Expected exit code {expectedExitCode} but got {result}.\nSTDOUT:\n" + output.ToString());
-            Assert.Equal(expectedUrls, actualUrls);
-        }
+        private static Task RunAsync(TestFile[] files, Job job, string[] expectedUrls, MockNuGetPackage[]? packages = null, string? repoContentsPath = null, int expectedExitCode = 0)
+            => EntryPointTestHelper.RunAsync("run", files, job, expectedUrls, packages, repoContentsPath, expectedExitCode);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/CloneCommand.cs
@@ -8,33 +8,24 @@ namespace NuGetUpdater.Cli.Commands;
 
 internal static class CloneCommand
 {
-    internal static readonly Option<FileInfo> JobPathOption = new("--job-path") { Required = true };
-    internal static readonly Option<DirectoryInfo> RepoContentsPathOption = new("--repo-contents-path") { Required = true };
-    internal static readonly Option<Uri> ApiUrlOption = new("--api-url")
-    {
-        Required = true,
-        CustomParser = (argumentResult) => Uri.TryCreate(argumentResult.Tokens.Single().Value, UriKind.Absolute, out var uri) ? uri : throw new ArgumentException("Invalid API URL format.")
-    };
-    internal static readonly Option<string> JobIdOption = new("--job-id") { Required = true };
-
     internal static Command GetCommand(Action<int> setExitCode)
     {
         var command = new Command("clone", "Clones a repository in preparation for a dependabot job.")
         {
-            JobPathOption,
-            RepoContentsPathOption,
-            ApiUrlOption,
-            JobIdOption,
+            SharedOptions.JobPathOption,
+            SharedOptions.RepoContentsPathOption,
+            SharedOptions.ApiUrlOption,
+            SharedOptions.JobIdOption,
         };
 
         command.TreatUnmatchedTokensAsErrors = true;
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
-            var jobPath = parseResult.GetValue(JobPathOption);
-            var repoContentsPath = parseResult.GetValue(RepoContentsPathOption);
-            var apiUrl = parseResult.GetValue(ApiUrlOption);
-            var jobId = parseResult.GetValue(JobIdOption);
+            var jobPath = parseResult.GetValue(SharedOptions.JobPathOption);
+            var repoContentsPath = parseResult.GetValue(SharedOptions.RepoContentsPathOption);
+            var apiUrl = parseResult.GetValue(SharedOptions.ApiUrlOption);
+            var jobId = parseResult.GetValue(SharedOptions.JobIdOption);
 
             var apiHandler = new HttpApiHandler(apiUrl!.ToString(), jobId!);
             var logger = new OpenTelemetryLogger();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/GraphCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/GraphCommand.cs
@@ -1,17 +1,17 @@
 using System.CommandLine;
 
 using NuGetUpdater.Core;
-using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Graph;
 using NuGetUpdater.Core.Run;
 
 namespace NuGetUpdater.Cli.Commands;
 
-internal static class RunCommand
+internal static class GraphCommand
 {
     internal static Command GetCommand(Action<int> setExitCode)
     {
-        Command command = new("run", "Runs a full dependabot job.")
+        Command command = new("graph", "Generates a dependency graph for a repository.")
         {
             SharedOptions.JobPathOption,
             SharedOptions.RepoContentsPathOption,
@@ -36,9 +36,7 @@ internal static class RunCommand
             var (experimentsManager, _errorResult) = await ExperimentsManager.FromJobFileAsync(jobId!, jobPath!.FullName);
             var logger = new OpenTelemetryLogger();
             var discoverWorker = new DiscoveryWorker(jobId!, experimentsManager, logger);
-            var analyzeWorker = new AnalyzeWorker(jobId!, experimentsManager, logger);
-            var updateWorker = new UpdaterWorker(jobId!, experimentsManager, logger);
-            var worker = new RunWorker(jobId!, apiHandler, discoverWorker, analyzeWorker, updateWorker, logger);
+            var worker = new GraphWorker(jobId!, apiHandler, discoverWorker, logger);
             var result = await worker.RunAsync(jobPath!, repoContentsPath!, caseInsensitiveRepoContentsPath, baseCommitSha!);
             setExitCode(result);
             return 0;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/SharedOptions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Commands/SharedOptions.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+
+namespace NuGetUpdater.Cli.Commands;
+
+internal static class SharedOptions
+{
+    internal static readonly Option<FileInfo> JobPathOption = new("--job-path") { Required = true };
+    internal static readonly Option<DirectoryInfo> RepoContentsPathOption = new("--repo-contents-path") { Required = true };
+    internal static readonly Option<DirectoryInfo?> CaseInsensitiveRepoContentsPathOption = new("--case-insensitive-repo-contents-path") { Required = false };
+    internal static readonly Option<Uri> ApiUrlOption = new("--api-url")
+    {
+        Required = true,
+        CustomParser = (argumentResult) => Uri.TryCreate(argumentResult.Tokens.Single().Value, UriKind.Absolute, out var uri) ? uri : throw new ArgumentException("Invalid API URL format.")
+    };
+    internal static readonly Option<string> JobIdOption = new("--job-id") { Required = true };
+    internal static readonly Option<string> BaseCommitShaOption = new("--base-commit-sha") { Required = true };
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Program.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli/Program.cs
@@ -20,6 +20,7 @@ internal sealed class Program
         {
             CloneCommand.GetCommand(setExitCode),
             RunCommand.GetCommand(setExitCode),
+            GraphCommand.GetCommand(setExitCode),
         };
         command.TreatUnmatchedTokensAsErrors = true;
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -117,6 +117,16 @@ public class DiscoveryWorkerTestBase : TestBase
             {
                 Assert.Equal(expectedProject.ExpectedPackageManagementSpecialFileRelativePath, actualProject.PackageManagementSpecialFileRelativePath);
             }
+
+            if (expectedProject.ExpectedDependencyGraph is not null)
+            {
+                Assert.Equal(expectedProject.ExpectedDependencyGraph.Count, actualProject.DependencyGraph.Count);
+                foreach (var (key, expectedDeps) in expectedProject.ExpectedDependencyGraph)
+                {
+                    Assert.True(actualProject.DependencyGraph.TryGetValue(key, out var actualDeps), $"Dependency graph missing key: {key}. Available keys: [{string.Join(", ", actualProject.DependencyGraph.Keys)}]");
+                    AssertEx.Equal(expectedDeps, actualDeps, message: $"Dependency graph mismatch for key: {key}");
+                }
+            }
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -2149,4 +2149,121 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
+
+    [Fact]
+    public async Task TestDependencyGraphIsEmpty_PackagesConfig()
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net45",
+                    dependencyGroups: [(null, [("Some.Dependency", "2.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Some.Dependency", "2.0.0", "net45"),
+            ],
+            workspacePath: "src",
+            files:
+            [
+                ("src/project.csproj", """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Some.Package">
+                          <HintPath>packages\Some.Package.1.0.0\lib\net45\Some.Package.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """),
+                ("src/packages.config", """
+                    <packages>
+                      <package id="Some.Package" version="1.0.0" targetFramework="net45" />
+                    </packages>
+                    """),
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects =
+                [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net45"],
+                        Dependencies =
+                        [
+                            new Dependency("Some.Package", "1.0.0", DependencyType.PackagesConfig, TargetFrameworks: ["net45"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [
+                            "packages.config",
+                        ],
+                        ExpectedDependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["Some.Package/1.0.0"] = [],
+                        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
+    public async Task TestDependencyGraphIsPopulated()
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0",
+                    dependencyGroups: [(null, [("Some.Dependency", "2.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Some.Dependency", "2.0.0", "net8.0"),
+            ],
+            workspacePath: "src",
+            files:
+            [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects =
+                [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies =
+                        [
+                            new Dependency("Some.Dependency", "2.0.0", DependencyType.Unknown, TargetFrameworks: ["net8.0"], IsTopLevel: false),
+                            new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                        ExpectedDependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["Some.Package/1.0.0"] = ["Some.Dependency/2.0.0"],
+                            ["Some.Dependency/2.0.0"] = [],
+                        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+                    }
+                ]
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -24,6 +24,7 @@ public record ExpectedSdkProjectDiscoveryResult : ExpectedDependencyDiscoveryRes
     public string? ErrorDetails { get; init; }
     public PackageManagementKind? ExpectedPackageManagementKind { get; init; } = null;
     public string? ExpectedPackageManagementSpecialFileRelativePath { get; init; } = null;
+    public ImmutableDictionary<string, ImmutableArray<string>>? ExpectedDependencyGraph { get; init; }
 }
 
 public record ExpectedDependencyDiscoveryResult : IDiscoveryResultWithDependencies

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Graph/GraphWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Graph/GraphWorkerTests.cs
@@ -1,0 +1,465 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Graph;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Graph;
+
+public class GraphWorkerTests
+{
+    [Theory]
+    [MemberData(nameof(BuildDependencySubmissionTestData))]
+    public void BuildDependencySubmission_ConvertsDiscoveryResults(
+        WorkspaceDiscoveryResult discoveryResult,
+        Job job,
+        string baseCommitSha,
+        string repoRoot,
+        string directory,
+        string expectedStatus,
+        string? expectedReason,
+        int expectedManifestCount)
+    {
+        // Arrange
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = TestDiscoveryWorker.FromResults();
+        var worker = new GraphWorker("test-job-id", apiHandler, discoveryWorker, logger);
+
+        // Act
+        var result = worker.BuildDependencySubmission(discoveryResult, job, baseCommitSha, repoRoot, directory);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Version);
+        Assert.Equal(baseCommitSha, result.Sha);
+        Assert.Equal(expectedStatus, result.Metadata.Status);
+        Assert.Equal(expectedReason, result.Metadata.Reason);
+        Assert.Equal(expectedManifestCount, result.Manifests.Count);
+        Assert.Equal($"nuget::{directory}", result.Metadata.ScannedManifestPath);
+    }
+
+    public static IEnumerable<object?[]> BuildDependencySubmissionTestData()
+    {
+        var job = new Job
+        {
+            Source = new JobSource
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/",
+                Branch = "main"
+            }
+        };
+
+        // Test case 1: No projects discovered
+        yield return
+        [
+            // discoveryResult
+            new WorkspaceDiscoveryResult
+            {
+                Path = "/src",
+                Projects = ImmutableArray<ProjectDiscoveryResult>.Empty
+            },
+            // job
+            job,
+            // baseCommitSha
+            "abc123",
+            // repoRoot
+            "/repo",
+            // directory
+            "/src",
+            // expectedStatus
+            "skipped",
+            // expectedReason
+            "missing manifest files",
+            // expectedManifestCount
+            0
+        ];
+
+        // Test case 2: Project with no dependencies
+        yield return
+        [
+            // discoveryResult
+            new WorkspaceDiscoveryResult
+            {
+                Path = "/src",
+                Projects =
+                [
+                    new ProjectDiscoveryResult
+                    {
+                        FilePath = "project.csproj",
+                        Dependencies = ImmutableArray<Dependency>.Empty,
+                        ImportedFiles = ImmutableArray<string>.Empty,
+                        AdditionalFiles = ImmutableArray<string>.Empty
+                    }
+                ]
+            },
+            // job
+            job,
+            // baseCommitSha
+            "abc123",
+            // repoRoot
+            "/repo",
+            // directory
+            "/src",
+            // expectedStatus
+            "skipped",
+            // expectedReason
+            "missing manifest files",
+            // expectedManifestCount
+            0
+        ];
+
+        // Test case 3: Project with dependencies
+        yield return
+        [
+            // discoveryResult
+            new WorkspaceDiscoveryResult
+            {
+                Path = "/src",
+                Projects =
+                [
+                    new ProjectDiscoveryResult
+                    {
+                        FilePath = "project.csproj",
+                        Dependencies =
+                        [
+                            new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, IsTopLevel: true),
+                            new Dependency("Some.Dependency", "2.0.0", DependencyType.PackageReference, IsTopLevel: false)
+                        ],
+                        ImportedFiles = ImmutableArray<string>.Empty,
+                        AdditionalFiles = ImmutableArray<string>.Empty
+                    }
+                ]
+            },
+            // job
+            job,
+            // baseCommitSha
+            "def456",
+            // repoRoot
+            "/repo",
+            // directory
+            "/src",
+            // expectedStatus
+            "ok",
+            // expectedReason
+            null,
+            // expectedManifestCount
+            1
+        ];
+
+        // Test case 4: Multiple projects with dependencies
+        yield return
+        [
+            // discoveryResult
+            new WorkspaceDiscoveryResult
+            {
+                Path = "/src",
+                Projects =
+                [
+                    new ProjectDiscoveryResult
+                    {
+                        FilePath = "project1.csproj",
+                        Dependencies =
+                        [
+                            new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, IsTopLevel: true)
+                        ],
+                        ImportedFiles = ImmutableArray<string>.Empty,
+                        AdditionalFiles = ImmutableArray<string>.Empty
+                    },
+                    new ProjectDiscoveryResult
+                    {
+                        FilePath = "project2.csproj",
+                        Dependencies =
+                        [
+                            new Dependency("Some.Other.Package", "3.0.0", DependencyType.PackageReference, IsTopLevel: true)
+                        ],
+                        ImportedFiles = ImmutableArray<string>.Empty,
+                        AdditionalFiles = ImmutableArray<string>.Empty
+                    }
+                ]
+            },
+            // job
+            job,
+            // baseCommitSha
+            "ghi789",
+            // repoRoot
+            "/repo",
+            // directory
+            "/src",
+            // expectedStatus
+            "ok",
+            // expectedReason
+            null,
+            // expectedManifestCount
+            2
+        ];
+
+        // Test case 5: Dependencies without versions (should be skipped)
+        yield return
+        [
+            // discoveryResult
+            new WorkspaceDiscoveryResult
+            {
+                Path = "/src",
+                Projects =
+                [
+                    new ProjectDiscoveryResult
+                    {
+                        FilePath = "project.csproj",
+                        Dependencies =
+                        [
+                            new Dependency("SomePackage", null, DependencyType.PackageReference, IsTopLevel: true)
+                        ],
+                        ImportedFiles = ImmutableArray<string>.Empty,
+                        AdditionalFiles = ImmutableArray<string>.Empty
+                    }
+                ]
+            },
+            // job
+            job,
+            // baseCommitSha
+            "jkl012",
+            // repoRoot
+            "/repo",
+            // directory
+            "/src",
+            // expectedStatus
+            "skipped",
+            // expectedReason
+            "missing manifest files",
+            // expectedManifestCount
+            0
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(DependencyConversionTestData))]
+    public void BuildDependencySubmission_CorrectlyConvertsDependencies(
+        Dependency dependency,
+        string expectedPackageUrl,
+        string expectedRelationship,
+        string expectedScope)
+    {
+        // Arrange
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = TestDiscoveryWorker.FromResults();
+        var worker = new GraphWorker("test-job-id", apiHandler, discoveryWorker, logger);
+
+        var discoveryResult = new WorkspaceDiscoveryResult
+        {
+            Path = "/src",
+            Projects =
+            [
+                new ProjectDiscoveryResult
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [dependency],
+                    ImportedFiles = ImmutableArray<string>.Empty,
+                    AdditionalFiles = ImmutableArray<string>.Empty
+                }
+            ]
+        };
+
+        var job = new Job
+        {
+            Source = new JobSource
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/"
+            }
+        };
+
+        // Act
+        var result = worker.BuildDependencySubmission(discoveryResult, job, "abc123", "/repo", "/src");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Manifests);
+
+        var manifest = result.Manifests.Values.First();
+        Assert.Contains(expectedPackageUrl, manifest.Resolved.Keys);
+
+        var resolvedDep = manifest.Resolved[expectedPackageUrl];
+        Assert.Equal(expectedPackageUrl, resolvedDep.PackageUrl);
+        Assert.Equal(expectedRelationship, resolvedDep.Relationship);
+        Assert.Equal(expectedScope, resolvedDep.Scope);
+        Assert.Empty(resolvedDep.Dependencies);
+    }
+
+    public static IEnumerable<object[]> DependencyConversionTestData()
+    {
+        // Direct runtime dependency
+        yield return
+        [
+            // dependency
+            new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, IsTopLevel: true),
+            // expectedPackageUrl
+            "pkg:nuget/Some.Package@1.0.0",
+            // expectedRelationship
+            "direct",
+            // expectedScope
+            "runtime"
+        ];
+
+        // Indirect runtime dependency
+        yield return
+        [
+            // dependency
+            new Dependency("Some.Dependency", "2.0.0", DependencyType.PackageReference, IsTopLevel: false),
+            // expectedPackageUrl
+            "pkg:nuget/Some.Dependency@2.0.0",
+            // expectedRelationship
+            "indirect",
+            // expectedScope
+            "runtime"
+        ];
+
+        // PackageVersion dependency
+        yield return
+        [
+            // dependency
+            new Dependency("Some.Other.Package", "3.0.0", DependencyType.PackageVersion, IsTopLevel: true),
+            // expectedPackageUrl
+            "pkg:nuget/Some.Other.Package@3.0.0",
+            // expectedRelationship
+            "direct",
+            // expectedScope
+            "runtime"
+        ];
+    }
+
+    [Fact]
+    public void BuildDependencySubmission_PopulatesDependenciesFromGraph()
+    {
+        // Arrange
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = TestDiscoveryWorker.FromResults();
+        var worker = new GraphWorker("test-job-id", apiHandler, discoveryWorker, logger);
+
+        var dependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Some.Package/1.0.0"] = ["Some.Dependency/2.0.0", "Some.Other.Dependency/3.0.0"],
+            ["Some.Dependency/2.0.0"] = [],
+            ["Some.Other.Dependency/3.0.0"] = [],
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+        var discoveryResult = new WorkspaceDiscoveryResult
+        {
+            Path = "/src",
+            Projects =
+            [
+                new ProjectDiscoveryResult
+                {
+                    FilePath = "project.csproj",
+                    Dependencies =
+                    [
+                        new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, IsTopLevel: true),
+                        new Dependency("Some.Dependency", "2.0.0", DependencyType.PackageReference, IsTopLevel: false),
+                        new Dependency("Some.Other.Dependency", "3.0.0", DependencyType.PackageReference, IsTopLevel: false),
+                    ],
+                    ImportedFiles = ImmutableArray<string>.Empty,
+                    AdditionalFiles = ImmutableArray<string>.Empty,
+                    DependencyGraph = dependencyGraph,
+                }
+            ]
+        };
+
+        var job = new Job
+        {
+            Source = new JobSource
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/"
+            }
+        };
+
+        // Act
+        var result = worker.BuildDependencySubmission(discoveryResult, job, "abc123", "/repo", "/src");
+
+        // Assert
+        var manifest = Assert.Single(result.Manifests.Values);
+
+        // Some.Package should have two dependencies
+        var somePackage = manifest.Resolved["pkg:nuget/Some.Package@1.0.0"];
+        Assert.Equal("direct", somePackage.Relationship);
+        Assert.Equal(2, somePackage.Dependencies.Length);
+        Assert.Contains("pkg:nuget/Some.Dependency@2.0.0", somePackage.Dependencies);
+        Assert.Contains("pkg:nuget/Some.Other.Dependency@3.0.0", somePackage.Dependencies);
+
+        // Leaf packages should have no dependencies
+        var someDependency = manifest.Resolved["pkg:nuget/Some.Dependency@2.0.0"];
+        Assert.Empty(someDependency.Dependencies);
+
+        var someOtherDependency = manifest.Resolved["pkg:nuget/Some.Other.Dependency@3.0.0"];
+        Assert.Empty(someOtherDependency.Dependencies);
+    }
+
+    [Fact]
+    public void BuildDependencySubmission_OmitsGraphDependenciesNotInDiscoveredList()
+    {
+        // Arrange
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = TestDiscoveryWorker.FromResults();
+        var worker = new GraphWorker("test-job-id", apiHandler, discoveryWorker, logger);
+
+        var dependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Graph says Some.Package depends on both, but Undiscovered.Package is not discovered
+            ["Some.Package/1.0.0"] = ["Some.Dependency/2.0.0", "Undiscovered.Package/4.0.0"],
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+        var discoveryResult = new WorkspaceDiscoveryResult
+        {
+            Path = "/src",
+            Projects =
+            [
+                new ProjectDiscoveryResult
+                {
+                    FilePath = "project.csproj",
+                    Dependencies =
+                    [
+                        new Dependency("Some.Package", "1.0.0", DependencyType.PackageReference, IsTopLevel: true),
+                        new Dependency("Some.Dependency", "2.0.0", DependencyType.PackageReference, IsTopLevel: false),
+                    ],
+                    ImportedFiles = ImmutableArray<string>.Empty,
+                    AdditionalFiles = ImmutableArray<string>.Empty,
+                    DependencyGraph = dependencyGraph,
+                }
+            ]
+        };
+
+        var job = new Job
+        {
+            Source = new JobSource
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/"
+            }
+        };
+
+        // Act
+        var result = worker.BuildDependencySubmission(discoveryResult, job, "abc123", "/repo", "/src");
+
+        // Assert
+        var manifest = Assert.Single(result.Manifests.Values);
+        var somePackage = manifest.Resolved["pkg:nuget/Some.Package@1.0.0"];
+
+        // Only Some.Dependency should be listed; Undiscovered.Package is not in the discovered dependencies
+        Assert.Single(somePackage.Dependencies);
+        Assert.Contains("pkg:nuget/Some.Dependency@2.0.0", somePackage.Dependencies);
+
+        // Some.Dependency has no transitive dependencies
+        var someDependency = manifest.Resolved["pkg:nuget/Some.Dependency@2.0.0"];
+        Assert.Empty(someDependency.Dependencies);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -61,6 +61,41 @@ public class MessageReportTests
         yield return
         [
             // message
+            new CreateDependencySubmission()
+            {
+                Version = 0,
+                Sha = "unused",
+                Ref = "unused",
+                Job = new CreateDependencySubmission.SubmissionJob() { Correlator = "unused", Id = "unused" },
+                Detector = new CreateDependencySubmission.SubmissionDetector() { Name = "unused", Version = "unused", Url = "unused" },
+                Manifests = new Dictionary<string, CreateDependencySubmission.Manifest>()
+                {
+                    ["manifest1"] = new CreateDependencySubmission.Manifest()
+                    {
+                        Name = "manifest1",
+                        File = new CreateDependencySubmission.ManifestFile() { SourceLocation = "unused" },
+                        Metadata = new CreateDependencySubmission.ManifestMetadata() { Ecosystem = "unused" },
+                        Resolved = new Dictionary<string, CreateDependencySubmission.ResolvedDependency>(),
+                    },
+                },
+                Metadata = new CreateDependencySubmission.SubmissionMetadata()
+                {
+                    Status = "succeeded",
+                    ScannedManifestPath = "path/to/manifest",
+                },
+            },
+            // expected
+            """
+            CreateDependencySubmission
+            - Status: succeeded
+            - Scanned: path/to/manifest
+            - Manifests: 1
+            """
+        ];
+
+        yield return
+        [
+            // message
             new CreatePullRequest()
             {
                 Dependencies = [

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -978,4 +978,104 @@ public class SerializationTests : TestBase
             }
         ];
     }
+
+    [Fact]
+    public void SerializeCreateDependencySubmission()
+    {
+        var submission = new CreateDependencySubmission()
+        {
+            Version = 1,
+            Sha = "TEST-SHA",
+            Ref = "refs/heads/main",
+            Job = new CreateDependencySubmission.SubmissionJob()
+            {
+                Correlator = "dependabot-nuget-MyProject",
+                Id = "cli"
+            },
+            Detector = new CreateDependencySubmission.SubmissionDetector()
+            {
+                Name = "dependabot",
+                Version = "0.372.0",
+                Url = "https://github.com/dependabot/dependabot-core"
+            },
+            Manifests = new Dictionary<string, CreateDependencySubmission.Manifest>()
+            {
+                ["/src/MyProject.csproj"] = new CreateDependencySubmission.Manifest()
+                {
+                    Name = "/src/MyProject.csproj",
+                    File = new CreateDependencySubmission.ManifestFile()
+                    {
+                        SourceLocation = "src/MyProject.csproj"
+                    },
+                    Metadata = new CreateDependencySubmission.ManifestMetadata()
+                    {
+                        Ecosystem = "nuget"
+                    },
+                    Resolved = new Dictionary<string, CreateDependencySubmission.ResolvedDependency>()
+                    {
+                        ["pkg:nuget/Some.Package@1.0.0"] = new CreateDependencySubmission.ResolvedDependency()
+                        {
+                            PackageUrl = "pkg:nuget/Some.Package@1.0.0",
+                            Relationship = "direct",
+                            Scope = "runtime",
+                            Dependencies = ["pkg:nuget/Some.Dependency@2.0.0"]
+                        },
+                        ["pkg:nuget/Some.Dependency@2.0.0"] = new CreateDependencySubmission.ResolvedDependency()
+                        {
+                            PackageUrl = "pkg:nuget/Some.Dependency@2.0.0",
+                            Relationship = "indirect",
+                            Scope = "runtime",
+                            Dependencies = []
+                        }
+                    }
+                }
+            },
+            Metadata = new CreateDependencySubmission.SubmissionMetadata()
+            {
+                Status = "ok",
+                ScannedManifestPath = "nuget::/src"
+            }
+        };
+
+        var actual = HttpApiHandler.Serialize(submission);
+        var expected = """
+            {"data":{"version":1,"sha":"TEST-SHA","ref":"refs/heads/main","job":{"correlator":"dependabot-nuget-MyProject","id":"cli"},"detector":{"name":"dependabot","version":"0.372.0","url":"https://github.com/dependabot/dependabot-core"},"manifests":{"/src/MyProject.csproj":{"name":"/src/MyProject.csproj","file":{"source_location":"src/MyProject.csproj"},"metadata":{"ecosystem":"nuget"},"resolved":{"pkg:nuget/Some.Package@1.0.0":{"package_url":"pkg:nuget/Some.Package@1.0.0","relationship":"direct","scope":"runtime","dependencies":["pkg:nuget/Some.Dependency@2.0.0"]},"pkg:nuget/Some.Dependency@2.0.0":{"package_url":"pkg:nuget/Some.Dependency@2.0.0","relationship":"indirect","scope":"runtime","dependencies":[]}}}},"metadata":{"status":"ok","scanned_manifest_path":"nuget::/src"}}}
+            """;
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SerializeCreateDependencySubmission_Skipped()
+    {
+        var submission = new CreateDependencySubmission()
+        {
+            Version = 1,
+            Sha = "TEST-SHA",
+            Ref = "refs/heads/main",
+            Job = new CreateDependencySubmission.SubmissionJob()
+            {
+                Correlator = "dependabot-nuget-casing",
+                Id = "cli"
+            },
+            Detector = new CreateDependencySubmission.SubmissionDetector()
+            {
+                Name = "dependabot",
+                Version = "0.372.0",
+                Url = "https://github.com/dependabot/dependabot-core"
+            },
+            Manifests = new Dictionary<string, CreateDependencySubmission.Manifest>(),
+            Metadata = new CreateDependencySubmission.SubmissionMetadata()
+            {
+                Status = "skipped",
+                ScannedManifestPath = "nuget::/casing",
+                Reason = "missing manifest files"
+            }
+        };
+
+        var actual = HttpApiHandler.Serialize(submission);
+        var expected = """
+            {"data":{"version":1,"sha":"TEST-SHA","ref":"refs/heads/main","job":{"correlator":"dependabot-nuget-casing","id":"cli"},"detector":{"name":"dependabot","version":"0.372.0","url":"https://github.com/dependabot/dependabot-core"},"manifests":{},"metadata":{"status":"skipped","scanned_manifest_path":"nuget::/casing","reason":"missing manifest files"}}}
+            """;
+        Assert.Equal(expected, actual);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -398,6 +398,13 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 if (packagesConfigResult is not null)
                 {
                     var relativeProjectPath = Path.GetRelativePath(workspacePath, expandedProject).NormalizePathToUnix();
+                    var dependencyGraph = packagesConfigResult.Dependencies
+                        .Where(d => !string.IsNullOrEmpty(d.Version))
+                        .OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                        .ToImmutableDictionary(
+                            d => $"{d.Name}/{d.Version}",
+                            _ => ImmutableArray<string>.Empty,
+                            StringComparer.OrdinalIgnoreCase);
                     results[relativeProjectPath] = new ProjectDiscoveryResult()
                     {
                         FilePath = relativeProjectPath,
@@ -405,6 +412,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                         TargetFrameworks = packagesConfigResult.TargetFrameworks,
                         ImportedFiles = [], // no imported files resolved for packages.config scenarios
                         AdditionalFiles = packagesConfigResult.AdditionalFiles,
+                        DependencyGraph = dependencyGraph,
                     };
                 }
             }
@@ -520,6 +528,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             PackageManagementKind = (PackageManagementKind)Math.Max((int)result1.PackageManagementKind, (int)result2.PackageManagementKind),
             PackageManagementSpecialFileRelativePath = result1.PackageManagementSpecialFileRelativePath ?? result2.PackageManagementSpecialFileRelativePath,
             HasNoWarnNU1701 = result1.HasNoWarnNU1701 || result2.HasNoWarnNU1701,
+            DependencyGraph = MergeDependencyGraphs(result1.DependencyGraph, result2.DependencyGraph),
         };
         return mergedResult;
     }
@@ -544,6 +553,29 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
 
         return [.. filtered];
+    }
+
+    private static ImmutableDictionary<string, ImmutableArray<string>> MergeDependencyGraphs(
+        ImmutableDictionary<string, ImmutableArray<string>> graph1,
+        ImmutableDictionary<string, ImmutableArray<string>> graph2)
+    {
+        var merged = graph1.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in graph2)
+        {
+            if (merged.TryGetValue(kvp.Key, out var existing))
+            {
+                merged[kvp.Key] = existing
+                    .Union(kvp.Value, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                    .ToImmutableArray();
+            }
+            else
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return merged.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     internal static async Task WriteResultsAsync(string repoRootPath, string outputPath, WorkspaceDiscoveryResult result)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -17,4 +17,8 @@ public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
     public required ImmutableArray<string> AdditionalFiles { get; init; }
     public required ImmutableArray<Dependency> Dependencies { get; init; }
     public bool HasNoWarnNU1701 { get; init; } = false;
+    /// <summary>
+    /// Maps each package (keyed as "Name/Version") to its direct dependency package names, as extracted from project.assets.json.
+    /// </summary>
+    public ImmutableDictionary<string, ImmutableArray<string>> DependencyGraph { get; init; } = ImmutableDictionary<string, ImmutableArray<string>>.Empty;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -642,7 +642,9 @@ internal static class SdkProjectDiscovery
             {
                 foreach (var tfmObject in graphTargets.EnumerateObject())
                 {
-                    // build a lookup of package name -> resolved version for this TFM
+                    // Build a complete lookup of package name -> resolved version for this TFM.
+                    // This must be a separate pass because the dependency resolution below needs to
+                    // look up any package by name, including ones that appear later in the enumeration.
                     var resolvedVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var packageObject in tfmObject.Value.EnumerateObject())
                     {
@@ -653,6 +655,7 @@ internal static class SdkProjectDiscovery
                         }
                     }
 
+                    // Now that all resolved versions are known, build the dependency graph edges.
                     foreach (var packageObject in tfmObject.Value.EnumerateObject())
                     {
                         var parts = packageObject.Name.Split('/');

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -635,6 +635,57 @@ internal static class SdkProjectDiscovery
                 .ThenBy(d => d.Version)
                 .ToImmutableArray();
 
+            // extract dependency graph from project.assets.json
+            var dependencyGraphBuilder = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase);
+            if (assetsJson.Value is { } assetsForGraph &&
+                assetsForGraph.TryGetProperty("targets", out var graphTargets))
+            {
+                foreach (var tfmObject in graphTargets.EnumerateObject())
+                {
+                    // build a lookup of package name -> resolved version for this TFM
+                    var resolvedVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var packageObject in tfmObject.Value.EnumerateObject())
+                    {
+                        var parts = packageObject.Name.Split('/');
+                        if (parts.Length == 2)
+                        {
+                            resolvedVersions[parts[0]] = parts[1];
+                        }
+                    }
+
+                    foreach (var packageObject in tfmObject.Value.EnumerateObject())
+                    {
+                        var parts = packageObject.Name.Split('/');
+                        if (parts.Length == 2)
+                        {
+                            var packageName = parts[0];
+                            var packageVersion = parts[1];
+                            var graphKey = $"{packageName}/{packageVersion}";
+                            var depEntries = packageObject.Value.TryGetProperty("dependencies", out var deps)
+                                ? deps.EnumerateObject()
+                                    .Where(d => resolvedVersions.ContainsKey(d.Name))
+                                    .Select(d => $"{d.Name}/{resolvedVersions[d.Name]}")
+                                : [];
+                            if (!dependencyGraphBuilder.TryGetValue(graphKey, out var existing))
+                            {
+                                dependencyGraphBuilder[graphKey] = depEntries
+                                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                                    .ToImmutableArray();
+                            }
+                            else
+                            {
+                                dependencyGraphBuilder[graphKey] = existing
+                                    .Union(depEntries, StringComparer.OrdinalIgnoreCase)
+                                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                                    .ToImmutableArray();
+                            }
+                        }
+                    }
+                }
+            }
+
+            var dependencyGraph = dependencyGraphBuilder.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
             // other values
             var projectProperties = resolvedProperties[projectPath];
             var referenced = referencedProjects.GetOrAdd(projectPath, () => new(PathComparer.Instance))
@@ -702,6 +753,7 @@ internal static class SdkProjectDiscovery
                 PackageManagementKind = packageManagementKind,
                 PackageManagementSpecialFileRelativePath = packageManagementFile,
                 HasNoWarnNU1701 = hasNoWarnNU1701,
+                DependencyGraph = dependencyGraph,
             };
             projectDiscoveryResults.Add(projectDiscoveryResult);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
@@ -1,0 +1,227 @@
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Run.ApiModel;
+
+using PackageUrl;
+
+namespace NuGetUpdater.Core.Graph;
+
+public class GraphWorker : IGraphWorker
+{
+    private readonly string _jobId;
+    private readonly IApiHandler _apiHandler;
+    private readonly IDiscoveryWorker _discoveryWorker;
+    private readonly ILogger _logger;
+
+    public GraphWorker(string jobId, IApiHandler apiHandler, IDiscoveryWorker discoveryWorker, ILogger logger)
+    {
+        _jobId = jobId;
+        _apiHandler = apiHandler;
+        _discoveryWorker = discoveryWorker;
+        _logger = logger;
+    }
+
+    public async Task<int> RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha)
+    {
+        // Deserialize the job file
+        var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
+        var jobWrapper = RunWorker.Deserialize(jobFileContent);
+        var job = jobWrapper.Job;
+        var experimentsManager = ExperimentsManager.GetExperimentsManager(job.Experiments);
+
+        // Use the case-insensitive repo contents path if provided, otherwise use the original
+        var actualRepoContentsPath = caseInsensitiveRepoContentsPath ?? repoContentsPath;
+
+        int result = 0;
+        JobErrorBase? error = null;
+
+        try
+        {
+            // Process each directory in the job
+            foreach (var directory in job.GetAllDirectories(actualRepoContentsPath.FullName))
+            {
+                _logger.Info($"Running dependency discovery for directory: {directory}");
+
+                // Run dependency discovery
+                var discoveryResult = await _discoveryWorker.RunAsync(actualRepoContentsPath.FullName, directory);
+
+                // Check for discovery errors
+                if (discoveryResult.Error is not null)
+                {
+                    _logger.Error($"Discovery error in {directory}: {discoveryResult.Error.GetReport()}");
+                    await _apiHandler.RecordUpdateJobError(discoveryResult.Error, _logger);
+                    error = discoveryResult.Error;
+                    result = 1;
+                    continue;
+                }
+
+                // Build the dependency submission from the discovery results
+                var submission = BuildDependencySubmission(
+                    discoveryResult,
+                    job,
+                    baseCommitSha,
+                    repoContentsPath.FullName,
+                    directory);
+
+                // Submit the dependency graph
+                _logger.Info($"Submitting dependency graph for {directory}");
+                await _apiHandler.CreateDependencySubmission(submission);
+            }
+        }
+        catch (Exception ex)
+        {
+            error = JobErrorBase.ErrorFromException(ex, _jobId, actualRepoContentsPath.FullName);
+            await _apiHandler.RecordUpdateJobError(error, _logger);
+            result = 1;
+        }
+
+        // Mark the job as processed
+        await _apiHandler.MarkAsProcessed(new(baseCommitSha));
+
+        return result;
+    }
+
+    internal CreateDependencySubmission BuildDependencySubmission(
+        WorkspaceDiscoveryResult discoveryResult,
+        Job job,
+        string baseCommitSha,
+        string repoRoot,
+        string directory)
+    {
+        var manifests = new Dictionary<string, CreateDependencySubmission.Manifest>();
+        string status = "ok";
+        string? reason = null;
+
+        // If no projects were discovered, return a skipped submission
+        if (discoveryResult.Projects.IsEmpty)
+        {
+            _logger.Info($"No projects discovered in {directory}");
+            status = "skipped";
+            reason = "missing manifest files";
+        }
+        else
+        {
+            // Process each project
+            foreach (var project in discoveryResult.Projects)
+            {
+                var combinedPath = PathHelper.JoinPath(discoveryResult.Path, project.FilePath).NormalizePathToUnix();
+                var manifestPath = $"/{combinedPath}";
+                var sourceLocation = combinedPath;
+
+                var resolvedDependencies = new Dictionary<string, CreateDependencySubmission.ResolvedDependency>();
+
+                // Build a set of discovered dependency keys for filtering graph edges
+                var discoveredKeys = project.Dependencies
+                    .Where(d => !string.IsNullOrEmpty(d.Version))
+                    .Select(d => $"{d.Name}/{d.Version}")
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                // Process each dependency
+                foreach (var dependency in project.Dependencies)
+                {
+                    if (string.IsNullOrEmpty(dependency.Version))
+                    {
+                        continue; // Skip dependencies without versions
+                    }
+
+                    var packageUrl = new PackageURL("nuget", null, dependency.Name, dependency.Version, null, null).ToString();
+
+                    // Determine relationship (direct vs indirect)
+                    var relationship = dependency.IsTopLevel ? "direct" : "indirect";
+
+                    // Determine scope (runtime, development, etc.)
+                    var scope = dependency.Type switch
+                    {
+                        DependencyType.PackageReference => "runtime",
+                        DependencyType.PackageVersion => "runtime",
+                        _ => "runtime"
+                    };
+
+                    // Populate direct dependencies from the dependency graph (values are "Name/Version")
+                    var graphKey = $"{dependency.Name}/{dependency.Version}";
+                    var directDeps = project.DependencyGraph.TryGetValue(graphKey, out var depEntries)
+                        ? depEntries
+                            .Where(entry => discoveredKeys.Contains(entry))
+                            .Select(entry => entry.Split('/'))
+                            .Where(parts => parts.Length == 2)
+                            .Select(parts => new PackageURL("nuget", null, parts[0], parts[1], null, null).ToString())
+                            .ToArray()
+                        : [];
+
+                    resolvedDependencies[packageUrl] = new CreateDependencySubmission.ResolvedDependency
+                    {
+                        PackageUrl = packageUrl,
+                        Relationship = relationship,
+                        Scope = scope,
+                        Dependencies = directDeps
+                    };
+                }
+
+                // Only add manifest if it has dependencies
+                if (resolvedDependencies.Count > 0)
+                {
+                    manifests[manifestPath] = new CreateDependencySubmission.Manifest
+                    {
+                        Name = manifestPath,
+                        File = new CreateDependencySubmission.ManifestFile
+                        {
+                            SourceLocation = sourceLocation
+                        },
+                        Metadata = new CreateDependencySubmission.ManifestMetadata
+                        {
+                            Ecosystem = "nuget"
+                        },
+                        Resolved = resolvedDependencies
+                    };
+                }
+            }
+
+            // If no manifests with dependencies, mark as skipped
+            if (manifests.Count == 0)
+            {
+                _logger.Info($"No dependencies found in {directory}");
+                status = "skipped";
+                reason = "missing manifest files";
+            }
+        }
+
+        // Build the submission (always return a submission, even if skipped)
+        return new CreateDependencySubmission
+        {
+            Version = 1,
+            Sha = baseCommitSha,
+            Ref = $"refs/heads/{job.Source.Branch ?? "main"}",
+            Job = new CreateDependencySubmission.SubmissionJob
+            {
+                Correlator = $"dependabot-nuget-{directory.Replace("/", "-").TrimStart('-')}",
+                Id = _jobId
+            },
+            Detector = new CreateDependencySubmission.SubmissionDetector
+            {
+                Name = "dependabot",
+                Version = GetDetectorVersion(),
+                Url = "https://github.com/dependabot/dependabot-core"
+            },
+            Manifests = manifests,
+            Metadata = new CreateDependencySubmission.SubmissionMetadata
+            {
+                Status = status,
+                ScannedManifestPath = $"nuget::{directory}",
+                Reason = reason
+            }
+        };
+    }
+
+    internal static string GetDetectorVersion()
+    {
+        var version = Environment.GetEnvironmentVariable("DEPENDABOT_VERSION") ?? "development";
+        var sha = Environment.GetEnvironmentVariable("DEPENDABOT_UPDATER_SHA");
+        if (!string.IsNullOrEmpty(sha))
+        {
+            version = $"{version}-{sha}";
+        }
+
+        return version;
+    }
+}
+

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
@@ -27,7 +30,6 @@ public class GraphWorker : IGraphWorker
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
         var jobWrapper = RunWorker.Deserialize(jobFileContent);
         var job = jobWrapper.Job;
-        var experimentsManager = ExperimentsManager.GetExperimentsManager(job.Experiments);
 
         // Use the case-insensitive repo contents path if provided, otherwise use the original
         var actualRepoContentsPath = caseInsensitiveRepoContentsPath ?? repoContentsPath;
@@ -190,10 +192,10 @@ public class GraphWorker : IGraphWorker
         {
             Version = 1,
             Sha = baseCommitSha,
-            Ref = $"refs/heads/{job.Source.Branch ?? "main"}",
+            Ref = GetSymbolicRef(job.Source.Branch),
             Job = new CreateDependencySubmission.SubmissionJob
             {
-                Correlator = $"dependabot-nuget-{directory.Replace("/", "-").TrimStart('-')}",
+                Correlator = GetCorrelator(directory),
                 Id = _jobId
             },
             Detector = new CreateDependencySubmission.SubmissionDetector
@@ -212,9 +214,36 @@ public class GraphWorker : IGraphWorker
         };
     }
 
+    internal static string GetSymbolicRef(string? branch)
+    {
+        branch = (branch ?? "main").TrimStart('/');
+        if (branch.StartsWith("refs/", StringComparison.OrdinalIgnoreCase))
+        {
+            return branch;
+        }
+
+        return $"refs/heads/{branch}";
+    }
+
+    internal static string GetCorrelator(string directory)
+    {
+        var sanitized = directory.TrimStart('/').Replace("/", "-").TrimStart('-');
+        if (Encoding.UTF8.GetByteCount(sanitized) > 32)
+        {
+            sanitized = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(sanitized)));
+        }
+
+        return string.IsNullOrEmpty(sanitized) ? "dependabot-nuget" : $"dependabot-nuget-{sanitized}";
+    }
+
     internal static string GetDetectorVersion()
     {
-        var version = Environment.GetEnvironmentVariable("DEPENDABOT_VERSION") ?? "development";
+        var version = Environment.GetEnvironmentVariable("DEPENDABOT_VERSION");
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            version = "development";
+        }
+
         var sha = Environment.GetEnvironmentVariable("DEPENDABOT_UPDATER_SHA");
         if (!string.IsNullOrEmpty(sha))
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IGraphWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/IGraphWorker.cs
@@ -1,0 +1,6 @@
+namespace NuGetUpdater.Core;
+
+public interface IGraphWorker
+{
+    Task<int> RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="packageurl-dotnet" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreateDependencySubmission.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreateDependencySubmission.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public sealed record CreateDependencySubmission : MessageBase
+{
+    public required int Version { get; init; }
+
+    public required string Sha { get; init; }
+
+    public required string Ref { get; init; }
+
+    public required SubmissionJob Job { get; init; }
+
+    public required SubmissionDetector Detector { get; init; }
+
+    public required Dictionary<string, Manifest> Manifests { get; init; }
+
+    public required SubmissionMetadata Metadata { get; init; }
+
+    public override string GetReport()
+    {
+        var report = new StringBuilder();
+        report.AppendLine(nameof(CreateDependencySubmission));
+        report.AppendLine($"- Status: {Metadata.Status}");
+        report.AppendLine($"- Scanned: {Metadata.ScannedManifestPath}");
+        report.AppendLine($"- Manifests: {Manifests.Count}");
+        return report.ToString().Trim();
+    }
+
+    public sealed record SubmissionJob
+    {
+        public required string Correlator { get; init; }
+
+        public required string Id { get; init; }
+    }
+
+    public sealed record SubmissionDetector
+    {
+        public required string Name { get; init; }
+
+        public required string Version { get; init; }
+
+        public required string Url { get; init; }
+    }
+
+    public sealed record Manifest
+    {
+        public required string Name { get; init; }
+
+        public required ManifestFile File { get; init; }
+
+        public required ManifestMetadata Metadata { get; init; }
+
+        public required Dictionary<string, ResolvedDependency> Resolved { get; init; }
+    }
+
+    public sealed record ManifestFile
+    {
+        [JsonPropertyName("source_location")]
+        public required string SourceLocation { get; init; }
+    }
+
+    public sealed record ManifestMetadata
+    {
+        public required string Ecosystem { get; init; }
+    }
+
+    public sealed record ResolvedDependency
+    {
+        [JsonPropertyName("package_url")]
+        public required string PackageUrl { get; init; }
+
+        public required string Relationship { get; init; }
+
+        public required string Scope { get; init; }
+
+        public required string[] Dependencies { get; init; }
+    }
+
+    public sealed record SubmissionMetadata
+    {
+        public required string Status { get; init; }
+
+        [JsonPropertyName("scanned_manifest_path")]
+        public required string ScannedManifestPath { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Reason { get; init; }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -46,6 +46,7 @@ public static class IApiHandlerExtensions
     public static Task ClosePullRequest(this IApiHandler handler, ClosePullRequest closePullRequest) => handler.PostAsJson("close_pull_request", closePullRequest);
     public static Task UpdatePullRequest(this IApiHandler handler, UpdatePullRequest updatePullRequest) => handler.PostAsJson("update_pull_request", updatePullRequest);
     public static Task MarkAsProcessed(this IApiHandler handler, MarkAsProcessed markAsProcessed) => handler.PatchAsJson("mark_as_processed", markAsProcessed);
+    public static Task CreateDependencySubmission(this IApiHandler handler, CreateDependencySubmission createDependencySubmission) => handler.PostAsJson("create_dependency_submission", createDependencySubmission);
 
     private static Task PostAsJson(this IApiHandler handler, string endpoint, object body) => handler.WithRetries(() => handler.SendAsync(endpoint, body, "POST"));
     private static Task PatchAsJson(this IApiHandler handler, string endpoint, object body) => handler.WithRetries(() => handler.SendAsync(endpoint, body, "PATCH"));

--- a/nuget/script/run
+++ b/nuget/script/run
@@ -1,5 +1,8 @@
 #!/bin/bash
 # shellcheck disable=all
 
-export DEPENDABOT_VERSION=$(cat "$DEPENDABOT_HOME/.dependabot-version")
+VERSION_FILE="$DEPENDABOT_HOME/.dependabot-version"
+if [ -f "$VERSION_FILE" ] && [ -s "$VERSION_FILE" ]; then
+  export DEPENDABOT_VERSION=$(cat "$VERSION_FILE")
+fi
 pwsh "$DEPENDABOT_HOME/dependabot-updater/bin/main.ps1" $*

--- a/nuget/script/run
+++ b/nuget/script/run
@@ -1,4 +1,5 @@
 #!/bin/bash
 # shellcheck disable=all
 
+export DEPENDABOT_VERSION=$(cat "$DEPENDABOT_HOME/.dependabot-version")
 pwsh "$DEPENDABOT_HOME/dependabot-updater/bin/main.ps1" $*

--- a/nuget/updater/main.ps1
+++ b/nuget/updater/main.ps1
@@ -35,7 +35,15 @@ function Get-Files {
     }
 }
 
-function Update-Files {
+function Get-BaseCommitSha {
+    Push-Location $env:DEPENDABOT_REPO_CONTENTS_PATH
+    $baseCommitSha = git rev-parse HEAD
+    Pop-Location
+    Write-Host "Base commit SHA: $baseCommitSha"
+    return $baseCommitSha
+}
+
+function Initialize-UpdateEnvironment {
     # install relevant SDKs
     Install-Sdks `
         -jobFilePath $env:DEPENDABOT_JOB_PATH `
@@ -45,14 +53,16 @@ function Update-Files {
     # TODO: install workloads?
 
     Set-NuGetConfig
+}
 
-    Push-Location $env:DEPENDABOT_REPO_CONTENTS_PATH
-    $baseCommitSha = git rev-parse HEAD
-    Pop-Location
-    Write-Host "Base commit SHA: $baseCommitSha"
+function Build-UpdaterArguments {
+    param(
+        [string]$command,
+        [string]$baseCommitSha
+    )
 
     $arguments = @()
-    $arguments += "run"
+    $arguments += $command
     $arguments += "--job-path", $env:DEPENDABOT_JOB_PATH
     $arguments += "--repo-contents-path", $env:DEPENDABOT_REPO_CONTENTS_PATH
     $arguments += "--api-url", $env:DEPENDABOT_API_URL
@@ -73,25 +83,48 @@ function Update-Files {
         $env:NUGET_FALLBACK_PACKAGES = "$env:DEPENDABOT_HOME/.nuget/packages"
     }
 
+    return $arguments
+}
+
+function Invoke-Updater {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('run', 'graph')]
+        [string]$command
+    )
+
+    Initialize-UpdateEnvironment
+    $baseCommitSha = Get-BaseCommitSha
+
+    $arguments = Build-UpdaterArguments -command $command -baseCommitSha $baseCommitSha
+
     $process = Start-Process -FilePath $updaterTool -ArgumentList $arguments -NoNewWindow -Wait -PassThru
     $process.WaitForExit()
     $script:operationExitCode = $process.ExitCode
 }
 
-function Update-Dependencies {
+function Invoke-DependencyProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('run', 'graph')]
+        [string]$command
+    )
+
     $env:DEPENDABOT_LOG_MESSAGES = "true"
+
     Get-Files
     if ($script:operationExitCode -ne 0) {
         return
     }
 
-    Update-Files
+    Invoke-Updater -command $command
 }
 
 try {
     Switch ($args[0]) {
         "fetch_files" { }
-        "update_files" { Update-Dependencies }
+        "update_files" { Invoke-DependencyProcess -command run }
+        "update_graph" { Invoke-DependencyProcess -command graph }
         default { throw "unknown command: $args[0]" }
     }
     exit $operationExitCode


### PR DESCRIPTION
Allow the NuGet updater to respond to the `update_graph` command.

Most of this is just converting the existing project discovery results to a different format, with the exception that we now track dependency requirements in a new dictionary.  This new object doesn't slow down discovery because the information was already there, we're just pulling it out of the generated `project.assets.json` file.