### PR TITLE
Support grouped dependency updates for Nix flake inputs

### DIFF
--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "shellwords"
 
 require "dependabot/errors"
 require "dependabot/file_updaters"
@@ -25,7 +26,7 @@ module Dependabot
 
         if updated_lockfile_content == flake_lock.content
           raise Dependabot::DependencyFileContentNotChanged,
-                "Expected flake.lock to change for #{dependency.name}, but it didn't"
+                "Expected flake.lock to change for #{dependency_names.join(', ')}, but it didn't"
         end
 
         updated_files << updated_file(file: flake_lock, content: updated_lockfile_content)
@@ -34,22 +35,31 @@ module Dependabot
 
       private
 
-      sig { returns(Dependabot::Dependency) }
-      def dependency
-        T.must(dependencies.first)
+      sig { returns(T::Array[Dependabot::Dependency]) }
+      def unique_dependencies
+        dependencies.uniq(&:name)
       end
 
       # Returns updated flake.nix content if the ref changed, nil otherwise.
       sig { returns(T.nilable(String)) }
       def update_flake_nix
-        new_ref = new_source_ref
-        return unless new_ref
+        updated_content = T.let(T.must(flake_nix.content), String)
 
-        old_ref = old_source_ref
-        return unless old_ref
-        return if old_ref == new_ref
+        unique_dependencies.each do |dependency|
+          new_ref = new_source_ref(dependency)
+          next unless new_ref
 
-        FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+          old_ref = old_source_ref(dependency)
+          next unless old_ref
+          next if old_ref == new_ref
+
+          updated_input_content = FlakeNixParser.update_input_ref(updated_content, dependency.name, new_ref)
+          updated_content = updated_input_content if updated_input_content
+        end
+
+        return if updated_content == flake_nix.content
+
+        updated_content
       end
 
       sig { params(updated_nix_content: T.nilable(String)).returns(String) }
@@ -62,21 +72,26 @@ module Dependabot
           File.write("flake.lock", T.must(flake_lock.content))
 
           SharedHelpers.run_shell_command(
-            "nix flake update #{dependency.name}",
-            fingerprint: "nix flake update <input_name>"
+            Shellwords.join(["nix", "flake", "update", *dependency_names]),
+            fingerprint: "nix flake update <input_names>"
           )
 
           File.read("flake.lock")
         end
       end
 
-      sig { returns(T.nilable(String)) }
-      def new_source_ref
+      sig { returns(T::Array[String]) }
+      def dependency_names
+        unique_dependencies.map(&:name)
+      end
+
+      sig { params(dependency: Dependabot::Dependency).returns(T.nilable(String)) }
+      def new_source_ref(dependency)
         dependency.requirements.first&.dig(:source, :ref)
       end
 
-      sig { returns(T.nilable(String)) }
-      def old_source_ref
+      sig { params(dependency: Dependabot::Dependency).returns(T.nilable(String)) }
+      def old_source_ref(dependency)
         dependency.previous_requirements&.first&.dig(:source, :ref)
       end
 

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dependabot::Nix::FileUpdater do
   let(:updater) do
     described_class.new(
       dependency_files: [flake_nix, flake_lock],
-      dependencies: [dependency],
+      dependencies: dependencies,
       credentials: [{
         "type" => "git_source",
         "host" => "github.com",
@@ -50,6 +50,7 @@ RSpec.describe Dependabot::Nix::FileUpdater do
       }]
     )
   end
+  let(:dependencies) { [dependency] }
 
   let(:flake_nix) do
     Dependabot::DependencyFile.new(
@@ -75,6 +76,37 @@ RSpec.describe Dependabot::Nix::FileUpdater do
 
   def fixture(filename)
     File.read(File.join(__dir__, "fixtures", filename))
+  end
+
+  def dependency_for(name:, version:, previous_version:, url:, ref:, previous_ref:)
+    Dependabot::Dependency.new(
+      name: name,
+      version: version,
+      previous_version: previous_version,
+      requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        source: {
+          type: "git",
+          url: url,
+          branch: nil,
+          ref: ref
+        },
+        groups: []
+      }],
+      previous_requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        source: {
+          type: "git",
+          url: url,
+          branch: nil,
+          ref: previous_ref
+        },
+        groups: []
+      }],
+      package_manager: "nix"
+    )
   end
 
   it_behaves_like "a dependency file updater"
@@ -112,7 +144,55 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         updated_files
         expect(Dependabot::SharedHelpers)
           .to have_received(:run_shell_command)
-          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_names>")
+      end
+    end
+
+    context "with grouped branch-tracking inputs" do
+      let(:dependencies) { [dependency, home_manager_dependency] }
+
+      let(:home_manager_dependency) do
+        dependency_for(
+          name: "home-manager",
+          version: "new_home_manager_sha",
+          previous_version: "old_home_manager_sha",
+          url: "https://github.com/nix-community/home-manager",
+          ref: nil,
+          previous_ref: nil
+        )
+      end
+
+      it "calls nix flake update with every input name" do
+        updated_files
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with("nix flake update nixpkgs home-manager", fingerprint: "nix flake update <input_names>")
+      end
+
+      context "when the first input alone would not change the lockfile" do
+        before do
+          command = nil
+
+          allow(Dependabot::SharedHelpers)
+            .to receive(:run_shell_command) do |actual_command, **_kwargs|
+              command = actual_command
+            end
+
+          allow(File)
+            .to receive(:read)
+            .with("flake.lock") do
+              if command == "nix flake update nixpkgs home-manager"
+                updated_lock_content
+              else
+                flake_lock_content
+              end
+            end
+        end
+
+        it "does not treat the grouped update as unchanged" do
+          expect { updated_files }.not_to raise_error
+          expect(updated_files.map(&:name)).to eq(["flake.lock"])
+        end
       end
     end
 
@@ -221,6 +301,42 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         nix_file = updated_files.find { |f| f.name == "flake.nix" }
         expect(nix_file.content).to include('"github:NixOS/nixpkgs/nixos-25.05"')
         expect(nix_file.content).not_to include("nixos-24.11")
+      end
+    end
+
+    context "with grouped inputs that change refs" do
+      let(:flake_nix_content) { fixture("flake_with_versioned_branch.nix") }
+      let(:dependencies) { [dependency, home_manager_dependency] }
+      let(:updated_lock_content) { '{"updated": true}' }
+
+      let(:dependency) do
+        dependency_for(
+          name: "nixpkgs",
+          version: "new_sha_def456",
+          previous_version: "old_sha_abc123",
+          url: "https://github.com/NixOS/nixpkgs",
+          ref: "nixos-25.05",
+          previous_ref: "nixos-24.11"
+        )
+      end
+
+      let(:home_manager_dependency) do
+        dependency_for(
+          name: "home-manager",
+          version: "new_home_manager_sha",
+          previous_version: "old_home_manager_sha",
+          url: "https://github.com/nix-community/home-manager",
+          ref: "release-25.05",
+          previous_ref: "release-24.11"
+        )
+      end
+
+      it "rewrites all changed refs in flake.nix before running nix" do
+        updated_files
+        expect(File).to have_received(:write)
+          .with("flake.nix", a_string_including("github:NixOS/nixpkgs/nixos-25.05"))
+        expect(File).to have_received(:write)
+          .with("flake.nix", a_string_including("github:nix-community/home-manager/release-25.05"))
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Fix grouped Nix flake updates when the updater is asked to update multiple flake inputs at once.

The Nix file updater accepted multiple dependencies, but only ran `nix flake update` for the first one. If that first input did not change `flake.lock`, Dependabot failed with `DependencyFileContentNotChanged` before the other grouped inputs were updated.

This only happens if there is already an open PR that Dependabot is rebasing.

### Anything you want to highlight for special attention from reviewers?

The fix keeps the existing flow, but applies it to all unique dependency names passed to the updater.

It also uses `Shellwords.join` to build the `nix flake update ...` command.

Disclaimer: the code was generated with Codex using gpt-5.5.

### How will you know you've accomplished your goal?

Added a regression test for a grouped update where updating only the first input leaves `flake.lock` unchanged, but updating the full input set changes it.


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
