### PR TITLE
Upgrade to Ubuntu 26.04

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,6 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu/.devcontainer/base.Dockerfile
-
-# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT="jammy"
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+# [Choice] Ubuntu version: ubuntu26.04, ubuntu24.04, ubuntu22.04
+ARG VARIANT="ubuntu26.04"
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,12 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu
+// https://github.com/devcontainers/images/tree/main/src/base-ubuntu
 {
   "name": "Ubuntu",
   "build": {
     "dockerfile": "Dockerfile",
-    // Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
-    // Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+    // Update 'VARIANT' to pick an Ubuntu version: ubuntu26.04, ubuntu24.04, ubuntu22.04
     "args": {
-      "VARIANT": "ubuntu-22.04"
+      "VARIANT": "ubuntu26.04"
     }
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM docker.io/library/ubuntu:24.04
+FROM docker.io/library/ubuntu:26.04
 
 ARG TARGETARCH
 
@@ -61,25 +61,8 @@ EOF
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
-    # needed to run add-apt-repository
-    software-properties-common \
-    # Used to download the git-lfs GPG key as well as dev dependencies for CI
+    # Used for dev dependencies for CI
     curl \
-    # Add git core ppa to get a more recent git version than the one provided by ubuntu
-    && add-apt-repository -y ppa:git-core/ppa \
-    # Install the git-lfs mirror. See https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md
-    # We need this because the version of git-lfs provided by Ubuntu is outdated
-    # apt-transport-https is a temporary dependency to install the git-lfs apt source
-    && apt-get install -y --no-install-recommends apt-transport-https \
-    && mkdir -p /etc/apt/keyrings \
-           && curl -fsSL 'https://packagecloud.io/github/git-lfs/gpgkey' | gpg --dearmor > /etc/apt/keyrings/github_git-lfs-archive-keyring.gpg \
-           && release=$( . /etc/os-release && echo "$VERSION_CODENAME" ) \
-           && echo "deb [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ $release main" \
-              > /etc/apt/sources.list.d/github_git-lfs.list \
-           && echo "deb-src [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ $release main" \
-              >> /etc/apt/sources.list.d/github_git-lfs.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
     # dev dependencies for CI
     build-essential \
     libgmp-dev \
@@ -104,8 +87,6 @@ RUN apt-get update \
     libyaml-dev \
     locales \
   && locale-gen en_US.UTF-8 \
-  # No longer needed post git-core ppa addition and git-lfs install
-  && apt purge software-properties-common apt-transport-https -y && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 ARG USER_UID=1000

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -5,13 +5,19 @@ ARG TARGETARCH
 ENV PATH="${PATH}:/opt/swift/usr/bin"
 
 # OS dependencies
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+# NOTE: Exclude i386 architecture to prevent apt from trying to install i386 variants
+# that are unavailable in Ubuntu 26.04 (e.g., libxml2:i386). This doesn't impact arm64 builds.
+RUN <<EOF
+  mkdir -p /etc/apt/preferences.d
+  echo -e 'Package: *:i386\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/exclude-i386
+  apt-get update
+  apt-get install -y --no-install-recommends \
     binutils \
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-13-dev \
+    libncurses6 \
     libpython3-dev \
     libsqlite3-0 \
     libstdc++-13-dev \
@@ -20,8 +26,9 @@ RUN apt-get update \
     libz3-dev \
     pkg-config \
     tzdata \
-    uuid-dev \
-  && rm -rf /var/lib/apt/lists/*
+    uuid-dev
+  rm -rf /var/lib/apt/lists/*
+EOF
 
 USER dependabot
 
@@ -29,6 +36,9 @@ USER dependabot
 # https://github.com/apple/swift-org-website/blob/main/_data/builds/swift_releases.yml
 ARG SWIFT_VERSION=6.3.1
 ARG SWIFT_UBUNTU_VERSION=ubuntu24.04
+# NOTE: Pinned to Ubuntu 24.04 because Swift builds are not yet available for Ubuntu 26.04.
+# See: https://github.com/swiftlang/swift/issues/88994
+# To check if builds are available: curl -L -o /dev/null -w "%{http_code}" https://download.swift.org/swift-6.2.3-release/ubuntu2604/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE-ubuntu26.04.tar.gz
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VERSION}-aarch64"; fi \
   && SWIFT_SHORT_UBUNTU_VERSION=$(echo $SWIFT_UBUNTU_VERSION | tr -d .) \


### PR DESCRIPTION
Upgrades from Ubuntu 24.04 (noble) to Ubuntu 26.04 (resolute)

### What are you trying to accomplish?

Upgrades to Ubuntu 26.04 as that's the latest long term support version

Closes https://github.com/dependabot/dependabot-core/issues/14553
Closes https://github.com/dependabot/dependabot-core/pull/14966

### Anything you want to highlight for special attention from reviewers?

Here are the decisions I made so far: 

- **Dockerfile.updater-core**                                                                                                                                                                                                                                                                                          
   
  - Removed the git-core PPA: Ubuntu 26.04 already includes git 2.53.0, which is sufficient for our use case. The PPA currently provides git 2.54.0, likely because it was released recently.                                                                                                                                                                      
   - Removed git-lfs packagecloud.io PPA setup: Ubuntu 26.04 has native git-lfs 3.7.1-1 in universe repository which is the same
   
- **Composer Dockerfile (PHP)**                                                                                                                                                                                                                                                                                        
                   
  Blocked by https://codeberg.org/oerdnj/deb.sury.org/issues/91
  
  There may be workarounds but as there is no urgency, it seems best to just wait for https://codeberg.org/oerdnj/deb.sury.org/issues/91 as it seems a few weeks away
                                                                                                                                                                                                                                                                                                                   
- **Bun Dockerfile**
                                                                                                                                                                                                                                                                                                                   
  - Upgraded Node.js from 20.x (EOL April 30, 2026) to 24.x (current LTS)

Node 20.x no longer works and it seems to be related to the EOL. 
                                                                                                                                                                                                                                                                                                                   
- **Swift Dockerfile** 
                                                   
  - Remains pinned to Ubuntu 24.04 (Swift doesn't provide Ubuntu 26.04 builds yet)                                                                                                                                                                                                                                 
  - Created issue to track Swift support: https://github.com/swiftlang/swift/issues/88994
  - Removed i386 multiarch because it fails to build with dependencies such as libxml2:i386                                                                                                                                                                                                                    

                                                                                                                                                                                                                                                                                            
- **Future Work**                                                                                                                                                                                                                                                                                                      
                                                   
  - Remove Swift Ubuntu 24.04 pin

### How will you know you've accomplished your goal?

- The build is upgraded
- The existing tests pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
